### PR TITLE
perf(vm): non-allocating finally-handler check on returns [2/4 of #39]

### DIFF
--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -42,6 +42,30 @@ func (vm *VM) findAllExceptionHandlers(pc int) []*ExceptionHandler {
 	return handlers
 }
 
+// findPendingHandler returns the first handler in exception-table order that
+// covers pc and is a finally block (or, when includeIterCleanup is set, an
+// iterator-cleanup block). It selects the same handler the callers of
+// findAllExceptionHandlers used to pick, but without allocating a slice —
+// this runs on every OpReturn/OpReturnUndefined, where the common case is an
+// empty table.
+func (vm *VM) findPendingHandler(pc int, includeIterCleanup bool) *ExceptionHandler {
+	if vm.frameCount == 0 {
+		return nil
+	}
+	frame := &vm.frames[vm.frameCount-1]
+	if frame.closure == nil {
+		return nil
+	}
+	table := frame.closure.Fn.Chunk.ExceptionTable
+	for i := range table {
+		h := &table[i]
+		if pc >= h.TryStart && pc < h.TryEnd && (h.IsFinally || (includeIterCleanup && h.IsIteratorCleanup)) {
+			return h
+		}
+	}
+	return nil
+}
+
 // throwException initiates exception unwinding with the given value
 func (vm *VM) throwException(value Value) {
 	if debugExceptions {

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -44,10 +44,15 @@ func (vm *VM) findAllExceptionHandlers(pc int) []*ExceptionHandler {
 
 // findPendingHandler returns the first handler in exception-table order that
 // covers pc and is a finally block (or, when includeIterCleanup is set, an
-// iterator-cleanup block). It selects the same handler the callers of
-// findAllExceptionHandlers used to pick, but without allocating a slice —
-// this runs on every OpReturn/OpReturnUndefined, where the common case is an
-// empty table.
+// iterator-cleanup block). It selects the same handler the
+// OpReturn/OpReturnUndefined/OpReturnFinally/OpHandlePending sites used to
+// pick, but without allocating a slice — this runs on every return, where the
+// common case is an empty table.
+//
+// Not a drop-in for every findAllExceptionHandlers caller: the generator-resume
+// path keeps the LAST covering finally and prefers a finally over an earlier
+// iterator-cleanup handler, which is not "first match". That site stays on
+// findAllExceptionHandlers deliberately.
 func (vm *VM) findPendingHandler(pc int, includeIterCleanup bool) *ExceptionHandler {
 	if vm.frameCount == 0 {
 		return nil

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -5138,7 +5138,9 @@ startExecution:
 
 			// If returning from the top-level script frame (and it's truly top-level), terminate immediately
 			// Don't do this for nested script frames (e.g., from eval()) which should continue normally
-			if function != nil && function.Name == "<script>" && vm.frameCount == 1 {
+			// (frameCount check first: it's a plain load, while the Name check is a
+			// string compare that would otherwise run on every function return)
+			if vm.frameCount == 1 && function != nil && function.Name == "<script>" {
 				// If currently unwinding, this is an uncaught exception at top level
 				if vm.unwinding {
 					vm.handleUncaughtException()
@@ -5154,28 +5156,13 @@ startExecution:
 			// fmt.Printf("// [VM DEBUG] OpReturn: Hit in module '%s', frameCount=%d, result=%s\n", vm.currentModulePath, vm.frameCount, result.ToString())
 
 			// Check if there are finally handlers that should execute
-			handlers := vm.findAllExceptionHandlers(frame.ip)
-			hasFinallyHandler := false
-			for _, handler := range handlers {
-				if handler.IsFinally {
-					hasFinallyHandler = true
-					break
-				}
-			}
-
-			if hasFinallyHandler {
+			if handler := vm.findPendingHandler(frame.ip, false); handler != nil {
 				// Set pending return action and let finally blocks execute
 				vm.pendingAction = ActionReturn
 				vm.pendingValue = result
 
-				// Find the finally handler and jump to it
-				for _, handler := range handlers {
-					if handler.IsFinally {
-						ip = handler.HandlerPC
-						break
-					}
-				}
-				// Continue executing from the finally handler
+				// Jump to the finally handler and continue executing from it
+				ip = handler.HandlerPC
 				continue
 			}
 
@@ -5408,7 +5395,7 @@ startExecution:
 
 			// If returning from the top-level script frame (and it's truly top-level), terminate immediately
 			// Don't do this for nested script frames (e.g., from eval()) which should continue normally
-			if function != nil && function.Name == "<script>" && vm.frameCount == 1 {
+			if vm.frameCount == 1 && function != nil && function.Name == "<script>" {
 				if vm.unwinding {
 					vm.handleUncaughtException()
 					return InterpretRuntimeError, vm.currentException
@@ -5434,16 +5421,7 @@ startExecution:
 			}
 
 			// Check if there are finally handlers that should execute
-			handlers := vm.findAllExceptionHandlers(frame.ip)
-			hasFinallyHandler := false
-			for _, handler := range handlers {
-				if handler.IsFinally {
-					hasFinallyHandler = true
-					break
-				}
-			}
-
-			if hasFinallyHandler {
+			if vm.findPendingHandler(frame.ip, false) != nil {
 				// Set pending return action and let finally blocks execute
 				vm.pendingAction = ActionReturn
 				vm.pendingValue = Undefined
@@ -13017,14 +12995,7 @@ startExecution:
 			}
 
 			// Check if we have more finally or iterator cleanup handlers that need to run
-			handlers := vm.findAllExceptionHandlers(frame.ip)
-			var nextHandler *ExceptionHandler
-			for _, handler := range handlers {
-				if handler.IsFinally || handler.IsIteratorCleanup {
-					nextHandler = handler
-					break
-				}
-			}
+			nextHandler := vm.findPendingHandler(frame.ip, true)
 
 			if nextHandler != nil {
 				// There are more handlers to execute - chain to them
@@ -13191,14 +13162,7 @@ startExecution:
 			case ActionReturn:
 				// Check if we have more finally or iterator cleanup handlers that need to run
 				// BEFORE completing the return
-				handlers := vm.findAllExceptionHandlers(frame.ip)
-				var nextHandler *ExceptionHandler
-				for _, handler := range handlers {
-					if handler.IsFinally || handler.IsIteratorCleanup {
-						nextHandler = handler
-						break
-					}
-				}
+				nextHandler := vm.findPendingHandler(frame.ip, true)
 
 				if nextHandler != nil {
 					// There are more handlers to execute - chain to them


### PR DESCRIPTION
Part 2 of the #39 split.

`findAllExceptionHandlers` allocates a `[]*ExceptionHandler` on every `OpReturn`/`OpReturnUndefined`, where the common case is an empty exception table and the result is immediately reduced to "first handler that is a finally". `findPendingHandler` fuses that filter into the scan and returns the handler directly.

It's an exact refactor of the selection logic: same `frameCount`/`closure` guards, same exception table, same iteration order, same `pc >= TryStart && pc < TryEnd` predicate. The `includeIterCleanup` flag covers the two call sites that also accept `IsIteratorCleanup`. `findAllExceptionHandlers` is unchanged and still used by the unwinding and generator paths.

Also reorders `vm.frameCount == 1 && function != nil && function.Name == "<script>"` so the plain load short-circuits before the string compare, which otherwise ran on every function return.

### Where this sits in the #39 split

#39 bundled ~6 changes; per review it's split into four independent PRs, all branched off current `main`:

| | branch | contents |
|---|---|---|
| 1 | `perf/vm-numeric-compare-rem` | comparison fast path, integer `%`, drop unreachable per-op guards |
| 2 | `perf/vm-finally-nonalloc` | non-allocating finally-handler check |
| 3 | `perf/vm-dispatch-deadcode` | dead debug blocks, redundant `IsNaN` cleanup |
| 4 | `perf/vm-array-index-accessor-atomic` | `arrayIndexAccessorSeen` → `atomic.Bool` |

The other three pieces you flagged as unmentioned — the `IsObject()` range check, the `ToInteger()` fast path, and the `arrayIndexAccessorSeen` latch itself — already landed on `main` separately, so they aren't repeated here. Together these four are the remainder of #39.

The four merge onto `main` in sequence with no conflicts; the union passes `TestScripts`, `pkg/vm`, `pkg/compiler`, and `go test -race ./pkg/vm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
