### PR TITLE
perf(vm): array-destructuring fast path for pristine arrays

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -2911,6 +2911,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	w, e, c := true, false, true // writable, not enumerable, configurable
 	arrayProto.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator), valuesFn, &w, &e, &c)
 
+	// Record the canonical values/[Symbol.iterator] so the compiler's
+	// array-destructuring fast path (OpArrayDestructFastCheck) can identity-check
+	// against it and skip the iterator protocol for pristine arrays.
+	vmInstance.ArrayValuesIterator = valuesFn
+
 	// Array.prototype.keys() - returns iterator yielding indices
 	keysFn := vm.NewNativeFunction(0, false, "keys", func(args []vm.Value) (vm.Value, error) {
 		thisVal := vmInstance.GetThis()

--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -2633,59 +2633,23 @@ func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructu
 func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestructuringDeclaration, iterableReg Register, line int) errors.PaseratiError {
 	// fmt.Printf("// [COMPILE-ITER] Starting iterator path compilation, iterableReg=R%d\n", iterableReg)
 
-	// Get Symbol.iterator via computed index
-	iteratorMethodReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorMethodReg)
+	// Set up the destructuring source. When the pattern has no rest element and
+	// the source is a pristine array at runtime, the fast path reads elements by
+	// index and skips the iterator protocol entirely (see beginArrayDestruct).
+	enableFast := arrayDeclPatternFastEligible(node.Elements)
+	st := c.beginArrayDestruct(iterableReg, enableFast, line)
+	defer c.endArrayDestruct(st)
+	iteratorObjReg := st.iterObjReg
+	doneReg := st.doneReg
 
-	// Load global Symbol
-	symbolObjReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(symbolObjReg)
-	symIdx := c.GetOrAssignGlobalIndex("Symbol")
-	// fmt.Printf("// [COMPILE-ITER] Getting global Symbol (idx=%d) into R%d\n", symIdx, symbolObjReg)
-	c.emitGetGlobal(symbolObjReg, symIdx, line)
-
-	// Get Symbol.iterator
-	propNameReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(propNameReg)
-	c.emitLoadNewConstant(propNameReg, vm.String("iterator"), line)
-	// fmt.Printf("// [COMPILE-ITER] Loading 'iterator' string into R%d\n", propNameReg)
-
-	iteratorKeyReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorKeyReg)
-	// fmt.Printf("// [COMPILE-ITER] Getting Symbol.iterator (Symbol[R%d]) into R%d\n", propNameReg, iteratorKeyReg)
-	c.emitOpCode(vm.OpGetIndex, line)
-	c.emitByte(byte(iteratorKeyReg))
-	c.emitByte(byte(symbolObjReg))
-	c.emitByte(byte(propNameReg))
-
-	// Get iterable[Symbol.iterator]
-	// fmt.Printf("// [COMPILE-ITER] Getting iterable[Symbol.iterator] (R%d[R%d]) into R%d\n", iterableReg, iteratorKeyReg, iteratorMethodReg)
-	c.emitOpCode(vm.OpGetIndex, line)
-	c.emitByte(byte(iteratorMethodReg))
-	c.emitByte(byte(iterableReg))
-	c.emitByte(byte(iteratorKeyReg))
-
-	// Call the iterator method to get iterator object
-	iteratorObjReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorObjReg)
-	// fmt.Printf("// [COMPILE-ITER] Calling iterator method R%d on R%d, result in R%d\n", iteratorMethodReg, iterableReg, iteratorObjReg)
-	c.emitCallMethod(iteratorObjReg, iteratorMethodReg, iterableReg, 0, line)
-
-	// Allocate register to track iterator.done state
-	// We update this each time we call next(), then check it before calling iterator.return()
-	doneReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(doneReg)
-	// Initialize to false
-	c.emitLoadFalse(doneReg, line)
-
-	// Track how many elements we've consumed for rest elements
+	// Track how many elements we've consumed (position in the pattern)
 	elementIndex := 0
 
-	// For each element, call iterator.next()
+	// For each element, produce the next value (fast index read or iterator.next())
 	for _, element := range node.Elements {
 		if element.Target == nil {
 			// Elision: consume iterator value but don't bind
-			c.compileIteratorNext(iteratorObjReg, BadRegister, doneReg, line, true)
+			c.compileDestructNext(st, iterableReg, elementIndex, BadRegister, true, line)
 			elementIndex++
 			continue
 		}
@@ -2720,9 +2684,9 @@ func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestr
 			break
 		}
 
-		// Regular element: get next value from iterator
+		// Regular element: get next value (fast index read or iterator.next())
 		valueReg := c.regAlloc.Alloc()
-		c.compileIteratorNext(iteratorObjReg, valueReg, doneReg, line, false)
+		c.compileDestructNext(st, iterableReg, elementIndex, valueReg, false, line)
 
 		// Handle assignment based on target type
 		if ident, ok := element.Target.(*parser.Identifier); ok {

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -497,40 +497,19 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 // This handles: for ([x, y] of items) where x, y are already declared
 // Per ECMAScript spec 13.7.5.13, array assignment patterns MUST use iterator protocol
 func (c *Compiler) compileForOfArrayAssignmentWithIterator(arrayLit *parser.ArrayLiteral, valueReg Register, line int) errors.PaseratiError {
-	// Get Symbol.iterator from the value
-	symbolObjReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(symbolObjReg)
-	symIdx := c.GetOrAssignGlobalIndex("Symbol")
-	c.emitGetGlobal(symbolObjReg, symIdx, line)
-
-	propNameReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(propNameReg)
-	c.emitLoadNewConstant(propNameReg, vm.String("iterator"), line)
-
-	iteratorKeyReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorKeyReg)
-	c.emitOpCode(vm.OpGetIndex, line)
-	c.emitByte(byte(iteratorKeyReg))
-	c.emitByte(byte(symbolObjReg))
-	c.emitByte(byte(propNameReg))
-
-	// Get iterable[Symbol.iterator]
-	iteratorMethodReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorMethodReg)
-	c.emitOpCode(vm.OpGetIndex, line)
-	c.emitByte(byte(iteratorMethodReg))
-	c.emitByte(byte(valueReg))
-	c.emitByte(byte(iteratorKeyReg))
-
-	// Call the iterator method
-	iteratorObjReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorObjReg)
-	c.emitCallMethod(iteratorObjReg, iteratorMethodReg, valueReg, 0, line)
-
-	// Track done state
-	doneReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(doneReg)
-	c.emitLoadFalse(doneReg, line)
+	// Fast path is eligible only without a rest (spread) element; rest still
+	// exhausts the iterator via the generic protocol.
+	enableFast := true
+	for _, element := range arrayLit.Elements {
+		if _, ok := element.(*parser.SpreadElement); ok {
+			enableFast = false
+			break
+		}
+	}
+	st := c.beginArrayDestruct(valueReg, enableFast, line)
+	defer c.endArrayDestruct(st)
+	iteratorObjReg := st.iterObjReg
+	doneReg := st.doneReg
 
 	// Mark the start of the "try" region for exception-triggered iterator cleanup
 	// This covers the element iteration where default expressions may throw or yield
@@ -540,7 +519,7 @@ func (c *Compiler) compileForOfArrayAssignmentWithIterator(arrayLit *parser.Arra
 	for i, element := range arrayLit.Elements {
 		if element == nil {
 			// Elision - consume but don't assign
-			c.compileIteratorNext(iteratorObjReg, BadRegister, doneReg, line, true)
+			c.compileDestructNext(st, valueReg, i, BadRegister, true, line)
 			continue
 		}
 
@@ -600,9 +579,9 @@ func (c *Compiler) compileForOfArrayAssignmentWithIterator(arrayLit *parser.Arra
 			return err
 		}
 
-		// Step 2: NOW call iterator.next() to get the value
+		// Step 2: NOW get the value (fast index read or iterator.next())
 		extractedReg := c.regAlloc.Alloc()
-		c.compileIteratorNext(iteratorObjReg, extractedReg, doneReg, line, false)
+		c.compileDestructNext(st, valueReg, i, extractedReg, false, line)
 
 		// Step 3: Complete assignment using the pre-evaluated reference
 		if defaultExpr != nil {
@@ -667,55 +646,24 @@ func (c *Compiler) compileForOfArrayAssignmentWithIterator(arrayLit *parser.Arra
 
 // compileForOfArrayDestructuring uses iterator protocol to destructure array patterns in for-of loops
 func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestructuringDeclaration, valueReg Register, isConst bool, line int) errors.PaseratiError {
-	// Get Symbol.iterator from the value using the same pattern as compileArrayDestructuringIteratorPath
-
-	// Get Symbol.iterator via computed index
-	iteratorMethodReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorMethodReg)
-
-	// Load global Symbol
-	symbolObjReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(symbolObjReg)
-	symIdx := c.GetOrAssignGlobalIndex("Symbol")
-	c.emitGetGlobal(symbolObjReg, symIdx, line)
-
-	// Get Symbol.iterator
-	propNameReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(propNameReg)
-	c.emitLoadNewConstant(propNameReg, vm.String("iterator"), line)
-
-	iteratorKeyReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorKeyReg)
-	c.emitOpCode(vm.OpGetIndex, line)
-	c.emitByte(byte(iteratorKeyReg))
-	c.emitByte(byte(symbolObjReg))
-	c.emitByte(byte(propNameReg))
-
-	// Get value[Symbol.iterator]
-	c.emitOpCode(vm.OpGetIndex, line)
-	c.emitByte(byte(iteratorMethodReg))
-	c.emitByte(byte(valueReg))
-	c.emitByte(byte(iteratorKeyReg))
-
-	// Call the iterator method to get iterator object
-	iteratorObjReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(iteratorObjReg)
-	c.emitCallMethod(iteratorObjReg, iteratorMethodReg, valueReg, 0, line)
-
-	// Allocate register to track iterator.done state
-	doneReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(doneReg)
-	c.emitLoadFalse(doneReg, line)
+	// Set up the destructuring source. Without a rest element and over a pristine
+	// array at runtime, elements are read by index and the iterator protocol is
+	// skipped (see beginArrayDestruct).
+	enableFast := arrayDeclPatternFastEligible(arrayDestr.Elements)
+	st := c.beginArrayDestruct(valueReg, enableFast, line)
+	defer c.endArrayDestruct(st)
+	iteratorObjReg := st.iterObjReg
+	doneReg := st.doneReg
 
 	// Mark the start of the "try" region for exception-triggered iterator cleanup
 	// This covers the element iteration where default expressions may throw or yield
 	iteratorCleanupTryStart := len(c.chunk.Code)
 
-	// For each element, call iterator.next()
-	for _, element := range arrayDestr.Elements {
+	// For each element, produce the next value (fast index read or iterator.next())
+	for idx, element := range arrayDestr.Elements {
 		if element.Target == nil {
 			// Elision: consume iterator value but don't bind
-			c.compileIteratorNext(iteratorObjReg, BadRegister, doneReg, line, true)
+			c.compileDestructNext(st, valueReg, idx, BadRegister, true, line)
 			continue
 		}
 
@@ -749,9 +697,9 @@ func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestru
 			break
 		}
 
-		// Regular element: get next value from iterator
+		// Regular element: get next value (fast index read or iterator.next())
 		extractedReg := c.regAlloc.Alloc()
-		c.compileIteratorNext(iteratorObjReg, extractedReg, doneReg, line, false)
+		c.compileDestructNext(st, valueReg, idx, extractedReg, false, line)
 
 		// Handle assignment based on target type
 		if ident, ok := element.Target.(*parser.Identifier); ok {

--- a/pkg/compiler/compile_iterator_helpers.go
+++ b/pkg/compiler/compile_iterator_helpers.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"github.com/nooga/paserati/pkg/errors"
+	"github.com/nooga/paserati/pkg/parser"
 	"github.com/nooga/paserati/pkg/vm"
 )
 
@@ -44,6 +45,121 @@ func (c *Compiler) compileIteratorNext(iteratorReg Register, destReg Register, d
 		doneConstIdx := c.chunk.AddConstant(vm.String("done"))
 		c.emitGetProp(doneReg, resultReg, doneConstIdx, line)
 	}
+}
+
+// arrayDestructState threads the registers used by an array-destructuring site.
+// When fastEnabled is true, a runtime check (fastFlagReg) selects per element
+// between reading the source array by index (no iterator, no next() call, no
+// {value, done} allocation) and the generic iterator protocol. When false, only
+// the generic protocol is emitted - byte-for-byte the pre-fast-path behaviour.
+type arrayDestructState struct {
+	fastEnabled bool
+	fastFlagReg Register // BadRegister when !fastEnabled
+	iterObjReg  Register // the iterator object (generic arm only; undefined on the fast arm)
+	doneReg     Register // iterator done flag; forced true on the fast arm so cleanup is a no-op
+}
+
+// emitBuildArrayIterator resolves src[Symbol.iterator], calls it, and leaves the
+// iterator object in iterObjReg. Factored out of the destructuring paths, which
+// each open-coded this identical sequence.
+func (c *Compiler) emitBuildArrayIterator(iterObjReg Register, src Register, line int) {
+	symbolObjReg := c.regAlloc.Alloc()
+	defer c.regAlloc.Free(symbolObjReg)
+	symIdx := c.GetOrAssignGlobalIndex("Symbol")
+	c.emitGetGlobal(symbolObjReg, symIdx, line)
+
+	propNameReg := c.regAlloc.Alloc()
+	defer c.regAlloc.Free(propNameReg)
+	c.emitLoadNewConstant(propNameReg, vm.String("iterator"), line)
+
+	iteratorKeyReg := c.regAlloc.Alloc()
+	defer c.regAlloc.Free(iteratorKeyReg)
+	c.emitOpCode(vm.OpGetIndex, line)
+	c.emitByte(byte(iteratorKeyReg))
+	c.emitByte(byte(symbolObjReg))
+	c.emitByte(byte(propNameReg))
+
+	iteratorMethodReg := c.regAlloc.Alloc()
+	defer c.regAlloc.Free(iteratorMethodReg)
+	c.emitOpCode(vm.OpGetIndex, line)
+	c.emitByte(byte(iteratorMethodReg))
+	c.emitByte(byte(src))
+	c.emitByte(byte(iteratorKeyReg))
+
+	c.emitCallMethod(iterObjReg, iteratorMethodReg, src, 0, line)
+}
+
+// beginArrayDestruct sets up an array-destructuring site over srcReg. It
+// allocates iterObjReg and doneReg (and, when enableFast, fastFlagReg) and emits
+// the branched setup: the fast arm skips iterator creation and marks done=true;
+// the generic arm builds the iterator and sets done=false. The caller must pair
+// this with endArrayDestruct to free the registers.
+func (c *Compiler) beginArrayDestruct(srcReg Register, enableFast bool, line int) arrayDestructState {
+	st := arrayDestructState{fastEnabled: enableFast, fastFlagReg: BadRegister}
+	st.iterObjReg = c.regAlloc.Alloc()
+	st.doneReg = c.regAlloc.Alloc()
+
+	if !enableFast {
+		c.emitBuildArrayIterator(st.iterObjReg, srcReg, line)
+		c.emitLoadFalse(st.doneReg, line)
+		return st
+	}
+
+	st.fastFlagReg = c.regAlloc.Alloc()
+	c.emitArrayDestructFastCheck(st.fastFlagReg, srcReg, line)
+	// The fast arm never dereferences iterObjReg (done=true skips cleanup), but
+	// give it a defined value so the register is never read while uninitialized.
+	c.emitLoadUndefined(st.iterObjReg, line)
+
+	toGeneric := c.emitPlaceholderJump(vm.OpJumpIfFalse, st.fastFlagReg, line)
+	c.emitLoadTrue(st.doneReg, line) // fast arm: no iterator to close
+	pastSetup := c.emitPlaceholderJump(vm.OpJump, 0, line)
+
+	c.patchJump(toGeneric)
+	c.emitBuildArrayIterator(st.iterObjReg, srcReg, line)
+	c.emitLoadFalse(st.doneReg, line)
+	c.patchJump(pastSetup)
+	return st
+}
+
+func (c *Compiler) endArrayDestruct(st arrayDestructState) {
+	if st.fastFlagReg != BadRegister {
+		c.regAlloc.Free(st.fastFlagReg)
+	}
+	c.regAlloc.Free(st.doneReg)
+	c.regAlloc.Free(st.iterObjReg)
+}
+
+// compileDestructNext produces the idx-th destructured value into destReg,
+// advancing the iterator by one. idx is the element's position in the pattern
+// (counting elisions). On the fast arm the value is read directly from the
+// source array; on the generic arm it comes from iterator.next(). When discard
+// is true (elision), the fast arm does nothing and the generic arm still steps
+// the iterator to stay in sync.
+func (c *Compiler) compileDestructNext(st arrayDestructState, srcReg Register, idx int, destReg Register, discard bool, line int) {
+	if !st.fastEnabled {
+		c.compileIteratorNext(st.iterObjReg, destReg, st.doneReg, line, discard)
+		return
+	}
+	toGeneric := c.emitPlaceholderJump(vm.OpJumpIfFalse, st.fastFlagReg, line)
+	if !discard && destReg != BadRegister {
+		c.emitArrayRawGetInt(destReg, srcReg, idx, line)
+	}
+	pastGeneric := c.emitPlaceholderJump(vm.OpJump, 0, line)
+	c.patchJump(toGeneric)
+	c.compileIteratorNext(st.iterObjReg, destReg, st.doneReg, line, discard)
+	c.patchJump(pastGeneric)
+}
+
+// arrayDeclPatternFastEligible reports whether an array pattern can use the fast
+// path: no rest element (rest still exhausts the iterator via the generic path).
+func arrayDeclPatternFastEligible(elements []*parser.DestructuringElement) bool {
+	for _, el := range elements {
+		if el.IsRest {
+			return false
+		}
+	}
+	return true
 }
 
 // compileIteratorToArray collects all remaining values from iterator into an array

--- a/pkg/compiler/emit.go
+++ b/pkg/compiler/emit.go
@@ -687,6 +687,23 @@ func (c *Compiler) emitGetGlobal(dest Register, globalIdx uint16, line int) {
 	c.emitUint16(globalIdx)
 }
 
+// emitArrayDestructFastCheck emits OpArrayDestructFastCheck: dest = true if src
+// is a plain array with the canonical Symbol.iterator (destructurable by index).
+func (c *Compiler) emitArrayDestructFastCheck(dest Register, src Register, line int) {
+	c.emitOpCode(vm.OpArrayDestructFastCheck, line)
+	c.emitByte(byte(dest))
+	c.emitByte(byte(src))
+}
+
+// emitArrayRawGetInt emits OpArrayRawGetInt: dest = src[idx] by direct array
+// read (undefined if out of range). Only valid after a passing fast check.
+func (c *Compiler) emitArrayRawGetInt(dest Register, src Register, idx int, line int) {
+	c.emitOpCode(vm.OpArrayRawGetInt, line)
+	c.emitByte(byte(dest))
+	c.emitByte(byte(src))
+	c.emitUint16(uint16(idx))
+}
+
 // emitSetGlobal emits OpSetGlobal instruction with direct global index
 func (c *Compiler) emitSetGlobal(globalIdx uint16, src Register, line int) {
 	c.emitOpCode(vm.OpSetGlobal, line)

--- a/pkg/vm/array_iterator.go
+++ b/pkg/vm/array_iterator.go
@@ -85,6 +85,24 @@ func resolveFastIterState(iterVal, nextVal Value) *BuiltinIterState {
 	return nil
 }
 
+// isFastDestructureArray reports whether v can be destructured by direct index
+// reads instead of the iterator protocol: v must be a plain array whose
+// Symbol.iterator is still the canonical Array.prototype iterator. When true,
+// default iteration is exactly Arr.Get(0..len-1) (what BuiltinIterState.Step
+// yields), so OpArrayRawGetInt reproduces it bit-for-bit. Any instance- or
+// prototype-level override of Symbol.iterator fails the identity check and the
+// caller falls back to the generic protocol.
+func (vm *VM) isFastDestructureArray(v Value) bool {
+	if v.typ != TypeArray || vm.ArrayValuesIterator.typ != TypeNativeFunction {
+		return false
+	}
+	it, ok := vm.GetSymbolProperty(v, vm.SymbolIterator)
+	if !ok || it.typ != TypeNativeFunction {
+		return false
+	}
+	return it.AsNativeFunction() == vm.ArrayValuesIterator.AsNativeFunction()
+}
+
 // likeLength reads the array-like's current length the same way the original
 // closures did: GetOwn("length") if numeric, else 0.
 func (st *BuiltinIterState) likeLength() int {

--- a/pkg/vm/array_iterator.go
+++ b/pkg/vm/array_iterator.go
@@ -92,15 +92,55 @@ func resolveFastIterState(iterVal, nextVal Value) *BuiltinIterState {
 // yields), so OpArrayRawGetInt reproduces it bit-for-bit. Any instance- or
 // prototype-level override of Symbol.iterator fails the identity check and the
 // caller falls back to the generic protocol.
+//
+// Symbol.iterator is resolved the way opGetPropSymbol resolves it — own symbol
+// properties, then the per-instance prototype override (`class X extends Array`),
+// then the realm's intrinsic Array.prototype and its chain. vm.GetSymbolProperty
+// is deliberately not used: its array branch falls back to vm.ArrayPrototype
+// unconditionally, so a subclass whose Symbol.iterator lives on X.prototype
+// would be missed and this fast path wrongly approved — destructuring would
+// silently skip the custom iterator that for-of still honors.
 func (vm *VM) isFastDestructureArray(v Value) bool {
 	if v.typ != TypeArray || vm.ArrayValuesIterator.typ != TypeNativeFunction {
 		return false
 	}
-	it, ok := vm.GetSymbolProperty(v, vm.SymbolIterator)
-	if !ok || it.typ != TypeNativeFunction {
+	arr := v.AsArray()
+	if arr == nil {
 		return false
 	}
-	return it.AsNativeFunction() == vm.ArrayValuesIterator.AsNativeFunction()
+
+	// An own symbol property shadows everything on the chain.
+	if sym := vm.SymbolIterator.AsSymbolObject(); sym != nil {
+		if it, ok := arr.GetSymbolProp(sym); ok {
+			return vm.isCanonicalArrayValuesIterator(it)
+		}
+	}
+
+	proto := arr.prototype
+	if !proto.IsObject() {
+		proto = vm.ArrayPrototype
+	}
+	symKey := NewSymbolKey(vm.SymbolIterator)
+	for cur := proto; cur.IsObject(); {
+		po := cur.AsPlainObject()
+		if po == nil {
+			// A non-plain link (dictionary-mode object) may still carry an
+			// override we can't inspect here — take the generic path rather
+			// than assume the array is pristine.
+			return false
+		}
+		if it, ok := po.GetOwnByKey(symKey); ok {
+			return vm.isCanonicalArrayValuesIterator(it)
+		}
+		cur = po.prototype
+	}
+	// No Symbol.iterator anywhere on the chain: not canonical array iteration.
+	return false
+}
+
+func (vm *VM) isCanonicalArrayValuesIterator(it Value) bool {
+	return it.typ == TypeNativeFunction &&
+		it.AsNativeFunction() == vm.ArrayValuesIterator.AsNativeFunction()
 }
 
 // likeLength reads the array-like's current length the same way the original

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -200,6 +200,16 @@ const (
 	// Rx Ry Rz: step the built-in iterator behind next-method Rz: Rx = value, Ry = done. No call, no result object.
 	OpFastIterNext OpCode = 173
 
+	// --- Array-destructuring fast path (const [a,b] = arr, for-of element patterns) ---
+	// Rx Ry: Rx = true if Ry is a plain array whose Symbol.iterator is still the
+	// canonical array iterator - so destructuring can read elements by index
+	// directly instead of building an iterator object and calling next() per element.
+	OpArrayDestructFastCheck OpCode = 174
+	// Rx Ry Idx(16bit): Rx = Ry.AsArray().Get(Idx), or undefined if out of range /
+	// Ry is not an array. Bit-identical to what the built-in array iterator's Step
+	// yields, so it stands in for one next() on the fast destructuring path.
+	OpArrayRawGetInt OpCode = 175
+
 	// --- NEW: Global Variable Operations ---
 	OpGetGlobal     OpCode = 46 // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
 	OpSetGlobal     OpCode = 47 // GlobalIdx(16bit) Ry: Globals[GlobalIdx] = Ry (direct indexed access)
@@ -361,6 +371,10 @@ func (op OpCode) String() string {
 		return "OpIterFastCheck"
 	case OpFastIterNext:
 		return "OpFastIterNext"
+	case OpArrayDestructFastCheck:
+		return "OpArrayDestructFastCheck"
+	case OpArrayRawGetInt:
+		return "OpArrayRawGetInt"
 	case OpEqual:
 		return "OpEqual"
 	case OpNotEqual:
@@ -1006,6 +1020,11 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 
 	case OpFastIterNext:
 		return c.registerRegisterRegisterRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry, Rz, Rw
+
+	case OpArrayDestructFastCheck:
+		return c.registerRegisterInstruction(builder, instruction.String(), offset) // Rx, Ry
+	case OpArrayRawGetInt:
+		return c.registerRegisterUint16Instruction(builder, instruction.String(), offset, "Idx") // Rx, Ry, Idx(16bit)
 
 	case OpCall, OpTailCall:
 		return c.callInstruction(builder, instruction.String(), offset)
@@ -1873,6 +1892,20 @@ func (c *Chunk) registerRegisterConstantInstruction(builder *strings.Builder, na
 
 	builder.WriteString(fmt.Sprintf("%-16s R%d, R%d, %s %d (%s)\n", name, regX, regY, constName, constIdx, constValue))
 	return offset + 5 // Opcode + Rx + Ry + ConstIdx(2 bytes)
+}
+
+// registerRegisterUint16Instruction handles OpCode Rx Ry Imm(16bit) where the
+// 16-bit operand is a raw immediate (not a constant-pool index).
+func (c *Chunk) registerRegisterUint16Instruction(builder *strings.Builder, name string, offset int, immName string) int {
+	if offset+4 >= len(c.Code) {
+		builder.WriteString(fmt.Sprintf("%s (missing operands)\n", name))
+		return offset + 5
+	}
+	regX := c.Code[offset+1]
+	regY := c.Code[offset+2]
+	imm := uint16(c.Code[offset+3])<<8 | uint16(c.Code[offset+4])
+	builder.WriteString(fmt.Sprintf("%-16s R%d, R%d, %s %d\n", name, regX, regY, immName, imm))
+	return offset + 5 // Opcode + Rx + Ry + Imm(2 bytes)
 }
 
 // registerRegisterRegisterConstantInstruction handles OpCode Rx Ry Rz ConstIdx(16bit)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -229,6 +229,7 @@ type VM struct {
 	IteratorHelperPrototype  Value // %IteratorHelperPrototype% - for iterator helper objects (map, filter, etc.)
 	WrapForValidIteratorPrototype Value // For Iterator.from() wrapped iterators
 	ArrayIteratorPrototype   Value // %ArrayIteratorPrototype% - for array iterators
+	ArrayValuesIterator      Value // canonical Array.prototype.values / [Symbol.iterator]; identity-checked by OpArrayDestructFastCheck
 	MapIteratorPrototype     Value // %MapIteratorPrototype% - for map iterators
 	SetIteratorPrototype     Value // %SetIteratorPrototype% - for set iterators
 	StringIteratorPrototype        Value // %StringIteratorPrototype% - for string iterators
@@ -1699,6 +1700,40 @@ startExecution:
 			v, done := st.Step()
 			registers[valueReg] = v
 			registers[doneReg] = BooleanValue(done)
+
+		case OpArrayDestructFastCheck:
+			// Emitted once per array-destructuring site, on the source value.
+			// True only when the source is a plain array whose Symbol.iterator is
+			// still the canonical array iterator: then default iteration is exactly
+			// an index walk (Arr.Get(0..len-1)), so the elements can be read
+			// directly with OpArrayRawGetInt - no iterator object, no next() calls,
+			// no {value, done} result allocations. Any override (instance or on
+			// Array.prototype) fails the identity check and takes the generic path.
+			destReg := code[ip]
+			srcReg := code[ip+1]
+			ip += 2
+			registers[destReg] = BooleanValue(vm.isFastDestructureArray(registers[srcReg]))
+
+		case OpArrayRawGetInt:
+			// Fast destructuring element read: the i-th element of the source
+			// array, or undefined when i is past the end (matching the iterator,
+			// which yields done with value undefined). Guarded by a preceding
+			// OpArrayDestructFastCheck, so the source is known to be a plain array.
+			destReg := code[ip]
+			srcReg := code[ip+1]
+			idx := int(uint16(code[ip+2])<<8 | uint16(code[ip+3]))
+			ip += 4
+			src := registers[srcReg]
+			if src.typ == TypeArray {
+				arr := src.AsArray()
+				if idx < arr.Length() {
+					registers[destReg] = arr.Get(idx)
+				} else {
+					registers[destReg] = Undefined
+				}
+			} else {
+				registers[destReg] = Undefined
+			}
 
 		case OpTypeof:
 			destReg := code[ip]

--- a/tests/scripts/destructure_array_fast_path.ts
+++ b/tests/scripts/destructure_array_fast_path.ts
@@ -1,0 +1,54 @@
+// Exercises the array-destructuring fast path (OpArrayDestructFastCheck /
+// OpArrayRawGetInt): pristine plain arrays are destructured by direct index
+// read with no iterator object, next() call, or {value, done} allocation.
+// Covers the behaviors it must preserve: short source -> undefined tail,
+// holes -> undefined, defaults, elisions, nested patterns, rest (which stays on
+// the generic path), for-of element patterns, and deopt to the generic protocol
+// when Symbol.iterator is customized on the prototype.
+// expect: 1,2|10,undefined,undefined|5,20|1,undefined,3|2,4|7,8,9|1;2,3,4|a=1,b=2|100,200
+let out: string[] = [];
+
+// basic + fewer-than-pattern tail
+const [a, b] = [1, 2];
+const [c, d, e] = [10] as number[];
+out.push([a, b].join(","));
+out.push([c, d, e].join(","));
+
+// defaults + holes
+const [f = 5, g = 6] = [undefined, 20];
+const arr: any[] = [1, , 3];
+const [h, i, j] = arr;
+out.push([f, g].join(","));
+out.push([h, i, j].join(","));
+
+// elision + nested
+const [, k, , l] = [1, 2, 3, 4];
+const [[m, n], o] = [[7, 8], 9];
+out.push([k, l].join(","));
+out.push([m, n, o].join(","));
+
+// rest (generic path) + for-of element pattern over a Map
+const [p, ...rest] = [1, 2, 3, 4];
+out.push(p + ";" + rest.join(","));
+const mp = new Map([["a", 1], ["b", 2]]);
+let mparts: string[] = [];
+for (const [mk, mv] of mp) mparts.push(mk + "=" + mv);
+out.push(mparts.join(","));
+
+// prototype-level Symbol.iterator override must deopt to the generic protocol
+const origIt = Array.prototype[Symbol.iterator];
+(Array.prototype as any)[Symbol.iterator] = function () {
+  let idx = 0;
+  const self: any = this;
+  return {
+    next: () =>
+      idx < self.length
+        ? { value: self[idx++] * 100, done: false }
+        : { value: undefined, done: true },
+  };
+};
+const [q, r] = [1, 2];
+(Array.prototype as any)[Symbol.iterator] = origIt;
+out.push([q, r].join(","));
+
+out.join("|");

--- a/tests/scripts/destructure_array_fast_path.ts
+++ b/tests/scripts/destructure_array_fast_path.ts
@@ -4,8 +4,8 @@
 // Covers the behaviors it must preserve: short source -> undefined tail,
 // holes -> undefined, defaults, elisions, nested patterns, rest (which stays on
 // the generic path), for-of element patterns, and deopt to the generic protocol
-// when Symbol.iterator is customized on the prototype.
-// expect: 1,2|10,undefined,undefined|5,20|1,undefined,3|2,4|7,8,9|1;2,3,4|a=1,b=2|100,200
+// when Symbol.iterator is customized on the prototype or on an Array subclass.
+// expect: 1,2|10,undefined,undefined|5,20|1,undefined,3|2,4|7,8,9|1;2,3,4|a=1,b=2|100,200|1000,2000,3000/1000,2000,3000
 let out: string[] = [];
 
 // basic + fewer-than-pattern tail
@@ -50,5 +50,29 @@ const origIt = Array.prototype[Symbol.iterator];
 const [q, r] = [1, 2];
 (Array.prototype as any)[Symbol.iterator] = origIt;
 out.push([q, r].join(","));
+
+// A subclass whose Symbol.iterator lives on its own prototype must also deopt.
+// Regression: the fast-path gate resolved Symbol.iterator through a helper that
+// fell back straight to Array.prototype, never consulting the per-instance
+// prototype, so it approved the fast path and destructuring silently skipped the
+// override that for-of still honored. Both forms must agree.
+class MyArray extends Array {
+  [Symbol.iterator](): any {
+    let i = 0;
+    const self: any = this;
+    return {
+      next: () =>
+        i < self.length
+          ? { value: self[i++] * 1000, done: false }
+          : { value: undefined, done: true },
+    };
+  }
+}
+const sub: any = new MyArray();
+sub.push(1, 2, 3);
+const [s1, s2, s3] = sub;
+let subForOf: number[] = [];
+for (const sv of sub) subForOf.push(sv);
+out.push([s1, s2, s3].join(",") + "/" + subForOf.join(","));
 
 out.join("|");


### PR DESCRIPTION
> **Stacks on #29** (iterator fast path). `b0e1462` modifies `pkg/vm/array_iterator.go`, which #29's commits remove/replace, and shares the vm.go/bytecode.go opcode regions — so this branch is cut on top of #29 and its diff includes those commits until #29 merges. **Review/merge after #29;** this branch then rebases onto `main` and its diff shrinks to the single destructuring commit. Net new commit here: `b0e1462`.

`const [k, v] = pair` and `for-of` element patterns ran the full iterator protocol per pattern — build an iterator object, then a `next()` call per element with a `{value, done}` allocation each. For a pristine array the whole thing is equivalent to indexed reads.

## What this does

- **Two opcodes.** `OpArrayDestructFastCheck` identity-checks the source's `Symbol.iterator` against the recorded canonical array iterator; any instance- or prototype-level override fails the check and takes the generic path. `OpArrayRawGetInt` reads `Arr.Get(idx)` — bit-identical to what the built-in array iterator's `Step` yields, so no accessor/proxy divergence.
- **Per-element branch** selects fast (index read) vs generic (`next()`); both converge on the value register, so the existing binding, default, nested-pattern, and elision logic is untouched. On the fast arm `done` is forced true, which short-circuits the existing iterator-cleanup emit to a no-op — correct, since a pristine array iterator has no `return()` anyway.
- Rest patterns keep the generic path. Applied at all three destructuring sites (declaration, for-of decl, for-of assignment) via shared helpers.

Behavior preserved: short source → undefined tail, holes → undefined, defaults, nested patterns, and (verified) deopt on a prototype-level `Symbol.iterator` override.

**Design point for review:** the `Symbol.iterator` identity check that guards the fast path.

## Numbers

Local (M2, min of 5 interleaved A/B): `const [k,v]=pair` hot loop 4.8×; `for (const [k,v] of map)` 3.8×. The `perf`-label A/B is authoritative.

## Verification

`TestScripts` green + `tests/scripts/destructure_array_fast_path.ts` (short source, holes, defaults, elisions, nested patterns, rest, Map for-of, prototype-override deopt). Test262 language 0 new failures (differential vs upstream/main control); targeted built-ins 0 new failures.

*Aside (filed separately, not part of this PR):* while testing, instance-level `arr[Symbol.iterator] = ...` overrides on arrays turn out to be ignored by the existing generic for-of/spread paths too. The fast path matches that behavior, so no regression — but it's a pre-existing conformance gap worth an issue.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
