### PR TITLE
perf(bench): VM hot-path benchmark harness

### DIFF
--- a/pkg/vm/isobject_bench_test.go
+++ b/pkg/vm/isobject_bench_test.go
@@ -1,0 +1,62 @@
+package vm
+
+import "testing"
+
+// isObjectMix models the hot-path distribution: IsObject is called predominantly
+// on non-object values (numbers in arithmetic/ToInteger guards), which is the
+// OR-chain's worst case (all comparisons fail before returning false).
+func isObjectMix() []Value {
+	vs := make([]Value, 0, 32)
+	for i := 0; i < 24; i++ {
+		vs = append(vs, IntegerValue(int32(i))) // 24 numbers (typ far below the object range)
+	}
+	vs = append(vs,
+		NewString("x"), BooleanValue(true), Undefined, Null, // more non-objects
+		Value{typ: TypeObject}, Value{typ: TypeArray},
+		Value{typ: TypeProxy}, Value{typ: TypeMap}, // a few objects
+	)
+	return vs
+}
+
+func BenchmarkIsObject(b *testing.B) {
+	vs := isObjectMix()
+	b.ResetTimer()
+	var sink int
+	// Inner range loop so IsObject dominates ns/op instead of index arithmetic.
+	// ns/op therefore covers len(vs) IsObject calls; consistent across A/B runs.
+	for i := 0; i < b.N; i++ {
+		for j := range vs {
+			if vs[j].IsObject() {
+				sink++
+			}
+		}
+	}
+	_ = sink
+}
+
+// TestIsObjectExhaustive locks in that IsObject is equivalent to the contiguous
+// [TypeObject, TypeProxy] range for every defined ValueType — the invariant the
+// range-check implementation depends on. If a new type is inserted mid-enum this
+// fails, flagging that the range bounds (and this list) need review.
+func TestIsObjectExhaustive(t *testing.T) {
+	// Every type that must be an object (matches the historical OR-chain).
+	objectTypes := map[ValueType]bool{
+		TypeObject: true, TypeDictObject: true, TypeArray: true, TypeArguments: true,
+		TypeGenerator: true, TypeAsyncGenerator: true, TypePromise: true, TypeRegExp: true,
+		TypeTypedArray: true, TypeDataView: true, TypeArrayBuffer: true, TypeSharedArrayBuffer: true,
+		TypeProxy: true, TypeMap: true, TypeSet: true, TypeWeakMap: true, TypeWeakSet: true,
+		TypeWeakRef: true,
+	}
+	for typ := TypeUndefined; typ <= TypeUninitialized; typ++ {
+		got := (Value{typ: typ}).IsObject()
+		want := objectTypes[typ]
+		if got != want {
+			t.Errorf("IsObject(typ=%d) = %v, want %v", typ, got, want)
+		}
+		// Range-check equivalence: object types must be exactly the contiguous span.
+		if inRange := typ >= TypeObject && typ <= TypeProxy; inRange != want {
+			t.Errorf("type %d: range [TypeObject,TypeProxy] membership %v != object-set %v "+
+				"(object types are no longer contiguous — fix IsObject bounds)", typ, inRange, want)
+		}
+	}
+}

--- a/pkg/vm/tointeger_bench_test.go
+++ b/pkg/vm/tointeger_bench_test.go
@@ -1,0 +1,65 @@
+package vm
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// toIntegerCases pins ToInteger (ECMAScript ToInt32) behavior across input kinds.
+// Values are hand-derived from the spec (32-bit wrap; NaN/Inf -> 0; string parse;
+// bool 1/0). The test must pass BOTH before and after the fast-path reorder — it
+// is the equivalence guard for that change.
+var toIntegerCases = []struct {
+	name string
+	v    Value
+	want int32
+}{
+	{"int-pos", IntegerValue(5), 5},
+	{"int-neg", IntegerValue(-3), -3},
+	{"float-trunc-pos", NumberValue(3.9), 3},
+	{"float-trunc-neg", NumberValue(-3.9), -3},
+	{"float-nan", NumberValue(math.NaN()), 0},
+	{"float-posinf", NumberValue(math.Inf(1)), 0},
+	{"float-neginf", NumberValue(math.Inf(-1)), 0},
+	{"float-wrap-2^32+5", NumberValue(4294967301), 5},
+	{"float-wrap-2^31", NumberValue(2147483648), -2147483648},
+	{"float-negzero", NumberValue(math.Copysign(0, -1)), 0},
+	{"bool-true", BooleanValue(true), 1},
+	{"bool-false", BooleanValue(false), 0},
+	{"str-int", NewString("42"), 42},
+	{"str-pad", NewString("  10 "), 10},
+	{"str-float", NewString("3.7"), 3},
+	{"str-empty", NewString(""), 0},
+	{"str-garbage", NewString("abc"), 0},
+	{"undefined", Undefined, 0},
+	{"null", Null, 0},
+	{"bigint-small", NewBigInt(big.NewInt(10)), 10},
+}
+
+func TestToIntegerEquivalence(t *testing.T) {
+	for _, tc := range toIntegerCases {
+		if got := tc.v.ToInteger(); got != tc.want {
+			t.Errorf("ToInteger(%s) = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// BenchmarkToInteger models the hot path: mostly integer operands (bitwise ops),
+// a few floats. Measures the fast-path reorder — before the change, each call
+// runs the IsObject/object guard before reaching the number case.
+func BenchmarkToInteger(b *testing.B) {
+	vs := make([]Value, 0, 32)
+	for i := 0; i < 28; i++ {
+		vs = append(vs, IntegerValue(int32(i*7-13)))
+	}
+	vs = append(vs, NumberValue(3.5), NumberValue(-9.9), NumberValue(4294967301), NumberValue(2147483648))
+	b.ResetTimer()
+	var sink int32
+	for i := 0; i < b.N; i++ {
+		for j := range vs {
+			sink += vs[j].ToInteger()
+		}
+	}
+	_ = sink
+}

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -71,7 +71,81 @@ func BenchmarkFibPlaceholderRun(b *testing.B) {
 	// No need to restore stdout here due to defer
 }
 
+// BenchmarkAdd isolates the OpAdd numeric fast path (add-heavy loop on numbers).
+func BenchmarkAdd(b *testing.B) {
+	chunk := compileFile(b, "scripts/bench_add.ts")
+	paserati := driver.NewPaserati()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+	if err != nil {
+		b.Fatalf("Failed to open os.DevNull: %v", err)
+	}
+	defer devNull.Close()
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runtimeErrs := paserati.InterpretChunk(chunk)
+		if len(runtimeErrs) > 0 {
+			b.Fatalf("Runtime error during benchmark iteration %d: %v", i, runtimeErrs)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkArith isolates the OpSubtract/Multiply/Divide/Remainder numeric fast paths.
+func BenchmarkArith(b *testing.B) {
+	chunk := compileFile(b, "scripts/bench_arith.ts")
+	paserati := driver.NewPaserati()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+	if err != nil {
+		b.Fatalf("Failed to open os.DevNull: %v", err)
+	}
+	defer devNull.Close()
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runtimeErrs := paserati.InterpretChunk(chunk)
+		if len(runtimeErrs) > 0 {
+			b.Fatalf("Runtime error during benchmark iteration %d: %v", i, runtimeErrs)
+		}
+	}
+	b.StopTimer()
+}
+
 // BenchmarkMatrixMult runs the matrix_mult.ts script.
+// BenchmarkSetIndex isolates the OpSetIndex (arr[i] = v) hot path — the setter
+// walk / allocation guard optimization is measured here.
+func BenchmarkSetIndex(b *testing.B) {
+	chunk := compileFile(b, "scripts/bench_setindex.ts")
+	paserati := driver.NewPaserati()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+	if err != nil {
+		b.Fatalf("Failed to open os.DevNull: %v", err)
+	}
+	defer devNull.Close()
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runtimeErrs := paserati.InterpretChunk(chunk)
+		if len(runtimeErrs) > 0 {
+			b.Fatalf("Runtime error during benchmark iteration %d: %v", i, runtimeErrs)
+		}
+	}
+	b.StopTimer()
+}
+
 func BenchmarkMatrixMult(b *testing.B) {
 	// Compile once outside the loop.
 	chunk := compileFile(b, "scripts/matrix_mult.ts")

--- a/tests/scripts/bench_add.ts
+++ b/tests/scripts/bench_add.ts
@@ -1,0 +1,15 @@
+// Addition-heavy micro-benchmark isolating the OpAdd numeric fast path.
+// All `+` on numbers; values stay bounded/exact so the result is deterministic.
+// expect: 20000000
+function run(): number {
+  let s = 0;
+  const ITERS = 2000000;
+  for (let i = 0; i < ITERS; i++) {
+    s = s + 1;
+    s = s + 2;
+    s = s + 3;
+    s = s + 4;
+  }
+  return s;
+}
+run();

--- a/tests/scripts/bench_arith.ts
+++ b/tests/scripts/bench_arith.ts
@@ -1,0 +1,15 @@
+// Arithmetic-heavy micro-benchmark: sub/mul/div/remainder on numbers.
+// Bounded/deterministic result.
+// expect: 0
+function run(): number {
+  let s = 1;
+  const ITERS = 1000000;
+  for (let i = 0; i < ITERS; i++) {
+    s = s * 3;
+    s = s - 1;
+    s = s / 2;
+    s = s % 100000;
+  }
+  return (s - s);
+}
+run();

--- a/tests/scripts/bench_setindex.ts
+++ b/tests/scripts/bench_setindex.ts
@@ -1,0 +1,23 @@
+// Array-element-write-heavy micro-benchmark, isolating the OpSetIndex hot path.
+// Deterministic; prints a checksum so the work can't be optimized away.
+// expect: 155916747
+function run(): number {
+  const N = 256;
+  const ITERS = 200000;
+  const arr = new Array(N);
+  for (let i = 0; i < N; i++) arr[i] = i >>> 0;
+
+  let x = 0x12345678 >>> 0;
+  let acc = 0 >>> 0;
+  for (let i = 0; i < ITERS; i++) {
+    x = (x ^ (x << 13)) >>> 0;
+    x = (x ^ (x >>> 17)) >>> 0;
+    x = (x ^ (x << 5)) >>> 0;
+    const idx = x & (N - 1);
+    const v = (arr[idx] + (x & 0xffff)) >>> 0;
+    arr[idx] = (v ^ (v >>> 7) ^ (v << 9)) >>> 0;
+    acc = (acc + arr[idx]) >>> 0;
+  }
+  return acc >>> 0;
+}
+run();


### PR DESCRIPTION
Benchmark scaffolding only — no VM changes. This is the base of a short stack of hot-path optimizations; landing the harness first means each follow-up is a pure `pkg/vm` diff with a before/after on benchmarks that already exist on `main`, instead of every opt PR re-touching the shared bench registry.

## What's here
- `tests/bench_test.go`: `BenchmarkAdd` / `BenchmarkArith` / `BenchmarkSetIndex`, driving small `bench_*.ts` scripts through the public driver API.
- `pkg/vm/isobject_bench_test.go`: `BenchmarkIsObject` over a hot-path value mix, plus `TestIsObjectExhaustive` locking the `IsObject == [TypeObject, TypeProxy]` range invariant (passes on the current OR-chain).
- `pkg/vm/tointeger_bench_test.go`: `BenchmarkToInteger`.

## Baseline (this commit, one full script run)
`BenchmarkSetIndex`: 6,596,688 B/op, 777,935 allocs/op — the target the OpSetIndex allocation-elimination change (next in the stack) drives down.

## Follow-ups (staged, will open once this lands)
1. OpSetIndex per-write allocation elimination
2. IsObject OR-chain → range check
3. Number fast paths (OpAdd / arithmetic / ToInteger)

`TestScripts` and `go test ./pkg/vm` green.