### PR TITLE
perf: Test262 macro-benchmark (opt-in same-runner A/B)

### DIFF
--- a/.github/workflows/perf-test262.yml
+++ b/.github/workflows/perf-test262.yml
@@ -1,0 +1,213 @@
+name: Perf Test262
+
+# Same-runner A/B macro-benchmark: how long paserati takes to execute the whole
+# Test262 corpus. Benches the PR's merge-base and its head back to back on ONE
+# runner, then reports the delta. Like perf-pr.yml, running both halves on the
+# same machine cancels cross-runner CPU-tier noise.
+#
+# The metric is the SUM of per-test execution time over the tests that pass and
+# don't time out, divided by the calibration anchor (anchor-normalized, machine-
+# portable). Summing per-test durations (not wall-clock) keeps it parallelism-
+# invariant; restricting to the passing, non-timed-out set decouples speed from
+# correctness. Pass/fail/timeout counts are reported separately, so a correctness
+# change moves those numbers, not the timing.
+#
+# Heavy and opt-in: a two-pass full-suite run costs real runner minutes, so it
+# runs only on PRs carrying the `perf-test262` label (distinct from the cheap
+# `perf` micro check — adding `perf` must never trigger this multi-minute job).
+# Informational only: it never fails the PR.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'pkg/**'
+      - 'cmd/**'
+      - '.test262-rev'
+      - '.github/workflows/perf-test262.yml'
+  # Manual escape hatch: run against any PR by number without touching labels.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number for a real base-vs-head A/B'
+        required: false
+      ref:
+        description: 'Single ref to self-A/B (smoke test: runs the macro twice, expect ~0% — measures wall-time + noise floor)'
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-test262-${{ github.event.pull_request.number || github.event.inputs.pr || github.event.inputs.ref }}
+  cancel-in-progress: true
+
+env:
+  # Per-test timeout is a SAFETY BOUND, not part of the metric: timed-out tests
+  # are excluded from the sum (and from the intersection both sides share). 5s made
+  # the suite timeout-dominated (40+ min). 0.2s was too tight — it mislabeled
+  # slow-but-correct tests (e.g. RegExp backtracking) as timeouts and dropped them.
+  # 1.2s: every measured slow-correct test resolves under it; what still times out
+  # is a genuine hang. The intersection compare makes the exact value low-stakes.
+  PER_TEST_TIMEOUT: 1.2s
+
+jobs:
+  bench:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'perf-test262')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      pr: ${{ steps.refs.outputs.pr }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # The Test262 corpus is pinned by .test262-rev and is large; cache the clone
+      # across runs. setup-test262.sh re-pins to the current tree's rev after each
+      # checkout, so a cache hit just needs a checkout, not a re-clone.
+      - name: Cache Test262 corpus
+        uses: actions/cache@v4
+        with:
+          path: test262
+          key: test262-${{ hashFiles('.test262-rev') }}
+          restore-keys: test262-
+
+      - name: Resolve base and head
+        id: refs
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_FROM_INPUT: ${{ github.event.inputs.pr }}
+          REF_FROM_INPUT: ${{ github.event.inputs.ref }}
+          BASE_FROM_EVENT: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Self-A/B smoke test: dispatch with a `ref` and no `pr`. base == head,
+          # so the run measures full-suite wall-time and the run-to-run noise
+          # floor (expected ~0% delta). It also sidesteps the bootstrap problem
+          # that a real A/B can't bench a merge-base predating this tooling.
+          if [ "$EVENT" = "workflow_dispatch" ] && [ -n "$REF_FROM_INPUT" ]; then
+            git fetch --no-tags origin "$REF_FROM_INPUT"
+            sha="$(git rev-parse FETCH_HEAD)"
+            pr=""; base_sha="$sha"; head_sha="$sha"
+            echo "Self-A/B on ${REF_FROM_INPUT} (${sha})"
+          else
+            if [ "$EVENT" = "workflow_dispatch" ]; then
+              pr="$PR_FROM_INPUT"
+              [[ "$pr" =~ ^[0-9]+$ ]] || { echo "provide pr=<number> or ref=<branch>" >&2; exit 1; }
+              base_ref="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .base.ref)"
+            else
+              pr="$PR_FROM_EVENT"
+              base_ref="$BASE_FROM_EVENT"
+            fi
+            # refs/pull/<n>/head lives on the base repo for fork PRs too.
+            git fetch --no-tags origin "$base_ref" "refs/pull/${pr}/head:pr-head"
+            head_sha="$(git rev-parse pr-head)"
+            # Merge-base = the PR's own fork point, so we measure the PR's delta,
+            # not unrelated drift on the base branch since.
+            base_sha="$(git merge-base "origin/${base_ref}" pr-head)"
+          fi
+          {
+            echo "pr=${pr}"
+            echo "head=${head_sha}"
+            echo "base=${base_sha}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Base: ${base_sha}"
+          echo "Head: ${head_sha}"
+
+      - name: Bench merge-base
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+        run: |
+          set -euo pipefail
+          git checkout --force "$BASE"
+          ./setup-test262.sh
+          ./scripts/macro-test262.sh "${RUNNER_TEMP}/base.jsonl" "${RUNNER_TEMP}/base.stats.json"
+
+      - name: Bench head and compare
+        id: bench
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          HEAD: ${{ steps.refs.outputs.head }}
+        run: |
+          set -euo pipefail
+          git checkout --force "$HEAD"
+          ./setup-test262.sh
+          ./scripts/macro-test262.sh "${RUNNER_TEMP}/head.jsonl" "${RUNNER_TEMP}/head.stats.json"
+
+          # Same-runner A/B: intersection compare over the per-test results both
+          # passes produced (the .merged.json macro-test262.sh writes alongside).
+          ./scripts/macro-test262-compare.sh \
+            "${RUNNER_TEMP}/base.merged.json" "${RUNNER_TEMP}/head.merged.json" > "${RUNNER_TEMP}/timing.md"
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          counts() { # $1=stats.json  -> "passed / failed / timeouts (total)"
+            jq -r '"\(.Passed) / \(.Failed) / \(.Timeouts)  (\(.Total) total)"' "$1"
+          }
+          report() {
+            echo "## Test262 macro — base vs head, same runner"
+            echo
+            echo "Base \`${BASE:0:12}\` vs head \`${HEAD:0:12}\`. Same runner, raw sums; informational, not a gate."
+            echo
+            echo "**Correctness (passed / failed / timeouts):**"
+            echo "- base: $(counts "${RUNNER_TEMP}/base.stats.json")"
+            echo "- head: $(counts "${RUNNER_TEMP}/head.stats.json")"
+            echo
+            echo "**Execution time (summed over tests passing on both sides):**"
+            echo
+            cat "${RUNNER_TEMP}/timing.md"
+          }
+          report >> "$GITHUB_STEP_SUMMARY"
+          { report; echo; echo "_[Run details →](${run_url})_"; } > "${RUNNER_TEMP}/comment.md"
+
+      - name: Upload PR comment artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-test262-comment
+          path: ${{ runner.temp }}/comment.md
+          if-no-files-found: error
+
+  comment:
+    needs: bench
+    # Skip in self-test mode (no PR to comment on); the job summary still has the report.
+    if: needs.bench.result == 'success' && needs.bench.outputs.pr != ''
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: perf-test262-comment
+          path: ${{ runner.temp }}/perf-test262-comment
+
+      # Sticky PR comment (upsert by marker). Fork PRs get a read-only token, so
+      # continue-on-error keeps the run green — the job summary still carries the report.
+      - name: Upsert PR comment
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR: ${{ needs.bench.outputs.pr }}
+          COMMENT_PATH: ${{ runner.temp }}/perf-test262-comment/comment.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- perf-test262-report -->';
+            const body = marker + '\n' + fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR);
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ dome.js
 # Built binaries — anchored so they don't also swallow cmd/paserati-*/ source dirs.
 /paserati-analyze
 /paserati-v8bench
+/bench-ratchet
+/bench-test262
 bench/out/
 quickjs-bench/
 benchmarks/

--- a/cmd/bench-test262/main.go
+++ b/cmd/bench-test262/main.go
@@ -1,0 +1,166 @@
+// Command bench-test262 turns a `paserati-test262 -json` run into perf
+// StreamRecord(s) that bench-ratchet's aggregate step normalizes against
+// the calibration anchor — so the Test262 macro-benchmark lands on the
+// timeline page as just another series, with no new normalization code.
+//
+// The metric is the SUM of per-test execution time over the tests that
+// passed and did NOT time out. Two deliberate properties:
+//
+//   - Summing per-test durations (not wall-clock) is parallelism-invariant:
+//     the runner can fan out for throughput without moving the number.
+//   - Restricting to the passing, non-timed-out set decouples speed from
+//     correctness: a regression that makes tests time out changes the
+//     timeout COUNT (reported separately), not the timing sum.
+//
+// Usage:
+//
+//	paserati-test262 -path ./test262 -subpath language -json | bench-test262 >> run.jsonl
+//	bench-test262 -in results.json -out run.jsonl
+//
+// Emits one record for the whole suite (test262/total) plus one per
+// top-level suite (test262/<suite>) for the page's Breakdown toggle.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nooga/paserati/pkg/perfdata"
+	"github.com/nooga/paserati/pkg/test262"
+)
+
+func main() {
+	var (
+		inPath    = flag.String("in", "", "paserati-test262 -json input (default: stdin)")
+		outPath   = flag.String("out", "", "append StreamRecord JSONL here (default: stdout)")
+		timestamp = flag.String("timestamp", "", "RFC3339 capture time (default: now, UTC)")
+	)
+	flag.Parse()
+
+	out := readResults(*inPath)
+
+	capturedAt := strings.TrimSpace(*timestamp)
+	if capturedAt == "" {
+		capturedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	records := buildRecords(out, capturedAt)
+	writeRecords(records, *outPath)
+}
+
+// buildRecords sums per-test durations over the passing, non-timed-out set,
+// emitting a total plus per-top-level-suite breakdown. NSPerOp carries the
+// summed nanoseconds; aggregate divides it by the anchor to normalize.
+func buildRecords(out test262.Output, capturedAt string) []perfdata.StreamRecord {
+	type acc struct {
+		sumNS float64
+		count int64
+	}
+	bySuite := map[string]*acc{}
+	total := &acc{}
+
+	for _, r := range out.Results {
+		if !r.Passed || r.TimedOut {
+			continue
+		}
+		ns := float64(r.Duration) // time.Duration marshals as int64 nanoseconds
+		total.sumNS += ns
+		total.count++
+
+		suite := topLevelSuite(r.Path)
+		a := bySuite[suite]
+		if a == nil {
+			a = &acc{}
+			bySuite[suite] = a
+		}
+		a.sumNS += ns
+		a.count++
+	}
+
+	rec := func(name string, a *acc) perfdata.StreamRecord {
+		return perfdata.StreamRecord{
+			Package:    "test262",
+			Name:       name,
+			Iterations: a.count, // tests contributing to the sum
+			NSPerOp:    a.sumNS, // summed execution time; anchor-normalized downstream
+			CapturedAt: capturedAt,
+		}
+	}
+
+	records := []perfdata.StreamRecord{rec("total", total)}
+	suites := make([]string, 0, len(bySuite))
+	for s := range bySuite {
+		suites = append(suites, s)
+	}
+	sort.Strings(suites)
+	for _, s := range suites {
+		records = append(records, rec(s, bySuite[s]))
+	}
+	return records
+}
+
+// topLevelSuite extracts the chapter from a path like
+// "test262/test/built-ins/Math/abs/x.js" -> "built-ins".
+func topLevelSuite(path string) string {
+	const marker = "/test/"
+	i := strings.Index(path, marker)
+	if i < 0 {
+		return "unknown"
+	}
+	rest := path[i+len(marker):]
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		return rest[:j]
+	}
+	return "unknown"
+}
+
+func readResults(inPath string) test262.Output {
+	f := os.Stdin
+	if inPath != "" {
+		var err error
+		f, err = os.Open(inPath)
+		if err != nil {
+			die("open -in: %v", err)
+		}
+		defer f.Close()
+	}
+	var out test262.Output
+	if err := json.NewDecoder(f).Decode(&out); err != nil {
+		die("decode test262 json: %v", err)
+	}
+	if len(out.Results) == 0 {
+		die("no results in input (did the run produce -json output?)")
+	}
+	return out
+}
+
+func writeRecords(records []perfdata.StreamRecord, outPath string) {
+	w := os.Stdout
+	if outPath != "" {
+		f, err := os.OpenFile(outPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			die("open -out: %v", err)
+		}
+		defer f.Close()
+		w = f
+	}
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+	enc := json.NewEncoder(bw)
+	for _, r := range records {
+		if err := enc.Encode(r); err != nil {
+			die("encode record: %v", err)
+		}
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "bench-test262: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/macro-test262-compare.sh
+++ b/scripts/macro-test262-compare.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Compare two macro-test262 passes (same-runner A/B) → markdown delta table.
+#
+# Usage: scripts/macro-test262-compare.sh <base.merged.json> <head.merged.json>
+#
+# INTERSECTION compare: sums execution time only over tests that passed (and
+# didn't time out) on BOTH sides. A test that passes on one side but times out
+# or fails on the other is excluded from both sums, so boundary-churn (a slow
+# test flipping pass<->timeout between passes) can't move the delta. That churn
+# was the dominant noise source when summing each side's passing set independently.
+#
+# Δ% is on raw summed ns — both halves ran on one runner, so there's nothing to
+# normalize. The excluded-count is reported so churn is visible, not silent.
+set -euo pipefail
+
+base="${1:?usage: macro-test262-compare.sh <base.merged.json> <head.merged.json>}"
+head="${2:?usage: macro-test262-compare.sh <base.merged.json> <head.merged.json>}"
+
+jq -rn --slurpfile b "$base" --slurpfile h "$head" '
+  def suite($p): ($p | capture("/test/(?<s>[^/]+)/") | .s) // "unknown";
+  def passing($doc): [ $doc[0].results[] | select(.passed and (.timedOut|not)) ];
+
+  (passing($b) | map({(.path): .duration}) | add // {}) as $bmap |
+  (passing($h) | map({(.path): .duration}) | add // {}) as $hmap |
+  [ $bmap | keys[] | select($hmap[.] != null) ] as $common |
+
+  # Per-suite + total sums over the common (both-passing) set.
+  (reduce $common[] as $p ({};
+     suite($p) as $s |
+     .[$s].base += $bmap[$p] | .[$s].head += $hmap[$p] |
+     .["total"].base += $bmap[$p] | .["total"].head += $hmap[$p]
+   )) as $sum |
+
+  def ms($v): ($v / 1e6 * 10 | round / 10);
+  def pct($a; $b): (if $a > 0 then (($b - $a) / $a * 100 * 100 | round / 100) else 0 end);
+
+  ( ($bmap|length) - ($common|length) ) as $base_only |
+  ( ($hmap|length) - ($common|length) ) as $head_only |
+
+  "Intersection: \($common|length) tests passing on both sides " +
+    "(excluded — base-only \($base_only), head-only \($head_only)).",
+  "",
+  "| Series | Base (ms) | Head (ms) | Δ% |",
+  "|---|---:|---:|---:|",
+  ( ($sum | keys | sort)[] |
+    . as $k | $sum[$k] as $e |
+    pct($e.base; $e.head) as $d |
+    "| `test262.\($k)` | \(ms($e.base)) | \(ms($e.head)) | \(if $d >= 0 then "+\($d)" else "\($d)" end) |"
+  )
+'

--- a/scripts/macro-test262.sh
+++ b/scripts/macro-test262.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Run the Test262 macro-benchmark for the current checkout and emit the raw
+# per-series execution-time records plus the correctness stats.
+#
+# Usage: scripts/macro-test262.sh <records-out.jsonl> <stats-out.json>
+#
+# Writes:
+#   <records-out>.jsonl   StreamRecords: total + per top-level suite, ns_per_op =
+#                         summed execution time over passing, non-timed-out tests
+#   <stats-out>.json      Test262 pass/fail/timeout counts (the correctness signal)
+#
+# This is one same-runner A/B half: the caller runs it on the merge-base and the
+# head, then diffs the raw sums. No anchor normalization — both halves run on one
+# machine, so there's nothing to cancel (the anchor is for a cross-runner timeline).
+#
+# SHARDED: each second-level directory runs as its own process, so VM memory
+# (shapes, IC caches, interned strings — which otherwise grow unbounded across the
+# corpus and OOM a 7GB runner) is released between shards. Per-test durations are
+# process-independent, so sharding doesn't change the metric.
+#
+# Env:
+#   PER_TEST_TIMEOUT  per-test safety bound (default 0.2s). Timed-out tests are
+#                     excluded from the timing sum and counted separately, so a
+#                     tight bound just identifies them faster — it doesn't change
+#                     the speed metric, only the wasted wall-time on hangs.
+#   TEST262_CHAPTERS  space-separated chapters to shard under (default
+#                     "built-ins language" — the JS-execution core; intl402,
+#                     staging and annexB are skipped). Accepts deeper paths too,
+#                     e.g. "built-ins/Math" for a quick local run.
+set -euo pipefail
+
+records_out="${1:?usage: macro-test262.sh <records.jsonl> <stats.json>}"
+stats_out="${2:?usage: macro-test262.sh <records.jsonl> <stats.json>}"
+merged="${records_out%.jsonl}.merged.json"
+shard_dir="${records_out%.jsonl}.shards"
+
+timeout="${PER_TEST_TIMEOUT:-0.2s}"
+chapters="${TEST262_CHAPTERS:-built-ins language}"
+
+# bench-test262 -out appends; clear stale output so reruns don't accumulate.
+rm -f "$records_out" "$merged"
+rm -rf "$shard_dir"
+mkdir -p "$shard_dir"
+
+go build -o ./paserati-test262 ./cmd/paserati-test262
+go build -o ./bench-test262 ./cmd/bench-test262
+
+# Enumerate shards: each second-level directory under each chapter.
+shards=()
+for ch in $chapters; do
+  while IFS= read -r d; do
+    shards+=("${ch}/$(basename "$d")")
+  done < <(find "test262/test/${ch}" -mindepth 1 -maxdepth 1 -type d | sort)
+done
+echo "macro-test262: ${#shards[@]} shards across: ${chapters}"
+
+# Sharding by second-level dir misses any .js directly under a chapter root.
+# built-ins/ and language/ have none, but surface it rather than drop silently.
+for ch in $chapters; do
+  direct="$(find "test262/test/${ch}" -maxdepth 1 -type f -name '*.js' | wc -l | tr -d ' ')"
+  [ "$direct" -gt 0 ] && echo "macro-test262: WARNING — ${direct} root-level .js under ${ch}/ are NOT sharded" >&2
+done
+
+# Run each shard in its own process. Discard stderr: stack-overflow tests dump
+# the whole VM stack there, which unbounded floods the CI log enough to kill the
+# job. The runner exits non-zero on any failure (expected), so ignore exit codes.
+i=0
+for sub in "${shards[@]}"; do
+  raw="${shard_dir}/$(printf '%04d' "$i").json"
+  ./paserati-test262 -path ./test262 -timeout "$timeout" -subpath "${sub}/**" -json > "$raw" 2>/dev/null || true
+  i=$((i + 1))
+done
+
+# Merge shard outputs: concatenate per-test results, sum the stats counters.
+jq -s '{
+  stats: {
+    Total:    (map(.stats.Total)    | add // 0),
+    Passed:   (map(.stats.Passed)   | add // 0),
+    Failed:   (map(.stats.Failed)   | add // 0),
+    Timeouts: (map(.stats.Timeouts) | add // 0),
+    Skipped:  (map(.stats.Skipped)  | add // 0),
+    Duration: (map(.stats.Duration) | add // 0)
+  },
+  results: (map(.results) | add // [])
+}' "$shard_dir"/*.json > "$merged"
+
+./bench-test262 -in "$merged" -out "$records_out"
+jq '.stats' "$merged" > "$stats_out"
+
+echo "macro-test262: wrote $records_out and $stats_out"


### PR DESCRIPTION
Follows the perf work in #4 (`bench-ratchet`) and #5 (timeline page): the suggested **"total Test262 run time"** macro-benchmark.

## What it is

An **opt-in, same-runner A/B** that answers "did this PR make executing the Test262 corpus faster or slower?" It benches the PR's merge-base and head **back-to-back on one runner** and reports the delta. Informational — **it never fails the PR**.

- **Metric:** sum of per-test execution time over tests passing (and not timing out) on **both** sides. Pass/fail/timeout counts are reported **separately**, so a correctness change moves those numbers, not the timing.
- **Opt-in:** runs only on PRs labeled **`perf-test262`** (distinct from the cheap `perf` micro-check — adding `perf` must never kick off this multi-minute job), plus `workflow_dispatch`.
- **Scope:** `built-ins` + `language` (the JS-execution core).

## Why these choices (each was validated, several reversed a first guess)

- **Raw summed-ns, not anchor-normalized.** A same-runner A/B has no cross-runner drift to cancel; normalizing each half by its own separately-measured anchor only *injects* the anchor's measurement noise. (The anchor stays where it belongs — `bench-ratchet`.)
- **Sharded, one process per second-level dir.** A single process over the whole corpus grows VM state unbounded and OOMs a 7 GB runner (**5.3 GB → 439 MB peak** after sharding). Per-test durations are process-independent, so this doesn't change the metric.
- **1.2s per-test timeout.** 5s makes the suite timeout-dominated (40+ min); 0.2s mislabels slow-but-correct tests (e.g. RegExp backtracking) as timeouts and drops them. Every *measured* slow-correct test resolves under 1.2s; what still times out is a genuine hang.
- **Intersection compare.** Summing each side's passing set independently let a boundary test flipping pass↔timeout between passes move the delta. Comparing only tests passing on both sides drops identical-code noise from +1.57% to **−0.23% total**.

## Validation (CI self-A/B on identical code via `workflow_dispatch` `ref=`)

| | |
|---|---|
| Full A/B (2 passes + setup) | ~6.5 min |
| Peak RSS | 439 MB |
| **Total noise floor (identical code)** | **−0.23%** |
| Correctness | 40,194 passed / 7,085 failed / 12 timeouts, stable across passes |

**Caveat:** per-suite deltas swing ~±3% on identical code (shared-runner CPU contention across each ~3-min pass; the suites nearly cancel in the total). **Read the `total`** (sub-1% noise); per-suite is diagnostic with a ~±4% band.

## To use after merge

Add the **`perf-test262`** label to a PR (one-time label creation), or `workflow_dispatch` with a `pr` number. To smoke-test the harness itself, `workflow_dispatch` with a `ref` (runs base == head, expect ~0%).

## Notes

- New files only: `cmd/bench-test262/`, `scripts/macro-test262*.sh`, `.github/workflows/perf-test262.yml` (+ two `.gitignore` lines). No existing code touched.
- `go build ./...`, `go vet`, and `go test ./tests -run TestScripts` are green.
- Like `perf-pr.yml`, it's fork-safe (job-summary + best-effort sticky comment; a read-only fork token degrades gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
