### PR TITLE
perf(vm): pool the native-reentry sentinel register slice

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -160,6 +160,14 @@ type VM struct {
 	registerStack [RegFileSize * MaxFrames]Value
 	nextRegSlot   int // Points to the next available slot in registerStack
 
+	// sentinelRegPool is a LIFO free-list of 1-element register slices reused as
+	// the sentinel frame's result holder on native->JS reentry
+	// (executeUserFunctionSafe / ...WithNewTarget). Reentries nest strictly, so
+	// the pool grows to the max nesting depth and then recycles - eliminating a
+	// per-callback heap allocation (every Array.map/forEach/sort element,
+	// Promise executor, etc.).
+	sentinelRegPool [][]Value
+
 	// List of upvalues pointing to variables still on the registerStack
 	openUpvalues []*Upvalue
 	// Map for O(1) lookup of existing upvalues by location pointer

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1537,6 +1537,25 @@ func (vm *VM) ConstructWithNewTarget(constructor Value, args []Value, newTarget 
 }
 
 // executeUserFunctionWithNewTarget executes a user function with constructor semantics and custom new.target
+// getSentinelReg returns a 1-element register slice to serve as a native->JS
+// reentry's sentinel-frame result holder, reusing a pooled buffer when one is
+// free (reentries nest strictly LIFO, so the pool recycles).
+func (vm *VM) getSentinelReg() []Value {
+	if n := len(vm.sentinelRegPool); n > 0 {
+		r := vm.sentinelRegPool[n-1]
+		vm.sentinelRegPool = vm.sentinelRegPool[:n-1]
+		return r
+	}
+	return make([]Value, 1)
+}
+
+// putSentinelReg returns a sentinel register slice to the pool, clearing the
+// slot so the pooled buffer doesn't keep the last result value alive.
+func (vm *VM) putSentinelReg(r []Value) {
+	r[0] = Undefined
+	vm.sentinelRegPool = append(vm.sentinelRegPool, r)
+}
+
 func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args []Value, newTarget Value, isDerivedConstructor bool) (Value, error) {
 	// Clear stale unwinding state
 	if vm.unwinding && vm.currentException == Null {
@@ -1544,8 +1563,9 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 		vm.unwindingCrossedNative = false
 	}
 
-	// Set up the caller context
-	callerRegisters := make([]Value, 1)
+	// Set up the caller context (pooled 1-element result holder, not a per-call alloc)
+	callerRegisters := vm.getSentinelReg()
+	defer vm.putSentinelReg(callerRegisters)
 	destReg := byte(0)
 	callerIP := 0
 
@@ -1631,8 +1651,9 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 		vm.unwindingCrossedNative = false
 	}
 
-	// Set up the caller context first
-	callerRegisters := make([]Value, 1)
+	// Set up the caller context first (pooled 1-element result holder)
+	callerRegisters := vm.getSentinelReg()
+	defer vm.putSentinelReg(callerRegisters)
 	destReg := byte(0)
 	callerIP := 0
 


### PR DESCRIPTION
Every native→JS reentry allocated a fresh `make([]Value, 1)` to hold the sentinel frame's result — one heap slice per callback invocation (every Array.map/forEach/filter/reduce/sort element, Promise executor, JSON reviver).

## What this does

Reentries nest strictly LIFO, so a small free-list recycles these 1-element buffers: it grows to the max nesting depth once and then hands out reused slices. `put` clears the slot so a pooled buffer doesn't retain the last result. The result is read (via `run()`'s return or the native-direct path) before the deferred `put`, so clearing is safe. Self-contained in `pkg/vm/vm.go` + `vm_init.go`.

**Design point for review:** the LIFO free-list invariant (reentries nest strictly) and that `put` clears the slot for GC hygiene.

## Numbers

Local (M2, min of 6): a forEach+map+reduce+filter loop 1389 → 1184 ms (~15%) with ~18% fewer GC cycles (320 → 264). The `perf`-label A/B is authoritative.

## Verification

`TestScripts` green; vm tests under `-race` clean; nested/recursive callback correctness (map-in-map, sort comparator, deep recursion) verified. Test262 language 0 new failures (differential vs upstream/main control); callback-heavy built-ins 0 new failures.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
