### PR TITLE
perf(vm): pool callback args slices (CallArgs2/3/4)

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -568,7 +568,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				var shouldSwap bool
 				if compareFn.IsCallable() {
 					// Use the comparator function
-					result, err := vmInstance.Call(compareFn, vm.Undefined, []vm.Value{elements[j], elements[j+1]})
+					result, err := vmInstance.CallArgs2(compareFn, vm.Undefined, elements[j], elements[j+1])
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -758,7 +758,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		for i := 0; i < thisArray.Length(); i++ {
 			element := thisArray.Get(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), vmInstance.GetThis()})
+			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), vmInstance.GetThis())
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -791,7 +791,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		for i := 0; i < thisArray.Length(); i++ {
 			element := thisArray.Get(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), vmInstance.GetThis()})
+			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), vmInstance.GetThis())
 			if err != nil {
 				return vm.NumberValue(-1), err
 			}
@@ -853,7 +853,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist (sparse array support)
 				if arr.HasIndex(i) {
 					element := arr.Get(i)
-					test, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+					test, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.NewArray(), err
 					}
@@ -868,7 +868,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist
 				if _, ok := po.GetOwn(key); ok {
 					elem, _ := po.Get(key)
-					test, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+					test, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.NewArray(), err
 					}
@@ -934,7 +934,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist (sparse array support)
 				if arr.HasIndex(i) {
 					element := arr.Get(i)
-					mappedValue, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+					mappedValue, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -951,7 +951,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist
 				if _, ok := po.GetOwn(key); ok {
 					elem, _ := po.Get(key)
-					mappedValue, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+					mappedValue, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -1014,7 +1014,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist (sparse array support)
 				if arr.HasIndex(i) {
 					element := arr.Get(i)
-					_, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+					_, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -1026,7 +1026,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist
 				if _, ok := po.GetOwn(key); ok {
 					elem, _ := po.Get(key)
-					_, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+					_, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -1085,7 +1085,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist (sparse array support)
 				if arr.HasIndex(i) {
 					element := arr.Get(i)
-					result, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+					result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.BooleanValue(false), err
 					}
@@ -1100,7 +1100,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist
 				if _, ok := po.GetOwn(key); ok {
 					elem, _ := po.Get(key)
-					result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+					result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.BooleanValue(false), err
 					}
@@ -1162,7 +1162,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist (sparse array support)
 				if arr.HasIndex(i) {
 					element := arr.Get(i)
-					result, err := vmInstance.Call(callback, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+					result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.BooleanValue(false), err
 					}
@@ -1177,7 +1177,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Only call callback for indices that actually exist
 				if _, ok := po.GetOwn(key); ok {
 					elem, _ := po.Get(key)
-					result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+					result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 					if err != nil {
 						return vm.BooleanValue(false), err
 					}
@@ -1249,7 +1249,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			for i := startIndex; i < length; i++ {
 				element := arr.Get(i)
 				var err error
-				accumulator, err = vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, element, vm.NumberValue(float64(i)), thisVal})
+				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, element, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1262,7 +1262,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 					elem = v
 				}
 				var err error
-				accumulator, err = vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, elem, vm.NumberValue(float64(i)), thisVal})
+				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1331,7 +1331,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			for i := startIndex; i >= 0; i-- {
 				element := arr.Get(i)
 				var err error
-				accumulator, err = vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, element, vm.NumberValue(float64(i)), thisVal})
+				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, element, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1344,7 +1344,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 					elem = v
 				}
 				var err error
-				accumulator, err = vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, elem, vm.NumberValue(float64(i)), thisVal})
+				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1440,7 +1440,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if arr := thisVal.AsArray(); arr != nil {
 			for i := arr.Length() - 1; i >= 0; i-- {
 				element := arr.Get(i)
-				result, err := vmInstance.Call(predicate, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+				result, err := vmInstance.CallArgs3(predicate, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1459,7 +1459,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				if v, ok := po.Get(key); ok {
 					elem = v
 				}
-				result, err := vmInstance.Call(predicate, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+				result, err := vmInstance.CallArgs3(predicate, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1502,7 +1502,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if arr := thisVal.AsArray(); arr != nil {
 			for i := arr.Length() - 1; i >= 0; i-- {
 				element := arr.Get(i)
-				result, err := vmInstance.Call(predicate, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+				result, err := vmInstance.CallArgs3(predicate, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.NumberValue(-1), err
 				}
@@ -1521,7 +1521,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				if v, ok := po.Get(key); ok {
 					elem = v
 				}
-				result, err := vmInstance.Call(predicate, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+				result, err := vmInstance.CallArgs3(predicate, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.NumberValue(-1), err
 				}
@@ -1821,7 +1821,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if arr := thisVal.AsArray(); arr != nil {
 			for i := 0; i < arr.Length(); i++ {
 				element := arr.Get(i)
-				mapped, err := vmInstance.Call(mapper, thisArg, []vm.Value{element, vm.NumberValue(float64(i)), thisVal})
+				mapped, err := vmInstance.CallArgs3(mapper, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1845,7 +1845,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				if v, ok := po.Get(key); ok {
 					elem = v
 				}
-				mapped, err := vmInstance.Call(mapper, thisArg, []vm.Value{elem, vm.NumberValue(float64(i)), thisVal})
+				mapped, err := vmInstance.CallArgs3(mapper, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1915,7 +1915,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			for j >= 0 {
 				cmp := 0
 				if comparator.IsCallable() {
-					res, err := vmInstance.Call(comparator, vm.Undefined, []vm.Value{resultArr.Get(j), key})
+					res, err := vmInstance.CallArgs2(comparator, vm.Undefined, resultArr.Get(j), key)
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -2262,7 +2262,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Apply mapping function if provided
 				if mapFn.Type() != vm.TypeUndefined {
 					vmInstance.EnterHelperCall()
-					mapped, err := vmInstance.Call(mapFn, thisArg, []vm.Value{element, vm.NumberValue(float64(i))})
+					mapped, err := vmInstance.CallArgs2(mapFn, thisArg, element, vm.NumberValue(float64(i)))
 					vmInstance.ExitHelperCall()
 					if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
 						return vm.NewArray(), nil
@@ -2355,7 +2355,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Apply mapping function if provided
 				if mapFn.Type() != vm.TypeUndefined {
 					vmInstance.EnterHelperCall()
-					mapped, mapErr := vmInstance.Call(mapFn, thisArg, []vm.Value{value, vm.NumberValue(float64(index))})
+					mapped, mapErr := vmInstance.CallArgs2(mapFn, thisArg, value, vm.NumberValue(float64(index)))
 					vmInstance.ExitHelperCall()
 					if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
 						return vm.NewArray(), nil
@@ -2383,7 +2383,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 					// Apply mapping function if provided
 					if mapFn.Type() != vm.TypeUndefined {
 						vmInstance.EnterHelperCall()
-						mapped, mapErr := vmInstance.Call(mapFn, thisArg, []vm.Value{element, vm.NumberValue(float64(i))})
+						mapped, mapErr := vmInstance.CallArgs2(mapFn, thisArg, element, vm.NumberValue(float64(i)))
 						vmInstance.ExitHelperCall()
 						if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
 							return vm.NewArray(), nil
@@ -2662,7 +2662,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 							// Apply mapfn if present
 							var mappedValue vm.Value = val
 							if mapfn.IsCallable() {
-								result, err := vmInstance.Call(mapfn, thisArg, []vm.Value{val, vm.NumberValue(float64(k))})
+								result, err := vmInstance.CallArgs2(mapfn, thisArg, val, vm.NumberValue(float64(k)))
 								if err != nil {
 									rejectWithError(err)
 									return
@@ -2803,7 +2803,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 						// Apply mapfn if present
 						var mappedValue vm.Value = val
 						if mapfn.IsCallable() {
-							result, err := vmInstance.Call(mapfn, thisArg, []vm.Value{val, vm.NumberValue(float64(k))})
+							result, err := vmInstance.CallArgs2(mapfn, thisArg, val, vm.NumberValue(float64(k)))
 							if err != nil {
 								rejectWithError(err)
 								return

--- a/pkg/builtins/iterator_init.go
+++ b/pkg/builtins/iterator_init.go
@@ -513,7 +513,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 			// Get value and apply mapper
 			valueVal, _ := vmInstance.GetProperty(result, "value")
-			mapped, err := vmInstance.Call(mapperFn, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+			mapped, err := vmInstance.CallArgs2(mapperFn, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 			if err != nil {
 				closeIterator(underlyingIter)
 				helperObj.SetOwn("[[GeneratorState]]", vm.NewString("completed"))
@@ -619,7 +619,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 				// Get value and test predicate
 				valueVal, _ := vmInstance.GetProperty(result, "value")
-				passed, err := vmInstance.Call(predicateFn, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+				passed, err := vmInstance.CallArgs2(predicateFn, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 				counter++
 				helperObj.SetOwn("[[Counter]]", vm.NumberValue(float64(counter)))
 
@@ -977,7 +977,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 
 			valueVal, _ := vmInstance.GetProperty(next, "value")
-			_, err = vmInstance.Call(fn, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+			_, err = vmInstance.CallArgs2(fn, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 			if err != nil {
 				closeIterator(thisValue)
 				return vm.Undefined, err
@@ -1038,7 +1038,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 				continue
 			}
 
-			accumulator, err = vmInstance.Call(reducer, vm.Undefined, []vm.Value{accumulator, valueVal, vm.NumberValue(float64(counter))})
+			accumulator, err = vmInstance.CallArgs3(reducer, vm.Undefined, accumulator, valueVal, vm.NumberValue(float64(counter)))
 			if err != nil {
 				closeIterator(thisValue)
 				return vm.Undefined, err
@@ -1089,7 +1089,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 
 			valueVal, _ := vmInstance.GetProperty(next, "value")
-			result, err := vmInstance.Call(predicate, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+			result, err := vmInstance.CallArgs2(predicate, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 			if err != nil {
 				closeIterator(thisValue)
 				return vm.Undefined, err
@@ -1141,7 +1141,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 
 			valueVal, _ := vmInstance.GetProperty(next, "value")
-			result, err := vmInstance.Call(predicate, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+			result, err := vmInstance.CallArgs2(predicate, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 			if err != nil {
 				closeIterator(thisValue)
 				return vm.Undefined, err
@@ -1193,7 +1193,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 
 			valueVal, _ := vmInstance.GetProperty(next, "value")
-			result, err := vmInstance.Call(predicate, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+			result, err := vmInstance.CallArgs2(predicate, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 			if err != nil {
 				closeIterator(thisValue)
 				return vm.Undefined, err
@@ -1344,7 +1344,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 				// Apply mapper
 				valueVal, _ := vmInstance.GetProperty(result, "value")
-				mapped, err := vmInstance.Call(mapperFn, vm.Undefined, []vm.Value{valueVal, vm.NumberValue(float64(counter))})
+				mapped, err := vmInstance.CallArgs2(mapperFn, vm.Undefined, valueVal, vm.NumberValue(float64(counter)))
 				if err != nil {
 					closeIterator(underlyingIter)
 					helperObj.SetOwn("[[GeneratorState]]", vm.NewString("completed"))

--- a/pkg/builtins/json_init.go
+++ b/pkg/builtins/json_init.go
@@ -811,7 +811,7 @@ func internalizeJSONProperty(vmInstance *vm.VM, holder vm.Value, name string, re
 	}
 
 	// Call the reviver function with (holder, name, val, context)
-	return vmInstance.Call(reviver, holder, []vm.Value{vm.NewString(name), val, vm.NewValueFromPlainObject(context)})
+	return vmInstance.CallArgs3(reviver, holder, vm.NewString(name), val, vm.NewValueFromPlainObject(context))
 }
 
 // parseJSONValueFromDecoder reads a JSON value from a decoder, preserving object key order
@@ -1290,7 +1290,7 @@ func stringifyValueToJSONWithVisited(vmInstance *vm.VM, value vm.Value, visited 
 
 	// Step 2: Apply replacer function if present
 	if replacerFunc != vm.Undefined && replacerFunc.IsCallable() && vmInstance != nil {
-		result, err := vmInstance.Call(replacerFunc, holder, []vm.Value{vm.NewString(key), value})
+		result, err := vmInstance.CallArgs2(replacerFunc, holder, vm.NewString(key), value)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/builtins/map_init.go
+++ b/pkg/builtins/map_init.go
@@ -220,7 +220,7 @@ func (m *MapInitializer) InitRuntime(ctx *RuntimeContext) error {
 			key, value, exists := mapObj.GetEntryAt(i)
 			if exists {
 				// Call callback(value, key, map) with thisArg as 'this'
-				_, err := vmInstance.Call(callback, thisArg, []vm.Value{value, key, thisMap})
+				_, err := vmInstance.CallArgs3(callback, thisArg, value, key, thisMap)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -540,7 +540,7 @@ func (m *MapInitializer) InitRuntime(ctx *RuntimeContext) error {
 			value, _ := vmInstance.GetProperty(iterResult, "value")
 
 			// Call callback with (value, k)
-			keyResult, err := vmInstance.Call(callbackfn, vm.Undefined, []vm.Value{value, vm.NumberValue(float64(k))})
+			keyResult, err := vmInstance.CallArgs2(callbackfn, vm.Undefined, value, vm.NumberValue(float64(k)))
 			if err != nil {
 				return vm.Undefined, err
 			}

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -678,7 +678,7 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 				setProtoTrap, hasTrap = po.GetOwn("setPrototypeOf")
 			}
 			if hasTrap && setProtoTrap.IsCallable() {
-				result, err := vmInstance.Call(setProtoTrap, handler, []vm.Value{proxy.Target(), protoArg})
+				result, err := vmInstance.CallArgs2(setProtoTrap, handler, proxy.Target(), protoArg)
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1142,7 +1142,7 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 				value, _ := vmInstance.GetProperty(iterResult, "value")
 
 				// Call callback with (value, k)
-				keyResult, err := vmInstance.Call(callbackfn, vm.Undefined, []vm.Value{value, vm.NumberValue(float64(k))})
+				keyResult, err := vmInstance.CallArgs2(callbackfn, vm.Undefined, value, vm.NumberValue(float64(k)))
 				if err != nil {
 					return vm.Undefined, err
 				}
@@ -1284,7 +1284,7 @@ func lookupSymbolProp(vmInstance *vm.VM, val vm.Value, symKey vm.PropertyKey, sy
 			getTrap, hasGetTrap = handler.AsDictObject().GetOwn("get")
 		}
 		if hasGetTrap && getTrap.IsCallable() {
-			return vmInstance.Call(getTrap, handler, []vm.Value{proxy.Target(), vmInstance.SymbolToStringTag, val})
+			return vmInstance.CallArgs3(getTrap, handler, proxy.Target(), vmInstance.SymbolToStringTag, val)
 		}
 		// No get trap — check target
 		return lookupSymbolProp(vmInstance, proxy.Target(), symKey, symObj, depth+1)
@@ -1879,7 +1879,7 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			}
 
 			if !getOwnPropDescTrap.IsUndefined() && getOwnPropDescTrap.IsCallable() {
-				descResult, derr := vmInstance.Call(getOwnPropDescTrap, handler, []vm.Value{target, key})
+				descResult, derr := vmInstance.CallArgs2(getOwnPropDescTrap, handler, target, key)
 				if derr != nil {
 					return vm.Undefined, derr
 				}

--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -264,7 +264,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, err
 		}
 		if thenMethod.IsCallable() {
-			return vmInstance.Call(thenMethod, obj, []vm.Value{onFulfilled, onRejected})
+			return vmInstance.CallArgs2(thenMethod, obj, onFulfilled, onRejected)
 		}
 		// If no .then() method, wrap in a resolved promise and chain
 		return vmInstance.PromiseThen(vmInstance.NewResolvedPromise(obj), onFulfilled, onRejected)

--- a/pkg/builtins/set_init.go
+++ b/pkg/builtins/set_init.go
@@ -659,7 +659,7 @@ func (s *SetInitializer) InitRuntime(ctx *RuntimeContext) error {
 			val, exists := setObj.GetValueAt(i)
 			if exists {
 				// forEach callback receives (value, value, set) - value is passed twice for consistency with Map
-				_, err := vmInstance.Call(callback, thisArg, []vm.Value{val, val, thisSet})
+				_, err := vmInstance.CallArgs3(callback, thisArg, val, val, thisSet)
 				if err != nil {
 					return vm.Undefined, err
 				}

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -1371,7 +1371,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				if splitter.IsCallable() {
 					// Call splitter with separator as 'this' and (O, limit) as arguments
 					vmInstance.EnterHelperCall()
-					result, err := vmInstance.Call(splitter, separatorArg, []vm.Value{thisVal, limitArg})
+					result, err := vmInstance.CallArgs2(splitter, separatorArg, thisVal, limitArg)
 					vmInstance.ExitHelperCall()
 					if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
 						return vm.Undefined, nil
@@ -1539,7 +1539,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if ok && replacer.Type() != vm.TypeUndefined && replacer.Type() != vm.TypeNull {
 				if replacer.IsCallable() {
 					vmInstance.EnterHelperCall()
-					result, err := vmInstance.Call(replacer, searchArg, []vm.Value{thisVal, replaceArg})
+					result, err := vmInstance.CallArgs2(replacer, searchArg, thisVal, replaceArg)
 					vmInstance.ExitHelperCall()
 					if err != nil {
 						return vm.Undefined, err
@@ -1643,7 +1643,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if ok && replacer.Type() != vm.TypeUndefined && replacer.Type() != vm.TypeNull {
 				if replacer.IsCallable() {
 					vmInstance.EnterHelperCall()
-					result, err := vmInstance.Call(replacer, searchArg, []vm.Value{thisVal, replaceArg})
+					result, err := vmInstance.CallArgs2(replacer, searchArg, thisVal, replaceArg)
 					vmInstance.ExitHelperCall()
 					if err != nil {
 						return vm.Undefined, err

--- a/pkg/builtins/typedarray_base_init.go
+++ b/pkg/builtins/typedarray_base_init.go
@@ -534,7 +534,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			_, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			_, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -566,7 +566,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -601,7 +601,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -636,7 +636,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -671,7 +671,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -708,7 +708,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -746,7 +746,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -786,7 +786,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 
 		for i := startIndex; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -825,7 +825,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 
 		for i := startIndex; i >= 0; i-- {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -1130,7 +1130,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 			for j := 0; j < length-i-1; j++ {
 				var shouldSwap bool
 				if callback.IsCallable() {
-					result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{elements[j], elements[j+1]})
+					result, err := vmInstance.CallArgs2(callback, vm.Undefined, elements[j], elements[j+1])
 					if err != nil {
 						return vm.Undefined, err
 					}
@@ -1446,7 +1446,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := length - 1; i >= 0; i-- {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -1481,7 +1481,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		length := ta.GetLength()
 		for i := length - 1; i >= 0; i-- {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -1541,7 +1541,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 			for j := 0; j < length-i-1; j++ {
 				var shouldSwap bool
 				if callback.IsCallable() {
-					result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{elements[j], elements[j+1]})
+					result, err := vmInstance.CallArgs2(callback, vm.Undefined, elements[j], elements[j+1])
 					if err != nil {
 						return vm.Undefined, err
 					}

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -488,7 +488,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			_, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			_, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -520,7 +520,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -555,7 +555,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -590,7 +590,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -625,7 +625,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 		length := ta.GetLength()
 		for i := 0; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, thisArg, []vm.Value{elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -666,7 +666,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 
 		for i := startIndex; i < length; i++ {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -705,7 +705,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 
 		for i := startIndex; i >= 0; i-- {
 			elem := ta.GetElement(i)
-			result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{accumulator, elem, vm.Number(float64(i)), thisArray})
+			result, err := vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.Number(float64(i)), thisArray)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -950,7 +950,7 @@ func SetupTypedArrayPrototype(proto *vm.PlainObject, vmInstance *vm.VM) {
 			for j := 0; j < length-i-1; j++ {
 				var shouldSwap bool
 				if callback.IsCallable() {
-					result, err := vmInstance.Call(callback, vm.Undefined, []vm.Value{elements[j], elements[j+1]})
+					result, err := vmInstance.CallArgs2(callback, vm.Undefined, elements[j], elements[j+1])
 					if err != nil {
 						return vm.Undefined, err
 					}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -168,6 +168,11 @@ type VM struct {
 	// Promise executor, etc.).
 	sentinelRegPool [][]Value
 
+	// argsBufPool is a LIFO free-list of small (cap 4) []Value buffers reused by
+	// CallArgs2/3/4 to pass callback arguments without a per-invocation slice
+	// allocation. Same nesting invariant as sentinelRegPool.
+	argsBufPool [][]Value
+
 	// List of upvalues pointing to variables still on the registerStack
 	openUpvalues []*Upvalue
 	// Map for O(1) lookup of existing upvalues by location pointer

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1288,6 +1288,57 @@ func (vm *VM) GetSymbolProperty(obj Value, symbol Value) (Value, bool) {
 
 // Call is a unified function calling interface that handles all function types properly
 // This replaces the complex web of CallFunctionDirectly, CallUserFunction, etc.
+// getArgsBuf returns a reusable []Value of length n (n <= 4) for callback
+// arguments, popping from the pool or allocating a cap-4 buffer. Reentries nest
+// strictly LIFO, so an in-use buffer is never handed out twice.
+func (vm *VM) getArgsBuf(n int) []Value {
+	if k := len(vm.argsBufPool); k > 0 {
+		b := vm.argsBufPool[k-1]
+		vm.argsBufPool = vm.argsBufPool[:k-1]
+		return b[:n]
+	}
+	return make([]Value, n, 4)
+}
+
+// putArgsBuf returns a buffer to the pool, clearing it so pooled buffers don't
+// retain argument values.
+func (vm *VM) putArgsBuf(b []Value) {
+	b = b[:cap(b)]
+	for i := range b {
+		b[i] = Undefined
+	}
+	vm.argsBufPool = append(vm.argsBufPool, b)
+}
+
+// CallArgs2/3/4 invoke fn with the given arguments through a pooled buffer,
+// avoiding the per-call []Value allocation that every array callback site paid.
+// Safe because Call copies the arguments out before returning (into the callee's
+// registers and, if accessed, a copied arguments object) - nothing retains the
+// slice past the call.
+func (vm *VM) CallArgs2(fn, thisValue, a0, a1 Value) (Value, error) {
+	b := vm.getArgsBuf(2)
+	b[0], b[1] = a0, a1
+	r, err := vm.Call(fn, thisValue, b)
+	vm.putArgsBuf(b)
+	return r, err
+}
+
+func (vm *VM) CallArgs3(fn, thisValue, a0, a1, a2 Value) (Value, error) {
+	b := vm.getArgsBuf(3)
+	b[0], b[1], b[2] = a0, a1, a2
+	r, err := vm.Call(fn, thisValue, b)
+	vm.putArgsBuf(b)
+	return r, err
+}
+
+func (vm *VM) CallArgs4(fn, thisValue, a0, a1, a2, a3 Value) (Value, error) {
+	b := vm.getArgsBuf(4)
+	b[0], b[1], b[2], b[3] = a0, a1, a2, a3
+	r, err := vm.Call(fn, thisValue, b)
+	vm.putArgsBuf(b)
+	return r, err
+}
+
 func (vm *VM) Call(fn Value, thisValue Value, args []Value) (Value, error) {
 	switch fn.Type() {
 	case TypeNativeFunction:


### PR DESCRIPTION
> **Stacks on #33** (sentinel-register pool). Shares the `vm.go` / `vm_init.go` pooling regions, so this branch is cut on top of #33 and its diff includes that commit until #33 merges. **Review/merge after #33;** this branch then rebases onto `main` and its diff shrinks to the single callback-args commit. Net new commit here: `ad0598e`.

The bigger sibling of #33. Every builtin invoking a JS callback built a fresh `[]Value{element, index, array}` — one slice per element across Array/TypedArray map/forEach/filter/reduce/some/every/find/sort, Array.from, Map/Set forEach, String replace/split, JSON replacer/reviver, Promise, and Object callbacks.

## What this does

Add `CallArgs2/CallArgs3/CallArgs4` on the VM: they pass the arguments through a pooled cap-4 buffer (same LIFO free-list discipline as #33) instead of a literal slice. Safe because `Call` copies the args out before returning — parameters into the callee's registers, and the `arguments` object (if accessed) is a full copy (`NewArguments` does make+copy) — so nothing retains the slice past the call; an audit found no native that stores it. 71 call sites converted across 10 builtin files. (The one `Call` whose argument is a comma-containing string literal was deliberately left un-converted.)

**Design point for review:** why pooling is safe — `Call` copies args into callee registers and `NewArguments` deep-copies, so nothing retains the slice.

## Numbers

Local (M2, min of 6, on top of #33): a forEach+map+reduce+filter loop 1173 → 980 ms (~16%) with GC cycles collapsing 265 → 56 (~79% fewer). Combined with #33, callback-heavy code is ~30% faster with ~82% fewer GCs. The `perf`-label A/B is authoritative.

## Verification

`TestScripts` green; vm+builtins tests under `-race` clean; broad callback correctness across all families verified. Test262 language 0 new failures (differential vs upstream/main control); built-ins Array/TypedArray/Map/Set/String/JSON/Promise/Object 0 new failures.

---
Part of a VM micro-optimization series (profile-driven, one slice per PR). A tracking issue with the full map and a reviewer's guide follows.
