### PR TITLE
perf(vm): allocation-free Map/Set keys via a comparable struct

### DIFF
--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -291,10 +291,10 @@ type AsyncGeneratorObject GeneratorObject
 type MapObject struct {
 	Object
 	size       int
-	entries    map[string]Value // key -> value
-	keys       map[string]Value // key -> original key (for key iteration)
-	order      []string         // insertion order of keys (for deterministic iteration)
-	tombstones map[string]bool  // keys that were deleted but still in order (for live iteration)
+	entries    map[mapKey]Value // key -> value
+	keys       map[mapKey]Value // key -> original key (for key iteration)
+	order      []mapKey         // insertion order of keys (for deterministic iteration)
+	tombstones map[mapKey]bool  // keys that were deleted but still in order (for live iteration)
 	Properties *PlainObject     // User-defined properties on the Map object
 	prototype  Value            // Map prototype
 }
@@ -302,9 +302,9 @@ type MapObject struct {
 type SetObject struct {
 	Object
 	size       int
-	values     map[string]Value // key -> original value (for value iteration)
-	order      []string         // insertion order of values (for deterministic iteration)
-	tombstones map[string]bool  // values that were deleted but still in order (for live iteration)
+	values     map[mapKey]Value // key -> original value (for value iteration)
+	order      []mapKey         // insertion order of values (for deterministic iteration)
+	tombstones map[mapKey]bool  // values that were deleted but still in order (for live iteration)
 	Properties *PlainObject     // User-defined properties on the Set object
 	prototype  Value            // Set prototype
 }
@@ -604,8 +604,8 @@ func (a *ArrayObject) GetPrototype() Value {
 func NewMap() Value {
 	mapObj := &MapObject{
 		size:    0,
-		entries: make(map[string]Value),
-		keys:    make(map[string]Value),
+		entries: make(map[mapKey]Value),
+		keys:    make(map[mapKey]Value),
 	}
 	return Value{typ: TypeMap, obj: unsafe.Pointer(mapObj)}
 }
@@ -619,7 +619,7 @@ func (m *MapObject) GetPrototype() Value { return m.prototype }
 func NewSet() Value {
 	setObj := &SetObject{
 		size:   0,
-		values: make(map[string]Value),
+		values: make(map[mapKey]Value),
 	}
 	return Value{typ: TypeSet, obj: unsafe.Pointer(setObj)}
 }
@@ -708,33 +708,67 @@ func (wr *WeakRefObject) Deref() Value {
 	return Value{typ: wr.targetType, obj: unsafe.Pointer(p)}
 }
 
-// hashKey creates a unique string key for any JavaScript value
-// Uses SameValueZero equality (NaN === NaN, +0 === -0)
-func hashKey(v Value) string {
+// mapKeyKind discriminates the flavor of a Map/Set key so keys of different
+// types never collide even when their payloads coincide. mkDead (the zero
+// value) matches no real key and marks a revived entry's stale order slot.
+type mapKeyKind uint8
+
+const (
+	mkDead mapKeyKind = iota
+	mkNull
+	mkUndefined
+	mkBoolFalse
+	mkBoolTrue
+	mkNumber
+	mkString
+	mkObject // objects/functions/symbols/bigint - reference identity by pointer
+)
+
+// nanKeyBits is the canonical bit pattern all NaN keys collapse to, so
+// SameValueZero's NaN === NaN holds (distinct NaN payloads hash the same).
+const nanKeyBits uint64 = 0x7FF8000000000001
+
+// mapKey is an allocation-free Map/Set key. It replaces the old string hash
+// (which allocated via strconv/fmt on every operation) with a comparable value
+// struct: constructing one copies a tag plus a uint64 and, for strings, a
+// header that aliases the existing backing - no heap work. Go compares/hashes
+// the struct field-wise, giving the same SameValueZero partitioning the string
+// keys did.
+type mapKey struct {
+	kind mapKeyKind
+	bits uint64 // number bits (canonical) or pointer address
+	str  string // string keys only
+}
+
+// hashKey maps a value to its Map/Set key under SameValueZero equality
+// (NaN === NaN, +0 === -0). Allocation-free.
+func hashKey(v Value) mapKey {
 	switch v.Type() {
 	case TypeNull:
-		return "null"
+		return mapKey{kind: mkNull}
 	case TypeUndefined:
-		return "undefined"
+		return mapKey{kind: mkUndefined}
 	case TypeString:
-		return "s:" + v.ToString()
+		return mapKey{kind: mkString, str: v.ToString()}
 	case TypeBoolean:
 		if v.AsBoolean() {
-			return "b:true"
+			return mapKey{kind: mkBoolTrue}
 		}
-		return "b:false"
+		return mapKey{kind: mkBoolFalse}
 	case TypeFloatNumber, TypeIntegerNumber:
 		f := v.ToFloat()
+		var bits uint64
 		if math.IsNaN(f) {
-			return "n:NaN"
+			bits = nanKeyBits
+		} else if f != 0 { // +0 and -0 collapse to bits 0 (SameValueZero)
+			bits = math.Float64bits(f)
 		}
-		if f == 0 {
-			return "n:0" // Treat +0 and -0 as same (SameValueZero)
-		}
-		return "n:" + strconv.FormatFloat(f, 'g', -1, 64)
+		return mapKey{kind: mkNumber, bits: bits}
 	default:
-		// For objects, use pointer address as unique key
-		return "o:" + fmt.Sprintf("%p", v.obj)
+		// Objects (and functions/symbols/bigint) key on pointer identity, as
+		// before. The Map/Set holds the key Value strongly, so the address
+		// stays valid for the entry's lifetime and Go never moves heap objects.
+		return mapKey{kind: mkObject, bits: uint64(uintptr(v.obj))}
 	}
 }
 
@@ -2514,7 +2548,7 @@ func (m *MapObject) Set(key, value Value) {
 			delete(m.tombstones, keyStr)
 			for i, k := range m.order {
 				if k == keyStr {
-					m.order[i] = "" // dead entry marker
+					m.order[i] = mapKey{} // dead entry marker (mkDead)
 				}
 			}
 		}
@@ -2550,7 +2584,7 @@ func (m *MapObject) Delete(key Value) bool {
 		// Mark this key as a tombstone so live iterators skip it,
 		// but re-insertion can revive the entry at its original position.
 		if m.tombstones == nil {
-			m.tombstones = make(map[string]bool)
+			m.tombstones = make(map[mapKey]bool)
 		}
 		m.tombstones[keyStr] = true
 		m.size--
@@ -2560,8 +2594,8 @@ func (m *MapObject) Delete(key Value) bool {
 }
 
 func (m *MapObject) Clear() {
-	m.entries = make(map[string]Value)
-	m.keys = make(map[string]Value)
+	m.entries = make(map[mapKey]Value)
+	m.keys = make(map[mapKey]Value)
 	m.order = nil        // Reset insertion order
 	m.tombstones = nil   // Clear tombstones
 	m.size = 0
@@ -2585,10 +2619,9 @@ func (m *MapObject) ForEach(fn func(key Value, value Value)) {
 		}
 		if originalKey, ok := m.keys[keyStr]; ok {
 			fn(originalKey, value)
-		} else {
-			// Fallback: synthesize string key
-			fn(NewString(keyStr), value)
 		}
+		// keys is always populated alongside entries in Set, so the original
+		// key is present; there is no string to synthesize from a mapKey.
 	}
 }
 
@@ -2618,8 +2651,8 @@ func (m *MapObject) GetEntryAt(index int) (Value, Value, bool) {
 	if originalKey, ok := m.keys[keyStr]; ok {
 		return originalKey, value, true
 	}
-	// Fallback: synthesize string key
-	return NewString(keyStr), value, true
+	// keys is always populated alongside entries in Set; unreachable otherwise.
+	return Undefined, Undefined, false
 }
 
 // SetObject methods
@@ -2633,7 +2666,7 @@ func (s *SetObject) Add(value Value) {
 			delete(s.tombstones, keyStr)
 			for i, k := range s.order {
 				if k == keyStr {
-					s.order[i] = "" // dead entry marker
+					s.order[i] = mapKey{} // dead entry marker (mkDead)
 				}
 			}
 		}
@@ -2656,7 +2689,7 @@ func (s *SetObject) Delete(value Value) bool {
 		delete(s.values, keyStr)
 		// Mark as tombstone for live iteration
 		if s.tombstones == nil {
-			s.tombstones = make(map[string]bool)
+			s.tombstones = make(map[mapKey]bool)
 		}
 		s.tombstones[keyStr] = true
 		s.size--
@@ -2666,7 +2699,7 @@ func (s *SetObject) Delete(value Value) bool {
 }
 
 func (s *SetObject) Clear() {
-	s.values = make(map[string]Value)
+	s.values = make(map[mapKey]Value)
 	s.order = nil      // Reset insertion order
 	s.tombstones = nil // Clear tombstones
 	s.size = 0

--- a/tests/scripts/map_set_key_hashing.ts
+++ b/tests/scripts/map_set_key_hashing.ts
@@ -1,0 +1,41 @@
+// Exercises Map/Set key identity under the allocation-free mapKey hashing:
+// key-type disambiguation (string "1" != number 1, string "true" != boolean
+// true), SameValueZero canonicalization (NaN === NaN, +0 === -0), object
+// reference identity, and delete/re-insert insertion-order semantics.
+// expect: 1|str1|T|strT|nan|z|z2|11|x,z,y|1,3,22|5|1,2,2,NaN,[object Object]
+let out: string[] = [];
+
+const m = new Map<any, any>();
+m.set("a", 1); m.set(1, "n1"); m.set("1", "str1");
+m.set(true, "T"); m.set("true", "strT");
+m.set(null, "N"); m.set(undefined, "U");
+const o1: any = {}, o2: any = {};
+m.set(o1, "o1"); m.set(o2, "o2");
+out.push(String(m.get("a")));       // 1  (string key)
+out.push(m.get("1"));               // str1 (string "1" distinct from number 1)
+out.push(m.get(true));              // T  (boolean true distinct from string "true")
+out.push(m.get("true"));            // strT
+
+m.set(NaN, "nan");
+out.push(m.get(0 / 0));             // nan  (NaN === NaN)
+m.set(0, "z");
+out.push(m.get(-0));                // z    (+0 === -0)
+m.set(-0, "z2");
+out.push(m.get(0));                 // z2   (same key overwritten)
+
+// size: a,1,"1",true,"true",null,undefined,o1,o2,NaN,0 = 11
+out.push(String(m.size));           // 11
+
+// delete + re-insert moves the key to the END of iteration order
+const m2 = new Map<string, number>();
+m2.set("x", 1); m2.set("y", 2); m2.set("z", 3);
+m2.delete("y"); m2.set("y", 22);
+out.push([...m2.keys()].join(","));   // x,z,y
+out.push([...m2.values()].join(",")); // 1,3,22
+
+// Set dedup across key types + reference identity
+const s = new Set<any>([1, 2, 2, "2", NaN, NaN, o1, o1]);
+out.push(String(s.size));           // 5
+out.push([...s].join(","));         // 1,2,2,NaN,[object Object]  (o1 last)
+
+out.join("|");


### PR DESCRIPTION
`hashKey` turned every Map/Set key into a string (`"s:"+content`, `"n:"+FormatFloat`, `"o:"+Sprintf("%p")`), so every set/get/has/delete/add allocated — and object keys paid `fmt.Sprintf`'s reflection.

## What this does

Replace the string key with a comparable value struct `mapKey{kind, bits, str}`: a tag plus a `uint64`, and for string keys a header aliasing the existing backing. Constructing one does no heap work; Go hashes/compares it field-wise, giving the same SameValueZero partitioning — NaN === NaN via a canonical bit pattern, +0 === -0 via bits 0, key-type disambiguation via the `kind` tag instead of the string prefix. Object keys hash on pointer identity as before (the Map/Set holds the key strongly and Go never moves heap objects). Number keys collapse identically (bit-equal iff shortest-decimal-equal); delete/re-insert order preserved (the stale order slot is the zero `mapKey`, which matches no entry).

**Design point for review:** the SameValueZero canonicalization (NaN via canonical bits, ±0 via bits 0), the pointer-identity object key and why it stays GC-safe, and the tradeoff below.

**Tradeoff:** `mapKey` is 32 B vs a 16 B string header, so maps hold ~16 B more per entry; `clear()`+regrow-heavy workloads allocate more in the bucket arrays but are still faster on wall-clock.

## Numbers

Local (M2): get/has-heavy map (build-once) ~12% with fewer GCs; object-key set churn (was `fmt.Sprintf`) ~13%; number-key churn ~5%. The `perf`-label A/B is authoritative.

## Verification

`TestScripts` green + `tests/scripts/map_set_key_hashing.ts` (key-type disambiguation, NaN/±0 canonicalization, object identity, delete/re-insert order); vm tests under `-race` clean; Test262 language 0 new failures (differential vs upstream/main control); Map/Set/WeakMap/WeakSet built-ins 0 new failures.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
