### PR TITLE
perf(vm): numeric fast path for comparisons + integer % [1/4 of #39]

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2018,18 +2018,6 @@ startExecution:
 			// Type checking specific to operation groups
 			switch opcode {
 			case OpAdd:
-				// Fast path: both operands already numbers. Skips two non-inlinable
-				// vm.toPrimitive calls (each with helperCallDepth/unwinding/handler
-				// bookkeeping) plus the string/BigInt/Symbol branches. Semantically
-				// identical to the slow path: toPrimitive is the identity for
-				// numbers, and the numeric branch computes
-				// Number(lhs.ToFloat() + rhs.ToFloat()).
-				if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeIntegerNumber || lt == TypeFloatNumber) &&
-					(rt == TypeIntegerNumber || rt == TypeFloatNumber) {
-					registers[destReg] = Number(leftVal.ToFloat() + rightVal.ToFloat())
-					continue
-				}
-
 				// JS semantics: ToPrimitive on both first (for string check),
 				// then if either is String → concatenate ToString(lhs)+ToString(rhs);
 				// else ToNumeric on both; if both BigInt → BigInt add; else Number add.
@@ -2146,24 +2134,6 @@ startExecution:
 					registers[destReg] = Number(leftNum + rightNum)
 				}
 			case OpSubtract, OpMultiply, OpDivide:
-				// Fast path: both operands already numbers. Skips two non-inlinable
-				// vm.toPrimitive calls plus the Symbol/BigInt branches. Identical to
-				// the slow path's numeric case (toPrimitive is the identity for
-				// numbers, neither is Symbol/BigInt).
-				if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeIntegerNumber || lt == TypeFloatNumber) &&
-					(rt == TypeIntegerNumber || rt == TypeFloatNumber) {
-					ln, rn := leftVal.ToFloat(), rightVal.ToFloat()
-					switch opcode {
-					case OpSubtract:
-						registers[destReg] = Number(ln - rn)
-					case OpMultiply:
-						registers[destReg] = Number(ln * rn)
-					case OpDivide:
-						registers[destReg] = Number(ln / rn)
-					}
-					continue
-				}
-
 				// Apply ToPrimitive and type coercion like JavaScript
 				// ECMAScript order: ToNumeric(lhs) then ToNumeric(rhs)
 				// ToNumeric calls ToPrimitive internally, and ToNumber(Symbol) throws
@@ -2292,13 +2262,6 @@ startExecution:
 					}
 				}
 			case OpRemainder:
-				// Fast path: both operands already numbers (see OpSubtract above).
-				if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeIntegerNumber || lt == TypeFloatNumber) &&
-					(rt == TypeIntegerNumber || rt == TypeFloatNumber) {
-					registers[destReg] = Number(math.Mod(leftVal.ToFloat(), rightVal.ToFloat()))
-					continue
-				}
-
 				// Apply ToPrimitive and type coercion
 				// ECMAScript order: ToNumeric(lhs) then ToNumeric(rhs)
 				frame.ip = ip

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1968,6 +1968,7 @@ startExecution:
 				} else {
 					r = float64(rightVal.AsInteger())
 				}
+				fastPathHandled := true
 				switch opcode {
 				case OpAdd:
 					registers[destReg] = Number(l + r)
@@ -2011,8 +2012,18 @@ startExecution:
 					registers[destReg] = BooleanValue(l <= r)
 				case OpGreaterEqual:
 					registers[destReg] = BooleanValue(l >= r)
+				default:
+					// Every opcode in the enclosing case list has an arm above,
+					// so this is unreachable today. It exists so that adding an
+					// opcode to that list without a fast-path arm degrades to the
+					// general path below instead of falling out of the switch and
+					// continuing with destReg never written — a silently stale
+					// register is a far worse failure than the slower path.
+					fastPathHandled = false
 				}
-				continue
+				if fastPathHandled {
+					continue
+				}
 			}
 
 			// Type checking specific to operation groups

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1968,27 +1968,35 @@ startExecution:
 				} else {
 					r = float64(rightVal.AsInteger())
 				}
-				fastPathHandled := true
+				// Each arm continues the dispatch loop directly; the default
+				// falls out of the switch into the general path below.
 				switch opcode {
 				case OpAdd:
 					registers[destReg] = Number(l + r)
+					continue
 				case OpSubtract:
 					registers[destReg] = Number(l - r)
+					continue
 				case OpMultiply:
 					registers[destReg] = Number(l * r)
+					continue
 				case OpDivide:
 					registers[destReg] = Number(l / r)
+					continue
 				case OpRemainder:
 					// Integer fast path: math.Mod is a software frexp/ldexp
 					// loop (~7% of the recursion benchmark's profile via
 					// `i % k` patterns). Go's truncated int64 remainder has
 					// the dividend's sign, exactly matching JS %, so it is
-					// safe when: both operands are integral and within ±2^53
-					// (float64<->int64 round-trips exactly; beyond that the
-					// conversion can saturate), the divisor is nonzero
-					// (0 divisor => NaN), and the result is not a signed
-					// zero (JS requires -0 for a negative or -0 dividend
-					// with zero remainder; the int path would lose the sign).
+					// safe when: both operands are integral (the float64(li)==l
+					// round-trip below proves that), the divisor is nonzero
+					// (0 divisor => NaN), and the result is not a signed zero
+					// (JS requires -0 for a negative or -0 dividend with zero
+					// remainder; the int path would lose the sign). The ±2^53
+					// range test guards the conversion itself: Go leaves an
+					// out-of-range float64->int64 result implementation-defined
+					// (arm64 saturates, amd64 yields MinInt64), so the operands
+					// must be in range before int64(l) is even evaluated.
 					const maxExactInt = float64(1 << 53)
 					if l >= -maxExactInt && l <= maxExactInt && r >= -maxExactInt && r <= maxExactInt {
 						li, ri := int64(l), int64(r)
@@ -2000,29 +2008,32 @@ startExecution:
 						}
 					}
 					registers[destReg] = Number(math.Mod(l, r))
+					continue
 				case OpEqual, OpStrictEqual:
 					registers[destReg] = BooleanValue(l == r)
+					continue
 				case OpNotEqual, OpStrictNotEqual:
 					registers[destReg] = BooleanValue(l != r)
+					continue
 				case OpLess:
 					registers[destReg] = BooleanValue(l < r)
+					continue
 				case OpGreater:
 					registers[destReg] = BooleanValue(l > r)
+					continue
 				case OpLessEqual:
 					registers[destReg] = BooleanValue(l <= r)
+					continue
 				case OpGreaterEqual:
 					registers[destReg] = BooleanValue(l >= r)
+					continue
 				default:
 					// Every opcode in the enclosing case list has an arm above,
 					// so this is unreachable today. It exists so that adding an
 					// opcode to that list without a fast-path arm degrades to the
-					// general path below instead of falling out of the switch and
-					// continuing with destReg never written — a silently stale
-					// register is a far worse failure than the slower path.
-					fastPathHandled = false
-				}
-				if fastPathHandled {
-					continue
+					// general path below instead of continuing with destReg never
+					// written — a silently stale register is a far worse failure
+					// than the slower path.
 				}
 			}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1978,6 +1978,26 @@ startExecution:
 				case OpDivide:
 					registers[destReg] = Number(l / r)
 				case OpRemainder:
+					// Integer fast path: math.Mod is a software frexp/ldexp
+					// loop (~7% of the recursion benchmark's profile via
+					// `i % k` patterns). Go's truncated int64 remainder has
+					// the dividend's sign, exactly matching JS %, so it is
+					// safe when: both operands are integral and within ±2^53
+					// (float64<->int64 round-trips exactly; beyond that the
+					// conversion can saturate), the divisor is nonzero
+					// (0 divisor => NaN), and the result is not a signed
+					// zero (JS requires -0 for a negative or -0 dividend
+					// with zero remainder; the int path would lose the sign).
+					const maxExactInt = float64(1 << 53)
+					if l >= -maxExactInt && l <= maxExactInt && r >= -maxExactInt && r <= maxExactInt {
+						li, ri := int64(l), int64(r)
+						if float64(li) == l && float64(ri) == r && ri != 0 {
+							if rem := li % ri; rem != 0 || !math.Signbit(l) {
+								registers[destReg] = Number(float64(rem))
+								continue
+							}
+						}
+					}
 					registers[destReg] = Number(math.Mod(l, r))
 				case OpEqual, OpStrictEqual:
 					registers[destReg] = BooleanValue(l == r)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1944,6 +1944,57 @@ startExecution:
 			leftVal := registers[leftReg]
 			rightVal := registers[rightReg]
 
+			// Fast path: skip ToPrimitive/BigInt/Symbol bookkeeping entirely when
+			// both operands are already plain numbers - the overwhelmingly common
+			// case for arithmetic and loop comparisons. ToPrimitive(number) is a
+			// no-op per spec, so this computes exactly what the general path below
+			// would, just without the frame.ip/helperCallDepth bookkeeping and the
+			// unwinding/handlerFound checks that only matter when ToPrimitive can
+			// invoke user code (valueOf/toString/Symbol.toPrimitive on an object).
+			// The tags are read directly rather than via ToFloat(), which is too
+			// large to inline. JS NaN semantics need no special casing: Go float
+			// comparisons yield false when either operand is NaN (so the != case
+			// correctly makes NaN !== NaN true), and division by zero yields
+			// ±Inf/NaN per IEEE 754, matching ECMAScript.
+			if lt, rt := leftVal.typ, rightVal.typ; (lt == TypeFloatNumber || lt == TypeIntegerNumber) && (rt == TypeFloatNumber || rt == TypeIntegerNumber) {
+				var l, r float64
+				if lt == TypeFloatNumber {
+					l = leftVal.AsFloat()
+				} else {
+					l = float64(leftVal.AsInteger())
+				}
+				if rt == TypeFloatNumber {
+					r = rightVal.AsFloat()
+				} else {
+					r = float64(rightVal.AsInteger())
+				}
+				switch opcode {
+				case OpAdd:
+					registers[destReg] = Number(l + r)
+				case OpSubtract:
+					registers[destReg] = Number(l - r)
+				case OpMultiply:
+					registers[destReg] = Number(l * r)
+				case OpDivide:
+					registers[destReg] = Number(l / r)
+				case OpRemainder:
+					registers[destReg] = Number(math.Mod(l, r))
+				case OpEqual, OpStrictEqual:
+					registers[destReg] = BooleanValue(l == r)
+				case OpNotEqual, OpStrictNotEqual:
+					registers[destReg] = BooleanValue(l != r)
+				case OpLess:
+					registers[destReg] = BooleanValue(l < r)
+				case OpGreater:
+					registers[destReg] = BooleanValue(l > r)
+				case OpLessEqual:
+					registers[destReg] = BooleanValue(l <= r)
+				case OpGreaterEqual:
+					registers[destReg] = BooleanValue(l >= r)
+				}
+				continue
+			}
+
 			// Type checking specific to operation groups
 			switch opcode {
 			case OpAdd:

--- a/tests/scripts/remainder_semantics.ts
+++ b/tests/scripts/remainder_semantics.ts
@@ -1,0 +1,18 @@
+// Remainder operator edge cases: the VM's integer fast path must preserve JS
+// semantics exactly - truncated remainder with the dividend's sign, -0 for a
+// negative dividend with zero remainder (observable via 1/x), NaN for a zero
+// divisor, and fall-through to float math for non-integral operands.
+// expect: 1,-1,1,-1,0,-Infinity,Infinity,1.5,NaN,NaN,2
+let results: string[] = [];
+results.push(String(7 % 3));
+results.push(String(-7 % 3));
+results.push(String(7 % -3));
+results.push(String(-7 % -3));
+results.push(String(0 % 5));
+results.push(String(1 / (-7 % 7)));
+results.push(String(1 / (7 % 7)));
+results.push(String(5.5 % 2));
+results.push(String(7 % 0));
+results.push(String(Infinity % 2));
+results.push(String(2 % Infinity));
+results.join(",");


### PR DESCRIPTION
Part 1 of the #39 split.

Collapses the per-opcode number guards into one fast path shared by all 13 arithmetic and comparison opcodes, reading the type tags directly rather than through `ToFloat()` (too large to inline). Comparisons previously had no fast path at all and paid the full `ToPrimitive`/`helperCallDepth`/unwinding bookkeeping on every loop condition.

**Semantics.** `ToPrimitive` is the identity on numbers, so the fast path computes what the general path would. NaN needs no special casing: Go's float comparisons are already false in all four relational directions, and `l == r` is false for NaN, matching `StrictlyEquals`. For two numbers abstract and strict equality coincide, so `OpEqual`/`OpStrictEqual` share an arm.

**Integer `%`.** `math.Mod` is a software frexp/ldexp loop, ~7% of the recursion benchmark's profile. Go's truncated `int64` remainder takes the dividend's sign, exactly matching JS, so the integer path is used only when both operands round-trip exactly through `int64` (±2^53), the divisor is nonzero, and the result isn't a signed zero — JS requires `-0` for a negative dividend with zero remainder, which the integer path would lose. Everything else falls through to `math.Mod`. `tests/scripts/remainder_semantics.ts` pins these, including `1 / (-7 % 7) === -Infinity`.

The third commit drops the per-op number guards that the unified path made unreachable — the cleanup nit from your review.

The inner switch carries a `default` arm that degrades to the general path. It's unreachable today (the enclosing `case` list and the switch cover the same 13 opcodes), but without it, adding an opcode to that list without a fast-path arm would `continue` with `destReg` never written — a silently stale register, which is a worse failure than the slow path.

### Where this sits in the #39 split

#39 bundled ~6 changes; per review it's split into four independent PRs, all branched off current `main`:

| | branch | contents |
|---|---|---|
| 1 | `perf/vm-numeric-compare-rem` | comparison fast path, integer `%`, drop unreachable per-op guards |
| 2 | `perf/vm-finally-nonalloc` | non-allocating finally-handler check |
| 3 | `perf/vm-dispatch-deadcode` | dead debug blocks, redundant `IsNaN` cleanup |
| 4 | `perf/vm-array-index-accessor-atomic` | `arrayIndexAccessorSeen` → `atomic.Bool` |

The other three pieces you flagged as unmentioned — the `IsObject()` range check, the `ToInteger()` fast path, and the `arrayIndexAccessorSeen` latch itself — already landed on `main` separately, so they aren't repeated here. Together these four are the remainder of #39.

The four merge onto `main` in sequence with no conflicts; the union passes `TestScripts`, `pkg/vm`, `pkg/compiler`, and `go test -race ./pkg/vm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
