### PR TITLE
perf(vm): allocation-free string relational comparison for BMP strings

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2296,7 +2296,7 @@ startExecution:
 					// String comparison (lexicographic by UTF-16 code units per ECMAScript)
 					leftStr := leftVal.ToString()
 					rightStr := rightVal.ToString()
-					cmp := compareStringsUTF16(leftStr, rightStr)
+					cmp := compareStrings(leftStr, rightStr)
 					switch opcode {
 					case OpGreater:
 						result = cmp > 0
@@ -2368,7 +2368,7 @@ startExecution:
 					if leftPrim.Type() == TypeString && rightPrim.Type() == TypeString {
 						leftStr := leftPrim.AsString()
 						rightStr := rightPrim.AsString()
-						cmp := compareStringsUTF16(leftStr, rightStr)
+						cmp := compareStrings(leftStr, rightStr)
 						switch opcode {
 						case OpGreater:
 							result = cmp > 0
@@ -15953,6 +15953,25 @@ func compareStringsUTF16(a, b string) int {
 		return 1
 	}
 	return 0
+}
+
+// compareStrings returns the UTF-16 code-unit ordering of a and b (-1/0/1).
+// Allocation-free in the common case: when neither string contains an astral
+// character or lone surrogate - the only cases where UTF-8 byte order diverges
+// from UTF-16 code-unit order - Go's native byte comparison yields the same
+// ordering without materializing the two []uint16 slices. Falls back to the
+// full UTF-16 comparison only for astral/surrogate content.
+func compareStrings(a, b string) int {
+	if !stringNeedsUTF16Comparison(a) && !stringNeedsUTF16Comparison(b) {
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
+		return 0
+	}
+	return compareStringsUTF16(a, b)
 }
 
 // UTF16Length returns the number of UTF-16 code units in a string


### PR DESCRIPTION
`<`, `>`, `<=`, `>=` on strings called `compareStringsUTF16`, which materializes both operands as `[]uint16` (`StringToUTF16` does make + `[]byte(s)`) — ~4 allocations per comparison, on the hot path for any string-sorting or relational loop. The equality path already guarded this; the relational path did not.

## What this does

Add `compareStrings`, which uses Go's native byte comparison when neither operand contains an astral character or lone surrogate — exactly the cases where UTF-8 byte order diverges from UTF-16 code-unit order (astral chars sort as high surrogates 0xD800+ in UTF-16 but above all BMP in code-point order). For everything else byte order == UTF-16 order, including the shorter-is-less tiebreak. Astral/surrogate content still falls back to full UTF-16, so ordering stays spec-correct. Both relational sites (pre- and post-`toPrimitive`) routed through it.

**Design point for review:** why byte order == UTF-16 order for BMP (and only diverges on astral), mirroring the existing equality guard.

## Numbers

Local (M2, min of 5): a string-relational loop 647 → 479 ms (~26%) with GC cycles dropping 39 → 1. The `perf`-label A/B is authoritative.

## Verification

`TestScripts` + unit tests green; correctness across BMP, multibyte-BMP (accented/CJK), prefix/length, and the astral edge (`U+E000 > U+10428` in UTF-16 order — which byte/code-point order gets wrong) verified. Test262 language 0 new failures across all four relational operators (differential vs upstream/main control); built-ins/String 0 new failures.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
