### PR TITLE
bench-test262: fingerprint the contributing test set so test262.total is comparable

### DIFF
--- a/cmd/bench-ratchet/main.go
+++ b/cmd/bench-ratchet/main.go
@@ -110,6 +110,7 @@ type Result struct {
 	NSPerOp     float64
 	BytesPerOp  int64
 	AllocsPerOp int64
+	SetHash     string // identity of the aggregated set (test262 macro); empty for micro benchmarks
 	Samples     []BenchmarkSample
 }
 
@@ -654,6 +655,8 @@ func aggregateFromFile(path string) (Baseline, error) {
 		count                     int
 		nsSum, bytesSum, allocSum float64
 		iters                     int64
+		setHash                   string // shared set identity across this key's records
+		setHashConflict           bool   // records disagreed → no coherent identity
 		samples                   []BenchmarkSample
 	}
 	byName := map[string]*accum{}
@@ -676,6 +679,13 @@ func aggregateFromFile(path string) (Baseline, error) {
 		if rec.Iterations > a.iters {
 			a.iters = rec.Iterations
 		}
+		if rec.SetHash != "" && !a.setHashConflict {
+			if a.setHash == "" {
+				a.setHash = rec.SetHash
+			} else if a.setHash != rec.SetHash {
+				a.setHash, a.setHashConflict = "", true
+			}
+		}
 		a.samples = append(a.samples, rec.Sample())
 	}
 
@@ -688,6 +698,7 @@ func aggregateFromFile(path string) (Baseline, error) {
 			NSPerOp:     a.nsSum / float64(a.count),
 			BytesPerOp:  int64(a.bytesSum / float64(a.count)),
 			AllocsPerOp: int64(a.allocSum / float64(a.count)),
+			SetHash:     a.setHash,
 			Samples:     append([]BenchmarkSample(nil), a.samples...),
 		})
 	}
@@ -728,6 +739,7 @@ func buildCurrentBaseline(results []Result, anchor Result) Baseline {
 			AllocsPerOp:   r.AllocsPerOp,
 			BytesPerOp:    r.BytesPerOp,
 			RatioToAnchor: r.NSPerOp / anchor.NSPerOp,
+			SetHash:       r.SetHash,
 			Samples:       samples,
 		}
 	}

--- a/cmd/bench-ratchet/main_test.go
+++ b/cmd/bench-ratchet/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A minimal anchor pair — aggregateFromFile errors out without a positive-ns
+// BenchmarkRatchetAnchor to normalize against. Micro benchmarks carry no
+// set_hash, so the anchor never participates in the fingerprint logic.
+const anchorJSONL = `{"package":"github.com/nooga/paserati/pkg/vm","name":"BenchmarkRatchetAnchor","iterations":1000,"ns_per_op":1.0,"bytes_per_op":0,"allocs_per_op":0,"captured_at":"2026-07-13T00:00:00Z"}
+`
+
+func aggregate(t *testing.T, jsonl string) Baseline {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "runs.jsonl")
+	if err := os.WriteFile(path, []byte(anchorJSONL+jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base, err := aggregateFromFile(path)
+	if err != nil {
+		t.Fatalf("aggregateFromFile: %v", err)
+	}
+	return base
+}
+
+const macroKey = "github.com/nooga/paserati/pkg/test262.BenchmarkTest262"
+
+// TestAggregateBlanksConflictingSetHash covers the one branch in
+// aggregateFromFile without other coverage: when the -count repetitions of a
+// macro benchmark disagree on set_hash, the aggregated identity must blank to
+// "" — an honest "no coherent set" signal — rather than latch the first hash.
+func TestAggregateBlanksConflictingSetHash(t *testing.T) {
+	jsonl := `{"package":"github.com/nooga/paserati/pkg/test262","name":"BenchmarkTest262","iterations":10,"ns_per_op":100.0,"bytes_per_op":0,"allocs_per_op":0,"set_hash":"aaaa","captured_at":"2026-07-13T00:00:00Z"}
+{"package":"github.com/nooga/paserati/pkg/test262","name":"BenchmarkTest262","iterations":10,"ns_per_op":110.0,"bytes_per_op":0,"allocs_per_op":0,"set_hash":"bbbb","captured_at":"2026-07-13T00:00:00Z"}
+`
+	e, ok := aggregate(t, jsonl).Benchmarks[macroKey]
+	if !ok {
+		t.Fatalf("benchmark %q missing from baseline", macroKey)
+	}
+	if e.SetHash != "" {
+		t.Errorf("SetHash = %q, want \"\" (records disagreed → no coherent identity)", e.SetHash)
+	}
+}
+
+// TestAggregatePreservesAgreeingSetHash is the complement: repetitions that all
+// report the same set_hash keep it, so a genuine set identity survives aggregation.
+func TestAggregatePreservesAgreeingSetHash(t *testing.T) {
+	jsonl := `{"package":"github.com/nooga/paserati/pkg/test262","name":"BenchmarkTest262","iterations":10,"ns_per_op":100.0,"bytes_per_op":0,"allocs_per_op":0,"set_hash":"aaaa","captured_at":"2026-07-13T00:00:00Z"}
+{"package":"github.com/nooga/paserati/pkg/test262","name":"BenchmarkTest262","iterations":10,"ns_per_op":110.0,"bytes_per_op":0,"allocs_per_op":0,"set_hash":"aaaa","captured_at":"2026-07-13T00:00:00Z"}
+`
+	e, ok := aggregate(t, jsonl).Benchmarks[macroKey]
+	if !ok {
+		t.Fatalf("benchmark %q missing from baseline", macroKey)
+	}
+	if e.SetHash != "aaaa" {
+		t.Errorf("SetHash = %q, want \"aaaa\" (agreeing records preserve identity)", e.SetHash)
+	}
+}

--- a/cmd/bench-test262/main.go
+++ b/cmd/bench-test262/main.go
@@ -23,6 +23,8 @@ package main
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -57,10 +59,15 @@ func main() {
 // buildRecords sums per-test durations over the passing, non-timed-out set,
 // emitting a total plus per-top-level-suite breakdown. NSPerOp carries the
 // summed nanoseconds; aggregate divides it by the anchor to normalize.
+//
+// Each record also carries a SetHash over the exact set of tests it summed, so
+// a downstream consumer can tell whether two totals cover the same workload:
+// equal counts alone don't guarantee it (a test flipping pass->timeout while
+// another flips the other way keeps the count but changes the set and the sum).
 func buildRecords(out test262.Output, capturedAt string) []perfdata.StreamRecord {
 	type acc struct {
 		sumNS float64
-		count int64
+		paths []string // contributing test paths — hashed into the record's SetHash
 	}
 	bySuite := map[string]*acc{}
 	total := &acc{}
@@ -71,7 +78,7 @@ func buildRecords(out test262.Output, capturedAt string) []perfdata.StreamRecord
 		}
 		ns := float64(r.Duration) // time.Duration marshals as int64 nanoseconds
 		total.sumNS += ns
-		total.count++
+		total.paths = append(total.paths, r.Path)
 
 		suite := topLevelSuite(r.Path)
 		a := bySuite[suite]
@@ -80,15 +87,16 @@ func buildRecords(out test262.Output, capturedAt string) []perfdata.StreamRecord
 			bySuite[suite] = a
 		}
 		a.sumNS += ns
-		a.count++
+		a.paths = append(a.paths, r.Path)
 	}
 
 	rec := func(name string, a *acc) perfdata.StreamRecord {
 		return perfdata.StreamRecord{
 			Package:    "test262",
 			Name:       name,
-			Iterations: a.count, // tests contributing to the sum
-			NSPerOp:    a.sumNS, // summed execution time; anchor-normalized downstream
+			Iterations: int64(len(a.paths)), // tests contributing to the sum
+			NSPerOp:    a.sumNS,             // summed execution time; anchor-normalized downstream
+			SetHash:    setHash(a.paths),    // identity of that contributing set
 			CapturedAt: capturedAt,
 		}
 	}
@@ -103,6 +111,23 @@ func buildRecords(out test262.Output, capturedAt string) []perfdata.StreamRecord
 		records = append(records, rec(s, bySuite[s]))
 	}
 	return records
+}
+
+// setHash fingerprints a contributing set by its member test paths, order-
+// independent. Truncated SHA-256 (64 bits) — collision odds are negligible for
+// set sizes here, and it stays short in the JSON. Empty set -> empty hash.
+func setHash(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), paths...)
+	sort.Strings(sorted)
+	h := sha256.New()
+	for _, p := range sorted {
+		h.Write([]byte(p))
+		h.Write([]byte{'\n'}) // delimiter: no path joins with the next to forge the same digest
+	}
+	return hex.EncodeToString(h.Sum(nil)[:8])
 }
 
 // topLevelSuite extracts the chapter from a path like

--- a/cmd/bench-test262/main_test.go
+++ b/cmd/bench-test262/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nooga/paserati/pkg/test262"
+)
+
+func res(path string, passed, timedOut bool, d time.Duration) test262.Result {
+	return test262.Result{Path: path, Passed: passed, TimedOut: timedOut, Duration: d}
+}
+
+// totalRecord returns the "test262.total" record from a build.
+func totalRecord(t *testing.T, out test262.Output) (nsPerOp float64, iters int64, setHash string) {
+	t.Helper()
+	for _, r := range buildRecords(out, "2026-07-12T00:00:00Z") {
+		if r.Name == "total" {
+			return r.NSPerOp, r.Iterations, r.SetHash
+		}
+	}
+	t.Fatal("no total record emitted")
+	return 0, 0, ""
+}
+
+// The core F3 property: two runs with the SAME passing count but a DIFFERENT
+// set must get different SetHashes, so the total isn't silently comparable.
+func TestSetHashDistinguishesEqualCountDifferentSet(t *testing.T) {
+	runA := test262.Output{Results: []test262.Result{
+		res("test262/test/built-ins/Math/abs/a.js", true, false, 10),
+		res("test262/test/built-ins/Math/ceil/b.js", true, false, 20),
+	}}
+	// Same count (2), same summed ns (30), but c.js replaces ceil/b.js.
+	runB := test262.Output{Results: []test262.Result{
+		res("test262/test/built-ins/Math/abs/a.js", true, false, 10),
+		res("test262/test/built-ins/Math/floor/c.js", true, false, 20),
+	}}
+
+	nsA, cntA, hA := totalRecord(t, runA)
+	nsB, cntB, hB := totalRecord(t, runB)
+
+	if cntA != cntB || nsA != nsB {
+		t.Fatalf("precondition: expected equal count/sum, got A(%d,%.0f) B(%d,%.0f)", cntA, nsA, cntB, nsB)
+	}
+	if hA == "" || hB == "" {
+		t.Fatalf("expected non-empty set hashes, got %q %q", hA, hB)
+	}
+	if hA == hB {
+		t.Fatalf("equal-count different-set runs must hash differently; both = %q", hA)
+	}
+}
+
+// The hash is order-independent (it's a set) and stable across identical runs.
+func TestSetHashIsOrderIndependentAndStable(t *testing.T) {
+	forward := test262.Output{Results: []test262.Result{
+		res("test262/test/language/a.js", true, false, 5),
+		res("test262/test/language/b.js", true, false, 7),
+		res("test262/test/language/c.js", true, false, 9),
+	}}
+	reversed := test262.Output{Results: []test262.Result{
+		res("test262/test/language/c.js", true, false, 9),
+		res("test262/test/language/b.js", true, false, 7),
+		res("test262/test/language/a.js", true, false, 5),
+	}}
+
+	_, _, hF := totalRecord(t, forward)
+	_, _, hR := totalRecord(t, reversed)
+	if hF != hR {
+		t.Fatalf("set hash must be order-independent: %q != %q", hF, hR)
+	}
+}
+
+// Failing and timed-out tests are excluded from both the sum and the set,
+// matching the metric's definition.
+func TestSetHashExcludesFailedAndTimedOut(t *testing.T) {
+	withNoise := test262.Output{Results: []test262.Result{
+		res("test262/test/built-ins/Math/abs/a.js", true, false, 10),
+		res("test262/test/built-ins/Math/ceil/b.js", false, false, 20), // failed
+		res("test262/test/built-ins/Math/floor/c.js", true, true, 30),  // timed out
+	}}
+	clean := test262.Output{Results: []test262.Result{
+		res("test262/test/built-ins/Math/abs/a.js", true, false, 10),
+	}}
+
+	nsN, cntN, hN := totalRecord(t, withNoise)
+	nsC, cntC, hC := totalRecord(t, clean)
+	if cntN != 1 || nsN != 10 {
+		t.Fatalf("expected only the one passing test to count, got count=%d ns=%.0f", cntN, nsN)
+	}
+	if hN != hC || cntN != cntC || nsN != nsC {
+		t.Fatalf("passing-only set must match the clean run: h %q vs %q", hN, hC)
+	}
+}

--- a/pkg/perfdata/perfdata.go
+++ b/pkg/perfdata/perfdata.go
@@ -37,7 +37,14 @@ type BenchmarkEntry struct {
 	RatioToAnchor float64           `json:"ratio_to_anchor"`
 	BestSinceSHA  string            `json:"best_since_sha,omitempty"`
 	BestSinceAt   string            `json:"best_since_at,omitempty"`
-	Samples       []BenchmarkSample `json:"samples,omitempty"`
+	// SetHash fingerprints the set of operations aggregated into this measurement,
+	// for records whose metric sums over a variable set (e.g. the test262 macro
+	// sums per-test times over the passing, non-timed-out tests). Two captures
+	// with equal counts but different sets get different hashes, so a consumer can
+	// tell whether the number is comparable across snapshots. Empty for ordinary
+	// single-op benchmarks, where the op is fixed and the count is the sample size.
+	SetHash string            `json:"set_hash,omitempty"`
+	Samples []BenchmarkSample `json:"samples,omitempty"`
 }
 
 // BenchmarkSample is one raw benchmark measurement retained for statistics.
@@ -58,6 +65,7 @@ type StreamRecord struct {
 	NSPerOp     float64 `json:"ns_per_op"`
 	BytesPerOp  int64   `json:"bytes_per_op"`
 	AllocsPerOp int64   `json:"allocs_per_op"`
+	SetHash     string  `json:"set_hash,omitempty"` // identity of the aggregated set; see BenchmarkEntry.SetHash
 	CapturedAt  string  `json:"captured_at"`
 }
 


### PR DESCRIPTION
Resolves finding **F3** from the retrospective review of #10 (tracked in #23).

## The problem

The Test262 macro emits `test262.total` as **sum + count** of the passing, non-timed-out tests. That loses test identity: two captures with equal counts can cover *different* sets — a test flipping pass→timeout while another flips back keeps the count but changes both the set and the sum. The A/B comparator sidesteps this by diffing the per-test merged files, but the aggregate total advertised for the timeline (#16) can't, so a composition change reads as an engine change.

## The fix

Each `StreamRecord` now carries a **`set_hash`**: an order-independent, truncated SHA-256 over the exact set of test paths it summed.

- **Producer** (`cmd/bench-test262`): computes the hash per emitted record.
- **Schema** (`pkg/perfdata`): `SetHash` on `StreamRecord` and `BenchmarkEntry`, `omitempty` so ordinary micro benchmarks stay unaffected.
- **Aggregate** (`cmd/bench-ratchet`): threads the hash onto the snapshot's `BenchmarkEntry`. Disagreeing hashes across a key's `-count` samples blank out — no coherent identity — which is the honest signal for a flaky set.

A consumer can then gate: a `test262.total` point whose `set_hash` differs from the reference isn't comparable.

## Verification

- Unit tests (`cmd/bench-test262/main_test.go`): equal-count/different-set → different hash; order-independent; failed/timed-out excluded from both sum and set.
- End-to-end: a `set_hash` on a `test262.total` record survives aggregate into the snapshot entry alongside `ratio_to_anchor`, and correctly stays off per-sample rows.
- `go build ./...`, `go vet ./...` clean.

## Follow-on

**#16 should gate its `test262.total` series on `set_hash`** — this PR gives it the tool; the page-side drop/flag is #16's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
