### PR TITLE
checker: resolve inherited and index-signature members when destructuring

### DIFF
--- a/pkg/checker/assignment.go
+++ b/pkg/checker/assignment.go
@@ -411,7 +411,7 @@ func (c *Checker) checkObjectDestructuringAssignment(node *parser.ObjectDestruct
 		if widenedRhsType != types.Any {
 			switch rhsType := rhsType.(type) {
 			case *types.ObjectType:
-				if foundPropType, exists := rhsType.Properties[propName]; exists {
+				if foundPropType, exists := c.resolveObjectMemberForDestructuring(rhsType, propName); exists {
 					propType = foundPropType
 				} else if prop.Default == nil {
 					c.addError(prop.Key, fmt.Sprintf("property '%s' does not exist on type %s", propName, rhsType.String()))

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3616,7 +3616,7 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 		if keyIdent, ok := prop.Key.(*parser.Identifier); ok {
 			propName = keyIdent.Value
 			if objType != nil {
-				if pt, exists := objType.Properties[propName]; exists {
+				if pt, exists := c.resolveObjectMemberForDestructuring(objType, propName); exists {
 					propType = pt
 				} else if prop.Default == nil {
 					c.addError(prop.Key, fmt.Sprintf("property '%s' does not exist on type %s", propName, objType.String()))

--- a/pkg/checker/type_utils.go
+++ b/pkg/checker/type_utils.go
@@ -34,6 +34,49 @@ func (c *Checker) getPropertyTypeFromType(objectType types.Type, propertyName st
 	return types.GetPropertyType(objectType, propertyName, isOptionalChaining)
 }
 
+// resolveObjectMemberForDestructuring resolves a property access on an object
+// type for destructuring. It mirrors member-access resolution (see
+// checkMemberExpression): inherited properties, then index signatures, then the
+// object/function prototype. Returns the resolved property type and whether the
+// property exists. Destructuring must use this rather than a bare Properties
+// lookup, otherwise inherited or index-signature properties are wrongly reported
+// as missing.
+func (c *Checker) resolveObjectMemberForDestructuring(obj *types.ObjectType, propName string) (types.Type, bool) {
+	if obj == nil {
+		return types.Undefined, false
+	}
+
+	// Return the bare property type (no `| undefined` for optional members):
+	// the destructuring callers fold in defaults and undefined themselves, and
+	// widening optional props here defeats their default-collapsing logic.
+	if propType, exists := obj.GetEffectiveProperties()[propName]; exists {
+		if propType == nil {
+			return types.Undefined, false
+		}
+		return propType, true
+	}
+
+	for _, indexSig := range obj.IndexSignatures {
+		if indexSig.KeyType == types.String || indexSig.KeyType == types.Any {
+			if indexSig.ValueType == nil {
+				return types.Any, true
+			}
+			return indexSig.ValueType, true
+		}
+	}
+
+	if obj.IsCallable() {
+		if methodType := c.env.GetPrimitivePrototypeMethodType("function", propName); methodType != nil {
+			return methodType, true
+		}
+	}
+	if methodType := c.env.GetPrimitivePrototypeMethodType("object", propName); methodType != nil {
+		return methodType, true
+	}
+
+	return types.Undefined, false
+}
+
 // validateIndexSignatures checks if a source object type satisfies the index signature constraints of a target type
 // This is used when assigning object literals to types with index signatures
 func (c *Checker) validateIndexSignatures(sourceType, targetType types.Type) []IndexSignatureError {

--- a/tests/scripts/ts_destructure_inherited_index.ts
+++ b/tests/scripts/ts_destructure_inherited_index.ts
@@ -1,0 +1,13 @@
+// expect: 3
+// Destructuring must resolve inherited and index-signature members the same way
+// member access does — neither should be reported as a missing property.
+
+class Base { x: number = 1; }
+class Derived extends Base { y: number = 2; }
+const d = new Derived();
+const { x, y } = d;
+
+const bag: { [k: string]: number } = {};
+const { foo } = bag;
+
+x + y;


### PR DESCRIPTION
## What

The destructuring property-existence check added in #9 only consults `ObjectType.Properties`, so valid code that member access accepts is rejected when destructured:

```ts
const bag: { [k: string]: number } = {};
const { foo } = bag;            // wrongly errors — index signature

class Base { x = 1 }
class Derived extends Base { y = 2 }
const { x } = new Derived();    // wrongly errors — inherited member
```

Both the declaration and assignment paths now route through a new `resolveObjectMemberForDestructuring` helper that mirrors `checkMemberExpression`: effective (inherited) properties → index signatures → object/function prototype, before reporting a property as missing. The intended error for genuinely-absent properties is preserved, and the helper returns the bare property type (defaults/undefined are folded in by the callers, as before).

## Validation

- `go test ./tests -run TestScripts` — green (added `ts_destructure_inherited_index.ts`)
- TypeScript conformance (single-file runner, TS 6.0.3 locally): no net new false positives.

One conformance test changes status: `classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts` goes from pass to fail. That test is a negative test for private/protected access during destructuring, which the checker doesn't implement. It was passing only because the bare `Properties` lookup happened to emit "does not exist" on inherited members — including a **false positive** on `let { prot: b } = this` inside a subclass, which is valid TS. This change makes that valid line correct and stops masking the missing access-control diagnostic; it doesn't introduce a new defect. (The other test that flickered in diffs, `typeArgumentInferenceWithObjectLiteral.ts`, is 1s-timeout flaky and fails on `main` too.)

Opening as draft for a look at that trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)