### PR TITLE
perf-test262: pin corpus to head for both A/B halves; drop the paths filter

### DIFF
--- a/.github/workflows/perf-test262.yml
+++ b/.github/workflows/perf-test262.yml
@@ -18,12 +18,12 @@ name: Perf Test262
 # Informational only: it never fails the PR.
 on:
   pull_request:
+    # No `paths` filter: GitHub applies paths BEFORE the job's label `if`, so a
+    # paths filter would silently swallow a labeled PR that only touches the
+    # harness (scripts/macro-test262*.sh, setup-test262.sh). The `perf-test262`
+    # label is already the explicit heavy-run opt-in and the job `if` is the gate;
+    # unlabeled PRs just evaluate to a skipped job, which is ~free.
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - 'pkg/**'
-      - 'cmd/**'
-      - '.test262-rev'
-      - '.github/workflows/perf-test262.yml'
   # Manual escape hatch: run against any PR by number without touching labels.
   workflow_dispatch:
     inputs:
@@ -124,9 +124,17 @@ jobs:
       - name: Bench merge-base
         env:
           BASE: ${{ steps.refs.outputs.base }}
+          HEAD: ${{ steps.refs.outputs.head }}
         run: |
           set -euo pipefail
           git checkout --force "$BASE"
+          # Pin the corpus to HEAD's .test262-rev for BOTH halves. setup-test262.sh
+          # re-pins from the working tree's .test262-rev, so without this a PR that
+          # bumps the pin would bench BASE against a different corpus than HEAD and
+          # the intersection compare would book a corpus change as an engine delta.
+          # Resolve to HEAD's rev (the corpus the PR proposes); HEAD's own checkout
+          # already carries it, so only the base half needs the override.
+          git show "${HEAD}:.test262-rev" > .test262-rev
           ./setup-test262.sh
           ./scripts/macro-test262.sh "${RUNNER_TEMP}/base.jsonl" "${RUNNER_TEMP}/base.stats.json"
 


### PR DESCRIPTION
Resolves findings **F4** and **F5** from the retrospective review of #10 (tracked in #23). Both are correctness fixes to the opt-in Test262 macro A/B; workflow-only, one file.

## F4 — unpinned corpus across the two halves (P1)

Each half runs `setup-test262.sh`, which re-pins the corpus from the working tree's `.test262-rev`. A PR that bumps the pin therefore benched the merge-base against a *different* corpus than the head, under matching paths, and the intersection comparator booked that corpus change as an engine delta — and `.test262-rev` used to be a trigger path, so it was easy to hit.

Now the base half is forced to **head's** `.test262-rev` (the corpus the PR proposes) before setup; the head half already carries its own. Both halves run one corpus revision.

## F5 — paths filter swallowed harness-only opt-ins (P2)

GitHub applies the `pull_request` `paths` filter **before** the job's label `if`, so labeling a PR that only touched `scripts/macro-test262*.sh` or `setup-test262.sh` never ran. The `perf-test262` label is already the explicit heavy-run opt-in and the `if` is the gate, so the paths filter only created a false negative. Dropped it; unlabeled PRs evaluate to a skipped job (~free).

## Verification

- `actionlint` clean.
- `git show <sha>:.test262-rev` confirmed to resolve the pin file the base-half override reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
