### PR TITLE
perf-timeline: opt-in test262.total macro point

### DIFF
--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -48,6 +48,16 @@ jobs:
           # fetch-depth:0 pulled everything, so resolve any committish locally.
           git checkout --force "$TARGET_REF"
 
+      # Corpus for the opt-in Test262 macro series (see "Add Test262 macro" below).
+      # Gated on the same condition so non-opted-in commits skip the restore.
+      - name: Cache Test262 corpus
+        if: contains(github.event.head_commit.message, '[perf-test262]') || github.event_name == 'workflow_dispatch'
+        uses: actions/cache@v4
+        with:
+          path: test262
+          key: test262-${{ hashFiles('.test262-rev') }}
+          restore-keys: test262-
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -69,6 +79,40 @@ jobs:
 
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "out=${out}" >> "$GITHUB_OUTPUT"
+
+      # Opt-in: fold the Test262 macro-benchmark into the snapshot as a
+      # `test262.total` series. Runs only on commits whose message carries
+      # `[perf-test262]` (or a manual dispatch), since the macro adds ~4 min.
+      # Non-fatal: a macro hiccup must never drop the micro snapshot above.
+      - name: Add Test262 macro to snapshot
+        if: contains(github.event.head_commit.message, '[perf-test262]') || github.event_name == 'workflow_dispatch'
+        continue-on-error: true
+        env:
+          PER_TEST_TIMEOUT: 1.2s
+        run: |
+          set -euo pipefail
+          out="${{ steps.snap.outputs.out }}"
+          ./setup-test262.sh
+          ./scripts/macro-test262.sh "${RUNNER_TEMP}/t262.jsonl" "${RUNNER_TEMP}/t262.stats.json"
+
+          total_ns="$(jq -s '.[] | select(.name=="total") | .ns_per_op' "${RUNNER_TEMP}/t262.jsonl")"
+          passed="$(jq -s  '.[] | select(.name=="total") | .iterations' "${RUNNER_TEMP}/t262.jsonl")"
+          anchor_ns="$(jq -r '.anchor.ns_per_op' "$out")"
+
+          # Anchor-normalize the same way bench-ratchet does (ratio = summed_ns /
+          # anchor_ns) and fold it into the snapshot as a benchmark series. The page
+          # plots each series self-relative, so the large absolute ratio doesn't
+          # affect the chart scale. Passing-set size goes in a sample for provenance.
+          jq --argjson ns "$total_ns" --argjson a "$anchor_ns" --argjson p "$passed" '
+            .benchmarks["test262.total"] = {
+              ns_per_op: $ns, allocs_per_op: 0, bytes_per_op: 0,
+              ratio_to_anchor: ($ns / $a),
+              samples: [{ iterations: $p, ns_per_op: $ns, ratio_to_anchor: ($ns / $a) }]
+            }' "$out" > "${out}.tmp"
+          mv "${out}.tmp" "$out"
+
+          echo "test262.total: ${total_ns} ns over ${passed} passing tests" \
+               "(ratio $(jq -r '.benchmarks["test262.total"].ratio_to_anchor' "$out"))"
 
       - name: Render run summary
         run: |

--- a/.github/workflows/perf-timeline.yml
+++ b/.github/workflows/perf-timeline.yml
@@ -19,6 +19,10 @@ on:
         description: 'Commit SHA/ref to snapshot (backfill)'
         required: true
         default: 'main'
+      test262:
+        description: 'Also run the ~4-min Test262 macro benchmark'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -51,7 +55,7 @@ jobs:
       # Corpus for the opt-in Test262 macro series (see "Add Test262 macro" below).
       # Gated on the same condition so non-opted-in commits skip the restore.
       - name: Cache Test262 corpus
-        if: contains(github.event.head_commit.message, '[perf-test262]') || github.event_name == 'workflow_dispatch'
+        if: contains(github.event.head_commit.message, '[perf-test262]') || github.event.inputs.test262 == 'true'
         uses: actions/cache@v4
         with:
           path: test262
@@ -82,10 +86,11 @@ jobs:
 
       # Opt-in: fold the Test262 macro-benchmark into the snapshot as a
       # `test262.total` series. Runs only on commits whose message carries
-      # `[perf-test262]` (or a manual dispatch), since the macro adds ~4 min.
-      # Non-fatal: a macro hiccup must never drop the micro snapshot above.
+      # `[perf-test262]`, or a manual dispatch with the `test262` input checked,
+      # since the macro adds ~4 min. Non-fatal: a macro hiccup must never drop
+      # the micro snapshot above.
       - name: Add Test262 macro to snapshot
-        if: contains(github.event.head_commit.message, '[perf-test262]') || github.event_name == 'workflow_dispatch'
+        if: contains(github.event.head_commit.message, '[perf-test262]') || github.event.inputs.test262 == 'true'
         continue-on-error: true
         env:
           PER_TEST_TIMEOUT: 1.2s
@@ -95,24 +100,36 @@ jobs:
           ./setup-test262.sh
           ./scripts/macro-test262.sh "${RUNNER_TEMP}/t262.jsonl" "${RUNNER_TEMP}/t262.stats.json"
 
-          total_ns="$(jq -s '.[] | select(.name=="total") | .ns_per_op' "${RUNNER_TEMP}/t262.jsonl")"
-          passed="$(jq -s  '.[] | select(.name=="total") | .iterations' "${RUNNER_TEMP}/t262.jsonl")"
+          # JSONL: one record per line, so filter per-line — no -s slurp needed.
+          total_ns="$(jq 'select(.name=="total") | .ns_per_op' "${RUNNER_TEMP}/t262.jsonl")"
+          passed="$(jq  'select(.name=="total") | .iterations' "${RUNNER_TEMP}/t262.jsonl")"
+          set_hash="$(jq -r 'select(.name=="total") | .set_hash // ""' "${RUNNER_TEMP}/t262.jsonl")"
           anchor_ns="$(jq -r '.anchor.ns_per_op' "$out")"
 
-          # Anchor-normalize the same way bench-ratchet does (ratio = summed_ns /
-          # anchor_ns) and fold it into the snapshot as a benchmark series. The page
-          # plots each series self-relative, so the large absolute ratio doesn't
-          # affect the chart scale. Passing-set size goes in a sample for provenance.
-          jq --argjson ns "$total_ns" --argjson a "$anchor_ns" --argjson p "$passed" '
-            .benchmarks["test262.total"] = {
-              ns_per_op: $ns, allocs_per_op: 0, bytes_per_op: 0,
-              ratio_to_anchor: ($ns / $a),
-              samples: [{ iterations: $p, ns_per_op: $ns, ratio_to_anchor: ($ns / $a) }]
-            }' "$out" > "${out}.tmp"
+          # Skip the fold if nothing passed — mean over an empty set is undefined
+          # (and the series would carry no signal anyway).
+          if [ "${passed:-0}" -gt 0 ]; then
+          # Metric is the MEAN per-test ns (summed_ns / passing_count), not the sum:
+          # the sum conflates per-test speed with how many tests pass, so a
+          # conformance win (more passing tests add their durations) reads as a perf
+          # regression. The mean removes that count-inflation. set_hash fingerprints
+          # the exact contributing set (from bench-test262, #24), so the consumer can
+          # still see a residual composition shift the mean can't cancel. Anchor-
+          # normalized like every other series; the page plots each self-relative, so
+          # the absolute ratio doesn't affect chart scale.
+          jq --argjson ns "$total_ns" --argjson a "$anchor_ns" --argjson p "$passed" --arg h "$set_hash" '
+            ($ns / $p) as $mean
+            | .benchmarks["test262.total"] = ({
+                ns_per_op: $mean, allocs_per_op: 0, bytes_per_op: 0,
+                ratio_to_anchor: ($mean / $a),
+                samples: [{ iterations: $p, ns_per_op: $mean, ratio_to_anchor: ($mean / $a) }]
+              } + (if $h == "" then {} else { set_hash: $h } end))' "$out" > "${out}.tmp"
           mv "${out}.tmp" "$out"
 
-          echo "test262.total: ${total_ns} ns over ${passed} passing tests" \
-               "(ratio $(jq -r '.benchmarks["test262.total"].ratio_to_anchor' "$out"))"
+          echo "test262.total: mean $(jq -r '.benchmarks["test262.total"].ns_per_op' "$out") ns/test" \
+               "over ${passed} passing tests (set ${set_hash:-none}," \
+               "ratio $(jq -r '.benchmarks["test262.total"].ratio_to_anchor' "$out"))"
+          fi
 
       - name: Render run summary
         run: |


### PR DESCRIPTION
Pairs with #15 (touches a different file, so it can land in either order). Wires the Test262 macro-benchmark (the `cmd/bench-test262` tooling merged in #10) into the timeline, so an opted-in commit records a whole-suite point on the trend page.

## Relationship to #10

#10 added the `perf-test262` label, which runs an A/B on a PR (merge-base versus head) and comments the delta, a pre-merge "did this change move perf?" check. This is the complementary post-merge half: a single anchor-normalized `test262.total` point on the trend page. Same intent — run the test262 macro here — over two surfaces: a label on a PR, a marker in a commit.

## Opt-in by design

The macro adds ~4 minutes to a snapshot, so it doesn't run on every push — only when the commit message contains `[perf-test262]`, or via `workflow_dispatch` (with a boolean toggle so a manual backfill can skip the extra ~4 min). Without the marker the timeline is unchanged. The trade-off is a sparse, dotted trend rather than a continuous one: points appear where you ask for them.

## How it works

On an opted-in commit, after the usual snapshot it runs the macro (built-ins and language, sharded so memory stays bounded), then injects a `test262.total` entry. The metric is the **mean per-test execution time** over the passing, non-timed-out tests (`summed_ns / passing_count`), anchor-normalized like every other series and tagged with the run's **`set_hash`** (from `bench-test262`, #24). The step is non-fatal, so a macro hiccup never drops the micro snapshot. The page (#15) renders it as its own self-relative, segmented series.

## Metric: mean, not sum (updated after review)

The first version injected the *summed* per-test time. Summing conflates per-test speed with how many tests pass: a conformance win (more passing tests add their durations) reads as a slowdown on the trend (#26). The mean removes that count-inflation, and the `set_hash` tag carries the exact contributing set so a residual composition shift the mean can't cancel stays visible to the page. `set_hash` is soft — absent until #24 lands, in which case the entry simply omits it. A fixed-reference-set is the deeper follow-up tracked in #26; this is the near-term mitigation.
