### PR TITLE
[codex] improve TypeScript compat ROI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Right now it prioritizes **correctness** over raw speed, but the architecture is
 
 ### Wins
 
-- **Test262 language suite: 98.4%**, **built-ins: 72.4%**, **TypeScript 6.0.0 conformance: 67.0%** (see details below)
+- **Test262 language suite: 98.4%**, **built-ins: 72.4%**, **TypeScript 6.0.0 conformance: 67.6%** (see details below)
 - **Native TS execution**: no `tsc`, no TS→JS transpilation
 - **TCO**: tail call optimization (elite feature)
 - **Shapes + ICs**: fast-ish property access without a JIT
@@ -88,14 +88,14 @@ go test ./tests/...
 | :-- | --: | --: | --: | --: | --: |
 | Test262 language | 23,141/23,523 | 382 | 0 | 0 | 98.4% |
 | Test262 built-ins | 16,862/23,294 | 6,432 | 0 | 0 | 72.4% |
-| TypeScript 6.0.0 conformance | 3,303/4,928 | 1,152 | 473 | 0 | 67.0% |
+| TypeScript 6.0.0 conformance | 3,329/4,928 | 1,126 | 473 | 0 | 67.6% |
 <!-- compliance:end -->
 
 The Test262 language and built-ins figures come from the local baseline snapshots for the checked-out ECMA-262 conformance tests. The TypeScript figure comes from the single-file conformance runner against the TypeScript 6.0.0 test suite.
 
 ### Current status
 
-At **98.4% Test262 language compliance** and **67.0% TypeScript 6.0.0 conformance**, Paserati handles a large chunk of modern JavaScript/TypeScript semantics correctly. It's still evolving, but it's past the "toy project" phase.
+At **98.4% Test262 language compliance** and **67.6% TypeScript 6.0.0 conformance**, Paserati handles a large chunk of modern JavaScript/TypeScript semantics correctly. It's still evolving, but it's past the "toy project" phase.
 
 Core language features that work well:
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ go test ./tests/...
 | :-- | --: | --: | --: | --: | --: |
 | Test262 language | 23,141/23,523 | 382 | 0 | 0 | 98.4% |
 | Test262 built-ins | 16,862/23,294 | 6,432 | 0 | 0 | 72.4% |
-| TypeScript 6.0.0 conformance | 3,329/4,928 | 1,126 | 473 | 0 | 67.6% |
+| TypeScript 6.0.0 conformance | 3,332/4,928 | 1,123 | 473 | 0 | 67.6% |
 <!-- compliance:end -->
 
 The Test262 language and built-ins figures come from the local baseline snapshots for the checked-out ECMA-262 conformance tests. The TypeScript figure comes from the single-file conformance runner against the TypeScript 6.0.0 test suite.

--- a/cmd/paserati-testtsc/main.go
+++ b/cmd/paserati-testtsc/main.go
@@ -708,6 +708,7 @@ func createTscPaserati(directives TestDirectives) *driver.Paserati {
 	if !strictPropertyInitEnabled(directives) {
 		pas.SetSkipStrictPropertyInit(true)
 	}
+	pas.SetNoImplicitOverride(noImplicitOverrideEnabled(directives))
 	return pas
 }
 
@@ -721,6 +722,17 @@ func strictPropertyInitEnabled(d TestDirectives) bool {
 	}
 	if v, ok := d.Raw["strict"]; ok {
 		return v == "true"
+	}
+	return false
+}
+
+func noImplicitOverrideEnabled(d TestDirectives) bool {
+	if v, ok := d.Raw["noimplicitoverride"]; ok {
+		for _, part := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), "true") {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/docs/compliance.json
+++ b/docs/compliance.json
@@ -20,8 +20,8 @@
   "typescript": {
     "name": "TypeScript 6.0.0",
     "total": 4928,
-    "passed": 3329,
-    "failed": 1126,
+    "passed": 3332,
+    "failed": 1123,
     "skipped": 473,
     "timeout": 0,
     "version": "6.0.0"

--- a/docs/compliance.json
+++ b/docs/compliance.json
@@ -20,8 +20,8 @@
   "typescript": {
     "name": "TypeScript 6.0.0",
     "total": 4928,
-    "passed": 3303,
-    "failed": 1152,
+    "passed": 3329,
+    "failed": 1126,
     "skipped": 473,
     "timeout": 0,
     "version": "6.0.0"

--- a/docs/compliance.svg
+++ b/docs/compliance.svg
@@ -32,14 +32,14 @@
 <text x="340" y="255" text-anchor="middle" class="caption">16,862/23,294</text>
 </g>
   <g aria-label="TypeScript 6.0.0">
-<path d="M 690.00 135.00 L 634.66 162.96 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />
-<path d="M 690.00 135.00 L 654.84 83.94 A 62.00 62.00 0 0 0 634.66 162.96 Z" fill="#d64b4b" />
+<path d="M 690.00 135.00 L 634.56 162.75 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />
+<path d="M 690.00 135.00 L 654.84 83.94 A 62.00 62.00 0 0 0 634.56 162.75 Z" fill="#d64b4b" />
 <path d="M 690.00 135.00 L 690.00 73.00 A 62.00 62.00 0 0 0 654.84 83.94 Z" fill="#aeb7c2" />
 <circle cx="690" cy="135" r="38" fill="#ffffff" />
 <text x="690" y="131" text-anchor="middle" class="percent">67.6%</text>
 <text x="690" y="153" text-anchor="middle" class="caption">pass</text>
 <text x="690" y="233" text-anchor="middle" class="title">TypeScript 6.0.0</text>
-<text x="690" y="255" text-anchor="middle" class="caption">3,329/4,928</text>
+<text x="690" y="255" text-anchor="middle" class="caption">3,332/4,928</text>
 </g>
   <g transform="translate(575 278)">
     <rect x="0" y="-10" width="12" height="12" fill="#20a060" rx="2" /><text x="18" y="1" class="legend">Pass</text>

--- a/docs/compliance.svg
+++ b/docs/compliance.svg
@@ -32,14 +32,14 @@
 <text x="340" y="255" text-anchor="middle" class="caption">16,862/23,294</text>
 </g>
   <g aria-label="TypeScript 6.0.0">
-<path d="M 690.00 135.00 L 635.62 164.78 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />
-<path d="M 690.00 135.00 L 654.84 83.94 A 62.00 62.00 0 0 0 635.62 164.78 Z" fill="#d64b4b" />
+<path d="M 690.00 135.00 L 634.66 162.96 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />
+<path d="M 690.00 135.00 L 654.84 83.94 A 62.00 62.00 0 0 0 634.66 162.96 Z" fill="#d64b4b" />
 <path d="M 690.00 135.00 L 690.00 73.00 A 62.00 62.00 0 0 0 654.84 83.94 Z" fill="#aeb7c2" />
 <circle cx="690" cy="135" r="38" fill="#ffffff" />
-<text x="690" y="131" text-anchor="middle" class="percent">67.0%</text>
+<text x="690" y="131" text-anchor="middle" class="percent">67.6%</text>
 <text x="690" y="153" text-anchor="middle" class="caption">pass</text>
 <text x="690" y="233" text-anchor="middle" class="title">TypeScript 6.0.0</text>
-<text x="690" y="255" text-anchor="middle" class="caption">3,303/4,928</text>
+<text x="690" y="255" text-anchor="middle" class="caption">3,329/4,928</text>
 </g>
   <g transform="translate(575 278)">
     <rect x="0" y="-10" width="12" height="12" fill="#20a060" rx="2" /><text x="18" y="1" class="legend">Pass</text>

--- a/pkg/checker/assignment.go
+++ b/pkg/checker/assignment.go
@@ -413,9 +413,10 @@ func (c *Checker) checkObjectDestructuringAssignment(node *parser.ObjectDestruct
 			case *types.ObjectType:
 				if foundPropType, exists := rhsType.Properties[propName]; exists {
 					propType = foundPropType
+				} else if prop.Default == nil {
+					c.addError(prop.Key, fmt.Sprintf("property '%s' does not exist on type %s", propName, rhsType.String()))
 				} else {
 					// Property doesn't exist on object - will be undefined at runtime
-					// In TypeScript, this is allowed but results in undefined
 					propType = types.Undefined
 				}
 			}

--- a/pkg/checker/call.go
+++ b/pkg/checker/call.go
@@ -1706,6 +1706,9 @@ func (c *Checker) substituteTypeParameters(sig *types.Signature, solution map[*t
 			}
 			// After substitution, expand the mapped type to a concrete ObjectType
 			expanded := c.expandMappedType(substitutedMapped)
+			if expanded == nil {
+				return substitutedMapped
+			}
 			debugPrintf("// [Checker Substitute] Expanded mapped type: %s -> %s\n",
 				substitutedMapped.String(), expanded.String())
 			return expanded
@@ -1735,6 +1738,7 @@ func (c *Checker) substituteTypeParameters(sig *types.Signature, solution map[*t
 
 	return &types.Signature{
 		TypeParameters:    sig.TypeParameters,
+		ParameterNames:    sig.ParameterNames,
 		ParameterTypes:    newParamTypes,
 		ReturnType:        newReturnType,
 		OptionalParams:    sig.OptionalParams, // Copy as-is
@@ -1765,6 +1769,7 @@ func (c *Checker) substituteInSignature(sig *types.Signature, solution map[*type
 
 	return &types.Signature{
 		TypeParameters:    sig.TypeParameters,
+		ParameterNames:    sig.ParameterNames,
 		ParameterTypes:    newParamTypes,
 		ReturnType:        newReturnType,
 		OptionalParams:    sig.OptionalParams, // Copy as-is

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -299,6 +299,7 @@ type Checker struct {
 	functionNestingDepth   int // 0 = top level, >0 = inside function(s)
 	allowTopLevelReturn    bool
 	skipStrictPropertyInit bool // When true, TS2564 is not emitted (strict-init opt-out)
+	noImplicitOverride     bool // When true, overriding class members require explicit override
 
 	// --- Loop/switch/label context (reset when entering a new function scope) ---
 	loopDepth    int             // depth of enclosing iteration statements in current function
@@ -387,6 +388,12 @@ func (c *Checker) SetAllowTopLevelReturn(allow bool) {
 // `--strictPropertyInitialization` explicitly.
 func (c *Checker) SetSkipStrictPropertyInit(skip bool) {
 	c.skipStrictPropertyInit = skip
+}
+
+// SetNoImplicitOverride controls whether overriding class members require an
+// explicit `override` modifier. Default false.
+func (c *Checker) SetNoImplicitOverride(enabled bool) {
+	c.noImplicitOverride = enabled
 }
 
 // --- Access Control Helper Methods ---
@@ -3523,7 +3530,7 @@ func (c *Checker) checkArrayDestructuringDeclaration(node *parser.ArrayDestructu
 		}
 
 		// Define the variable(s) with inferred type - support both identifiers and nested patterns
-		c.checkDestructuringTargetForDeclaration(element.Target, elemType, node.IsConst)
+		c.checkDestructuringTargetForDeclaration(element.Target, elemType, node.IsConst, node.Token != nil && node.Token.Literal == "var")
 	}
 }
 
@@ -3611,6 +3618,8 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 			if objType != nil {
 				if pt, exists := objType.Properties[propName]; exists {
 					propType = pt
+				} else if prop.Default == nil {
+					c.addError(prop.Key, fmt.Sprintf("property '%s' does not exist on type %s", propName, objType.String()))
 				}
 			} else if isArray {
 				// For arrays, numeric keys access array elements
@@ -3641,7 +3650,7 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 		}
 
 		// Define the variable(s) with inferred type - support both identifiers and nested patterns
-		c.checkDestructuringTargetForDeclaration(prop.Target, propType, node.IsConst)
+		c.checkDestructuringTargetForDeclaration(prop.Target, propType, node.IsConst, node.Token != nil && node.Token.Literal == "var")
 	}
 
 	// Handle rest property if present

--- a/pkg/checker/class.go
+++ b/pkg/checker/class.go
@@ -623,10 +623,7 @@ func (c *Checker) createInstanceTypeInPlace(className string, body *parser.Class
 		if getter != nil {
 			c.setClassContext(className, types.AccessContextInstanceMethod)
 
-			// Validate override keyword usage for getter
-			if getter.IsOverride {
-				c.validateOverrideMethod(getter, superClass, className)
-			}
+			c.validateOverrideMethod(getter, superClass, className)
 
 			// TS2378: A 'get' accessor must return a value.
 			if getter.Value != nil && getter.Value.Body != nil && !bodyContainsReturn(getter.Value.Body) {
@@ -645,10 +642,7 @@ func (c *Checker) createInstanceTypeInPlace(className string, body *parser.Class
 		if setter != nil {
 			c.setClassContext(className, types.AccessContextInstanceMethod)
 
-			// Validate override keyword usage for setter
-			if setter.IsOverride {
-				c.validateOverrideMethod(setter, superClass, className)
-			}
+			c.validateOverrideMethod(setter, superClass, className)
 
 			methodType := c.inferMethodType(setter)
 			if objType, ok := methodType.(*types.ObjectType); ok && len(objType.CallSignatures) > 0 {
@@ -702,10 +696,7 @@ func (c *Checker) createInstanceTypeInPlace(className string, body *parser.Class
 			// Set method context for access control checking
 			c.setClassContext(className, types.AccessContextInstanceMethod)
 
-			// Validate override keyword usage
-			if method.IsOverride {
-				c.validateOverrideMethod(method, superClass, className)
-			}
+			c.validateOverrideMethod(method, superClass, className)
 
 			methodType := c.inferMethodType(method)
 
@@ -747,10 +738,7 @@ func (c *Checker) createInstanceTypeInPlace(className string, body *parser.Class
 			methodName := c.extractPropertyName(methodSig.Key)
 			c.setClassContext(className, types.AccessContextInstanceMethod)
 
-			// Validate override keyword usage for method signature
-			if methodSig.IsOverride {
-				c.validateOverrideMethodSignature(methodSig, superClass, className)
-			}
+			c.validateOverrideMethodSignature(methodSig, superClass, className)
 
 			// Validate the signature types
 			c.validateMethodSignature(methodSig)
@@ -786,6 +774,7 @@ func (c *Checker) createInstanceTypeInPlace(className string, body *parser.Class
 	// Add properties to instance type (excluding static properties)
 	for _, prop := range body.Properties {
 		if !prop.IsStatic {
+			c.validateOverrideProperty(prop, className, instanceType)
 			propType := c.inferPropertyType(prop)
 
 			// Determine access level
@@ -967,21 +956,9 @@ func (c *Checker) checkMethodBodyWithContext(fn *parser.FunctionLiteral) {
 
 // validateOverrideMethod validates the usage of the override keyword
 func (c *Checker) validateOverrideMethod(method *parser.MethodDefinition, superClass parser.Expression, className string) {
-	// Basic validation: if there's no superclass, override doesn't make sense
 	methodName := c.extractPropertyName(method.Key)
-	if superClass == nil {
-		c.addError(method.Key, fmt.Sprintf("method '%s' uses 'override' but class '%s' does not extend any class", methodName, className))
-		return
-	}
-
-	// TODO: When inheritance is implemented, add:
-	// 1. Check if the method exists in the superclass
-	// 2. Check if the method signatures are compatible
-	// 3. Check if the method is not final/sealed
-	// 4. Check access modifier compatibility
-
-	debugPrintf("// [Checker Class] Override validation for method '%s' in class '%s' (inheritance not yet implemented)\n",
-		methodName, className)
+	c.validateClassMemberOverride(method.Key, methodName, method.IsStatic, method.IsOverride, false, className, c.currentClassInstanceType)
+	debugPrintf("// [Checker Class] Override validation for method '%s' in class '%s'\n", methodName, className)
 }
 
 // inferMethodTypeFromSignature creates a function type from a method signature (for abstract methods)
@@ -1007,17 +984,140 @@ func (c *Checker) inferMethodTypeFromSignature(methodSig *parser.MethodSignature
 
 // validateOverrideMethodSignature validates the usage of the override keyword for method signatures
 func (c *Checker) validateOverrideMethodSignature(methodSig *parser.MethodSignature, superClass parser.Expression, className string) {
-	// Basic validation: if there's no superclass, override doesn't make sense
 	methodName := c.extractPropertyName(methodSig.Key)
-	if superClass == nil {
-		c.addError(methodSig.Key, fmt.Sprintf("method signature '%s' uses 'override' but class '%s' does not extend any class", methodName, className))
+	c.validateClassMemberOverride(methodSig.Key, methodName, methodSig.IsStatic, methodSig.IsOverride, methodSig.IsAbstract, className, c.currentClassInstanceType)
+	debugPrintf("// [Checker Class] Override validation for method signature '%s' in class '%s'\n", methodName, className)
+}
+
+func (c *Checker) validateOverrideProperty(prop *parser.PropertyDefinition, className string, instanceType *types.ObjectType) {
+	if prop.IsDeclare && !prop.IsOverride {
+		return
+	}
+	propName := c.extractPropertyName(prop.Key)
+	c.validateClassMemberOverride(prop.Key, propName, prop.IsStatic, prop.IsOverride, false, className, instanceType)
+	debugPrintf("// [Checker Class] Override validation for property '%s' in class '%s'\n", propName, className)
+}
+
+func (c *Checker) validateClassMemberOverride(node parser.Node, memberName string, isStatic, hasOverride, currentIsAbstract bool, className string, instanceType *types.ObjectType) {
+	if memberName == "" || instanceType == nil || instanceType.ClassMeta == nil {
 		return
 	}
 
-	// TODO: When inheritance is implemented, add similar validation as for method definitions
+	if instanceType.ClassMeta.SuperClassName == "" {
+		if hasOverride {
+			c.addError(node, fmt.Sprintf("This member cannot have an 'override' modifier because class '%s' does not extend another class.", className))
+		}
+		return
+	}
 
-	debugPrintf("// [Checker Class] Override validation for method signature '%s' in class '%s' (inheritance not yet implemented)\n",
-		methodName, className)
+	baseName, inherited := c.hasInheritedClassMember(instanceType, memberName, isStatic)
+	if hasOverride {
+		if !inherited {
+			c.addError(node, fmt.Sprintf("This member cannot have an 'override' modifier because it is not declared in the base class '%s'.", baseName))
+		}
+		return
+	}
+
+	if c.noImplicitOverride && inherited {
+		if !currentIsAbstract && c.inheritedAbstractClassMember(instanceType, memberName, isStatic) {
+			return
+		}
+		c.addError(node, fmt.Sprintf("This member must have an 'override' modifier because it overrides a member in the base class '%s'.", baseName))
+	}
+}
+
+func (c *Checker) inheritedAbstractClassMember(instanceType *types.ObjectType, memberName string, isStatic bool) bool {
+	if isStatic || instanceType == nil {
+		return false
+	}
+
+	visited := make(map[*types.ObjectType]bool)
+	var visit func(*types.ObjectType) bool
+	visit = func(obj *types.ObjectType) bool {
+		if obj == nil || visited[obj] {
+			return false
+		}
+		visited[obj] = true
+
+		if obj.ClassMeta != nil {
+			if methods := c.abstractMethods[obj.ClassMeta.ClassName]; methods != nil && methods[memberName] {
+				return true
+			}
+		}
+		for _, baseType := range obj.BaseTypes {
+			if baseObj, ok := baseType.(*types.ObjectType); ok && visit(baseObj) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, baseType := range instanceType.BaseTypes {
+		if baseObj, ok := baseType.(*types.ObjectType); ok && visit(baseObj) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Checker) hasInheritedClassMember(instanceType *types.ObjectType, memberName string, isStatic bool) (string, bool) {
+	if instanceType == nil || instanceType.ClassMeta == nil || instanceType.ClassMeta.SuperClassName == "" {
+		return "", false
+	}
+	baseName := instanceType.ClassMeta.SuperClassName
+	visited := make(map[*types.ObjectType]bool)
+
+	if isStatic {
+		if baseCtor, ok := instanceType.ClassMeta.SuperConstructorType.(*types.ObjectType); ok {
+			return baseName, c.objectTypeHasClassMember(baseCtor, memberName, true, visited)
+		}
+		return baseName, false
+	}
+
+	for _, baseType := range instanceType.BaseTypes {
+		if baseObj, ok := baseType.(*types.ObjectType); ok {
+			if c.objectTypeHasClassMember(baseObj, memberName, false, visited) {
+				return baseName, true
+			}
+		}
+	}
+	return baseName, false
+}
+
+func (c *Checker) objectTypeHasClassMember(obj *types.ObjectType, memberName string, isStatic bool, visited map[*types.ObjectType]bool) bool {
+	if obj == nil || visited[obj] {
+		return false
+	}
+	visited[obj] = true
+
+	if _, ok := obj.Properties[memberName]; ok {
+		return true
+	}
+	if obj.ClassMeta != nil {
+		if info := obj.ClassMeta.GetMemberAccess(memberName); info != nil && info.IsStatic == isStatic {
+			return true
+		}
+	}
+
+	if isStatic {
+		if obj.ClassMeta != nil {
+			if baseCtor, ok := obj.ClassMeta.SuperConstructorType.(*types.ObjectType); ok {
+				if c.objectTypeHasClassMember(baseCtor, memberName, true, visited) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, baseType := range obj.BaseTypes {
+		if baseObj, ok := baseType.(*types.ObjectType); ok {
+			if c.objectTypeHasClassMember(baseObj, memberName, false, visited) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // createConstructorSignatures creates the externally visible signatures for the class constructor.
@@ -1028,6 +1128,7 @@ func (c *Checker) createConstructorSignatures(body *parser.ClassBody, instanceTy
 		signatures := make([]*types.Signature, 0, len(body.ConstructorSigs))
 		for _, sig := range body.ConstructorSigs {
 			signatures = append(signatures, &types.Signature{
+				ParameterNames:    parameterNameStrings(sig.Parameters),
 				ParameterTypes:    c.extractParameterTypesFromSignature(sig),
 				ReturnType:        instanceType,
 				OptionalParams:    c.extractOptionalParamsFromSignature(sig),
@@ -1135,6 +1236,7 @@ func (c *Checker) inferMethodType(method *parser.MethodDefinition) types.Type {
 	restParameterType := c.extractRestParameterType(method.Value)
 
 	signature := &types.Signature{
+		ParameterNames:    parameterNameStrings(method.Value.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        returnType,
 		OptionalParams:    optionalParams,
@@ -1214,12 +1316,17 @@ func (c *Checker) getAccessLevel(isPublic, isPrivate, isProtected bool) types.Ac
 func (c *Checker) addStaticMembers(body *parser.ClassBody, constructorType *types.ObjectType, instanceType ...*types.ObjectType) *types.ObjectType {
 	// Get the class name from constructor metadata
 	className := constructorType.GetClassName()
+	var classInstanceType *types.ObjectType
+	if len(instanceType) > 0 {
+		classInstanceType = instanceType[0]
+	}
 
 	// Add static methods
 	for _, method := range body.Methods {
 		if method.IsStatic && method.Kind != "constructor" {
 			// Set static method context for access control checking
 			c.setClassContext(className, types.AccessContextStaticMethod)
+			c.validateClassMemberOverride(method.Key, c.extractPropertyName(method.Key), true, method.IsOverride, false, className, classInstanceType)
 
 			methodType := c.inferMethodType(method)
 
@@ -1244,12 +1351,13 @@ func (c *Checker) addStaticMembers(body *parser.ClassBody, constructorType *type
 	c.setClassContext(className, types.AccessContextStaticMethod)
 	// Set currentClassInstanceType so super expression check can find the class.
 	prevStaticInstanceType := c.currentClassInstanceType
-	if len(instanceType) > 0 && instanceType[0] != nil {
-		c.currentClassInstanceType = instanceType[0]
+	if classInstanceType != nil {
+		c.currentClassInstanceType = classInstanceType
 	}
 	defer func() { c.currentClassInstanceType = prevStaticInstanceType }()
 	for _, prop := range body.Properties {
 		if prop.IsStatic {
+			c.validateOverrideProperty(prop, className, classInstanceType)
 			propType := c.inferPropertyType(prop)
 
 			// Determine access level

--- a/pkg/checker/destructuring_nested.go
+++ b/pkg/checker/destructuring_nested.go
@@ -215,7 +215,7 @@ func (c *Checker) checkNestedObjectTarget(objectTarget *parser.ObjectLiteral, ex
 }
 
 // checkDestructuringTargetForDeclaration handles type checking and environment definition for destructuring targets in declarations
-func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expression, expectedType types.Type, isConst bool) {
+func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expression, expectedType types.Type, isConst bool, allowRedeclare bool) {
 	switch targetNode := target.(type) {
 	case *parser.Identifier:
 		// Simple identifier target - define in environment with refined type
@@ -233,21 +233,25 @@ func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expressio
 		}
 
 		if !c.env.Define(targetNode.Value, finalType, isConst) {
-			c.addError(targetNode, fmt.Sprintf("identifier '%s' already declared", targetNode.Value))
+			if allowRedeclare {
+				c.env.Update(targetNode.Value, finalType)
+			} else {
+				c.addError(targetNode, fmt.Sprintf("identifier '%s' already declared", targetNode.Value))
+			}
 		}
 		targetNode.SetComputedType(finalType)
 	case *parser.ArrayLiteral:
 		// Nested array destructuring declaration
-		c.checkNestedArrayTargetForDeclaration(targetNode, expectedType, isConst)
+		c.checkNestedArrayTargetForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
 	case *parser.ObjectLiteral:
 		// Nested object destructuring declaration
-		c.checkNestedObjectTargetForDeclaration(targetNode, expectedType, isConst)
+		c.checkNestedObjectTargetForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
 	case *parser.ArrayParameterPattern:
 		// Parameter patterns in declarations (shouldn't happen normally, but handle for consistency)
-		c.checkNestedArrayParameterPatternForDeclaration(targetNode, expectedType, isConst)
+		c.checkNestedArrayParameterPatternForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
 	case *parser.ObjectParameterPattern:
 		// Parameter patterns in declarations (shouldn't happen normally, but handle for consistency)
-		c.checkNestedObjectParameterPatternForDeclaration(targetNode, expectedType, isConst)
+		c.checkNestedObjectParameterPatternForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
 	case *parser.UndefinedLiteral:
 		// Elision in destructuring - no type checking needed, just skip this element
 		return
@@ -265,7 +269,7 @@ func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expressio
 }
 
 // checkNestedArrayTargetForDeclaration handles type checking for nested array destructuring in declarations
-func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.ArrayLiteral, expectedType types.Type, isConst bool) {
+func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.ArrayLiteral, expectedType types.Type, isConst bool, allowRedeclare bool) {
 	// Validate that expectedType is array-like
 	widenedType := types.GetWidenedType(expectedType)
 	var elementType types.Type
@@ -281,7 +285,7 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 			} else {
 				elemType = types.Undefined
 			}
-			c.checkDestructuringTargetForDeclaration(element, elemType, isConst)
+			c.checkDestructuringTargetForDeclaration(element, elemType, isConst, allowRedeclare)
 		}
 		return
 	} else if unionType, ok := expectedType.(*types.UnionType); ok {
@@ -299,7 +303,7 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 
 		if arrayLikeType != nil {
 			// Recursively check with the array-like type from the union
-			c.checkNestedArrayTargetForDeclaration(arrayTarget, arrayLikeType, isConst)
+			c.checkNestedArrayTargetForDeclaration(arrayTarget, arrayLikeType, isConst, allowRedeclare)
 			return
 		}
 
@@ -314,12 +318,12 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 
 	// For regular array types, check each element with the same element type
 	for _, element := range arrayTarget.Elements {
-		c.checkDestructuringTargetForDeclaration(element, elementType, isConst)
+		c.checkDestructuringTargetForDeclaration(element, elementType, isConst, allowRedeclare)
 	}
 }
 
 // checkNestedObjectTargetForDeclaration handles type checking for nested object destructuring in declarations
-func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.ObjectLiteral, expectedType types.Type, isConst bool) {
+func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.ObjectLiteral, expectedType types.Type, isConst bool, allowRedeclare bool) {
 	// Validate that expectedType is object-like
 	widenedType := types.GetWidenedType(expectedType)
 
@@ -380,12 +384,12 @@ func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.Obj
 				}
 			}
 
-			c.checkDestructuringTargetForDeclaration(prop.Value, propType, isConst)
+			c.checkDestructuringTargetForDeclaration(prop.Value, propType, isConst, allowRedeclare)
 		}
 	} else {
 		// For Any type, all nested targets get Any type
 		for _, prop := range objectTarget.Properties {
-			c.checkDestructuringTargetForDeclaration(prop.Value, types.Any, isConst)
+			c.checkDestructuringTargetForDeclaration(prop.Value, types.Any, isConst, allowRedeclare)
 		}
 	}
 }
@@ -466,7 +470,7 @@ func (c *Checker) checkNestedObjectParameterPattern(pattern *parser.ObjectParame
 }
 
 // checkNestedArrayParameterPatternForDeclaration handles type checking for nested array parameter patterns in declarations
-func (c *Checker) checkNestedArrayParameterPatternForDeclaration(pattern *parser.ArrayParameterPattern, expectedType types.Type, isConst bool) {
+func (c *Checker) checkNestedArrayParameterPatternForDeclaration(pattern *parser.ArrayParameterPattern, expectedType types.Type, isConst bool, allowRedeclare bool) {
 	widenedType := types.GetWidenedType(expectedType)
 	var elementType types.Type
 
@@ -480,12 +484,12 @@ func (c *Checker) checkNestedArrayParameterPatternForDeclaration(pattern *parser
 		if elem == nil || elem.Target == nil {
 			continue
 		}
-		c.checkDestructuringTargetForDeclaration(elem.Target, elementType, isConst)
+		c.checkDestructuringTargetForDeclaration(elem.Target, elementType, isConst, allowRedeclare)
 	}
 }
 
 // checkNestedObjectParameterPatternForDeclaration handles type checking for nested object parameter patterns in declarations
-func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parser.ObjectParameterPattern, expectedType types.Type, isConst bool) {
+func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parser.ObjectParameterPattern, expectedType types.Type, isConst bool, allowRedeclare bool) {
 	widenedType := types.GetWidenedType(expectedType)
 
 	if widenedType != types.Any {
@@ -497,9 +501,9 @@ func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parse
 					continue
 				}
 				if prop.Target != nil {
-					c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst)
+					c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst, allowRedeclare)
 				} else {
-					c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst)
+					c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst, allowRedeclare)
 				}
 			}
 			return
@@ -521,9 +525,9 @@ func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parse
 			}
 
 			if prop.Target != nil {
-				c.checkDestructuringTargetForDeclaration(prop.Target, propType, isConst)
+				c.checkDestructuringTargetForDeclaration(prop.Target, propType, isConst, allowRedeclare)
 			} else {
-				c.checkDestructuringTargetForDeclaration(prop.Key, propType, isConst)
+				c.checkDestructuringTargetForDeclaration(prop.Key, propType, isConst, allowRedeclare)
 			}
 		}
 	} else {
@@ -533,9 +537,9 @@ func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parse
 				continue
 			}
 			if prop.Target != nil {
-				c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst)
+				c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst, allowRedeclare)
 			} else {
-				c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst)
+				c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst, allowRedeclare)
 			}
 		}
 	}

--- a/pkg/checker/environment.go
+++ b/pkg/checker/environment.go
@@ -382,6 +382,17 @@ func (e *Environment) ResolveType(name string) (types.Type, bool) {
 	return nil, false
 }
 
+// ResolveTypeLocal looks up a type alias only in the current scope. Declaration
+// merging uses this so a nested namespace/interface does not accidentally merge
+// with an outer declaration of the same name.
+func (e *Environment) ResolveTypeLocal(name string) (types.Type, bool) {
+	if e == nil || e.typeAliases == nil {
+		return nil, false
+	}
+	typ, ok := e.typeAliases[name]
+	return typ, ok
+}
+
 // GetAllTypeAliases returns all type aliases in the current environment (not including outer scopes)
 func (e *Environment) GetAllTypeAliases() map[string]types.Type {
 	if e.typeAliases == nil {

--- a/pkg/checker/expressions.go
+++ b/pkg/checker/expressions.go
@@ -1198,6 +1198,14 @@ func (c *Checker) checkMemberExpression(node *parser.MemberExpression) {
 					// resultType remains types.Never
 				}
 			}
+		case *types.TupleType:
+			if propertyName == "length" {
+				resultType = types.Number
+			} else if methodType := c.env.GetPrimitivePrototypeMethodType("array", propertyName); methodType != nil {
+				resultType = c.instantiateGenericMethod(methodType, getTupleElementUnion(obj))
+			} else {
+				c.addError(node.Property, fmt.Sprintf("property '%s' does not exist on type %s", propertyName, obj.String()))
+			}
 		case *types.ObjectType: // <<< MODIFIED CASE
 			// Check if this is a function and we're accessing 'prototype'
 			if propertyName == "prototype" && obj != nil && obj.IsCallable() {

--- a/pkg/checker/function_common.go
+++ b/pkg/checker/function_common.go
@@ -228,6 +228,7 @@ func (c *Checker) resolveFunctionParameters(ctx *FunctionCheckContext) (*types.S
 
 	signature := &types.Signature{
 		TypeParameters:    c.signatureTypeParameters(ctx.TypeParameters),
+		ParameterNames:    parameterNameStrings(ctx.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        expectedReturnType,
 		OptionalParams:    optionalParams,
@@ -362,6 +363,7 @@ func (c *Checker) resolveFunctionParametersWithContext(ctx *FunctionCheckContext
 
 	// 5. Create preliminary signature
 	signature := &types.Signature{
+		ParameterNames:    parameterNameStrings(ctx.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        returnType,
 		OptionalParams:    optionalParams,
@@ -492,6 +494,9 @@ func (c *Checker) checkFunctionBody(ctx *FunctionCheckContext, expectedReturnTyp
 					sourceType = c.getAwaitedType(sourceType)
 					targetType = c.getAwaitedType(targetType)
 				}
+				if _, ok := targetType.(*types.TypePredicateType); ok {
+					targetType = types.Boolean
+				}
 				if !c.isAssignableWithExpansion(sourceType, targetType) {
 					c.addError(exprBody, fmt.Sprintf("cannot return expression of type '%s' from arrow function with return type annotation '%s'", bodyType.String(), expectedReturnType.String()))
 				}
@@ -550,6 +555,7 @@ func (c *Checker) createFinalFunctionType(ctx *FunctionCheckContext, paramTypes 
 	// Create final signature
 	sig := &types.Signature{
 		TypeParameters:    c.signatureTypeParameters(ctx.TypeParameters),
+		ParameterNames:    parameterNameStrings(ctx.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        finalReturnType,
 		OptionalParams:    optionalParams,
@@ -559,6 +565,19 @@ func (c *Checker) createFinalFunctionType(ctx *FunctionCheckContext, paramTypes 
 
 	// Create unified ObjectType with call signature
 	return types.NewFunctionType(sig)
+}
+
+func parameterNameStrings(params []*parser.Parameter) []string {
+	if len(params) == 0 {
+		return nil
+	}
+	names := make([]string, len(params))
+	for i, param := range params {
+		if param != nil && param.Name != nil {
+			names[i] = param.Name.Value
+		}
+	}
+	return names
 }
 
 func (c *Checker) signatureTypeParameters(typeParamNodes []*parser.TypeParameter) []*types.TypeParameter {

--- a/pkg/checker/namespace.go
+++ b/pkg/checker/namespace.go
@@ -29,7 +29,7 @@ func (c *Checker) checkNamespaceDeclaration(node *parser.NamespaceDeclaration) {
 	// 1. Get-or-create the NamespaceType in the current scope. We look in the
 	//    type env: a NamespaceType always lives there.
 	var nsType *types.NamespaceType
-	if existing, found := c.env.ResolveType(name); found {
+	if existing, found := c.env.ResolveTypeLocal(name); found {
 		if ns, ok := existing.(*types.NamespaceType); ok {
 			nsType = ns
 		}

--- a/pkg/checker/narrowing.go
+++ b/pkg/checker/narrowing.go
@@ -18,17 +18,40 @@ type TypeGuard struct {
 	OptionalChainingBaseExpr parser.Expression // For optional chaining guards: the base object expression (e.g., "opts" in "opts?.prop")
 }
 
+type typePredicateSignature struct {
+	predicate *types.TypePredicateType
+	signature *types.Signature
+}
+
 // extractTypePredicateFromType checks if a type has call signatures with a type predicate return type.
-// Returns the TypePredicateType if found, nil otherwise.
-func extractTypePredicateFromType(functionType types.Type) *types.TypePredicateType {
+// Returns the TypePredicateType and its signature if found, nil otherwise.
+func extractTypePredicateFromType(functionType types.Type) *typePredicateSignature {
 	if objType, ok := functionType.(*types.ObjectType); ok {
 		for _, sig := range objType.CallSignatures {
 			if predType, ok := sig.ReturnType.(*types.TypePredicateType); ok {
-				return predType
+				return &typePredicateSignature{predicate: predType, signature: sig}
 			}
 		}
 	}
 	return nil
+}
+
+func predicateArgumentIndex(predSig *typePredicateSignature, argCount int) int {
+	if predSig == nil || predSig.predicate == nil || predSig.signature == nil {
+		return -1
+	}
+	for i, name := range predSig.signature.ParameterNames {
+		if i >= argCount {
+			break
+		}
+		if name == predSig.predicate.ParameterName {
+			return i
+		}
+	}
+	if predSig.predicate.ParameterName != "" && argCount == 1 {
+		return 0
+	}
+	return -1
 }
 
 // isMemberOrOptionalChaining checks if an expression is a MemberExpression or OptionalChainingExpression
@@ -121,50 +144,49 @@ func (c *Checker) detectTypeGuard(condition parser.Expression) *TypeGuard {
 
 	// Pattern 0: Type predicate function calls like isString(x) or Array.isArray(x)
 	if callExpr, ok := condition.(*parser.CallExpression); ok {
-		// Check if this is a single-argument call to a function with type predicate return
-		if len(callExpr.Arguments) == 1 {
-			// Get narrowing key for the argument — supports identifiers, member expressions,
-			// and optional chaining expressions
-			argKey := expressionToNarrowingKey(callExpr.Arguments[0])
-			if argKey != "" {
-				// Resolve the function's type — try computed type, then environment
-				functionType := callExpr.Function.GetComputedType()
+		if len(callExpr.Arguments) > 0 {
+			// Resolve the function's type — try computed type, then environment
+			functionType := callExpr.Function.GetComputedType()
 
-				// For simple identifier calls like isString(x)
-				if funcIdent, ok := callExpr.Function.(*parser.Identifier); ok {
-					if envType, _, found := c.env.Resolve(funcIdent.Value); found {
-						if envType != functionType {
-							functionType = envType
+			// For simple identifier calls like isString(x)
+			if funcIdent, ok := callExpr.Function.(*parser.Identifier); ok {
+				if envType, _, found := c.env.Resolve(funcIdent.Value); found {
+					if envType != functionType {
+						functionType = envType
+					}
+				}
+			}
+
+			// For member expression calls like Array.isArray(x) — resolve the
+			// property type from the object (e.g., Array's "isArray" property)
+			if memberFunc, ok := callExpr.Function.(*parser.MemberExpression); ok {
+				c.visit(memberFunc.Object)
+				objType := memberFunc.Object.GetComputedType()
+				if objType != nil {
+					propName := c.extractPropertyName(memberFunc.Property)
+					if widened, ok := types.GetWidenedType(objType).(*types.ObjectType); ok {
+						if propType, exists := widened.Properties[propName]; exists {
+							functionType = propType
 						}
 					}
 				}
+			}
 
-				// For member expression calls like Array.isArray(x) — resolve the
-				// property type from the object (e.g., Array's "isArray" property)
-				if memberFunc, ok := callExpr.Function.(*parser.MemberExpression); ok {
-					c.visit(memberFunc.Object)
-					objType := memberFunc.Object.GetComputedType()
-					if objType != nil {
-						propName := c.extractPropertyName(memberFunc.Property)
-						if widened, ok := types.GetWidenedType(objType).(*types.ObjectType); ok {
-							if propType, exists := widened.Properties[propName]; exists {
-								functionType = propType
+			if functionType != nil {
+				if predSig := extractTypePredicateFromType(functionType); predSig != nil {
+					argIndex := predicateArgumentIndex(predSig, len(callExpr.Arguments))
+					if argIndex >= 0 {
+						arg := callExpr.Arguments[argIndex]
+						argKey := expressionToNarrowingKey(arg)
+						if argKey != "" {
+							guard := &TypeGuard{
+								VariableName: argKey,
+								NarrowedType: predSig.predicate.Type,
+								IsNegated:    false,
 							}
+							guard.OptionalChainingBaseExpr = extractOptionalChainingBase(arg)
+							return guard
 						}
-					}
-				}
-
-				if functionType != nil {
-					// Extract type predicate from call signatures
-					if predType := extractTypePredicateFromType(functionType); predType != nil {
-						guard := &TypeGuard{
-							VariableName: argKey,
-							NarrowedType: predType.Type,
-							IsNegated:    false,
-						}
-						// If the argument is optional chaining, also record the base for back-propagation
-						guard.OptionalChainingBaseExpr = extractOptionalChainingBase(callExpr.Arguments[0])
-						return guard
 					}
 				}
 			}
@@ -185,37 +207,28 @@ func (c *Checker) detectTypeGuard(condition parser.Expression) *TypeGuard {
 				debugPrintf("// [detectTypeGuard] typeof check detected, operand type: %T, key: %s\n", typeofExpr.Operand, narrowingKey)
 				if narrowingKey != "" {
 					if typeString, ok := staticStringLiteralValue(infix.Right); ok {
-						// Map string literal to corresponding type
-						var narrowedType types.Type
-						switch typeString {
-						case "string":
-							narrowedType = types.String
-						case "number":
-							narrowedType = types.Number
-						case "boolean":
-							narrowedType = types.Boolean
-						case "object":
-							// For typeof === "object", we need a special marker
-							// We'll handle this in the narrowing logic to filter to object types only
-							narrowedType = &types.ObjectTypeMarker{}
-						case "function":
-							// Create a generic function type for typeof narrowing
-							narrowedType = &types.ObjectType{
-								CallSignatures: []*types.Signature{
-									{
-										ParameterTypes: []types.Type{},
-										ReturnType:     types.Any,
-										OptionalParams: []bool{},
-										IsVariadic:     false,
-									},
-								},
-							}
-						case "undefined":
-							narrowedType = types.Undefined
-						default:
-							return nil // Unknown type string
+						narrowedType := typeFromTypeofString(typeString)
+						if narrowedType == nil {
+							return nil
 						}
 
+						return &TypeGuard{
+							VariableName: narrowingKey,
+							NarrowedType: narrowedType,
+							IsNegated:    isNegative,
+						}
+					}
+				}
+			}
+			// Reversed typeof check: "string" === typeof x
+			if typeofExpr, ok := infix.Right.(*parser.TypeofExpression); ok {
+				narrowingKey := expressionToNarrowingKey(typeofExpr.Operand)
+				if narrowingKey != "" {
+					if typeString, ok := staticStringLiteralValue(infix.Left); ok {
+						narrowedType := typeFromTypeofString(typeString)
+						if narrowedType == nil {
+							return nil
+						}
 						return &TypeGuard{
 							VariableName: narrowingKey,
 							NarrowedType: narrowedType,
@@ -422,6 +435,34 @@ func (c *Checker) detectTypeGuard(condition parser.Expression) *TypeGuard {
 		}
 	}
 	return nil
+}
+
+func typeFromTypeofString(typeString string) types.Type {
+	switch typeString {
+	case "string":
+		return types.String
+	case "number":
+		return types.Number
+	case "boolean":
+		return types.Boolean
+	case "object":
+		return &types.ObjectTypeMarker{}
+	case "function":
+		return &types.ObjectType{
+			CallSignatures: []*types.Signature{
+				{
+					ParameterTypes: []types.Type{},
+					ReturnType:     types.Any,
+					OptionalParams: []bool{},
+					IsVariadic:     false,
+				},
+			},
+		}
+	case "undefined":
+		return types.Undefined
+	default:
+		return nil
+	}
 }
 
 // literalToType converts a literal expression to its corresponding literal type

--- a/pkg/checker/resolve.go
+++ b/pkg/checker/resolve.go
@@ -717,6 +717,7 @@ func (c *Checker) extractConstructSignaturesFromType(typ types.Type) []*types.Si
 func (c *Checker) resolveObjectTypeSignature(node *parser.ObjectTypeExpression) types.Type {
 	properties := make(map[string]types.Type)
 	optionalProperties := make(map[string]bool)
+	readOnlyProperties := make(map[string]bool)
 	var callSignatures []*types.Signature
 	var constructSignatures []*types.Signature
 	var indexSignatures []*types.IndexSignature
@@ -830,6 +831,9 @@ func (c *Checker) resolveObjectTypeSignature(node *parser.ObjectTypeExpression) 
 			if prop.Optional {
 				optionalProperties[prop.Name.Value] = true
 			}
+			if prop.Readonly {
+				readOnlyProperties[prop.Name.Value] = true
+			}
 			debugPrintf("// [Checker ObjectType] Property '%s'%s: %s\n",
 				prop.Name.Value,
 				func() string {
@@ -848,6 +852,7 @@ func (c *Checker) resolveObjectTypeSignature(node *parser.ObjectTypeExpression) 
 	objectType := &types.ObjectType{
 		Properties:          properties,
 		OptionalProperties:  optionalProperties,
+		ReadOnlyProperties:  readOnlyProperties,
 		CallSignatures:      callSignatures,
 		ConstructSignatures: constructSignatures,
 		IndexSignatures:     indexSignatures,

--- a/pkg/checker/resolve.go
+++ b/pkg/checker/resolve.go
@@ -579,6 +579,7 @@ func (c *Checker) resolveFunctionTypeSignature(node *parser.FunctionTypeExpressi
 
 	// Create signature
 	sig := &types.Signature{
+		ParameterNames:    functionTypeParameterNameStrings(node.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        returnType,
 		OptionalParams:    node.OptionalParams,
@@ -662,6 +663,8 @@ func (c *Checker) resolveGenericFunctionType(node *parser.FunctionTypeExpression
 
 	// Create the function signature
 	sig := &types.Signature{
+		TypeParameters:    typeParams,
+		ParameterNames:    functionTypeParameterNameStrings(node.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        returnType,
 		OptionalParams:    node.OptionalParams,
@@ -1112,12 +1115,17 @@ func (c *Checker) resolveFunctionLiteralSignature(node *parser.FunctionLiteral, 
 
 	// Return a unified Signature
 	return &types.Signature{
+		ParameterNames:    parameterNameStrings(node.Parameters),
 		ParameterTypes:    paramTypes,
 		ReturnType:        resolvedReturnType, // Use the value assigned outside the if
 		OptionalParams:    optionalParams,
 		IsVariadic:        node.RestParameter != nil,
 		RestParameterType: restParameterType,
 	}
+}
+
+func functionTypeParameterNameStrings(params []parser.Expression) []string {
+	return nil
 }
 
 // instantiateGenericType creates a concrete type by substituting type arguments
@@ -1297,6 +1305,7 @@ func (c *Checker) substituteTypesWithVisited(t types.Type, substitution map[stri
 
 				result.CallSignatures[i] = &types.Signature{
 					TypeParameters:    sig.TypeParameters,
+					ParameterNames:    sig.ParameterNames,
 					ParameterTypes:    newParamTypes,
 					ReturnType:        newReturnType,
 					OptionalParams:    sig.OptionalParams, // Copy optional flags
@@ -1320,6 +1329,7 @@ func (c *Checker) substituteTypesWithVisited(t types.Type, substitution map[stri
 
 				result.ConstructSignatures[i] = &types.Signature{
 					TypeParameters:    sig.TypeParameters,
+					ParameterNames:    sig.ParameterNames,
 					ParameterTypes:    newParamTypes,
 					ReturnType:        newReturnType,
 					OptionalParams:    sig.OptionalParams,
@@ -2644,6 +2654,7 @@ func (c *Checker) substituteTypesPreservingInfer(typ types.Type, substitution ma
 
 				newSigs[i] = &types.Signature{
 					TypeParameters:    sig.TypeParameters,
+					ParameterNames:    sig.ParameterNames,
 					ParameterTypes:    newParamTypes,
 					ReturnType:        newReturnType,
 					OptionalParams:    sig.OptionalParams,

--- a/pkg/checker/statements.go
+++ b/pkg/checker/statements.go
@@ -17,7 +17,7 @@ func (c *Checker) checkTypeAliasStatement(node *parser.TypeAliasStatement) {
 	// Note: We use c.env which IS the globalEnv during Pass 1
 	// If the type exists but is a forward reference placeholder from Pass 0, we should continue
 	// to resolve the actual type
-	if existingType, exists := c.env.ResolveType(node.Name.Value); exists {
+	if existingType, exists := c.env.ResolveTypeLocal(node.Name.Value); exists {
 		if _, isForwardRef := existingType.(*types.TypeAliasForwardReference); !isForwardRef {
 			debugPrintf("// [Checker TypeAlias P1] Alias '%s' already defined? Skipping.\n", node.Name.Value)
 			return // Should not happen if parser prevents duplicates
@@ -178,7 +178,7 @@ func (c *Checker) checkInterfaceDeclaration(node *parser.InterfaceDeclaration) {
 	// same name are merged (TypeScript declaration merging). Each new declaration adds its
 	// members to the same ObjectType.
 	var interfaceType *types.ObjectType
-	if existingType, exists := c.env.ResolveType(node.Name.Value); exists {
+	if existingType, exists := c.env.ResolveTypeLocal(node.Name.Value); exists {
 		if objType, ok := existingType.(*types.ObjectType); ok {
 			// Merge into the existing interface type (declaration merging).
 			interfaceType = objType
@@ -334,10 +334,11 @@ func (c *Checker) checkInterfaceDeclaration(node *parser.InterfaceDeclaration) {
 
 			// Check if we're overriding an inherited property
 			if existingType, exists := properties[prop.Name.Value]; exists {
-				// Verify that the override is compatible (for now, just log a debug message)
+				if mergedType, merged := mergeInterfaceFunctionMemberTypes(existingType, propType); merged {
+					propType = mergedType
+				}
 				debugPrintf("// [Checker Interface P1] Interface '%s' overrides property '%s' (was: %s, now: %s)\n",
 					node.Name.Value, prop.Name.Value, existingType.String(), propType.String())
-				// TODO: Add stricter type compatibility checking for overrides if needed
 			}
 
 			properties[prop.Name.Value] = propType
@@ -367,20 +368,46 @@ func (c *Checker) checkGenericInterfaceDeclaration(node *parser.InterfaceDeclara
 	debugPrintf("// [Checker Interface P1] Processing generic interface '%s' with %d type parameters\n",
 		node.Name.Value, len(node.TypeParameters))
 
-	// 1. Create and register type parameters before resolving constraints.
-	// TypeScript permits later parameters in earlier constraints, e.g. <T extends U, U>.
-	typeParams := make([]*types.TypeParameter, len(node.TypeParameters))
-	for i, param := range node.TypeParameters {
-		typeParams[i] = &types.TypeParameter{
-			Name:       param.Name.Value,
-			Constraint: types.Any,
-			Index:      i,
+	var existingGeneric *types.GenericType
+	var bodyType *types.ObjectType
+	if existingType, exists := c.env.ResolveTypeLocal(node.Name.Value); exists {
+		switch existing := existingType.(type) {
+		case *types.GenericType:
+			existingGeneric = existing
+			if len(existing.TypeParameters) != len(node.TypeParameters) {
+				c.addError(node.Name, fmt.Sprintf("All declarations of '%s' must have identical type parameters.", node.Name.Value))
+				return
+			}
+			if existingBody, ok := existing.Body.(*types.ObjectType); ok {
+				bodyType = existingBody
+			}
+		case *types.ObjectType:
+			c.addError(node.Name, fmt.Sprintf("All declarations of '%s' must have identical type parameters.", node.Name.Value))
+			return
 		}
-		param.SetComputedType(&types.TypeParameterType{Parameter: typeParams[i]})
 	}
 
-	// 2. Create the body ObjectType with TypeParameterType references
-	// This is a template that will be instantiated with concrete types later
+	// 1. Create or reuse type parameters before resolving constraints.
+	// TypeScript permits later parameters in earlier constraints, e.g. <T extends U, U>.
+	typeParams := make([]*types.TypeParameter, len(node.TypeParameters))
+	if existingGeneric != nil {
+		typeParams = existingGeneric.TypeParameters
+		for i, param := range node.TypeParameters {
+			if param.Name.Value != typeParams[i].Name {
+				c.addError(param.Name, fmt.Sprintf("All declarations of '%s' must have identical type parameters.", node.Name.Value))
+			}
+			param.SetComputedType(&types.TypeParameterType{Parameter: typeParams[i]})
+		}
+	} else {
+		for i, param := range node.TypeParameters {
+			typeParams[i] = &types.TypeParameter{
+				Name:       param.Name.Value,
+				Constraint: types.Any,
+				Index:      i,
+			}
+			param.SetComputedType(&types.TypeParameterType{Parameter: typeParams[i]})
+		}
+	}
 
 	// Create a new environment with type parameters available as TypeParameterType
 	genericEnv := NewEnclosedEnvironment(c.env)
@@ -400,12 +427,18 @@ func (c *Checker) checkGenericInterfaceDeclaration(node *parser.InterfaceDeclara
 		if param.Constraint != nil {
 			c.checkTypeRefDefined(param.Constraint)
 			if constraintType := c.resolveTypeAnnotation(param.Constraint); constraintType != nil {
+				if existingGeneric != nil && typeParam.Constraint != nil && !typeParam.Constraint.Equals(constraintType) {
+					c.addError(param.Constraint, fmt.Sprintf("All declarations of '%s' must have identical type parameter constraints.", node.Name.Value))
+				}
 				typeParam.Constraint = constraintType
 			}
 		}
 
 		if param.DefaultType != nil {
 			if defaultType := c.resolveTypeAnnotation(param.DefaultType); defaultType != nil {
+				if existingGeneric != nil && typeParam.Default != nil && !typeParam.Default.Equals(defaultType) {
+					c.addError(param.DefaultType, fmt.Sprintf("All declarations of '%s' must have identical type parameter defaults.", node.Name.Value))
+				}
 				typeParam.Default = defaultType
 
 				if typeParam.Constraint != nil && !types.IsAssignable(defaultType, typeParam.Constraint) {
@@ -421,16 +454,22 @@ func (c *Checker) checkGenericInterfaceDeclaration(node *parser.InterfaceDeclara
 	c.env = genericEnv
 
 	// Build the ObjectType body with TypeParameterType references
-	properties := make(map[string]types.Type)
-	optionalProperties := make(map[string]bool)
-	var indexSignatures []*types.IndexSignature
-	var callSignatures []*types.Signature
-	bodyType := &types.ObjectType{
-		Properties:         properties,
-		OptionalProperties: optionalProperties,
-		IndexSignatures:    indexSignatures,
-		CallSignatures:     callSignatures,
+	if bodyType == nil {
+		bodyType = &types.ObjectType{
+			Properties:         make(map[string]types.Type),
+			OptionalProperties: make(map[string]bool),
+		}
 	}
+	if bodyType.Properties == nil {
+		bodyType.Properties = make(map[string]types.Type)
+	}
+	if bodyType.OptionalProperties == nil {
+		bodyType.OptionalProperties = make(map[string]bool)
+	}
+	properties := bodyType.Properties
+	optionalProperties := bodyType.OptionalProperties
+	indexSignatures := bodyType.IndexSignatures
+	callSignatures := bodyType.CallSignatures
 	c.currentThisType = bodyType
 
 	// Handle extends clause with generic environment
@@ -499,6 +538,11 @@ func (c *Checker) checkGenericInterfaceDeclaration(node *parser.InterfaceDeclara
 			if propType == nil {
 				propType = types.Any
 			}
+			if existingType, exists := properties[prop.Name.Value]; exists {
+				if mergedType, merged := mergeInterfaceFunctionMemberTypes(existingType, propType); merged {
+					propType = mergedType
+				}
+			}
 			properties[prop.Name.Value] = propType
 			if prop.Optional {
 				optionalProperties[prop.Name.Value] = true
@@ -512,6 +556,13 @@ func (c *Checker) checkGenericInterfaceDeclaration(node *parser.InterfaceDeclara
 	// Restore environment
 	c.env = savedEnv
 	c.currentThisType = savedThisType
+
+	if existingGeneric != nil {
+		existingGeneric.Body = bodyType
+		debugPrintf("// [Checker Interface P1] Merged generic interface '%s' with %d type parameters in env %p\n",
+			node.Name.Value, len(typeParams), c.env)
+		return
+	}
 
 	// 3. Create the GenericType
 	genericType := &types.GenericType{
@@ -527,6 +578,34 @@ func (c *Checker) checkGenericInterfaceDeclaration(node *parser.InterfaceDeclara
 		debugPrintf("// [Checker Interface P1] Defined generic interface '%s' with %d type parameters in env %p\n",
 			node.Name.Value, len(typeParams), c.env)
 	}
+}
+
+func mergeInterfaceFunctionMemberTypes(existingType, incomingType types.Type) (types.Type, bool) {
+	existingSigs, existingOK := interfaceMemberCallSignatures(existingType)
+	incomingSigs, incomingOK := interfaceMemberCallSignatures(incomingType)
+	if !existingOK || !incomingOK {
+		return nil, false
+	}
+
+	merged := types.NewObjectType()
+	merged.CallSignatures = append(merged.CallSignatures, existingSigs...)
+	merged.CallSignatures = append(merged.CallSignatures, incomingSigs...)
+	return merged, true
+}
+
+func interfaceMemberCallSignatures(t types.Type) ([]*types.Signature, bool) {
+	switch typ := t.(type) {
+	case *types.ObjectType:
+		if len(typ.CallSignatures) == 0 {
+			return nil, false
+		}
+		return typ.CallSignatures, true
+	case *types.GenericType:
+		if body, ok := typ.Body.(*types.ObjectType); ok && len(body.CallSignatures) > 0 {
+			return body.CallSignatures, true
+		}
+	}
+	return nil, false
 }
 
 func (c *Checker) rebindThisType(t types.Type, from *types.ObjectType, to *types.ObjectType) types.Type {
@@ -632,6 +711,8 @@ func (c *Checker) rebindSignaturesThisType(signatures []*types.Signature, from *
 			newParamTypes[j] = c.rebindThisTypeWithVisited(paramType, from, to, visited)
 		}
 		result[i] = &types.Signature{
+			TypeParameters:    sig.TypeParameters,
+			ParameterNames:    sig.ParameterNames,
 			ParameterTypes:    newParamTypes,
 			ReturnType:        c.rebindThisTypeWithVisited(sig.ReturnType, from, to, visited),
 			OptionalParams:    sig.OptionalParams,

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -84,6 +84,12 @@ func (p *Paserati) SetSkipStrictPropertyInit(skip bool) {
 	p.checker.SetSkipStrictPropertyInit(skip)
 }
 
+// SetNoImplicitOverride controls whether overriding class members require an
+// explicit `override` modifier.
+func (p *Paserati) SetNoImplicitOverride(enabled bool) {
+	p.checker.SetNoImplicitOverride(enabled)
+}
+
 // SetAllowTopLevelReturn controls whether script/eval style top-level returns
 // are accepted by the type checker.
 func (p *Paserati) SetAllowTopLevelReturn(allow bool) {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -3604,10 +3604,10 @@ func (cpn *ComputedPropertyName) String() string       { return "[" + cpn.Expr.S
 // PropertyDefinition represents a property declaration in a class
 type PropertyDefinition struct {
 	BaseExpression
-	Token          *lexer.Token // The property name token
-	Key            Expression   // Property name (Identifier or ComputedPropertyName)
-	TypeAnnotation Expression   // Type annotation (can be nil)
-	Value          Expression   // Initializer expression (can be nil)
+	Token              *lexer.Token // The property name token
+	Key                Expression   // Property name (Identifier or ComputedPropertyName)
+	TypeAnnotation     Expression   // Type annotation (can be nil)
+	Value              Expression   // Initializer expression (can be nil)
 	IsStatic           bool         // For static property support
 	Optional           bool         // Whether the property is optional (prop?)
 	Readonly           bool         // Whether the property is readonly
@@ -3615,6 +3615,8 @@ type PropertyDefinition struct {
 	IsPublic           bool         // For public access modifier
 	IsPrivate          bool         // For private access modifier
 	IsProtected        bool         // For private access modifier
+	IsOverride         bool         // For override keyword
+	IsDeclare          bool         // For declare keyword
 	Decorators         []*Decorator // Decorators applied to this property
 }
 
@@ -3633,6 +3635,9 @@ func (pd *PropertyDefinition) String() string {
 
 	if pd.Readonly {
 		out.WriteString("readonly ")
+	}
+	if pd.IsOverride {
+		out.WriteString("override ")
 	}
 	if pd.IsStatic {
 		out.WriteString("static ")

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -2694,6 +2694,7 @@ type ObjectTypeProperty struct {
 	Name                 *Identifier  // Property name (nil for call signatures and index signatures)
 	Type                 Expression   // Property type annotation or function type for call signatures
 	Optional             bool         // Whether the property is optional (for future use)
+	Readonly             bool         // Whether the property is readonly
 	IsCallSignature      bool         // Whether this is a call signature like (param: type): returnType
 	IsConstructSignature bool         // Whether this is a construct signature like new (param: type): T
 	Parameters           []Expression // Parameters for call/construct signatures
@@ -2741,6 +2742,9 @@ func (otp *ObjectTypeProperty) String() string {
 		}
 	} else {
 		// Regular property: name?: type
+		if otp.Readonly {
+			out.WriteString("readonly ")
+		}
 		if otp.Name != nil {
 			out.WriteString(otp.Name.String())
 		}

--- a/pkg/parser/parse_class.go
+++ b/pkg/parser/parse_class.go
@@ -395,11 +395,19 @@ func (p *Parser) parseClassBody() *ClassBody {
 		// Parse all modifiers until we hit something that's not a modifier
 		hasAccessibility := false
 		isDeclare := false
+		seenAsync := false
+		seenOverride := false
 		for {
 			if p.curTokenIs(lexer.READONLY) && !isReadonly && !isFieldName() {
+				if seenOverride {
+					p.addError(p.curToken, "'override' modifier must precede 'readonly' modifier.")
+				}
 				isReadonly = true
 				p.nextToken()
 			} else if p.curTokenIs(lexer.STATIC) && !isStatic && !isFieldName() {
+				if seenOverride {
+					p.addError(p.curToken, "'static' modifier must precede 'override' modifier.")
+				}
 				isStatic = true
 				p.nextToken()
 			} else if p.curTokenIs(lexer.STATIC) && isStatic && !isFieldName() {
@@ -421,6 +429,9 @@ func (p *Parser) parseClassBody() *ClassBody {
 				if isStatic {
 					p.addError(p.curToken, fmt.Sprintf("'%s' modifier must precede 'static' modifier.", p.curToken.Literal))
 				}
+				if seenOverride {
+					p.addError(p.curToken, fmt.Sprintf("'%s' modifier must precede 'override' modifier.", p.curToken.Literal))
+				}
 				hasAccessibility = true
 				if p.curTokenIs(lexer.PUBLIC) {
 					isPublic = true
@@ -431,13 +442,21 @@ func (p *Parser) parseClassBody() *ClassBody {
 				}
 				p.nextToken()
 			} else if p.curTokenIs(lexer.ABSTRACT) && !isAbstract && !isFieldName() {
+				if seenOverride {
+					p.addError(p.curToken, "'abstract' modifier must precede 'override' modifier.")
+				}
 				isAbstract = true
 				p.nextToken()
 			} else if p.curTokenIs(lexer.OVERRIDE) && !isOverride && !isFieldName() {
+				if seenAsync {
+					p.addError(p.curToken, "'override' modifier must precede 'async' modifier.")
+				}
 				isOverride = true
+				seenOverride = true
 				p.nextToken()
 			} else if p.curTokenIs(lexer.ASYNC) && !isAsync && !isFieldName() {
 				isAsync = true
+				seenAsync = true
 				p.nextToken()
 			} else {
 				break // No more modifiers
@@ -620,7 +639,7 @@ func (p *Parser) parseClassBody() *ClassBody {
 					}
 				} else {
 					// It's a property
-					property := p.parseProperty(isStatic, isReadonly, isPublic, isPrivate, isProtected)
+					property := p.parseProperty(isStatic, isReadonly, isPublic, isPrivate, isProtected, isOverride, isDeclare)
 					if property != nil {
 						attachDecorators(property)
 						properties = append(properties, property)
@@ -909,7 +928,7 @@ func (p *Parser) parseAsyncMethod(isStatic, isPublic, isPrivate, isProtected, is
 }
 
 // parseProperty parses a property declaration
-func (p *Parser) parseProperty(isStatic, isReadonly, isPublic, isPrivate, isProtected bool) *PropertyDefinition {
+func (p *Parser) parseProperty(isStatic, isReadonly, isPublic, isPrivate, isProtected, isOverride, isDeclare bool) *PropertyDefinition {
 	propertyToken := p.curToken
 	var propertyName Expression
 	if p.curToken.Type == lexer.STRING {
@@ -995,6 +1014,8 @@ func (p *Parser) parseProperty(isStatic, isReadonly, isPublic, isPrivate, isProt
 		IsPublic:           isPublic,
 		IsPrivate:          isPrivate,
 		IsProtected:        isProtected,
+		IsOverride:         isOverride,
+		IsDeclare:          isDeclare,
 	}
 }
 
@@ -1338,7 +1359,7 @@ func (p *Parser) parseComputedClassMember(isStatic, isReadonly, isPublic, isPriv
 		return p.parseComputedMethod(bracketToken, keyExpr, isStatic, isPublic, isPrivate, isProtected, isAbstract, isOverride, false)
 	} else {
 		// It's a computed property: [expr]: type = value or [expr] = value
-		return p.parseComputedProperty(bracketToken, keyExpr, isStatic, isReadonly, isPublic, isPrivate, isProtected)
+		return p.parseComputedProperty(bracketToken, keyExpr, isStatic, isReadonly, isPublic, isPrivate, isProtected, isOverride)
 	}
 }
 
@@ -1366,7 +1387,7 @@ func (p *Parser) parseComputedClassMemberAsync(isStatic, isReadonly, isPublic, i
 		return p.parseComputedMethod(bracketToken, keyExpr, isStatic, isPublic, isPrivate, isProtected, isAbstract, isOverride, isAsync)
 	}
 	// Computed property (not method) — fall back to non-async handling
-	return p.parseComputedProperty(bracketToken, keyExpr, isStatic, isReadonly, isPublic, isPrivate, isProtected)
+	return p.parseComputedProperty(bracketToken, keyExpr, isStatic, isReadonly, isPublic, isPrivate, isProtected, isOverride)
 }
 
 // parseComputedMethod parses a computed method in a class
@@ -1486,7 +1507,7 @@ func (p *Parser) parseComputedMethod(bracketToken *lexer.Token, keyExpr Expressi
 }
 
 // parseComputedProperty parses a computed property in a class
-func (p *Parser) parseComputedProperty(bracketToken *lexer.Token, keyExpr Expression, isStatic, isReadonly, isPublic, isPrivate, isProtected bool) *PropertyDefinition {
+func (p *Parser) parseComputedProperty(bracketToken *lexer.Token, keyExpr Expression, isStatic, isReadonly, isPublic, isPrivate, isProtected, isOverride bool) *PropertyDefinition {
 	// Check for optional marker '?' or definite-assignment '!' (mutually exclusive)
 	var isOptional bool
 	var hasDefiniteAssignment bool
@@ -1553,6 +1574,7 @@ func (p *Parser) parseComputedProperty(bracketToken *lexer.Token, keyExpr Expres
 		IsPublic:           isPublic,
 		IsPrivate:          isPrivate,
 		IsProtected:        isProtected,
+		IsOverride:         isOverride,
 	}
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -8486,12 +8486,21 @@ func (p *Parser) parseObjectTypeExpression() Expression {
 			objType.Properties = append(objType.Properties, prop)
 		} else {
 			// Regular property or method signature - try to parse property name (allowing keywords and string literals)
+			isReadonly := false
+			if p.curTokenIs(lexer.READONLY) && !p.peekTokenIs(lexer.COLON) && !p.peekTokenIs(lexer.QUESTION) &&
+				!p.peekTokenIs(lexer.LPAREN) && !p.peekTokenIs(lexer.LT) &&
+				!p.peekTokenIs(lexer.SEMICOLON) && !p.peekTokenIs(lexer.COMMA) && !p.peekTokenIs(lexer.RBRACE) {
+				isReadonly = true
+				p.nextToken()
+			}
+
 			propName := p.parsePropertyName()
 			var prop *ObjectTypeProperty
 
 			if propName != nil {
 				prop = &ObjectTypeProperty{
-					Name: propName,
+					Name:     propName,
+					Readonly: isReadonly,
 				}
 			} else if p.curTokenIs(lexer.STRING) {
 				// Handle string literal property names by creating an identifier with the string value
@@ -8499,13 +8508,15 @@ func (p *Parser) parseObjectTypeExpression() Expression {
 				// Create an identifier from the string literal for compatibility
 				identFromString := &Identifier{Token: p.curToken, Value: stringLit.Value}
 				prop = &ObjectTypeProperty{
-					Name: identFromString,
+					Name:     identFromString,
+					Readonly: isReadonly,
 				}
 			} else if p.curTokenIs(lexer.NUMBER) {
 				// Handle numeric literal property names
 				numIdent := &Identifier{Token: p.curToken, Value: p.curToken.Literal}
 				prop = &ObjectTypeProperty{
-					Name: numIdent,
+					Name:     numIdent,
+					Readonly: isReadonly,
 				}
 			} else {
 				p.addError(p.curToken, "expected property name (identifier or string literal), call signature '(', or index signature '[' in object type")

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1647,6 +1647,10 @@ func (p *Parser) parseTupleTypeExpression() Expression {
 		if p.curTokenIs(lexer.SPREAD) {
 			// Parse rest element: '...T[]'
 			p.nextToken() // Move past '...' to the type
+			if p.isTupleElementLabelStart() && p.peekTokenIs(lexer.COLON) {
+				p.nextToken() // Move to ':'
+				p.nextToken() // Move to the rest element type
+			}
 
 			restType := p.parseTypeExpression()
 			if restType == nil {
@@ -1675,7 +1679,21 @@ func (p *Parser) parseTupleTypeExpression() Expression {
 			break
 		}
 
-		// Parse regular element type
+		// Parse regular element type. Named tuple elements are type metadata only
+		// for our checker, so discard the label and keep the element type.
+		labelIsOptional := false
+		if p.isTupleElementLabelStart() {
+			if p.peekTokenIs(lexer.COLON) {
+				p.nextToken() // Move to ':'
+				p.nextToken() // Move to the element type
+			} else if p.peekTokenIs(lexer.QUESTION) && p.peekTokenIs2(lexer.COLON) {
+				labelIsOptional = true
+				p.nextToken() // Move to '?'
+				p.nextToken() // Move to ':'
+				p.nextToken() // Move to the element type
+			}
+		}
+
 		elemType := p.parseTypeExpression()
 		if elemType == nil {
 			return nil
@@ -1684,7 +1702,7 @@ func (p *Parser) parseTupleTypeExpression() Expression {
 		tupleTypeExp.ElementTypes = append(tupleTypeExp.ElementTypes, elemType)
 
 		// Check for optional marker '?'
-		isOptional := false
+		isOptional := labelIsOptional
 		if p.peekTokenIs(lexer.QUESTION) {
 			isOptional = true
 			p.nextToken() // Consume '?'
@@ -1719,6 +1737,16 @@ func (p *Parser) parseTupleTypeExpression() Expression {
 		len(tupleTypeExp.ElementTypes), tupleTypeExp.RestElement != nil)
 
 	return tupleTypeExp
+}
+
+func (p *Parser) isTupleElementLabelStart() bool {
+	switch p.curToken.Type {
+	case lexer.IDENT, lexer.SET, lexer.GET, lexer.FROM, lexer.OF, lexer.AS,
+		lexer.ASYNC, lexer.STATIC, lexer.TYPE, lexer.READONLY,
+		lexer.OVERRIDE, lexer.ABSTRACT:
+		return true
+	}
+	return false
 }
 
 func (p *Parser) parseLetStatement() Statement {
@@ -7886,7 +7914,8 @@ func (p *Parser) parseInterfaceDeclaration() *InterfaceDeclaration {
 func (p *Parser) parseInterfaceProperty() *InterfaceProperty {
 	// Check for invalid access modifiers on interface type members (TS1070)
 	if (p.curTokenIs(lexer.PUBLIC) || p.curTokenIs(lexer.PRIVATE) ||
-		p.curTokenIs(lexer.PROTECTED) || p.curTokenIs(lexer.STATIC)) &&
+		p.curTokenIs(lexer.PROTECTED) || p.curTokenIs(lexer.STATIC) ||
+		p.curTokenIs(lexer.OVERRIDE)) &&
 		!p.peekTokenIs(lexer.LPAREN) && !p.peekTokenIs(lexer.QUESTION) &&
 		!p.peekTokenIs(lexer.COLON) && !p.peekTokenIs(lexer.SEMICOLON) &&
 		!p.peekTokenIs(lexer.RBRACE) && p.peekToken.Line == p.curToken.Line {
@@ -10935,6 +10964,10 @@ func (p *Parser) parseMappedTypeExpression(startToken *lexer.Token) Expression {
 		return nil
 	}
 	debugPrint("Parsed value type, cur: %s, peek: %s", p.curToken.Literal, p.peekToken.Literal)
+
+	if p.peekTokenIs(lexer.SEMICOLON) || p.peekTokenIs(lexer.COMMA) {
+		p.nextToken()
+	}
 
 	// Expect '}'
 	if !p.expectPeek(lexer.RBRACE) {

--- a/pkg/types/assignable.go
+++ b/pkg/types/assignable.go
@@ -124,6 +124,17 @@ func isAssignable(source, target Type) bool {
 		return true
 	}
 
+	// Type predicate results are boolean values at runtime, but carry extra
+	// metadata in function return types for control-flow narrowing.
+	if _, ok := source.(*TypePredicateType); ok && target == Boolean {
+		return true
+	}
+	if sourcePred, ok := source.(*TypePredicateType); ok {
+		if targetPred, ok := target.(*TypePredicateType); ok {
+			return isAssignable(sourcePred.Type, targetPred.Type)
+		}
+	}
+
 	// TypeScript compatibility: undefined is assignable to void
 	if target == Void && source == Undefined {
 		return true

--- a/pkg/types/object.go
+++ b/pkg/types/object.go
@@ -16,6 +16,7 @@ var objectEqualsVisited sync.Map
 // Signature represents a function or constructor signature
 type Signature struct {
 	TypeParameters    []*TypeParameter
+	ParameterNames    []string
 	ParameterTypes    []Type
 	ReturnType        Type
 	OptionalParams    []bool // Tracks which parameters are optional

--- a/tests/scripts/class_override_error.ts
+++ b/tests/scripts/class_override_error.ts
@@ -1,4 +1,4 @@
-// expect_compile_error: method 'test' uses 'override' but class 'MyClass' does not extend any class
+// expect_compile_error: This member cannot have an 'override' modifier because class 'MyClass' does not extend another class.
 // Test override error without inheritance
 
 class MyClass {

--- a/tests/scripts/ts_tuple_readonly_object_type.ts
+++ b/tests/scripts/ts_tuple_readonly_object_type.ts
@@ -1,0 +1,8 @@
+// expect: ok
+
+let obj: { readonly x: number; y?: string } = { x: 1 };
+let pair: [number, string] = [1, "a"];
+
+pair.push(2);
+
+obj.x === 1 && pair.length === 3 ? "ok" : "fail";


### PR DESCRIPTION
## Summary

Improves TypeScript conformance compatibility across the requested ROI areas: override diagnostics, declaration merging, type guards, destructuring, and tuple/mapped parsing.

Measured TypeScript conformance moved from `3302 passed / 1153 failed` to `3329 passed / 1126 failed`, for a net `+27` with no phase-boundary regressions.

Phase gains:

| Phase | New passes | New failures | Net |
|---|---:|---:|---:|
| override | +12 | 0 | +12 |
| merging | +7 | 0 | +7 |
| type guards | +2 | 0 | +2 |
| destructuring | +4 | 0 | +4 |
| tuple/mapped | +2 | 0 | +2 |
| total | +27 | 0 | +27 |

Also updates the generated compliance docs after the push hook refresh.

## Validation

- `go build ./...`
- `go test ./tests -run TestScripts`
- `./paserati-testtsc -path /Users/nooga/lab/TypeScript -timeout 1s -diff scratch/tsc_after_destructuring.txt -dump scratch/tsc_after_tuple_mapped.txt`

Final TypeScript compliance shown by the push hook: `3329/4928 (67.6%)`.
