### PR TITLE
checker: use destructuring annotations for binding types

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ go test ./tests/...
 | :-- | --: | --: | --: | --: | --: |
 | Test262 language | 23,141/23,523 | 382 | 0 | 0 | 98.4% |
 | Test262 built-ins | 16,862/23,294 | 6,432 | 0 | 0 | 72.4% |
-| TypeScript 6.0.0 conformance | 3,341/4,928 | 1,114 | 473 | 0 | 67.8% |
+| TypeScript 6.0.0 conformance | 3,342/4,928 | 1,113 | 473 | 0 | 67.8% |
 <!-- compliance:end -->
 
 The Test262 language and built-ins figures come from the local baseline snapshots for the checked-out ECMA-262 conformance tests. The TypeScript figure comes from the single-file conformance runner against the TypeScript 6.0.0 test suite.

--- a/docs/compliance.json
+++ b/docs/compliance.json
@@ -20,8 +20,8 @@
   "typescript": {
     "name": "TypeScript 6.0.0",
     "total": 4928,
-    "passed": 3341,
-    "failed": 1114,
+    "passed": 3342,
+    "failed": 1113,
     "skipped": 473,
     "timeout": 0,
     "version": "6.0.0"

--- a/docs/compliance.svg
+++ b/docs/compliance.svg
@@ -32,14 +32,14 @@
 <text x="340" y="255" text-anchor="middle" class="caption">16,862/23,294</text>
 </g>
   <g aria-label="TypeScript 6.0.0">
-<path d="M 690.00 135.00 L 634.24 162.11 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />
-<path d="M 690.00 135.00 L 654.84 83.94 A 62.00 62.00 0 0 0 634.24 162.11 Z" fill="#d64b4b" />
+<path d="M 690.00 135.00 L 634.21 162.04 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />
+<path d="M 690.00 135.00 L 654.84 83.94 A 62.00 62.00 0 0 0 634.21 162.04 Z" fill="#d64b4b" />
 <path d="M 690.00 135.00 L 690.00 73.00 A 62.00 62.00 0 0 0 654.84 83.94 Z" fill="#aeb7c2" />
 <circle cx="690" cy="135" r="38" fill="#ffffff" />
 <text x="690" y="131" text-anchor="middle" class="percent">67.8%</text>
 <text x="690" y="153" text-anchor="middle" class="caption">pass</text>
 <text x="690" y="233" text-anchor="middle" class="title">TypeScript 6.0.0</text>
-<text x="690" y="255" text-anchor="middle" class="caption">3,341/4,928</text>
+<text x="690" y="255" text-anchor="middle" class="caption">3,342/4,928</text>
 </g>
   <g transform="translate(575 278)">
     <rect x="0" y="-10" width="12" height="12" fill="#20a060" rx="2" /><text x="18" y="1" class="legend">Pass</text>

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3428,17 +3428,28 @@ func (c *Checker) checkArrayDestructuringDeclaration(node *parser.ArrayDestructu
 		return
 	}
 
-	// Check the RHS value
-	c.visit(node.Value)
+	// Check if we have a type annotation
+	var expectedType types.Type
+	if node.TypeAnnotation != nil {
+		expectedType = c.resolveTypeAnnotation(node.TypeAnnotation)
+	}
+
+	// Check the RHS value. Annotated array binding declarations contextually type
+	// array literals the same way ordinary variable declarations do.
+	if _, ok := node.Value.(*parser.ArrayLiteral); ok && expectedType != nil {
+		c.visitWithContext(node.Value, &ContextualType{
+			ExpectedType: expectedType,
+			IsContextual: true,
+		})
+	} else {
+		c.visit(node.Value)
+	}
 	valueType := node.Value.GetComputedType()
 	if valueType == nil {
 		valueType = types.Any
 	}
 
-	// Check if we have a type annotation
-	var expectedType types.Type
-	if node.TypeAnnotation != nil {
-		expectedType = c.resolveTypeAnnotation(node.TypeAnnotation)
+	if expectedType != nil {
 		// Verify that the value is assignable to the expected type
 		if !types.IsAssignable(valueType, expectedType) {
 			c.addError(node.Value, fmt.Sprintf("cannot assign type '%s' to type '%s'", valueType.String(), expectedType.String()))
@@ -3591,17 +3602,22 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 		}
 	}
 
+	destructureType := valueType
+	if expectedType != nil {
+		destructureType = expectedType
+	}
+
 	// Check if the value is an object-like type (arrays are also objects in JavaScript)
 	var objType *types.ObjectType
 	var isArray bool
-	if ot, ok := valueType.(*types.ObjectType); ok {
+	if ot, ok := destructureType.(*types.ObjectType); ok {
 		objType = ot
-	} else if _, ok := valueType.(*types.ArrayType); ok {
+	} else if _, ok := destructureType.(*types.ArrayType); ok {
 		// Arrays can be destructured as objects (e.g., {0: x, 1: y} from [10, 20])
 		isArray = true
-	} else if valueType != types.Any {
+	} else if destructureType != types.Any {
 		// Not an object-like type
-		c.addError(node.Value, fmt.Sprintf("cannot destructure non-object type '%s'", valueType.String()))
+		c.addError(node.Value, fmt.Sprintf("cannot destructure non-object type '%s'", destructureType.String()))
 	}
 
 	// Process each destructuring property
@@ -3623,10 +3639,10 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 				}
 			} else if isArray {
 				// For arrays, numeric keys access array elements
-				if arrType, ok := valueType.(*types.ArrayType); ok {
+				if arrType, ok := destructureType.(*types.ArrayType); ok {
 					propType = arrType.ElementType
 				}
-			} else if valueType == types.Any {
+			} else if destructureType == types.Any {
 				propType = types.Any
 			}
 		} else {
@@ -3658,7 +3674,7 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 		// Rest property gets an object type containing all remaining properties
 		var restType types.Type
 
-		if valueType == types.Any {
+		if destructureType == types.Any {
 			// If RHS is Any, rest property is also Any
 			restType = types.Any
 		} else if objType != nil {

--- a/tests/scripts/ts_destructuring_contextual_tuple.ts
+++ b/tests/scripts/ts_destructuring_contextual_tuple.ts
@@ -1,0 +1,10 @@
+// expect: annotated destructuring uses declared types
+
+var [a, b]: [number, any] = [undefined, undefined];
+let [x]: [string | number] = [1];
+let [y]: [string | undefined] = [""];
+let [z = ""]: [string | undefined] = [undefined];
+let { q }: { q?: string | number } = {};
+let { r = "" }: { r?: string | undefined } = {};
+
+"annotated destructuring uses declared types";


### PR DESCRIPTION
## Summary
- Contextually type annotated array destructuring initializers when the RHS is an array literal.
- Use an object destructuring annotation as the source type for binding properties instead of extracting from a bare initializer like `{}`.
- Add a smoke script covering annotated tuple and optional object destructuring.

## Compatibility impact
- Focused `types/tuple`: +1 (`types/tuple/tupleElementTypes1.ts`).
- Focused `controlFlow`: +1 (`controlFlow/controlFlowDestructuringDeclaration.ts`).
- Full local diff vs `scratch/tsc_next_current_full.txt` (3340/4928): +3 new passes, -2 noisy/pre-existing failures, net +1 in that run.
- Push hook best-observed compliance snapshot: TypeScript 6.0.0 conformance 3342/4928, +1 over committed main docs and +2 over the exact local pre-change dump.

No Test262 change; post-commit and push hooks kept Test262 language/built-ins snapshots unchanged.

## Verification
- `go build ./...`
- `go test ./tests -run TestScripts`
- `./paserati-testtsc -path /Users/nooga/lab/TypeScript -subpath types/tuple -timeout 1s -diff scratch/tsc_next_current_tuple.txt -dump scratch/tsc_next_after_destruct2_tuple.txt`
- `./paserati-testtsc -path /Users/nooga/lab/TypeScript -subpath controlFlow -timeout 1s -diff scratch/tsc_next_current_controlflow.txt -dump scratch/tsc_next_after_destruct2_controlflow.txt`
- `./paserati-testtsc -path /Users/nooga/lab/TypeScript -timeout 1s -diff scratch/tsc_next_current_full.txt -dump scratch/tsc_next_after_destruct2_full.txt`
