### PR TITLE
perf(vm): iterator fast path — step built-in iterators without a call or result object

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -2992,28 +2992,33 @@ func createArrayIterator(vmInstance *vm.VM, array *vm.ArrayObject) vm.Value {
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
 
-	// Iterator state: current index
-	currentIndex := 0
+	// Iterator state, shared between the next closure below and the VM's
+	// for-of fast path (OpArrayIterNext reaches it through the next method's
+	// NativeFunctionObject), so manual next() calls and a for-of over the
+	// same iterator advance one index.
+	state := &vm.ArrayIterState{Arr: array}
 
 	// Add next() method to iterator
-	iterator.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
+	nextFn := vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
 		// Create iterator result object {value, done}
 		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 
-		if currentIndex >= array.Length() {
+		if state.Index >= state.Arr.Length() {
 			// Iterator is exhausted
 			result.SetOwnNonEnumerable("value", vm.Undefined)
 			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
 		} else {
 			// Return current element and advance
-			val := array.Get(currentIndex)
+			val := state.Arr.Get(state.Index)
 			result.SetOwnNonEnumerable("value", val)
 			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-			currentIndex++
+			state.Index++
 		}
 
 		return vm.NewValueFromPlainObject(result), nil
-	}))
+	})
+	nextFn.AsNativeFunction().ArrayIterState = state
+	iterator.SetOwnNonEnumerable("next", nextFn)
 
 	// Add [Symbol.iterator] that returns the iterator itself (required for for-of)
 	iterSelfFn := vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -2986,39 +2986,31 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	return ctx.DefineGlobal("Array", arrayCtor)
 }
 
+// makeBuiltinIterNext builds the standard next() closure over shared iterator
+// state and tags its NativeFunctionObject so the VM's for-of fast path
+// (OpIterFastCheck/OpFastIterNext) can step the same state without a call or
+// {value, done} allocation. Manual next() calls and the fast path advance one
+// shared index.
+func makeBuiltinIterNext(vmInstance *vm.VM, state *vm.BuiltinIterState) vm.Value {
+	nextFn := vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
+		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+		v, done := state.Step()
+		result.SetOwnNonEnumerable("value", v)
+		result.SetOwnNonEnumerable("done", vm.BooleanValue(done))
+		return vm.NewValueFromPlainObject(result), nil
+	})
+	nextFn.AsNativeFunction().IterState = state
+	return nextFn
+}
+
 // createArrayIterator creates an iterator object for array iteration
 func createArrayIterator(vmInstance *vm.VM, array *vm.ArrayObject) vm.Value {
 	// Create iterator object inheriting from ArrayIteratorPrototype
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
 
-	// Iterator state, shared between the next closure below and the VM's
-	// for-of fast path (OpArrayIterNext reaches it through the next method's
-	// NativeFunctionObject), so manual next() calls and a for-of over the
-	// same iterator advance one index.
-	state := &vm.ArrayIterState{Arr: array}
-
-	// Add next() method to iterator
-	nextFn := vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
-		// Create iterator result object {value, done}
-		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-
-		if state.Index >= state.Arr.Length() {
-			// Iterator is exhausted
-			result.SetOwnNonEnumerable("value", vm.Undefined)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
-		} else {
-			// Return current element and advance
-			val := state.Arr.Get(state.Index)
-			result.SetOwnNonEnumerable("value", val)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-			state.Index++
-		}
-
-		return vm.NewValueFromPlainObject(result), nil
-	})
-	nextFn.AsNativeFunction().ArrayIterState = state
-	iterator.SetOwnNonEnumerable("next", nextFn)
+	state := &vm.BuiltinIterState{Kind: vm.IterKindArrayValues, Arr: array}
+	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	// Add [Symbol.iterator] that returns the iterator itself (required for for-of)
 	iterSelfFn := vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(args []vm.Value) (vm.Value, error) {
@@ -3036,28 +3028,8 @@ func createArgumentsIterator(vmInstance *vm.VM, args *vm.ArgumentsObject) vm.Val
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
 
-	// Iterator state: current index
-	currentIndex := 0
-
-	// Add next() method to iterator
-	iterator.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(innerArgs []vm.Value) (vm.Value, error) {
-		// Create iterator result object {value, done}
-		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-
-		if currentIndex >= args.Length() {
-			// Iterator is exhausted
-			result.SetOwnNonEnumerable("value", vm.Undefined)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
-		} else {
-			// Return current element and advance
-			val := args.Get(currentIndex)
-			result.SetOwnNonEnumerable("value", val)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-			currentIndex++
-		}
-
-		return vm.NewValueFromPlainObject(result), nil
-	}))
+	state := &vm.BuiltinIterState{Kind: vm.IterKindArguments, Args: args}
+	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	// Add [Symbol.iterator] that returns the iterator itself
 	iterSelfFn := vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(fnArgs []vm.Value) (vm.Value, error) {
@@ -3075,42 +3047,8 @@ func createArrayLikeIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
 
-	// Iterator state: current index
-	currentIndex := 0
-
-	// Add next() method to iterator
-	iterator.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(innerArgs []vm.Value) (vm.Value, error) {
-		// Create iterator result object {value, done}
-		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-
-		// Get length from the array-like object
-		var length int
-		if obj := arrayLike.AsPlainObject(); obj != nil {
-			if lenVal, ok := obj.GetOwn("length"); ok && lenVal.IsNumber() {
-				length = int(lenVal.ToFloat())
-			}
-		}
-
-		if currentIndex >= length {
-			// Iterator is exhausted
-			result.SetOwnNonEnumerable("value", vm.Undefined)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
-		} else {
-			// Get value at current index
-			var val vm.Value = vm.Undefined
-			if obj := arrayLike.AsPlainObject(); obj != nil {
-				indexStr := fmt.Sprintf("%d", currentIndex)
-				if v, ok := obj.GetOwn(indexStr); ok {
-					val = v
-				}
-			}
-			result.SetOwnNonEnumerable("value", val)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-			currentIndex++
-		}
-
-		return vm.NewValueFromPlainObject(result), nil
-	}))
+	state := &vm.BuiltinIterState{Kind: vm.IterKindLikeValues, Like: arrayLike.AsPlainObject()}
+	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	// Add [Symbol.iterator] that returns the iterator itself
 	iterSelfFn := vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(fnArgs []vm.Value) (vm.Value, error) {
@@ -3126,32 +3064,14 @@ func createArrayLikeIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 func createArrayKeysIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
-	currentIndex := 0
 
-	iterator.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
-		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-
-		// Get length from the array or array-like object
-		var length int
-		if arrayLike.Type() == vm.TypeArray {
-			length = arrayLike.AsArray().Length()
-		} else if obj := arrayLike.AsPlainObject(); obj != nil {
-			if lenVal, ok := obj.GetOwn("length"); ok && lenVal.IsNumber() {
-				length = int(lenVal.ToFloat())
-			}
-		}
-
-		if currentIndex >= length {
-			result.SetOwnNonEnumerable("value", vm.Undefined)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
-		} else {
-			result.SetOwnNonEnumerable("value", vm.Number(float64(currentIndex)))
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-			currentIndex++
-		}
-
-		return vm.NewValueFromPlainObject(result), nil
-	}))
+	state := &vm.BuiltinIterState{Kind: vm.IterKindArrayKeys}
+	if arrayLike.Type() == vm.TypeArray {
+		state.Arr = arrayLike.AsArray()
+	} else {
+		state.Like = arrayLike.AsPlainObject() // nil-safe: nil source iterates as length 0
+	}
+	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	// Add [Symbol.iterator] that returns the iterator itself
 	iterSelfFn := vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(fnArgs []vm.Value) (vm.Value, error) {
@@ -3167,50 +3087,14 @@ func createArrayKeysIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 func createArrayEntriesIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
-	currentIndex := 0
 
-	iterator.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
-		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-
-		// Get length and value from the array or array-like object
-		var length int
-		var getValue func(int) vm.Value
-
-		if arrayLike.Type() == vm.TypeArray {
-			arr := arrayLike.AsArray()
-			length = arr.Length()
-			getValue = func(i int) vm.Value { return arr.Get(i) }
-		} else if obj := arrayLike.AsPlainObject(); obj != nil {
-			if lenVal, ok := obj.GetOwn("length"); ok && lenVal.IsNumber() {
-				length = int(lenVal.ToFloat())
-			}
-			getValue = func(i int) vm.Value {
-				if v, ok := obj.GetOwn(fmt.Sprintf("%d", i)); ok {
-					return v
-				}
-				return vm.Undefined
-			}
-		} else {
-			length = 0
-			getValue = func(i int) vm.Value { return vm.Undefined }
-		}
-
-		if currentIndex >= length {
-			result.SetOwnNonEnumerable("value", vm.Undefined)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
-		} else {
-			// Create [index, value] pair array
-			pair := vm.NewArray()
-			pairArr := pair.AsArray()
-			pairArr.Append(vm.Number(float64(currentIndex)))
-			pairArr.Append(getValue(currentIndex))
-			result.SetOwnNonEnumerable("value", pair)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-			currentIndex++
-		}
-
-		return vm.NewValueFromPlainObject(result), nil
-	}))
+	state := &vm.BuiltinIterState{Kind: vm.IterKindArrayEntries}
+	if arrayLike.Type() == vm.TypeArray {
+		state.Arr = arrayLike.AsArray()
+	} else {
+		state.Like = arrayLike.AsPlainObject() // nil-safe: nil source iterates as length 0
+	}
+	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	// Add [Symbol.iterator] that returns the iterator itself
 	iterSelfFn := vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(fnArgs []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/iterator_init.go
+++ b/pkg/builtins/iterator_init.go
@@ -1428,71 +1428,24 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisObj == nil {
 			return vm.Undefined, vmInstance.NewTypeError("%MapIteratorPrototype%.next requires that 'this' be an Object")
 		}
-		// Check for [[IteratedMap]] internal slot
-		iteratedMap, hasSlot := thisObj.GetOwn("[[IteratedMap]]")
-		if !hasSlot {
+		// Brand check: the internal iterator state doubles as the spec's
+		// [[IteratedMap]] internal slot (a Set iterator has Set-kind state
+		// and must be rejected here).
+		st := thisObj.InternalIterState()
+		if st == nil || !st.Kind.IsMapKind() {
 			return vm.Undefined, vmInstance.NewTypeError("%MapIteratorPrototype%.next requires that 'this' be a Map Iterator")
 		}
 
 		result := vm.NewObject(vm.Undefined).AsPlainObject()
-
-		// Check if exhausted
-		if exhaustedVal, ok := thisObj.GetOwn("[[Exhausted]]"); ok && exhaustedVal == vm.True {
-			result.SetOwn("value", vm.Undefined)
-			result.SetOwn("done", vm.BooleanValue(true))
-			return vm.NewValueFromPlainObject(result), nil
-		}
-
-		// Get current index and kind
-		indexVal, _ := thisObj.GetOwn("[[MapNextIndex]]")
-		kindVal, _ := thisObj.GetOwn("[[MapIterationKind]]")
-		currentIndex := int(indexVal.ToFloat())
-		kind := kindVal.ToString() // "entries", "keys", or "values"
-
-		// Get the map
-		if iteratedMap.Type() != vm.TypeMap {
-			result.SetOwn("value", vm.Undefined)
-			result.SetOwn("done", vm.BooleanValue(true))
-			return vm.NewValueFromPlainObject(result), nil
-		}
-		mapObj := iteratedMap.AsMap()
-
-		// Iterate
-		for currentIndex < mapObj.OrderLen() {
-			key, value, exists := mapObj.GetEntryAt(currentIndex)
-			currentIndex++
-			thisObj.SetOwn("[[MapNextIndex]]", vm.NumberValue(float64(currentIndex)))
-			if exists {
-				var resultValue vm.Value
-				switch kind {
-				case "entries":
-					entry := vm.NewArray()
-					entry.AsArray().Append(key)
-					entry.AsArray().Append(value)
-					resultValue = entry
-				case "keys":
-					resultValue = key
-				case "values":
-					resultValue = value
-				default:
-					entry := vm.NewArray()
-					entry.AsArray().Append(key)
-					entry.AsArray().Append(value)
-					resultValue = entry
-				}
-				result.SetOwn("value", resultValue)
-				result.SetOwn("done", vm.BooleanValue(false))
-				return vm.NewValueFromPlainObject(result), nil
-			}
-		}
-
-		// Exhausted
-		thisObj.SetOwn("[[Exhausted]]", vm.BooleanValue(true))
-		thisObj.SetOwn("[[MapNextIndex]]", vm.NumberValue(float64(currentIndex)))
-		result.SetOwn("value", vm.Undefined)
-		result.SetOwn("done", vm.BooleanValue(true))
+		v, done := st.Step()
+		result.SetOwn("value", v)
+		result.SetOwn("done", vm.BooleanValue(done))
 		return vm.NewValueFromPlainObject(result), nil
 	})
+	// Tag the shared next so the for-of fast path (OpIterFastCheck) can
+	// recognize it; the sentinel kind tells OpFastIterNext to resolve the
+	// real per-iterator state from the iterator object instead.
+	mapIterNextFn.AsNativeFunction().IterState = &vm.BuiltinIterState{Kind: vm.IterKindStateOnIterator}
 	// Set length and name properties on the next function
 	mapIterNextFnObj := mapIterNextFn.AsNativeFunction()
 	_ = mapIterNextFnObj // length and name are already set by NewNativeFunction
@@ -1519,67 +1472,22 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisObj == nil {
 			return vm.Undefined, vmInstance.NewTypeError("%SetIteratorPrototype%.next requires that 'this' be an Object")
 		}
-		// Check for [[IteratedSet]] internal slot
-		iteratedSet, hasSlot := thisObj.GetOwn("[[IteratedSet]]")
-		if !hasSlot {
+		// Brand check: the internal iterator state doubles as the spec's
+		// [[IteratedSet]] internal slot (a Map iterator has Map-kind state
+		// and must be rejected here).
+		st := thisObj.InternalIterState()
+		if st == nil || !st.Kind.IsSetKind() {
 			return vm.Undefined, vmInstance.NewTypeError("%SetIteratorPrototype%.next requires that 'this' be a Set Iterator")
 		}
 
 		result := vm.NewObject(vm.Undefined).AsPlainObject()
-
-		// Check if exhausted
-		if exhaustedVal, ok := thisObj.GetOwn("[[Exhausted]]"); ok && exhaustedVal == vm.True {
-			result.SetOwn("value", vm.Undefined)
-			result.SetOwn("done", vm.BooleanValue(true))
-			return vm.NewValueFromPlainObject(result), nil
-		}
-
-		// Get current index and kind
-		indexVal, _ := thisObj.GetOwn("[[SetNextIndex]]")
-		kindVal, _ := thisObj.GetOwn("[[SetIterationKind]]")
-		currentIndex := int(indexVal.ToFloat())
-		kind := kindVal.ToString() // "entries", "keys", or "values"
-
-		// Get the set
-		if iteratedSet.Type() != vm.TypeSet {
-			result.SetOwn("value", vm.Undefined)
-			result.SetOwn("done", vm.BooleanValue(true))
-			return vm.NewValueFromPlainObject(result), nil
-		}
-		setObj := iteratedSet.AsSet()
-
-		// Iterate
-		for currentIndex < setObj.OrderLen() {
-			value, exists := setObj.GetValueAt(currentIndex)
-			currentIndex++
-			thisObj.SetOwn("[[SetNextIndex]]", vm.NumberValue(float64(currentIndex)))
-			if exists {
-				var resultValue vm.Value
-				switch kind {
-				case "entries":
-					// For Set entries(), return [value, value]
-					entry := vm.NewArray()
-					entry.AsArray().Append(value)
-					entry.AsArray().Append(value)
-					resultValue = entry
-				case "keys", "values":
-					resultValue = value
-				default:
-					resultValue = value
-				}
-				result.SetOwn("value", resultValue)
-				result.SetOwn("done", vm.BooleanValue(false))
-				return vm.NewValueFromPlainObject(result), nil
-			}
-		}
-
-		// Exhausted
-		thisObj.SetOwn("[[Exhausted]]", vm.BooleanValue(true))
-		thisObj.SetOwn("[[SetNextIndex]]", vm.NumberValue(float64(currentIndex)))
-		result.SetOwn("value", vm.Undefined)
-		result.SetOwn("done", vm.BooleanValue(true))
+		v, done := st.Step()
+		result.SetOwn("value", v)
+		result.SetOwn("done", vm.BooleanValue(done))
 		return vm.NewValueFromPlainObject(result), nil
 	})
+	// Tag the shared next for the for-of fast path (see map next above).
+	setIterNextFn.AsNativeFunction().IterState = &vm.BuiltinIterState{Kind: vm.IterKindStateOnIterator}
 	setIteratorProto.DefineOwnProperty("next", setIterNextFn, &trueVal, &falseVal, &trueVal)
 	vmInstance.SetIteratorPrototype = vm.NewValueFromPlainObject(setIteratorProto)
 

--- a/pkg/builtins/map_init.go
+++ b/pkg/builtins/map_init.go
@@ -338,10 +338,10 @@ func (m *MapInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Create iterator object with internal slots, inheriting from MapIteratorPrototype
 		// The prototype's next() method uses these slots for iteration
 		it := vm.NewObject(vmInstance.MapIteratorPrototype).AsPlainObject()
-		it.SetOwn("[[IteratedMap]]", thisMap)
-		it.SetOwn("[[MapNextIndex]]", vm.NumberValue(0))
-		it.SetOwn("[[MapIterationKind]]", vm.NewString("entries"))
-		it.SetOwn("[[Exhausted]]", vm.BooleanValue(false))
+		// Internal slots live in a Go struct (invisible to user code, like
+		// real spec internal slots) shared by the prototype next and the
+		// VM's for-of fast path.
+		it.SetInternalIterState(&vm.BuiltinIterState{Kind: vm.IterKindMapEntries, M: thisMap.AsMap()})
 
 		// [Symbol.iterator]() { return this }
 		it.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator), vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(a []vm.Value) (vm.Value, error) {
@@ -368,10 +368,10 @@ func (m *MapInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Create iterator object with internal slots, inheriting from MapIteratorPrototype
 		it := vm.NewObject(vmInstance.MapIteratorPrototype).AsPlainObject()
-		it.SetOwn("[[IteratedMap]]", thisMap)
-		it.SetOwn("[[MapNextIndex]]", vm.NumberValue(0))
-		it.SetOwn("[[MapIterationKind]]", vm.NewString("values"))
-		it.SetOwn("[[Exhausted]]", vm.BooleanValue(false))
+		// Internal slots live in a Go struct (invisible to user code, like
+		// real spec internal slots) shared by the prototype next and the
+		// VM's for-of fast path.
+		it.SetInternalIterState(&vm.BuiltinIterState{Kind: vm.IterKindMapValues, M: thisMap.AsMap()})
 
 		it.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator), vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(a []vm.Value) (vm.Value, error) {
 			return vm.NewValueFromPlainObject(it), nil
@@ -391,10 +391,10 @@ func (m *MapInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Create iterator object with internal slots, inheriting from MapIteratorPrototype
 		it := vm.NewObject(vmInstance.MapIteratorPrototype).AsPlainObject()
-		it.SetOwn("[[IteratedMap]]", thisMap)
-		it.SetOwn("[[MapNextIndex]]", vm.NumberValue(0))
-		it.SetOwn("[[MapIterationKind]]", vm.NewString("keys"))
-		it.SetOwn("[[Exhausted]]", vm.BooleanValue(false))
+		// Internal slots live in a Go struct (invisible to user code, like
+		// real spec internal slots) shared by the prototype next and the
+		// VM's for-of fast path.
+		it.SetInternalIterState(&vm.BuiltinIterState{Kind: vm.IterKindMapKeys, M: thisMap.AsMap()})
 
 		it.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator), vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(a []vm.Value) (vm.Value, error) {
 			return vm.NewValueFromPlainObject(it), nil

--- a/pkg/builtins/set_init.go
+++ b/pkg/builtins/set_init.go
@@ -684,10 +684,10 @@ func (s *SetInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Create iterator object with internal slots, inheriting from SetIteratorPrototype
 		it := vm.NewObject(vmInstance.SetIteratorPrototype).AsPlainObject()
-		it.SetOwn("[[IteratedSet]]", thisSet)
-		it.SetOwn("[[SetNextIndex]]", vm.NumberValue(0))
-		it.SetOwn("[[SetIterationKind]]", vm.NewString("values"))
-		it.SetOwn("[[Exhausted]]", vm.BooleanValue(false))
+		// Internal slots live in a Go struct (invisible to user code, like
+		// real spec internal slots) shared by the prototype next and the
+		// VM's for-of fast path.
+		it.SetInternalIterState(&vm.BuiltinIterState{Kind: vm.IterKindSetValues, S: thisSet.AsSet()})
 
 		it.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator), vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(a []vm.Value) (vm.Value, error) {
 			return vm.NewValueFromPlainObject(it), nil
@@ -719,10 +719,10 @@ func (s *SetInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Create iterator object with internal slots, inheriting from SetIteratorPrototype
 		it := vm.NewObject(vmInstance.SetIteratorPrototype).AsPlainObject()
-		it.SetOwn("[[IteratedSet]]", thisSet)
-		it.SetOwn("[[SetNextIndex]]", vm.NumberValue(0))
-		it.SetOwn("[[SetIterationKind]]", vm.NewString("entries"))
-		it.SetOwn("[[Exhausted]]", vm.BooleanValue(false))
+		// Internal slots live in a Go struct (invisible to user code, like
+		// real spec internal slots) shared by the prototype next and the
+		// VM's for-of fast path.
+		it.SetInternalIterState(&vm.BuiltinIterState{Kind: vm.IterKindSetEntries, S: thisSet.AsSet()})
 
 		it.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator), vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(a []vm.Value) (vm.Value, error) {
 			return vm.NewValueFromPlainObject(it), nil

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -2371,57 +2371,11 @@ func createStringIterator(vmInstance *vm.VM, str string) vm.Value {
 	// Create iterator object inheriting from StringIteratorPrototype
 	iterator := vm.NewObject(vmInstance.StringIteratorPrototype).AsPlainObject()
 
-	// Convert string to UTF-16 code units for proper JavaScript semantics
-	// JavaScript strings are UTF-16 encoded, so we need to iterate by code points,
-	// which may span two UTF-16 code units (surrogate pairs)
-	utf16Units := vm.StringToUTF16(str)
-
-	// Iterator state: current index into UTF-16 code units
-	currentIndex := 0
-
-	// Add next() method to iterator
-	iterator.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
-		// Create iterator result object {value, done}
-		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-
-		if currentIndex >= len(utf16Units) {
-			// Iterator is exhausted
-			result.SetOwnNonEnumerable("value", vm.Undefined)
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
-		} else {
-			// Return current code point as a string and advance
-			// ECMAScript string iteration yields code points, not UTF-16 code units
-			// Check for surrogate pairs and combine them into a single code point
-			c := utf16Units[currentIndex]
-			var codeUnits []uint16
-
-			// Check if this is a high surrogate (0xD800-0xDBFF)
-			if c >= 0xD800 && c <= 0xDBFF && currentIndex+1 < len(utf16Units) {
-				// Check if next is a low surrogate (0xDC00-0xDFFF)
-				low := utf16Units[currentIndex+1]
-				if low >= 0xDC00 && low <= 0xDFFF {
-					// Valid surrogate pair - yield both as a single code point
-					codeUnits = []uint16{c, low}
-					currentIndex += 2 // Advance past both surrogates
-				} else {
-					// Lone high surrogate - yield as-is (use WTF-8 encoding)
-					codeUnits = []uint16{c}
-					currentIndex++
-				}
-			} else {
-				// Regular BMP character or lone low surrogate
-				// Use WTF-8 encoding to preserve lone surrogates
-				codeUnits = []uint16{c}
-				currentIndex++
-			}
-
-			// Convert UTF-16 code units back to a Go string (preserves surrogates via WTF-8)
-			result.SetOwnNonEnumerable("value", vm.NewString(vm.UTF16ToString(codeUnits)))
-			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
-		}
-
-		return vm.NewValueFromPlainObject(result), nil
-	}))
+	// Iterate by UTF-16 code units, yielding code points (surrogate-pair
+	// aware, lone surrogates preserved via WTF-8). The step logic lives in
+	// BuiltinIterState.Step, shared with the VM's for-of fast path.
+	state := &vm.BuiltinIterState{Kind: vm.IterKindString, Str: vm.StringToUTF16(str)}
+	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	return vm.NewValueFromPlainObject(iterator)
 }

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -144,7 +144,7 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 
 	// 6a. Fast-path probe (sync loops only): if the cached next method is the
 	// built-in array iterator's, each iteration can step the array directly
-	// (OpArrayIterNext) with no call and no {value, done} allocation. Checked
+	// (OpFastIterNext) with no call and no {value, done} allocation. Checked
 	// once per loop - next is cached in a register above, matching the spec's
 	// IteratorRecord.[[NextMethod]], so a mid-loop replacement of next is
 	// unobservable on the generic path too.
@@ -193,7 +193,7 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	fastToBodyJump := -1
 	if fastFlagReg != BadRegister {
 		toGenericJump := c.emitPlaceholderJump(vm.OpJumpIfFalse, fastFlagReg, node.Token.Line)
-		c.emitOpCode(vm.OpArrayIterNext, node.Token.Line)
+		c.emitOpCode(vm.OpFastIterNext, node.Token.Line)
 		c.emitByte(byte(valueReg))
 		c.emitByte(byte(doneReg))
 		c.emitByte(byte(nextMethodReg))

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -142,6 +142,21 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	nextConstIdx := c.chunk.AddConstant(vm.String("next"))
 	c.emitGetProp(nextMethodReg, iteratorObjReg, nextConstIdx, node.Token.Line)
 
+	// 6a. Fast-path probe (sync loops only): if the cached next method is the
+	// built-in array iterator's, each iteration can step the array directly
+	// (OpArrayIterNext) with no call and no {value, done} allocation. Checked
+	// once per loop - next is cached in a register above, matching the spec's
+	// IteratorRecord.[[NextMethod]], so a mid-loop replacement of next is
+	// unobservable on the generic path too.
+	fastFlagReg := BadRegister
+	if !node.IsAsync {
+		fastFlagReg = c.regAlloc.Alloc()
+		tempRegs = append(tempRegs, fastFlagReg)
+		c.emitOpCode(vm.OpIterFastCheck, node.Token.Line)
+		c.emitByte(byte(fastFlagReg))
+		c.emitByte(byte(nextMethodReg))
+	}
+
 	// Per ECMAScript spec, initialize completion value V = undefined
 	c.emitLoadUndefined(hint, node.Token.Line)
 
@@ -160,9 +175,38 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	}
 	c.loopContextStack = append(c.loopContextStack, loopContext)
 
-	// 8. Call iterator.next() to get {value, done} (or Promise<{value, done}> for async)
+	// 8. Produce {value, done} for this iteration. The fast path steps the
+	// array iterator in place (no call, no result object); the generic path
+	// calls next() and reads .done/.value exactly as before. Both paths
+	// converge with doneReg and valueReg populated. Registers are allocated
+	// up front so the two emission paths share them.
 	resultReg := c.regAlloc.Alloc()
 	tempRegs = append(tempRegs, resultReg)
+	doneReg := c.regAlloc.Alloc()
+	tempRegs = append(tempRegs, doneReg)
+	notDoneReg := c.regAlloc.Alloc()
+	tempRegs = append(tempRegs, notDoneReg)
+	valueReg := c.regAlloc.Alloc()
+	tempRegs = append(tempRegs, valueReg)
+
+	fastExitJump := -1
+	fastToBodyJump := -1
+	if fastFlagReg != BadRegister {
+		toGenericJump := c.emitPlaceholderJump(vm.OpJumpIfFalse, fastFlagReg, node.Token.Line)
+		c.emitOpCode(vm.OpArrayIterNext, node.Token.Line)
+		c.emitByte(byte(valueReg))
+		c.emitByte(byte(doneReg))
+		c.emitByte(byte(nextMethodReg))
+		c.emitOpCode(vm.OpNot, node.Token.Line)
+		c.emitByte(byte(notDoneReg))
+		c.emitByte(byte(doneReg))
+		fastExitJump = c.emitPlaceholderJump(vm.OpJumpIfFalse, notDoneReg, node.Token.Line)
+		fastToBodyJump = c.emitPlaceholderJump(vm.OpJump, 0, node.Token.Line)
+		c.patchJump(toGenericJump) // generic next-step starts here
+	}
+
+	// Generic path: call iterator.next() to get {value, done} (or
+	// Promise<{value, done}> for async)
 	c.emitCallMethod(resultReg, nextMethodReg, iteratorObjReg, 0, node.Token.Line)
 
 	// 8a. For async iterators, await the promise
@@ -181,14 +225,10 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	c.emitByte(byte(resultReg))
 
 	// 9. Get result.done
-	doneReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, doneReg)
 	doneConstIdx := c.chunk.AddConstant(vm.String("done"))
 	c.emitGetProp(doneReg, resultReg, doneConstIdx, node.Token.Line)
 
 	// 10. Negate done to check if NOT done (continue looping)
-	notDoneReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, notDoneReg)
 	c.emitOpCode(vm.OpNot, node.Token.Line)
 	c.emitByte(byte(notDoneReg))
 	c.emitByte(byte(doneReg))
@@ -197,10 +237,13 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	exitJump := c.emitPlaceholderJump(vm.OpJumpIfFalse, notDoneReg, node.Token.Line)
 
 	// 12. Get result.value
-	valueReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, valueReg)
 	valueConstIdx := c.chunk.AddConstant(vm.String("value"))
 	c.emitGetProp(valueReg, resultReg, valueConstIdx, node.Token.Line)
+
+	// Fast path re-enters here with valueReg/doneReg already set
+	if fastToBodyJump >= 0 {
+		c.patchJump(fastToBodyJump)
+	}
 
 	// 13. Assign value to loop variable
 	// Track per-iteration binding registers for let/const loop variables (not var - var is function-scoped)
@@ -401,8 +444,12 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	c.emitOpCode(vm.OpJump, node.Token.Line)
 	c.emitUint16(uint16(int16(backOffset)))
 
-	// 17. Patch exit jump - this is where loop exits normally when done=true
+	// 17. Patch exit jumps - this is where the loop exits normally when
+	// done=true (the fast path has its own exit jump to the same target)
 	c.patchJump(exitJump)
+	if fastExitJump >= 0 {
+		c.patchJump(fastExitJump)
+	}
 
 	// 18. Add exception handler for iterator cleanup when exception propagates out
 	// Per ECMAScript spec, when an exception propagates out of a for-of loop,

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -154,6 +154,7 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		tempRegs = append(tempRegs, fastFlagReg)
 		c.emitOpCode(vm.OpIterFastCheck, node.Token.Line)
 		c.emitByte(byte(fastFlagReg))
+		c.emitByte(byte(iteratorObjReg))
 		c.emitByte(byte(nextMethodReg))
 	}
 
@@ -196,6 +197,7 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		c.emitOpCode(vm.OpFastIterNext, node.Token.Line)
 		c.emitByte(byte(valueReg))
 		c.emitByte(byte(doneReg))
+		c.emitByte(byte(iteratorObjReg))
 		c.emitByte(byte(nextMethodReg))
 		c.emitOpCode(vm.OpNot, node.Token.Line)
 		c.emitByte(byte(notDoneReg))

--- a/pkg/vm/array_iterator.go
+++ b/pkg/vm/array_iterator.go
@@ -1,0 +1,17 @@
+package vm
+
+// ArrayIterState is the shared mutable state behind the built-in array
+// iterator's `next` method. The builtins package hangs it on the
+// NativeFunctionObject of the per-iterator next closure; the closure and the
+// OpArrayIterNext fast path in the dispatch loop both read and advance the
+// same Index, so mixing manual it.next() calls with a for-of over the same
+// iterator stays coherent.
+//
+// The for-of fast path is sound because the compiler caches the `next` method
+// in a register once per loop (matching the spec's IteratorRecord.[[NextMethod]]
+// caching): OpIterFastCheck inspects that cached value once, and a replaced or
+// user-defined next simply fails the check and takes the generic call path.
+type ArrayIterState struct {
+	Arr   *ArrayObject
+	Index int
+}

--- a/pkg/vm/array_iterator.go
+++ b/pkg/vm/array_iterator.go
@@ -1,17 +1,146 @@
 package vm
 
-// ArrayIterState is the shared mutable state behind the built-in array
-// iterator's `next` method. The builtins package hangs it on the
+import "strconv"
+
+// BuiltinIterState is the shared mutable state behind the built-in
+// closure-based iterators (array values/keys/entries, array-likes,
+// arguments, string). The builtins package hangs it on the
 // NativeFunctionObject of the per-iterator next closure; the closure and the
-// OpArrayIterNext fast path in the dispatch loop both read and advance the
-// same Index, so mixing manual it.next() calls with a for-of over the same
+// OpFastIterNext fast path in the dispatch loop both step the same state via
+// Step(), so mixing manual it.next() calls with a for-of over the same
 // iterator stays coherent.
 //
 // The for-of fast path is sound because the compiler caches the `next` method
 // in a register once per loop (matching the spec's IteratorRecord.[[NextMethod]]
 // caching): OpIterFastCheck inspects that cached value once, and a replaced or
 // user-defined next simply fails the check and takes the generic call path.
-type ArrayIterState struct {
-	Arr   *ArrayObject
+type BuiltinIterState struct {
+	Kind  IterKind
 	Index int
+
+	Arr  *ArrayObject     // IterKindArrayValues/Keys/Entries when the source is a real array
+	Args *ArgumentsObject // IterKindArguments
+	Like *PlainObject     // array-like source for Keys/Entries/LikeValues (may be nil -> length 0)
+	Str  []uint16         // IterKindString: UTF-16 code units of the iterated string
+}
+
+// IterKind selects what Step yields per iteration.
+type IterKind uint8
+
+const (
+	IterKindArrayValues IterKind = iota // Arr.Get(i)
+	IterKindArrayKeys                   // Number(i) over Arr or Like
+	IterKindArrayEntries                // [i, value] pair over Arr or Like
+	IterKindArguments                   // Args.Get(i)
+	IterKindLikeValues                  // Like[i] via GetOwn
+	IterKindString                      // code point (surrogate-pair aware) at UTF-16 index
+)
+
+// likeLength reads the array-like's current length the same way the original
+// closures did: GetOwn("length") if numeric, else 0.
+func (st *BuiltinIterState) likeLength() int {
+	if st.Like == nil {
+		return 0
+	}
+	if lenVal, ok := st.Like.GetOwn("length"); ok && lenVal.IsNumber() {
+		return int(lenVal.ToFloat())
+	}
+	return 0
+}
+
+// Step advances the iterator by one element and returns (value, done).
+// Length/content are re-read from the source every step, so growth,
+// truncation, and hole normalization behave exactly like the closures this
+// replaces. Called from both the native next closure (which wraps the pair
+// in a spec {value, done} object) and the OpFastIterNext opcode (which lands
+// value and done directly in registers).
+func (st *BuiltinIterState) Step() (Value, bool) {
+	switch st.Kind {
+	case IterKindArrayValues:
+		if st.Index >= st.Arr.Length() {
+			return Undefined, true
+		}
+		v := st.Arr.Get(st.Index)
+		st.Index++
+		return v, false
+
+	case IterKindArguments:
+		if st.Index >= st.Args.Length() {
+			return Undefined, true
+		}
+		v := st.Args.Get(st.Index)
+		st.Index++
+		return v, false
+
+	case IterKindArrayKeys:
+		length := 0
+		if st.Arr != nil {
+			length = st.Arr.Length()
+		} else {
+			length = st.likeLength()
+		}
+		if st.Index >= length {
+			return Undefined, true
+		}
+		v := Number(float64(st.Index))
+		st.Index++
+		return v, false
+
+	case IterKindArrayEntries:
+		length := 0
+		if st.Arr != nil {
+			length = st.Arr.Length()
+		} else {
+			length = st.likeLength()
+		}
+		if st.Index >= length {
+			return Undefined, true
+		}
+		var elem Value = Undefined
+		if st.Arr != nil {
+			elem = st.Arr.Get(st.Index)
+		} else if st.Like != nil {
+			if v, ok := st.Like.GetOwn(strconv.Itoa(st.Index)); ok {
+				elem = v
+			}
+		}
+		pair := NewArray()
+		pairArr := pair.AsArray()
+		pairArr.Append(Number(float64(st.Index)))
+		pairArr.Append(elem)
+		st.Index++
+		return pair, false
+
+	case IterKindLikeValues:
+		if st.Index >= st.likeLength() {
+			return Undefined, true
+		}
+		var v Value = Undefined
+		if st.Like != nil {
+			if pv, ok := st.Like.GetOwn(strconv.Itoa(st.Index)); ok {
+				v = pv
+			}
+		}
+		st.Index++
+		return v, false
+
+	case IterKindString:
+		if st.Index >= len(st.Str) {
+			return Undefined, true
+		}
+		// ECMAScript string iteration yields code points: combine a valid
+		// surrogate pair into one result, pass lone surrogates through
+		// (UTF16ToString preserves them via WTF-8).
+		c := st.Str[st.Index]
+		n := 1
+		if c >= 0xD800 && c <= 0xDBFF && st.Index+1 < len(st.Str) {
+			if low := st.Str[st.Index+1]; low >= 0xDC00 && low <= 0xDFFF {
+				n = 2
+			}
+		}
+		v := NewString(UTF16ToString(st.Str[st.Index : st.Index+n]))
+		st.Index += n
+		return v, false
+	}
+	return Undefined, true
 }

--- a/pkg/vm/array_iterator.go
+++ b/pkg/vm/array_iterator.go
@@ -15,13 +15,16 @@ import "strconv"
 // caching): OpIterFastCheck inspects that cached value once, and a replaced or
 // user-defined next simply fails the check and takes the generic call path.
 type BuiltinIterState struct {
-	Kind  IterKind
-	Index int
+	Kind      IterKind
+	Index     int
+	Exhausted bool // Map/Set kinds: sticky done flag (spec [[Exhausted]])
 
 	Arr  *ArrayObject     // IterKindArrayValues/Keys/Entries when the source is a real array
 	Args *ArgumentsObject // IterKindArguments
 	Like *PlainObject     // array-like source for Keys/Entries/LikeValues (may be nil -> length 0)
 	Str  []uint16         // IterKindString: UTF-16 code units of the iterated string
+	M    *MapObject       // IterKindMapKeys/Values/Entries
+	S    *SetObject       // IterKindSetValues/Entries
 }
 
 // IterKind selects what Step yields per iteration.
@@ -34,7 +37,53 @@ const (
 	IterKindArguments                   // Args.Get(i)
 	IterKindLikeValues                  // Like[i] via GetOwn
 	IterKindString                      // code point (surrogate-pair aware) at UTF-16 index
+	IterKindMapKeys                     // M key at insertion-order index (tombstones skipped)
+	IterKindMapValues                   // M value at insertion-order index
+	IterKindMapEntries                  // [k, v] pair
+	IterKindSetValues                   // S value at insertion-order index (keys() aliases this)
+	IterKindSetEntries                  // [v, v] pair
+	// IterKindStateOnIterator marks the SHARED %MapIteratorPrototype%.next /
+	// %SetIteratorPrototype%.next natives: their per-iterator state lives on
+	// the iterator PlainObject (InternalIterState), not on the next closure.
+	// This sentinel state must never be stepped itself - the fast path
+	// resolves the real state from the iterator register instead.
+	IterKindStateOnIterator
 )
+
+// IsMapKind/IsSetKind report the collection family, used for the prototype
+// next brand checks (a Map next called on a Set iterator must throw).
+func (k IterKind) IsMapKind() bool {
+	return k == IterKindMapKeys || k == IterKindMapValues || k == IterKindMapEntries
+}
+func (k IterKind) IsSetKind() bool {
+	return k == IterKindSetValues || k == IterKindSetEntries
+}
+
+// resolveFastIterState returns the steppable iterator state for the for-of
+// fast path, or nil when the loop must take the generic call path. State
+// normally hangs off the next method's closure (array/string/arguments
+// family); for Map/Set iterators the shared prototype next carries the
+// IterKindStateOnIterator sentinel and the per-iterator state lives on the
+// iterator object itself.
+func resolveFastIterState(iterVal, nextVal Value) *BuiltinIterState {
+	if nextVal.typ != TypeNativeFunction {
+		return nil
+	}
+	nf := nextVal.AsNativeFunction()
+	if nf == nil || nf.IterState == nil {
+		return nil
+	}
+	st := nf.IterState
+	if st.Kind != IterKindStateOnIterator {
+		return st
+	}
+	if iterVal.typ == TypeObject {
+		if po := AsPlainObject(iterVal); po != nil {
+			return po.internalIterState
+		}
+	}
+	return nil
+}
 
 // likeLength reads the array-like's current length the same way the original
 // closures did: GetOwn("length") if numeric, else 0.
@@ -141,6 +190,57 @@ func (st *BuiltinIterState) Step() (Value, bool) {
 		v := NewString(UTF16ToString(st.Str[st.Index : st.Index+n]))
 		st.Index += n
 		return v, false
+
+	case IterKindMapKeys, IterKindMapValues, IterKindMapEntries:
+		// Live iteration over insertion order: entries deleted during
+		// iteration are skipped (tombstones), entries added during
+		// iteration are visited. Matches the previous slot-property-based
+		// %MapIteratorPrototype%.next exactly, including advancing Index
+		// past tombstones and the sticky Exhausted flag.
+		if st.Exhausted {
+			return Undefined, true
+		}
+		for st.Index < st.M.OrderLen() {
+			key, value, exists := st.M.GetEntryAt(st.Index)
+			st.Index++
+			if exists {
+				switch st.Kind {
+				case IterKindMapKeys:
+					return key, false
+				case IterKindMapValues:
+					return value, false
+				default: // entries
+					entry := NewArray()
+					entryArr := entry.AsArray()
+					entryArr.Append(key)
+					entryArr.Append(value)
+					return entry, false
+				}
+			}
+		}
+		st.Exhausted = true
+		return Undefined, true
+
+	case IterKindSetValues, IterKindSetEntries:
+		if st.Exhausted {
+			return Undefined, true
+		}
+		for st.Index < st.S.OrderLen() {
+			value, exists := st.S.GetValueAt(st.Index)
+			st.Index++
+			if exists {
+				if st.Kind == IterKindSetEntries {
+					entry := NewArray()
+					entryArr := entry.AsArray()
+					entryArr.Append(value)
+					entryArr.Append(value)
+					return entry, false
+				}
+				return value, false
+			}
+		}
+		st.Exhausted = true
+		return Undefined, true
 	}
 	return Undefined, true
 }

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -194,6 +194,12 @@ const (
 	// Dst ValReg: n = ToNumeric(ValReg); Dst = n; ValReg = n-1 (postfix old value)
 	OpDecPost OpCode = 171
 
+	// --- Iterator fast path (for-of over plain arrays) ---
+	// Rx Ry: Rx = true if Ry is the built-in array-iterator next method (carries ArrayIterState)
+	OpIterFastCheck OpCode = 172
+	// Rx Ry Rz: step the array iterator behind next-method Rz: Rx = value, Ry = done. No call, no result object.
+	OpArrayIterNext OpCode = 173
+
 	// --- NEW: Global Variable Operations ---
 	OpGetGlobal     OpCode = 46 // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
 	OpSetGlobal     OpCode = 47 // GlobalIdx(16bit) Ry: Globals[GlobalIdx] = Ry (direct indexed access)
@@ -351,6 +357,10 @@ func (op OpCode) String() string {
 		return "OpDecPre"
 	case OpDecPost:
 		return "OpDecPost"
+	case OpIterFastCheck:
+		return "OpIterFastCheck"
+	case OpArrayIterNext:
+		return "OpArrayIterNext"
 	case OpEqual:
 		return "OpEqual"
 	case OpNotEqual:
@@ -982,7 +992,7 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 	case OpMakeAddInitializer, OpRunInitializers:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx Ry
 	case OpNegate, OpNot, OpTypeof, OpToNumber, OpToNumeric, OpLoadNumericOne, OpBitwiseNot, OpGetLength, OpIsNull, OpIsUndefined, OpIsNullish, OpIteratorCleanupAbruptIfNotDone,
-		OpIncPre, OpIncPost, OpDecPre, OpDecPost:
+		OpIncPre, OpIncPost, OpDecPre, OpDecPost, OpIterFastCheck:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry
 	case OpMove:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry
@@ -990,7 +1000,8 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 		OpRemainder, OpExponent,
 		OpIn, OpInstanceof,
 		OpBitwiseAnd, OpBitwiseOr, OpBitwiseXor,
-		OpShiftLeft, OpShiftRight, OpUnsignedShiftRight:
+		OpShiftLeft, OpShiftRight, OpUnsignedShiftRight,
+		OpArrayIterNext:
 		return c.registerRegisterRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry, Rz
 
 	case OpCall, OpTailCall:

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -197,8 +197,8 @@ const (
 	// --- Iterator fast path (for-of over plain arrays) ---
 	// Rx Ry: Rx = true if Ry is the built-in array-iterator next method (carries ArrayIterState)
 	OpIterFastCheck OpCode = 172
-	// Rx Ry Rz: step the array iterator behind next-method Rz: Rx = value, Ry = done. No call, no result object.
-	OpArrayIterNext OpCode = 173
+	// Rx Ry Rz: step the built-in iterator behind next-method Rz: Rx = value, Ry = done. No call, no result object.
+	OpFastIterNext OpCode = 173
 
 	// --- NEW: Global Variable Operations ---
 	OpGetGlobal     OpCode = 46 // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
@@ -359,8 +359,8 @@ func (op OpCode) String() string {
 		return "OpDecPost"
 	case OpIterFastCheck:
 		return "OpIterFastCheck"
-	case OpArrayIterNext:
-		return "OpArrayIterNext"
+	case OpFastIterNext:
+		return "OpFastIterNext"
 	case OpEqual:
 		return "OpEqual"
 	case OpNotEqual:
@@ -1001,7 +1001,7 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 		OpIn, OpInstanceof,
 		OpBitwiseAnd, OpBitwiseOr, OpBitwiseXor,
 		OpShiftLeft, OpShiftRight, OpUnsignedShiftRight,
-		OpArrayIterNext:
+		OpFastIterNext:
 		return c.registerRegisterRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry, Rz
 
 	case OpCall, OpTailCall:

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -992,7 +992,7 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 	case OpMakeAddInitializer, OpRunInitializers:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx Ry
 	case OpNegate, OpNot, OpTypeof, OpToNumber, OpToNumeric, OpLoadNumericOne, OpBitwiseNot, OpGetLength, OpIsNull, OpIsUndefined, OpIsNullish, OpIteratorCleanupAbruptIfNotDone,
-		OpIncPre, OpIncPost, OpDecPre, OpDecPost, OpIterFastCheck:
+		OpIncPre, OpIncPost, OpDecPre, OpDecPost:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry
 	case OpMove:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry
@@ -1001,8 +1001,11 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 		OpIn, OpInstanceof,
 		OpBitwiseAnd, OpBitwiseOr, OpBitwiseXor,
 		OpShiftLeft, OpShiftRight, OpUnsignedShiftRight,
-		OpFastIterNext:
+		OpIterFastCheck:
 		return c.registerRegisterRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry, Rz
+
+	case OpFastIterNext:
+		return c.registerRegisterRegisterRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry, Rz, Rw
 
 	case OpCall, OpTailCall:
 		return c.callInstruction(builder, instruction.String(), offset)
@@ -1439,6 +1442,24 @@ func (c *Chunk) registerRegisterRegisterInstruction(builder *strings.Builder, na
 	regZ := c.Code[offset+3]
 	builder.WriteString(fmt.Sprintf("%-16s R%d, R%d, R%d\n", name, regX, regY, regZ))
 	return offset + 4 // Opcode + 3 register bytes
+}
+
+// registerRegisterRegisterRegisterInstruction handles OpCode Rx, Ry, Rz, Rw
+func (c *Chunk) registerRegisterRegisterRegisterInstruction(builder *strings.Builder, name string, offset int) int {
+	if offset+4 >= len(c.Code) {
+		builder.WriteString(fmt.Sprintf("%s (missing register operands)\n", name))
+		next := offset + 5
+		if next > len(c.Code) {
+			next = len(c.Code)
+		}
+		return next
+	}
+	regX := c.Code[offset+1]
+	regY := c.Code[offset+2]
+	regZ := c.Code[offset+3]
+	regW := c.Code[offset+4]
+	builder.WriteString(fmt.Sprintf("%-16s R%d, R%d, R%d, R%d\n", name, regX, regY, regZ, regW))
+	return offset + 5 // Opcode + 4 register bytes
 }
 
 // registerConstantInstruction handles OpCode Rx, ConstIdx

--- a/pkg/vm/function.go
+++ b/pkg/vm/function.go
@@ -87,6 +87,12 @@ type NativeFunctionObject struct {
 	HomeRealm     *Realm       // [[Realm]] - the realm where this function was created
 	DeletedName   bool         // True if the 'name' property has been deleted
 	DeletedLength bool         // True if the 'length' property has been deleted
+
+	// ArrayIterState is non-nil only on the built-in array iterator's `next`
+	// closure. It lets the for-of fast path (OpIterFastCheck/OpArrayIterNext)
+	// recognize the intrinsic iterator and step it without a call or result
+	// object, while sharing the same index state with manual next() calls.
+	ArrayIterState *ArrayIterState
 }
 
 // BoundNativeFunctionObject represents a native function bound to a 'this' value

--- a/pkg/vm/function.go
+++ b/pkg/vm/function.go
@@ -88,11 +88,12 @@ type NativeFunctionObject struct {
 	DeletedName   bool         // True if the 'name' property has been deleted
 	DeletedLength bool         // True if the 'length' property has been deleted
 
-	// ArrayIterState is non-nil only on the built-in array iterator's `next`
-	// closure. It lets the for-of fast path (OpIterFastCheck/OpArrayIterNext)
+	// IterState is non-nil only on the built-in closure-based iterators'
+	// `next` methods (array values/keys/entries, array-likes, arguments,
+	// string). It lets the for-of fast path (OpIterFastCheck/OpFastIterNext)
 	// recognize the intrinsic iterator and step it without a call or result
 	// object, while sharing the same index state with manual next() calls.
-	ArrayIterState *ArrayIterState
+	IterState *BuiltinIterState
 }
 
 // BoundNativeFunctionObject represents a native function bound to a 'this' value

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -195,6 +195,25 @@ type PlainObject struct {
 	// Immutable prototype flag - when true, [[SetPrototypeOf]] only succeeds if
 	// the new value is SameValue as current prototype (ECMAScript 9.4.7)
 	immutablePrototype bool
+	// Internal iterator state for Map/Set iterator objects (spec internal
+	// slots [[IteratedMap]]/[[MapNextIndex]]/etc.). Nil for ordinary objects.
+	// Kept off the property storage so it is invisible to user code (matching
+	// spec internal slots) and reachable in O(1) by both the shared
+	// %MapIteratorPrototype%/%SetIteratorPrototype% next natives and the
+	// VM's for-of fast path.
+	internalIterState *BuiltinIterState
+}
+
+// InternalIterState returns the Map/Set iterator internal state, or nil for
+// ordinary objects. Non-nil doubles as the spec's internal-slot brand check.
+func (o *PlainObject) InternalIterState() *BuiltinIterState {
+	return o.internalIterState
+}
+
+// SetInternalIterState attaches Map/Set iterator internal state; called by
+// the builtins when constructing iterator objects.
+func (o *PlainObject) SetInternalIterState(st *BuiltinIterState) {
+	o.internalIterState = st
 }
 
 // lookupStringField returns the index of the string-keyed field with the given

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1657,54 +1657,48 @@ startExecution:
 		case OpIterFastCheck:
 			// Emitted once per for-of loop, after the compiler has cached the
 			// iterator's next method in a register (matching the spec's
-			// IteratorRecord.[[NextMethod]] caching). True only for the
-			// built-in array iterator's next closure, which carries its
-			// shared ArrayIterState; anything else (user iterators,
-			// generators, replaced next) takes the generic call path.
+			// IteratorRecord.[[NextMethod]] caching). True only for built-in
+			// closure-based iterators' next methods, which carry a shared
+			// BuiltinIterState; anything else (user iterators, generators,
+			// replaced next) takes the generic call path.
 			destReg := code[ip]
 			nextReg := code[ip+1]
 			ip += 2
 			fast := false
 			if nv := registers[nextReg]; nv.typ == TypeNativeFunction {
-				if nf := nv.AsNativeFunction(); nf != nil && nf.ArrayIterState != nil && nf.ArrayIterState.Arr != nil {
+				if nf := nv.AsNativeFunction(); nf != nil && nf.IterState != nil {
 					fast = true
 				}
 			}
 			registers[destReg] = BooleanValue(fast)
 
-		case OpArrayIterNext:
-			// Fast for-of step: read the next array element directly from the
-			// iterator state hung off the cached next method - no method call,
-			// no {value, done} result object. Length is re-read every step so
-			// growth/truncation during iteration behaves exactly like the
-			// native next closure it bypasses (both use Arr.Length()/Get,
-			// including hole normalization to undefined).
+		case OpFastIterNext:
+			// Fast for-of step: advance the built-in iterator state hung off
+			// the cached next method - no method call, no {value, done}
+			// result object. Step re-reads source length/content each
+			// iteration, so mutation during iteration behaves exactly like
+			// the native next closure it bypasses (both call the same Step).
 			valueReg := code[ip]
 			doneReg := code[ip+1]
 			nextReg := code[ip+2]
 			ip += 3
 			nv := registers[nextReg]
-			var st *ArrayIterState
+			var st *BuiltinIterState
 			if nv.typ == TypeNativeFunction {
 				if nf := nv.AsNativeFunction(); nf != nil {
-					st = nf.ArrayIterState
+					st = nf.IterState
 				}
 			}
 			if st == nil {
 				// Unreachable when emitted behind OpIterFastCheck; fail loudly
 				// rather than silently terminating the loop.
 				frame.ip = ip
-				status := vm.runtimeError("OpArrayIterNext on non-array-iterator next method")
+				status := vm.runtimeError("OpFastIterNext on a next method without iterator state")
 				return status, Undefined
 			}
-			if st.Index >= st.Arr.Length() {
-				registers[valueReg] = Undefined
-				registers[doneReg] = BooleanValue(true)
-			} else {
-				registers[valueReg] = st.Arr.Get(st.Index)
-				st.Index++
-				registers[doneReg] = BooleanValue(false)
-			}
+			v, done := st.Step()
+			registers[valueReg] = v
+			registers[doneReg] = BooleanValue(done)
 
 		case OpTypeof:
 			destReg := code[ip]

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1658,42 +1658,34 @@ startExecution:
 			// Emitted once per for-of loop, after the compiler has cached the
 			// iterator's next method in a register (matching the spec's
 			// IteratorRecord.[[NextMethod]] caching). True only for built-in
-			// closure-based iterators' next methods, which carry a shared
-			// BuiltinIterState; anything else (user iterators, generators,
-			// replaced next) takes the generic call path.
+			// iterators the VM can step directly: closure-based ones carry
+			// state on the next method itself; Map/Set iterators carry it on
+			// the iterator object behind the shared prototype next. Anything
+			// else (user iterators, generators, replaced next) takes the
+			// generic call path.
 			destReg := code[ip]
-			nextReg := code[ip+1]
-			ip += 2
-			fast := false
-			if nv := registers[nextReg]; nv.typ == TypeNativeFunction {
-				if nf := nv.AsNativeFunction(); nf != nil && nf.IterState != nil {
-					fast = true
-				}
-			}
-			registers[destReg] = BooleanValue(fast)
-
-		case OpFastIterNext:
-			// Fast for-of step: advance the built-in iterator state hung off
-			// the cached next method - no method call, no {value, done}
-			// result object. Step re-reads source length/content each
-			// iteration, so mutation during iteration behaves exactly like
-			// the native next closure it bypasses (both call the same Step).
-			valueReg := code[ip]
-			doneReg := code[ip+1]
+			iterReg := code[ip+1]
 			nextReg := code[ip+2]
 			ip += 3
-			nv := registers[nextReg]
-			var st *BuiltinIterState
-			if nv.typ == TypeNativeFunction {
-				if nf := nv.AsNativeFunction(); nf != nil {
-					st = nf.IterState
-				}
-			}
+			registers[destReg] = BooleanValue(resolveFastIterState(registers[iterReg], registers[nextReg]) != nil)
+
+		case OpFastIterNext:
+			// Fast for-of step: advance the built-in iterator state - no
+			// method call, no {value, done} result object. Step re-reads
+			// source length/content each iteration, so mutation during
+			// iteration behaves exactly like the native next it bypasses
+			// (both call the same Step).
+			valueReg := code[ip]
+			doneReg := code[ip+1]
+			iterReg := code[ip+2]
+			nextReg := code[ip+3]
+			ip += 4
+			st := resolveFastIterState(registers[iterReg], registers[nextReg])
 			if st == nil {
 				// Unreachable when emitted behind OpIterFastCheck; fail loudly
 				// rather than silently terminating the loop.
 				frame.ip = ip
-				status := vm.runtimeError("OpFastIterNext on a next method without iterator state")
+				status := vm.runtimeError("OpFastIterNext without steppable iterator state")
 				return status, Undefined
 			}
 			v, done := st.Step()

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1654,6 +1654,58 @@ startExecution:
 			// In many languages, ! evaluates truthiness
 			registers[destReg] = BooleanValue(isFalsey(srcVal)) // Use local Bool
 
+		case OpIterFastCheck:
+			// Emitted once per for-of loop, after the compiler has cached the
+			// iterator's next method in a register (matching the spec's
+			// IteratorRecord.[[NextMethod]] caching). True only for the
+			// built-in array iterator's next closure, which carries its
+			// shared ArrayIterState; anything else (user iterators,
+			// generators, replaced next) takes the generic call path.
+			destReg := code[ip]
+			nextReg := code[ip+1]
+			ip += 2
+			fast := false
+			if nv := registers[nextReg]; nv.typ == TypeNativeFunction {
+				if nf := nv.AsNativeFunction(); nf != nil && nf.ArrayIterState != nil && nf.ArrayIterState.Arr != nil {
+					fast = true
+				}
+			}
+			registers[destReg] = BooleanValue(fast)
+
+		case OpArrayIterNext:
+			// Fast for-of step: read the next array element directly from the
+			// iterator state hung off the cached next method - no method call,
+			// no {value, done} result object. Length is re-read every step so
+			// growth/truncation during iteration behaves exactly like the
+			// native next closure it bypasses (both use Arr.Length()/Get,
+			// including hole normalization to undefined).
+			valueReg := code[ip]
+			doneReg := code[ip+1]
+			nextReg := code[ip+2]
+			ip += 3
+			nv := registers[nextReg]
+			var st *ArrayIterState
+			if nv.typ == TypeNativeFunction {
+				if nf := nv.AsNativeFunction(); nf != nil {
+					st = nf.ArrayIterState
+				}
+			}
+			if st == nil {
+				// Unreachable when emitted behind OpIterFastCheck; fail loudly
+				// rather than silently terminating the loop.
+				frame.ip = ip
+				status := vm.runtimeError("OpArrayIterNext on non-array-iterator next method")
+				return status, Undefined
+			}
+			if st.Index >= st.Arr.Length() {
+				registers[valueReg] = Undefined
+				registers[doneReg] = BooleanValue(true)
+			} else {
+				registers[valueReg] = st.Arr.Get(st.Index)
+				st.Index++
+				registers[doneReg] = BooleanValue(false)
+			}
+
 		case OpTypeof:
 			destReg := code[ip]
 			srcReg := code[ip+1]

--- a/tests/scripts/for_of_array_fast_path.ts
+++ b/tests/scripts/for_of_array_fast_path.ts
@@ -1,0 +1,41 @@
+// Exercises the for-of array fast path (OpIterFastCheck/OpArrayIterNext)
+// against the behaviors it must preserve: hole normalization, length re-read
+// on growth/truncation, index state shared with manual next() calls,
+// deopt to the generic path when next is replaced, and iterator reuse after
+// an early break (array iterators have no return method, so state persists).
+// expect: 1,undefined,3,g1,g2,g3,t1,t2,m20,m30,r99,r99,b1,c2,c3
+let log: any[] = [];
+
+const a: any[] = [1, , 3];
+for (const x of a) log.push(String(x));
+
+const b: any[] = [1];
+for (const x of b) {
+  if (x < 3) b.push(x + 1);
+  log.push("g" + x);
+}
+
+const c: any[] = [1, 2, 3, 4];
+for (const x of c) {
+  log.push("t" + x);
+  if (x === 1) c.length = 2;
+}
+
+const it: any = [10, 20, 30][Symbol.iterator]();
+it.next();
+for (const x of it) log.push("m" + x);
+
+const it2: any = [1, 2][Symbol.iterator]();
+let calls = 0;
+it2.next = () =>
+  calls++ < 2 ? { value: 99, done: false } : { value: undefined, done: true };
+for (const x of it2) log.push("r" + x);
+
+const it3: any = [1, 2, 3][Symbol.iterator]();
+for (const x of it3) {
+  log.push("b" + x);
+  break;
+}
+for (const x of it3) log.push("c" + x);
+
+log.join(",");

--- a/tests/scripts/for_of_builtin_iterators.ts
+++ b/tests/scripts/for_of_builtin_iterators.ts
@@ -1,0 +1,48 @@
+// Exercises the generalized for-of fast path (BuiltinIterState kinds beyond
+// plain array values): string iteration by code point incl. surrogate pairs
+// and a lone surrogate, arguments objects, Array.prototype.keys/entries
+// (incl. destructuring), and manual next() interleaved with for-of on a
+// string iterator (shared index state).
+// expect: a,b,𝄞,c|2|args:x,y,z|keys:0,1,2|0=p,1=q|mix:c
+let out: any[] = [];
+
+// String: "ab" + U+1D11E (surrogate pair) + "c"
+let chars: any[] = [];
+for (const ch of "ab\u{1D11E}c") chars.push(ch);
+out.push(chars.join(","));
+
+// Lone high surrogate iterates as a single unit
+let lone = 0;
+for (const ch of "\uD834x") lone++;
+out.push(String(lone));
+
+// Arguments object
+function collect(...unused: any[]) {
+  let got: any[] = [];
+  // the checker doesn't type `arguments` as iterable; the runtime does
+  const argsAny: any = arguments;
+  for (const a of argsAny) got.push(a);
+  return "args:" + got.join(",");
+}
+out.push(collect("x", "y", "z"));
+
+// keys()
+const arr: any[] = ["p", "q", "r"];
+let ks: any[] = [];
+for (const k of arr.keys()) ks.push(k);
+out.push("keys:" + ks.join(","));
+
+// entries() with destructuring
+let es: any[] = [];
+for (const [i, v] of ["p", "q"].entries()) es.push(i + "=" + v);
+out.push(es.join(","));
+
+// Manual next() shares state with for-of on a string iterator
+const sit: any = "abc"[Symbol.iterator]();
+sit.next(); // consume "a"
+sit.next(); // consume "b"
+let rest: any[] = [];
+for (const ch of sit) rest.push(ch);
+out.push("mix:" + rest.join(","));
+
+out.join("|");

--- a/tests/scripts/for_of_map_set_iterators.ts
+++ b/tests/scripts/for_of_map_set_iterators.ts
@@ -1,0 +1,81 @@
+// Exercises the Map/Set for-of fast path (internal iterator state on the
+// iterator object behind the shared prototype next): live iteration with
+// delete-during-iteration (tombstones skipped) and add-during-iteration
+// (visited), keys/values/entries kinds, manual next() sharing state with
+// for-of, and cross-brand next.call rejection.
+// expect: m:a=1,b=2,c=3|del:a,c|add:1,2,3|keys:a,b|vals:1,2|s:x,y,z|sdel:x,z|se:y=y|mix:b=2|brand:ok
+let out: any[] = [];
+
+// Map entries via for-of (Symbol.iterator === entries)
+const m = new Map<any, any>([["a", 1], ["b", 2], ["c", 3]]);
+let acc: any[] = [];
+for (const [k, v] of m) acc.push(k + "=" + v);
+out.push("m:" + acc.join(","));
+
+// Delete during iteration: "b" removed while visiting "a" -> skipped
+const m2 = new Map<any, any>([["a", 1], ["b", 2], ["c", 3]]);
+acc = [];
+for (const [k, v] of m2) {
+  acc.push(k);
+  if (k === "a") m2.delete("b");
+}
+out.push("del:" + acc.join(","));
+
+// Add during iteration: entries appended while iterating are visited
+const m3 = new Map<any, any>([[1, "x"]]);
+acc = [];
+for (const [k, v] of m3) {
+  acc.push(k);
+  if (k < 3) m3.set(k + 1, "y");
+}
+out.push("add:" + acc.join(","));
+
+// keys() and values()
+const m4 = new Map<any, any>([["a", 1], ["b", 2]]);
+acc = [];
+for (const k of m4.keys()) acc.push(k);
+out.push("keys:" + acc.join(","));
+acc = [];
+for (const v of m4.values()) acc.push(v);
+out.push("vals:" + acc.join(","));
+
+// Set values via for-of
+const s = new Set<any>(["x", "y", "z"]);
+acc = [];
+for (const v of s) acc.push(v);
+out.push("s:" + acc.join(","));
+
+// Set delete during iteration
+const s2 = new Set<any>(["x", "y", "z"]);
+acc = [];
+for (const v of s2) {
+  acc.push(v);
+  if (v === "x") s2.delete("y");
+}
+out.push("sdel:" + acc.join(","));
+
+// Set entries: [v, v] pairs
+const s3 = new Set<any>(["y"]);
+acc = [];
+for (const [a, b] of s3.entries()) acc.push(a + "=" + b);
+out.push("se:" + acc.join(","));
+
+// Manual next() shares state with for-of on a Map iterator
+const mit: any = new Map<any, any>([["a", 1], ["b", 2]]).entries();
+mit.next(); // consume ["a", 1]
+acc = [];
+for (const [k, v] of mit) acc.push(k + "=" + v);
+out.push("mix:" + acc.join(","));
+
+// Brand check: Map prototype next on a Set iterator must throw
+const setIter: any = new Set<any>([1]).values();
+const mapIter: any = new Map<any, any>().entries();
+let branded = "no-throw";
+try {
+  mapIter.next.call(setIter);
+} catch (e) {
+  branded = "ok";
+}
+out.push("brand:" + branded);
+
+out.join("|");


### PR DESCRIPTION
`for-of` over the built-in iterables spent a method call and a `{value, done}` allocation per element. When the loop's cached `next` is a recognized built-in iterator, step it directly with no call and no result object.

## What this does

- **Two opcodes** (`OpIterFastCheck` 172, `OpFastIterNext` 173). The compiler already caches the iterator's `next` in a register once per loop (matching the spec's `IteratorRecord.[[NextMethod]]` caching). `OpIterFastCheck` inspects that cached value once; `OpFastIterNext` advances the built-in iterator state in place. Anything unrecognized — a user iterator, a replaced `next` — fails the check and takes the unchanged generic call path.
- **Coverage** grows across the three commits: plain arrays first, then string / arguments / array-likes / `keys()` / `entries()` (via a shared `BuiltinIterState` with a per-kind `Step`), then Map / Set iterators.
- **Design point for review:** Map/Set iterators share a single `next` on their prototype, so per-iterator state can't ride the `next` closure the way the array family's does. It lives in a new `PlainObject.internalIterState` pointer (+8 bytes per object). Offsetting correctness win: those slots were previously *enumerable user-visible properties*; moving them into the struct makes them unobservable internal slots (spec-correct) and the brand check O(1).

`Step` re-reads the source length/content every iteration, so growth, truncation, and hole normalization during iteration behave exactly like the native `next` it bypasses (both call the same `Step`).

## Numbers

Local (M2): for-of over a plain array 4.1×, string iteration 2.4×, Set iteration 2.6×, Map for-of ~10% (destructuring-bound; see the destructuring PR). The `perf`-label same-runner A/B is the authoritative check.

## Verification

`TestScripts` green; `tests/scripts/for_of_array_fast_path.ts` and the builtin/Map-Set iterator scripts cover hole normalization, length re-read on growth/truncation, shared state with manual `next()`, deopt on replaced `next`, and reuse after early break. Test262 language 0 new failures (differential vs upstream/main control); targeted built-ins 0 new failures.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
