### PR TITLE
compiler: report oversized-function jumps as a compile error, not a panic

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -2986,14 +2986,25 @@ func (c *Compiler) patchJump(placeholderPos int) {
 	}
 
 	if offset > math.MaxInt16 || offset < math.MinInt16 { // Use math constants
-		// Handle error: jump offset too large
-		// TODO: Add proper error handling instead of panic
-		panic(fmt.Sprintf("Compiler error: jump offset %d exceeds 16-bit limit", offset))
+		c.recordJumpOverflow(placeholderPos, offset)
+		return
 	}
 
 	// Write the 16-bit offset back into the placeholder bytes (Big Endian)
 	c.chunk.Code[operandStartPos] = byte(int16(offset) >> 8)     // High byte
 	c.chunk.Code[operandStartPos+1] = byte(int16(offset) & 0xFF) // Low byte
+}
+
+// recordJumpOverflow reports a jump whose distance exceeds the 16-bit branch
+// offset — i.e. a function too large for the bytecode format — as a graceful
+// compile error instead of panicking. The unpatched placeholder is harmless: a
+// non-empty error list aborts the compile before the chunk can run.
+func (c *Compiler) recordJumpOverflow(placeholderPos, offset int) {
+	c.errors = append(c.errors, &errors.CompileError{
+		Position: errors.Position{Line: c.chunk.GetLine(placeholderPos)},
+		Msg: fmt.Sprintf("function too large: a jump offset of %d bytes exceeds the 16-bit "+
+			"branch limit (±32767); split this function into smaller ones", offset),
+	})
 }
 
 // patchJumpToTarget patches a jump to a specific target PC
@@ -3014,7 +3025,8 @@ func (c *Compiler) patchJumpToTarget(placeholderPos int, targetPC int) {
 	}
 
 	if offset > math.MaxInt16 || offset < math.MinInt16 {
-		panic(fmt.Sprintf("Compiler error: jump offset %d exceeds 16-bit limit", offset))
+		c.recordJumpOverflow(placeholderPos, offset)
+		return
 	}
 
 	// Write the 16-bit offset back into the placeholder bytes (Big Endian)

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -1130,3 +1130,38 @@ func TestBasicFunctionalCorrectness(t *testing.T) {
 		})
 	}
 }
+
+// TestJumpOffsetOverflowIsGracefulError verifies that a function too large for
+// the 16-bit branch offset fails with a compile error instead of panicking the
+// compiler. Regression for the old
+// `panic("jump offset ... exceeds 16-bit limit")` in patchJump/patchJumpToTarget.
+func TestJumpOffsetOverflowIsGracefulError(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("function big(x) {\n  let s = 0;\n  if (x > 0) {\n")
+	// ~6000 statements between the `if` test and its merge point pushes the
+	// OpJumpIfFalse offset well past 32767 bytes.
+	for i := 0; i < 6000; i++ {
+		fmt.Fprintf(&b, "    s = s + %d;\n", i)
+	}
+	b.WriteString("  }\n  return s;\n}\nbig(1);\n")
+
+	program, parseErrs := compileSource(b.String())
+	if len(parseErrs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", parseErrs)
+	}
+	// The call itself must not panic (that is the core of the regression).
+	_, compileErrs := NewCompiler().Compile(program)
+	if len(compileErrs) == 0 {
+		t.Fatal("expected a compile error for the oversized function, got none")
+	}
+	found := false
+	for _, e := range compileErrs {
+		if strings.Contains(e.Error(), "too large") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'function too large' error, got: %v", compileErrs)
+	}
+}


### PR DESCRIPTION
## Problem

`patchJump` / `patchJumpToTarget` panic when a jump offset exceeds the int16
branch encoding (±32767 bytes):

```go
if offset > math.MaxInt16 || offset < math.MinInt16 {
    // TODO: Add proper error handling instead of panic
    panic(fmt.Sprintf("Compiler error: jump offset %d exceeds 16-bit limit", offset))
}
```

This is a hard crash with a Go stack trace on **valid input** — any single
function large enough that a branch spans more than 32 KB of bytecode. A big
`switch`, a long `if`/`else` chain, or machine-generated / bundled code all reach
it. Minimal repro:

```js
function big(x) {
  let s = 0;
  if (x > 0) {
    s = s + 0; s = s + 1; /* …~12k statements… */
  }
  return s;
}
big(1);
```

```
panic: Compiler error: jump offset 132005 exceeds 16-bit limit
        …/pkg/compiler/compiler.go:2991 patchJump
```

The code already flagged this with a `TODO: Add proper error handling instead of
panic`.

## Fix

Route both overflow sites through a new `recordJumpOverflow`, which appends a
positioned `CompileError` and returns instead of panicking:

```
PS3001 [ERROR]: function too large: a jump offset of 132005 bytes exceeds the
16-bit branch limit (±32767); split this function into smaller ones
  3:   if (x > 0) {
     ^
    at line 3, column 0
```

The unpatched placeholder left behind is harmless: a non-empty error list aborts
the compile before the chunk can run, so no malformed bytecode executes. No
signatures change (the 126 `patchJump` call sites are untouched) — the error goes
through the compiler's existing `c.errors` accumulator.

## Testing

- New `TestJumpOffsetOverflowIsGracefulError` compiles a ~6000-statement function
  and asserts a graceful "function too large" compile error — and, by not
  panicking, that the crash is gone.
- `go test ./pkg/compiler/` and the `TestScripts` smoke suite stay green; `go vet`
  clean.

## Scope / follow-up

This makes oversized functions fail gracefully; it does not make them *compile*.
Actually compiling them would need 32-bit long-jump opcodes plus branch
relaxation in the emitter — a larger, separate change. This PR is the minimal
robustness fix: don't crash the process on valid input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
