### PR TITLE
perf(vm): comparison fast path, integer %, non-allocating finally, dead-code cleanup

### DIFF
--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -42,6 +42,30 @@ func (vm *VM) findAllExceptionHandlers(pc int) []*ExceptionHandler {
 	return handlers
 }
 
+// findPendingHandler returns the first handler in exception-table order that
+// covers pc and is a finally block (or, when includeIterCleanup is set, an
+// iterator-cleanup block). It selects the same handler the callers of
+// findAllExceptionHandlers used to pick, but without allocating a slice —
+// this runs on every OpReturn/OpReturnUndefined, where the common case is an
+// empty table.
+func (vm *VM) findPendingHandler(pc int, includeIterCleanup bool) *ExceptionHandler {
+	if vm.frameCount == 0 {
+		return nil
+	}
+	frame := &vm.frames[vm.frameCount-1]
+	if frame.closure == nil {
+		return nil
+	}
+	table := frame.closure.Fn.Chunk.ExceptionTable
+	for i := range table {
+		h := &table[i]
+		if pc >= h.TryStart && pc < h.TryEnd && (h.IsFinally || (includeIterCleanup && h.IsIteratorCleanup)) {
+			return h
+		}
+	}
+	return nil
+}
+
 // throwException initiates exception unwinding with the given value
 func (vm *VM) throwException(value Value) {
 	if debugExceptions {

--- a/pkg/vm/isobject_bench_test.go
+++ b/pkg/vm/isobject_bench_test.go
@@ -1,0 +1,62 @@
+package vm
+
+import "testing"
+
+// isObjectMix models the hot-path distribution: IsObject is called predominantly
+// on non-object values (numbers in arithmetic/ToInteger guards), which is the
+// OR-chain's worst case (all comparisons fail before returning false).
+func isObjectMix() []Value {
+	vs := make([]Value, 0, 32)
+	for i := 0; i < 24; i++ {
+		vs = append(vs, IntegerValue(int32(i))) // 24 numbers (typ far below the object range)
+	}
+	vs = append(vs,
+		NewString("x"), BooleanValue(true), Undefined, Null, // more non-objects
+		Value{typ: TypeObject}, Value{typ: TypeArray},
+		Value{typ: TypeProxy}, Value{typ: TypeMap}, // a few objects
+	)
+	return vs
+}
+
+func BenchmarkIsObject(b *testing.B) {
+	vs := isObjectMix()
+	b.ResetTimer()
+	var sink int
+	// Inner range loop so IsObject dominates ns/op instead of index arithmetic.
+	// ns/op therefore covers len(vs) IsObject calls; consistent across A/B runs.
+	for i := 0; i < b.N; i++ {
+		for j := range vs {
+			if vs[j].IsObject() {
+				sink++
+			}
+		}
+	}
+	_ = sink
+}
+
+// TestIsObjectExhaustive locks in that IsObject is equivalent to the contiguous
+// [TypeObject, TypeProxy] range for every defined ValueType — the invariant the
+// range-check implementation depends on. If a new type is inserted mid-enum this
+// fails, flagging that the range bounds (and this list) need review.
+func TestIsObjectExhaustive(t *testing.T) {
+	// Every type that must be an object (matches the historical OR-chain).
+	objectTypes := map[ValueType]bool{
+		TypeObject: true, TypeDictObject: true, TypeArray: true, TypeArguments: true,
+		TypeGenerator: true, TypeAsyncGenerator: true, TypePromise: true, TypeRegExp: true,
+		TypeTypedArray: true, TypeDataView: true, TypeArrayBuffer: true, TypeSharedArrayBuffer: true,
+		TypeProxy: true, TypeMap: true, TypeSet: true, TypeWeakMap: true, TypeWeakSet: true,
+		TypeWeakRef: true,
+	}
+	for typ := TypeUndefined; typ <= TypeUninitialized; typ++ {
+		got := (Value{typ: typ}).IsObject()
+		want := objectTypes[typ]
+		if got != want {
+			t.Errorf("IsObject(typ=%d) = %v, want %v", typ, got, want)
+		}
+		// Range-check equivalence: object types must be exactly the contiguous span.
+		if inRange := typ >= TypeObject && typ <= TypeProxy; inRange != want {
+			t.Errorf("type %d: range [TypeObject,TypeProxy] membership %v != object-set %v "+
+				"(object types are no longer contiguous — fix IsObject bounds)", typ, inRange, want)
+		}
+	}
+}

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -639,8 +640,52 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 	o.properties = append(o.properties, value)
 }
 
+// arrayIndexAccessorSeen latches to true the first time any accessor property is
+// defined under a canonical array-index key (e.g. Object.defineProperty(proto,
+// "5", {get})). OpSetIndex's inherited-index-setter walk — a strconv.Itoa + string
+// concat + Array.prototype chain scan on *every* `arr[i] = v` — is skipped while
+// this is false, which is the overwhelmingly common case (integer-indexed
+// accessors on the prototype chain essentially never occur). It only ever latches
+// true and never resets; that is safe because the walk is a pure correctness guard,
+// so a stale-true merely restores the original (slow) behavior. Process-global
+// rather than per-realm to keep the accessor-definition choke points VM-free; the
+// only cost of the coarser scope is that one realm defining such an accessor also
+// disables the fast path for others, which is negligible in practice.
+var arrayIndexAccessorSeen bool
+
+// isCanonicalArrayIndexKey reports whether name is a canonical array-index string
+// ("0", or a digit-string with no leading zero, within the 0..2^32-2 index range) —
+// the only keys the OpSetIndex setter walk can ever match.
+func isCanonicalArrayIndexKey(name string) bool {
+	if len(name) == 0 || len(name) > 10 {
+		return false
+	}
+	if name == "0" {
+		return true
+	}
+	if name[0] < '1' || name[0] > '9' { // reject leading zero and non-digits
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	n, err := strconv.ParseUint(name, 10, 64)
+	return err == nil && n <= 0xFFFFFFFE
+}
+
+// noteAccessorKey latches arrayIndexAccessorSeen when a string key is a canonical
+// array index. Called from every accessor-definition choke point.
+func noteAccessorKey(name string) {
+	if !arrayIndexAccessorSeen && isCanonicalArrayIndexKey(name) {
+		arrayIndexAccessorSeen = true
+	}
+}
+
 // DefineAccessorProperty defines or updates an accessor own property.
 func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+	noteAccessorKey(name)
 	// Wrapper using string name
 	// Find existing field
 	for i, f := range o.shape.fields {
@@ -780,6 +825,9 @@ func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writa
 
 // DefineAccessorPropertyByKey defines or updates an accessor property for arbitrary key kinds.
 func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+	if key.isString() {
+		noteAccessorKey(key.name)
+	}
 	// Find existing field
 	for i, f := range o.shape.fields {
 		match := (key.isString() && f.keyKind == KeyKindString && f.name == key.name) ||

--- a/pkg/vm/tointeger_bench_test.go
+++ b/pkg/vm/tointeger_bench_test.go
@@ -1,0 +1,65 @@
+package vm
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// toIntegerCases pins ToInteger (ECMAScript ToInt32) behavior across input kinds.
+// Values are hand-derived from the spec (32-bit wrap; NaN/Inf -> 0; string parse;
+// bool 1/0). The test must pass BOTH before and after the fast-path reorder — it
+// is the equivalence guard for that change.
+var toIntegerCases = []struct {
+	name string
+	v    Value
+	want int32
+}{
+	{"int-pos", IntegerValue(5), 5},
+	{"int-neg", IntegerValue(-3), -3},
+	{"float-trunc-pos", NumberValue(3.9), 3},
+	{"float-trunc-neg", NumberValue(-3.9), -3},
+	{"float-nan", NumberValue(math.NaN()), 0},
+	{"float-posinf", NumberValue(math.Inf(1)), 0},
+	{"float-neginf", NumberValue(math.Inf(-1)), 0},
+	{"float-wrap-2^32+5", NumberValue(4294967301), 5},
+	{"float-wrap-2^31", NumberValue(2147483648), -2147483648},
+	{"float-negzero", NumberValue(math.Copysign(0, -1)), 0},
+	{"bool-true", BooleanValue(true), 1},
+	{"bool-false", BooleanValue(false), 0},
+	{"str-int", NewString("42"), 42},
+	{"str-pad", NewString("  10 "), 10},
+	{"str-float", NewString("3.7"), 3},
+	{"str-empty", NewString(""), 0},
+	{"str-garbage", NewString("abc"), 0},
+	{"undefined", Undefined, 0},
+	{"null", Null, 0},
+	{"bigint-small", NewBigInt(big.NewInt(10)), 10},
+}
+
+func TestToIntegerEquivalence(t *testing.T) {
+	for _, tc := range toIntegerCases {
+		if got := tc.v.ToInteger(); got != tc.want {
+			t.Errorf("ToInteger(%s) = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// BenchmarkToInteger models the hot path: mostly integer operands (bitwise ops),
+// a few floats. Measures the fast-path reorder — before the change, each call
+// runs the IsObject/object guard before reaching the number case.
+func BenchmarkToInteger(b *testing.B) {
+	vs := make([]Value, 0, 32)
+	for i := 0; i < 28; i++ {
+		vs = append(vs, IntegerValue(int32(i*7-13)))
+	}
+	vs = append(vs, NumberValue(3.5), NumberValue(-9.9), NumberValue(4294967301), NumberValue(2147483648))
+	b.ResetTimer()
+	var sink int32
+	for i := 0; i < b.N; i++ {
+		for j := range vs {
+			sink += vs[j].ToInteger()
+		}
+	}
+	_ = sink
+}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -767,7 +767,12 @@ func (v Value) IsBoolean() bool {
 }
 
 func (v Value) IsObject() bool {
-	return v.typ == TypeObject || v.typ == TypeDictObject || v.typ == TypeArray || v.typ == TypeArguments || v.typ == TypeGenerator || v.typ == TypeAsyncGenerator || v.typ == TypePromise || v.typ == TypeRegExp || v.typ == TypeTypedArray || v.typ == TypeDataView || v.typ == TypeArrayBuffer || v.typ == TypeSharedArrayBuffer || v.typ == TypeProxy || v.typ == TypeMap || v.typ == TypeSet || v.typ == TypeWeakMap || v.typ == TypeWeakSet || v.typ == TypeWeakRef
+	// The object ValueTypes form a contiguous span [TypeObject, TypeProxy], so this
+	// range check is equivalent to (and much faster than) an 18-way OR-chain — it
+	// rejects the common non-object case (numbers) in one comparison instead of 18.
+	// TestIsObjectExhaustive locks in the equivalence; if a type is ever inserted
+	// mid-enum and breaks contiguity, that test fails.
+	return v.typ >= TypeObject && v.typ <= TypeProxy
 }
 
 func (v Value) IsDictObject() bool {

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -1326,6 +1326,21 @@ func (v Value) ToPrimitive(hint string) Value {
 }
 
 func (v Value) ToInteger() int32 {
+	// Fast path: already a number — the overwhelmingly common operand for ToInt32
+	// coercions (bitwise & | ^ << >> >>> ~, asm.js-style `x | 0`). A number is
+	// never an object, so this takes the identical path the switch below would;
+	// short-circuiting here skips the object/ToPrimitive guard entirely.
+	switch v.typ {
+	case TypeIntegerNumber:
+		return v.AsInteger()
+	case TypeFloatNumber:
+		f := v.AsFloat()
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0
+		}
+		return int32(uint32(int64(f)))
+	}
+
 	// First apply ToPrimitive if it's an object
 	if v.IsObject() || v.typ == TypeArray || v.typ == TypeArguments || v.typ == TypeRegExp || v.typ == TypeMap || v.typ == TypeSet || v.typ == TypeProxy {
 		v = v.ToPrimitive("number")

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2290,6 +2290,7 @@ func (a *ArrayObject) HasOwnSymbolProp(sym *SymbolObject) bool {
 
 // DefineAccessorProperty defines an accessor property on the array object
 func (a *ArrayObject) DefineAccessorProperty(name string, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+	noteAccessorKey(name)
 	// Initialize maps if needed
 	if a.getters == nil {
 		a.getters = make(map[string]Value)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -7478,7 +7478,7 @@ startExecution:
 				if !isValidArrayIndex {
 					// Handle Symbol keys directly
 					if indexVal.Type() == TypeSymbol {
-						if ok, status, res := vm.opSetPropSymbol(ip, &baseVal, indexVal, &valueVal); !ok {
+						if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
 							return status, res
 						}
 						continue
@@ -7499,7 +7499,7 @@ startExecution:
 						}
 						// Per ECMAScript ToPropertyKey: if ToPrimitive returns a Symbol, use it directly
 						if primitiveVal.Type() == TypeSymbol {
-							if ok, status, res := vm.opSetPropSymbol(ip, &baseVal, primitiveVal, &valueVal); !ok {
+							if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], primitiveVal, &valueVal); !ok {
 								return status, res
 							}
 							continue
@@ -7508,7 +7508,7 @@ startExecution:
 					} else {
 						key = indexVal.ToString()
 					}
-					if ok, status, res := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+					if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 						if status != InterpretOK {
 							return status, res
 						}
@@ -7520,12 +7520,17 @@ startExecution:
 				// idx is now set from either number or string path
 				// and we've verified it's a valid array index (non-negative integer)
 
-				// Check for setter on Array.prototype chain before direct write
-				// ECMAScript requires invoking inherited setters for array indices
-				idxKey := strconv.Itoa(idx)
-				setterKey := "s:" + idxKey // PropertyKey hash format for string keys
+				// Check for setter on Array.prototype chain before direct write.
+				// ECMAScript requires invoking inherited setters for array indices,
+				// but integer-indexed accessors on the prototype chain essentially
+				// never exist, so guard the whole walk (a strconv.Itoa + string
+				// concat + chain scan, on every element write) behind a latch that is
+				// only set once such an accessor is actually defined. See
+				// arrayIndexAccessorSeen in object.go.
 				setterFound := false
-				if vm.ArrayPrototype.IsObject() {
+				if arrayIndexAccessorSeen && vm.ArrayPrototype.IsObject() {
+					idxKey := strconv.Itoa(idx)
+					setterKey := "s:" + idxKey // PropertyKey hash format for string keys
 					for cur := vm.ArrayPrototype.AsPlainObject(); cur != nil; {
 						// Check directly in the setters map (keyed by PropertyKey.hash())
 						if cur.setters != nil {
@@ -7585,7 +7590,7 @@ startExecution:
 						// Convert index to string for property key
 						key := fmt.Sprintf("%d", idx)
 						// Use opSetProp to handle property setting with accessor awareness
-						if ok, status, res := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+						if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 							if status != InterpretOK {
 								return status, res
 							}
@@ -7623,7 +7628,7 @@ startExecution:
 						// Skip setting silently (spec-incomplete structure)
 						continue
 					}
-					if ok, status, res := vm.opSetPropSymbol(ip, &baseVal, indexVal, &valueVal); !ok {
+					if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
 						return status, res
 					}
 					continue
@@ -7646,7 +7651,7 @@ startExecution:
 						}
 						// Per ECMAScript ToPropertyKey: if ToPrimitive returns a Symbol, use it directly
 						if primitiveVal.Type() == TypeSymbol {
-							if ok, status, res := vm.opSetPropSymbol(ip, &baseVal, primitiveVal, &valueVal); !ok {
+							if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], primitiveVal, &valueVal); !ok {
 								return status, res
 							}
 							continue
@@ -7718,7 +7723,7 @@ startExecution:
 				} else {
 					// Route through opSetProp which handles extensibility, writable,
 					// prototype chain accessors, and global object sync
-					if ok, status, res := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+					if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 						if status != InterpretOK {
 							return status, res
 						}
@@ -7736,18 +7741,18 @@ startExecution:
 					// Non-numeric index (Symbol, string, etc.) - set property via prototype chain
 					switch indexVal.Type() {
 					case TypeSymbol:
-						if ok, status, value := vm.opSetPropSymbol(ip, &baseVal, indexVal, &valueVal); !ok {
+						if ok, status, value := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
 							return status, value
 						}
 					case TypeString:
 						key := AsString(indexVal)
-						if ok, status, value := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+						if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 							return status, value
 						}
 					default:
 						// Convert to string for property access
 						key := indexVal.ToString()
-						if ok, status, value := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+						if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 							return status, value
 						}
 					}
@@ -7757,17 +7762,17 @@ startExecution:
 				// Proxy objects: route all property setting through the proxy protocol via opSetProp
 				switch indexVal.Type() {
 				case TypeSymbol:
-					if ok, status, value := vm.opSetPropSymbol(ip, &baseVal, indexVal, &valueVal); !ok {
+					if ok, status, value := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
 						return status, value
 					}
 				case TypeString:
 					key := AsString(indexVal)
-					if ok, status, value := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+					if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 						return status, value
 					}
 				default:
 					key := indexVal.ToString()
-					if ok, status, value := vm.opSetProp(ip, &baseVal, key, &valueVal); !ok {
+					if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
 						return status, value
 					}
 				}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -12198,21 +12198,6 @@ startExecution:
 				goto reloadFrame
 			}
 
-			// NUCLEAR DEBUG for fnGlobalObject
-			if value.IsFunction() {
-				name := ""
-				switch value.Type() {
-				case TypeFunction:
-					name = value.AsFunction().Name
-				case TypeClosure:
-					name = value.AsClosure().Fn.Name
-				case TypeNativeFunction:
-					name = value.AsNativeFunction().Name
-				}
-				if name == "fnGlobalObject" || name == "Test262Error" {
-				}
-			}
-
 			// TDZ check: throw ReferenceError if accessing an uninitialized let/const variable
 			if value.typ == TypeUninitialized {
 				frame.ip = ip
@@ -12311,21 +12296,6 @@ startExecution:
 						return InterpretRuntimeError, Undefined
 					}
 					continue // Don't also set in heap
-				}
-			}
-
-			// NUCLEAR DEBUG for fnGlobalObject
-			if value.IsFunction() {
-				name := ""
-				switch value.Type() {
-				case TypeFunction:
-					name = value.AsFunction().Name
-				case TypeClosure:
-					name = value.AsClosure().Fn.Name
-				case TypeNativeFunction:
-					name = value.AsNativeFunction().Name
-				}
-				if name == "fnGlobalObject" || name == "Test262Error" {
 				}
 			}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1926,6 +1926,26 @@ startExecution:
 				case OpDivide:
 					registers[destReg] = Number(l / r)
 				case OpRemainder:
+					// Integer fast path: math.Mod is a software frexp/ldexp
+					// loop (~7% of the recursion benchmark's profile via
+					// `i % k` patterns). Go's truncated int64 remainder has
+					// the dividend's sign, exactly matching JS %, so it is
+					// safe when: both operands are integral and within ±2^53
+					// (float64<->int64 round-trips exactly; beyond that the
+					// conversion can saturate), the divisor is nonzero
+					// (0 divisor => NaN), and the result is not a signed
+					// zero (JS requires -0 for a negative or -0 dividend
+					// with zero remainder; the int path would lose the sign).
+					const maxExactInt = float64(1 << 53)
+					if l >= -maxExactInt && l <= maxExactInt && r >= -maxExactInt && r <= maxExactInt {
+						li, ri := int64(l), int64(r)
+						if float64(li) == l && float64(ri) == r && ri != 0 {
+							if rem := li % ri; rem != 0 || !math.Signbit(l) {
+								registers[destReg] = Number(float64(rem))
+								continue
+							}
+						}
+					}
 					registers[destReg] = Number(math.Mod(l, r))
 				case OpEqual, OpStrictEqual:
 					registers[destReg] = BooleanValue(l == r)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1898,6 +1898,57 @@ startExecution:
 			leftVal := registers[leftReg]
 			rightVal := registers[rightReg]
 
+			// Fast path: skip ToPrimitive/BigInt/Symbol bookkeeping entirely when
+			// both operands are already plain numbers - the overwhelmingly common
+			// case for arithmetic and loop comparisons. ToPrimitive(number) is a
+			// no-op per spec, so this computes exactly what the general path below
+			// would, just without the frame.ip/helperCallDepth bookkeeping and the
+			// unwinding/handlerFound checks that only matter when ToPrimitive can
+			// invoke user code (valueOf/toString/Symbol.toPrimitive on an object).
+			// The tags are read directly rather than via ToFloat(), which is too
+			// large to inline. JS NaN semantics need no special casing: Go float
+			// comparisons yield false when either operand is NaN (so the != case
+			// correctly makes NaN !== NaN true), and division by zero yields
+			// ±Inf/NaN per IEEE 754, matching ECMAScript.
+			if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeFloatNumber || lt == TypeIntegerNumber) && (rt == TypeFloatNumber || rt == TypeIntegerNumber) {
+				var l, r float64
+				if lt == TypeFloatNumber {
+					l = leftVal.AsFloat()
+				} else {
+					l = float64(leftVal.AsInteger())
+				}
+				if rt == TypeFloatNumber {
+					r = rightVal.AsFloat()
+				} else {
+					r = float64(rightVal.AsInteger())
+				}
+				switch opcode {
+				case OpAdd:
+					registers[destReg] = Number(l + r)
+				case OpSubtract:
+					registers[destReg] = Number(l - r)
+				case OpMultiply:
+					registers[destReg] = Number(l * r)
+				case OpDivide:
+					registers[destReg] = Number(l / r)
+				case OpRemainder:
+					registers[destReg] = Number(math.Mod(l, r))
+				case OpEqual, OpStrictEqual:
+					registers[destReg] = BooleanValue(l == r)
+				case OpNotEqual, OpStrictNotEqual:
+					registers[destReg] = BooleanValue(l != r)
+				case OpLess:
+					registers[destReg] = BooleanValue(l < r)
+				case OpGreater:
+					registers[destReg] = BooleanValue(l > r)
+				case OpLessEqual:
+					registers[destReg] = BooleanValue(l <= r)
+				case OpGreaterEqual:
+					registers[destReg] = BooleanValue(l >= r)
+				}
+				continue
+			}
+
 			// Type checking specific to operation groups
 			switch opcode {
 			case OpAdd:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1901,6 +1901,18 @@ startExecution:
 			// Type checking specific to operation groups
 			switch opcode {
 			case OpAdd:
+				// Fast path: both operands already numbers. Skips two non-inlinable
+				// vm.toPrimitive calls (each with helperCallDepth/unwinding/handler
+				// bookkeeping) plus the string/BigInt/Symbol branches. Semantically
+				// identical to the slow path: toPrimitive is the identity for
+				// numbers, and the numeric branch computes
+				// Number(lhs.ToFloat() + rhs.ToFloat()).
+				if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeIntegerNumber || lt == TypeFloatNumber) &&
+					(rt == TypeIntegerNumber || rt == TypeFloatNumber) {
+					registers[destReg] = Number(leftVal.ToFloat() + rightVal.ToFloat())
+					continue
+				}
+
 				// JS semantics: ToPrimitive on both first (for string check),
 				// then if either is String → concatenate ToString(lhs)+ToString(rhs);
 				// else ToNumeric on both; if both BigInt → BigInt add; else Number add.
@@ -2017,6 +2029,24 @@ startExecution:
 					registers[destReg] = Number(leftNum + rightNum)
 				}
 			case OpSubtract, OpMultiply, OpDivide:
+				// Fast path: both operands already numbers. Skips two non-inlinable
+				// vm.toPrimitive calls plus the Symbol/BigInt branches. Identical to
+				// the slow path's numeric case (toPrimitive is the identity for
+				// numbers, neither is Symbol/BigInt).
+				if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeIntegerNumber || lt == TypeFloatNumber) &&
+					(rt == TypeIntegerNumber || rt == TypeFloatNumber) {
+					ln, rn := leftVal.ToFloat(), rightVal.ToFloat()
+					switch opcode {
+					case OpSubtract:
+						registers[destReg] = Number(ln - rn)
+					case OpMultiply:
+						registers[destReg] = Number(ln * rn)
+					case OpDivide:
+						registers[destReg] = Number(ln / rn)
+					}
+					continue
+				}
+
 				// Apply ToPrimitive and type coercion like JavaScript
 				// ECMAScript order: ToNumeric(lhs) then ToNumeric(rhs)
 				// ToNumeric calls ToPrimitive internally, and ToNumber(Symbol) throws
@@ -2145,6 +2175,13 @@ startExecution:
 					}
 				}
 			case OpRemainder:
+				// Fast path: both operands already numbers (see OpSubtract above).
+				if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeIntegerNumber || lt == TypeFloatNumber) &&
+					(rt == TypeIntegerNumber || rt == TypeFloatNumber) {
+					registers[destReg] = Number(math.Mod(leftVal.ToFloat(), rightVal.ToFloat()))
+					continue
+				}
+
 				// Apply ToPrimitive and type coercion
 				// ECMAScript order: ToNumeric(lhs) then ToNumeric(rhs)
 				frame.ip = ip

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1317,12 +1317,6 @@ startExecution:
 			}
 		}
 
-		if ip >= len(code) {
-			frame.ip = ip
-			status := vm.runtimeError("IP %d beyond code length %d", ip, len(code))
-			return status, Undefined
-		}
-
 		// Check for cancellation request
 		if vm.cancelled.Load() {
 			frame.ip = ip
@@ -2471,20 +2465,18 @@ startExecution:
 						l := leftPrim.ToFloat()
 						r := rightPrim.ToFloat()
 
-						// Per ECMAScript spec, if either operand is NaN, comparison returns false
-						if math.IsNaN(l) || math.IsNaN(r) {
-							result = false
-						} else {
-							switch opcode {
-							case OpGreater:
-								result = l > r
-							case OpLess:
-								result = l < r
-							case OpLessEqual:
-								result = l <= r
-							case OpGreaterEqual:
-								result = l >= r
-							}
+						// Per ECMAScript, a NaN operand makes every relational
+						// comparison false - which is exactly Go's float semantics,
+						// so no explicit IsNaN guard is needed.
+						switch opcode {
+						case OpGreater:
+							result = l > r
+						case OpLess:
+							result = l < r
+						case OpLessEqual:
+							result = l <= r
+						case OpGreaterEqual:
+							result = l >= r
 						}
 					}
 				}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -5143,7 +5143,9 @@ startExecution:
 
 			// If returning from the top-level script frame (and it's truly top-level), terminate immediately
 			// Don't do this for nested script frames (e.g., from eval()) which should continue normally
-			if function != nil && function.Name == "<script>" && vm.frameCount == 1 {
+			// (frameCount check first: it's a plain load, while the Name check is a
+			// string compare that would otherwise run on every function return)
+			if vm.frameCount == 1 && function != nil && function.Name == "<script>" {
 				// If currently unwinding, this is an uncaught exception at top level
 				if vm.unwinding {
 					vm.handleUncaughtException()
@@ -5159,28 +5161,13 @@ startExecution:
 			// fmt.Printf("// [VM DEBUG] OpReturn: Hit in module '%s', frameCount=%d, result=%s\n", vm.currentModulePath, vm.frameCount, result.ToString())
 
 			// Check if there are finally handlers that should execute
-			handlers := vm.findAllExceptionHandlers(frame.ip)
-			hasFinallyHandler := false
-			for _, handler := range handlers {
-				if handler.IsFinally {
-					hasFinallyHandler = true
-					break
-				}
-			}
-
-			if hasFinallyHandler {
+			if handler := vm.findPendingHandler(frame.ip, false); handler != nil {
 				// Set pending return action and let finally blocks execute
 				vm.pendingAction = ActionReturn
 				vm.pendingValue = result
 
-				// Find the finally handler and jump to it
-				for _, handler := range handlers {
-					if handler.IsFinally {
-						ip = handler.HandlerPC
-						break
-					}
-				}
-				// Continue executing from the finally handler
+				// Jump to the finally handler and continue executing from it
+				ip = handler.HandlerPC
 				continue
 			}
 
@@ -5413,7 +5400,7 @@ startExecution:
 
 			// If returning from the top-level script frame (and it's truly top-level), terminate immediately
 			// Don't do this for nested script frames (e.g., from eval()) which should continue normally
-			if function != nil && function.Name == "<script>" && vm.frameCount == 1 {
+			if vm.frameCount == 1 && function != nil && function.Name == "<script>" {
 				if vm.unwinding {
 					vm.handleUncaughtException()
 					return InterpretRuntimeError, vm.currentException
@@ -5439,16 +5426,7 @@ startExecution:
 			}
 
 			// Check if there are finally handlers that should execute
-			handlers := vm.findAllExceptionHandlers(frame.ip)
-			hasFinallyHandler := false
-			for _, handler := range handlers {
-				if handler.IsFinally {
-					hasFinallyHandler = true
-					break
-				}
-			}
-
-			if hasFinallyHandler {
+			if vm.findPendingHandler(frame.ip, false) != nil {
 				// Set pending return action and let finally blocks execute
 				vm.pendingAction = ActionReturn
 				vm.pendingValue = Undefined
@@ -12992,14 +12970,7 @@ startExecution:
 			}
 
 			// Check if we have more finally or iterator cleanup handlers that need to run
-			handlers := vm.findAllExceptionHandlers(frame.ip)
-			var nextHandler *ExceptionHandler
-			for _, handler := range handlers {
-				if handler.IsFinally || handler.IsIteratorCleanup {
-					nextHandler = handler
-					break
-				}
-			}
+			nextHandler := vm.findPendingHandler(frame.ip, true)
 
 			if nextHandler != nil {
 				// There are more handlers to execute - chain to them
@@ -13166,14 +13137,7 @@ startExecution:
 			case ActionReturn:
 				// Check if we have more finally or iterator cleanup handlers that need to run
 				// BEFORE completing the return
-				handlers := vm.findAllExceptionHandlers(frame.ip)
-				var nextHandler *ExceptionHandler
-				for _, handler := range handlers {
-					if handler.IsFinally || handler.IsIteratorCleanup {
-						nextHandler = handler
-						break
-					}
-				}
+				nextHandler := vm.findPendingHandler(frame.ip, true)
 
 				if nextHandler != nil {
 					// There are more handlers to execute - chain to them

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -71,7 +71,81 @@ func BenchmarkFibPlaceholderRun(b *testing.B) {
 	// No need to restore stdout here due to defer
 }
 
+// BenchmarkAdd isolates the OpAdd numeric fast path (add-heavy loop on numbers).
+func BenchmarkAdd(b *testing.B) {
+	chunk := compileFile(b, "scripts/bench_add.ts")
+	paserati := driver.NewPaserati()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+	if err != nil {
+		b.Fatalf("Failed to open os.DevNull: %v", err)
+	}
+	defer devNull.Close()
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runtimeErrs := paserati.InterpretChunk(chunk)
+		if len(runtimeErrs) > 0 {
+			b.Fatalf("Runtime error during benchmark iteration %d: %v", i, runtimeErrs)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkArith isolates the OpSubtract/Multiply/Divide/Remainder numeric fast paths.
+func BenchmarkArith(b *testing.B) {
+	chunk := compileFile(b, "scripts/bench_arith.ts")
+	paserati := driver.NewPaserati()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+	if err != nil {
+		b.Fatalf("Failed to open os.DevNull: %v", err)
+	}
+	defer devNull.Close()
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runtimeErrs := paserati.InterpretChunk(chunk)
+		if len(runtimeErrs) > 0 {
+			b.Fatalf("Runtime error during benchmark iteration %d: %v", i, runtimeErrs)
+		}
+	}
+	b.StopTimer()
+}
+
 // BenchmarkMatrixMult runs the matrix_mult.ts script.
+// BenchmarkSetIndex isolates the OpSetIndex (arr[i] = v) hot path — the setter
+// walk / allocation guard optimization is measured here.
+func BenchmarkSetIndex(b *testing.B) {
+	chunk := compileFile(b, "scripts/bench_setindex.ts")
+	paserati := driver.NewPaserati()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
+	if err != nil {
+		b.Fatalf("Failed to open os.DevNull: %v", err)
+	}
+	defer devNull.Close()
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, runtimeErrs := paserati.InterpretChunk(chunk)
+		if len(runtimeErrs) > 0 {
+			b.Fatalf("Runtime error during benchmark iteration %d: %v", i, runtimeErrs)
+		}
+	}
+	b.StopTimer()
+}
+
 func BenchmarkMatrixMult(b *testing.B) {
 	// Compile once outside the loop.
 	chunk := compileFile(b, "scripts/matrix_mult.ts")

--- a/tests/scripts/array_inherited_index_setter.ts
+++ b/tests/scripts/array_inherited_index_setter.ts
@@ -1,0 +1,19 @@
+// Regression: OpSetIndex skips the Array.prototype index-setter walk via a latch
+// (arrayIndexAccessorSeen) that must flip when an integer-indexed accessor is
+// defined on the prototype chain. Verifies inherited index setters still fire.
+// expect: true
+let called = 0;
+let lastVal: any = null;
+Object.defineProperty(Array.prototype, "5", {
+  set: function (v: any) { called++; lastVal = v; },
+  configurable: true,
+});
+const a: any[] = [];
+a[5] = 999; // must invoke the inherited setter, not store directly
+// setter-only accessor: the write is swallowed, so reading a[5] yields undefined
+const setterFired = called === 1 && lastVal === 999 && a[5] === undefined;
+a[6] = 111; // no setter for index 6 -> normal store
+const normalStore = a[6] === 111;
+// clean up so the global prototype mutation doesn't leak to other scripts
+delete (Array.prototype as any)["5"];
+setterFired && normalStore;

--- a/tests/scripts/bench_add.ts
+++ b/tests/scripts/bench_add.ts
@@ -1,0 +1,15 @@
+// Addition-heavy micro-benchmark isolating the OpAdd numeric fast path.
+// All `+` on numbers; values stay bounded/exact so the result is deterministic.
+// expect: 20000000
+function run(): number {
+  let s = 0;
+  const ITERS = 2000000;
+  for (let i = 0; i < ITERS; i++) {
+    s = s + 1;
+    s = s + 2;
+    s = s + 3;
+    s = s + 4;
+  }
+  return s;
+}
+run();

--- a/tests/scripts/bench_arith.ts
+++ b/tests/scripts/bench_arith.ts
@@ -1,0 +1,15 @@
+// Arithmetic-heavy micro-benchmark: sub/mul/div/remainder on numbers.
+// Bounded/deterministic result.
+// expect: 0
+function run(): number {
+  let s = 1;
+  const ITERS = 1000000;
+  for (let i = 0; i < ITERS; i++) {
+    s = s * 3;
+    s = s - 1;
+    s = s / 2;
+    s = s % 100000;
+  }
+  return (s - s);
+}
+run();

--- a/tests/scripts/bench_setindex.ts
+++ b/tests/scripts/bench_setindex.ts
@@ -1,0 +1,23 @@
+// Array-element-write-heavy micro-benchmark, isolating the OpSetIndex hot path.
+// Deterministic; prints a checksum so the work can't be optimized away.
+// expect: 155916747
+function run(): number {
+  const N = 256;
+  const ITERS = 200000;
+  const arr = new Array(N);
+  for (let i = 0; i < N; i++) arr[i] = i >>> 0;
+
+  let x = 0x12345678 >>> 0;
+  let acc = 0 >>> 0;
+  for (let i = 0; i < ITERS; i++) {
+    x = (x ^ (x << 13)) >>> 0;
+    x = (x ^ (x >>> 17)) >>> 0;
+    x = (x ^ (x << 5)) >>> 0;
+    const idx = x & (N - 1);
+    const v = (arr[idx] + (x & 0xffff)) >>> 0;
+    arr[idx] = (v ^ (v >>> 7) ^ (v << 9)) >>> 0;
+    acc = (acc + arr[idx]) >>> 0;
+  }
+  return acc >>> 0;
+}
+run();

--- a/tests/scripts/remainder_semantics.ts
+++ b/tests/scripts/remainder_semantics.ts
@@ -1,0 +1,18 @@
+// Remainder operator edge cases: the VM's integer fast path must preserve JS
+// semantics exactly - truncated remainder with the dividend's sign, -0 for a
+// negative dividend with zero remainder (observable via 1/x), NaN for a zero
+// divisor, and fall-through to float math for non-integral operands.
+// expect: 1,-1,1,-1,0,-Infinity,Infinity,1.5,NaN,NaN,2
+let results: string[] = [];
+results.push(String(7 % 3));
+results.push(String(-7 % 3));
+results.push(String(7 % -3));
+results.push(String(-7 % -3));
+results.push(String(0 % 5));
+results.push(String(1 / (-7 % 7)));
+results.push(String(1 / (7 % 7)));
+results.push(String(5.5 % 2));
+results.push(String(7 % 0));
+results.push(String(Infinity % 2));
+results.push(String(2 % Infinity));
+results.join(",");


### PR DESCRIPTION
Follow-up to the number-fast-path lane: the pieces of the dispatch-loop audit that lane didn't pick up. Five commits in distinct `vm.go` regions.

> **Stacks on the number-fast-paths PR.** Until that merges, this PR's diff includes its parent commits (same pattern as #35 on #29). Rebase onto `main` after the parent lands — do **not** `--delete` the parent branch on merge.

## What this does

- **Numeric fast path for relational comparisons.** `<`, `>`, `<=`, `>=` with two number operands — loop bounds, sort inner loops — take the same tag-direct path as arithmetic. No NaN special-casing: Go float comparisons already yield ECMAScript's result for NaN operands.
- **Integer fast path for `%`.** `math.Mod` is a software frexp/ldexp loop and was ~7.6% of the recursion benchmark's profile. Go's truncated int64 remainder carries the dividend's sign, matching JS; guarded for integral operands within ±2^53, nonzero divisor, and signed-zero results (deferred to `math.Mod`).
- **Non-allocating finally check on returns.** Every `OpReturn` / `OpReturnUndefined` called `findAllExceptionHandlers`, which heap-allocates a handler slice whenever the return PC sits inside a try region. Replaced with a single table-order scan returning the same handler; top-level-return test short-circuits on `frameCount` before the `"<script>"` string compare.
- **Dead code out of the hot loop.** Leftover debug blocks in `OpGetGlobal` / `OpSetGlobal` (type switch + `Name` loads + string compares into an empty if-body on every global load/store of a function). Plus an unreachable `ip` guard at the loop head and redundant `IsNaN` guards in the relational slow path.

## Numbers

Local (M2): the `%` integer path alone is ~−15% on the recursion benchmark; together with the parent lane this is the shootout's **full** column (~−50% Fib / Matrix / Add / Arith vs upstream tip — noisy machine, alloc/GC signal was clean). Per-commit figures are in the commit messages. The `perf` label's same-runner A/B is authoritative.

## Verification

- `TestScripts` green at every commit; `tests/scripts/remainder_semantics.ts` pins `%` sign combinations, signed zeros (via `1/x`), zero divisor, Infinity operands, and the non-integral fall-through.
- Test262 language on the merged stack: 0 new failures, 0 new passes vs upstream tip.
- No semantics changes. Latent inconsistencies the audit surfaced (`IsCallable` vs `IsFunction` on async natives; `OpIn` accepted-type list) were deliberately preserved and will be filed separately.


Made with [Cursor](https://cursor.com)