### PR TITLE
perf(vm): store primitive strings inline in Value

### DIFF
--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -151,11 +151,6 @@ func (vt ValueType) String() string {
 	}
 }
 
-type StringObject struct {
-	Object
-	value string
-}
-
 type SymbolObject struct {
 	Object
 	value          string
@@ -484,8 +479,21 @@ func NewBigInt(value *big.Int) Value {
 	return Value{typ: TypeBigInt, obj: unsafe.Pointer(&BigIntObject{value: value})}
 }
 
+// NewString stores the string's header (data pointer + length) directly in the
+// Value's obj/payload fields instead of boxing it in a heap-allocated
+// StringObject. The Go GC scans the unsafe.Pointer field, so the backing bytes
+// stay alive as long as the Value is reachable; AsString reconstructs the
+// string without copying via unsafe.String. The empty string stores a nil
+// pointer (unsafe.StringData("") is not guaranteed dereferenceable).
 func NewString(value string) Value {
-	return Value{typ: TypeString, obj: unsafe.Pointer(&StringObject{value: value})}
+	if len(value) == 0 {
+		return Value{typ: TypeString}
+	}
+	return Value{
+		typ:     TypeString,
+		payload: uint64(len(value)),
+		obj:     unsafe.Pointer(unsafe.StringData(value)),
+	}
 }
 
 func NewSymbol(value string) Value {
@@ -876,7 +884,10 @@ func (v Value) AsString() string {
 	if v.typ != TypeString {
 		panic("value is not a string")
 	}
-	return (*StringObject)(v.obj).value
+	if v.payload == 0 {
+		return ""
+	}
+	return unsafe.String((*byte)(v.obj), int(v.payload))
 }
 
 func (v Value) AsSymbol() string {
@@ -1044,7 +1055,7 @@ func (v Value) AsBoolean() bool {
 func (v Value) ToString() string {
 	switch v.typ {
 	case TypeString:
-		return (*StringObject)(v.obj).value
+		return v.AsString()
 	case TypeSymbol:
 		return fmt.Sprintf("Symbol(%s)", (*SymbolObject)(v.obj).value)
 	case TypeFloatNumber:


### PR DESCRIPTION
Primitive strings were boxed in a heap-allocated `StringObject{value string}` (its embedded `Object` is empty, so the box was just a 16-byte string header on the heap), with `Value.payload` unused.

## What this does

Store the string header directly: `obj` holds the backing pointer (via `unsafe.StringData`), `payload` holds the length. `AsString` reconstructs with `unsafe.String` — no copy, no indirection — and `NewString` no longer allocates. The empty string stores a nil pointer (`payload 0`). The GC scans the `unsafe.Pointer` field, so the backing stays live while the Value is reachable; retention matches the old box. `StringObject` is removed (the `new String()` wrapper is a separate `PlainObject` path, untouched). All primitive-string access already funnels through `NewString` / `AsString` / `ToString`, so the change is three sites in one file.

**Design point for review:** the `unsafe.StringData`/`unsafe.String` round-trip and the GC-liveness argument (the GC scans the `unsafe.Pointer` field, so the backing outlives the Value).

## Numbers

Local (M2): ~23% fewer GC cycles on a concat loop (13 → 10), ~7% wall-clock on string-creation-heavy code; strings built from an existing backing (substring, key materialization) now allocate nothing. The `perf`-label A/B is authoritative.

## Verification

`TestScripts` + unit tests green; vm tests under `-race` (checkptr) clean; a GOGC=1 20k-string stress kept 20000/20000 intact after aggressive GC; empty-string edge cases correct. Test262 language 0 new failures (differential vs upstream/main control); targeted string built-ins 0 new failures.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
