### PR TITLE
perf(vm): make arrayIndexAccessorSeen an atomic.Bool [4/4 of #39]

### DIFF
--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -670,7 +670,11 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 // rather than per-realm to keep the accessor-definition choke points VM-free; the
 // only cost of the coarser scope is that one realm defining such an accessor also
 // disables the fast path for others, which is negligible in practice.
-var arrayIndexAccessorSeen bool
+//
+// atomic.Bool so concurrent VMs / -race builds don't data-race the latch. A
+// torn false→true under a plain bool would be fail-safe (restore slow path) but
+// still races; Store/Load make the publication well-defined.
+var arrayIndexAccessorSeen atomic.Bool
 
 // isCanonicalArrayIndexKey reports whether name is a canonical array-index string
 // ("0", or a digit-string with no leading zero, within the 0..2^32-2 index range) —
@@ -697,8 +701,8 @@ func isCanonicalArrayIndexKey(name string) bool {
 // noteAccessorKey latches arrayIndexAccessorSeen when a string key is a canonical
 // array index. Called from every accessor-definition choke point.
 func noteAccessorKey(name string) {
-	if !arrayIndexAccessorSeen && isCanonicalArrayIndexKey(name) {
-		arrayIndexAccessorSeen = true
+	if !arrayIndexAccessorSeen.Load() && isCanonicalArrayIndexKey(name) {
+		arrayIndexAccessorSeen.Store(true)
 	}
 }
 

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -672,8 +672,11 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 // disables the fast path for others, which is negligible in practice.
 //
 // atomic.Bool so concurrent VMs / -race builds don't data-race the latch. A
-// torn false→true under a plain bool would be fail-safe (restore slow path) but
-// still races; Store/Load make the publication well-defined.
+// plain bool can't tear, and a racing read was already fail-safe (it sees false
+// and restores the slow path) — but it is a data race regardless: -race flags
+// it, and nothing stops the compiler caching the load across an `arr[i] = v`
+// loop. Load/Store order the flag only; the accessor maps it guards stay
+// unsynchronized, which is moot because Array.prototype is per-realm.
 var arrayIndexAccessorSeen atomic.Bool
 
 // isCanonicalArrayIndexKey reports whether name is a canonical array-index string

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -7611,7 +7611,7 @@ startExecution:
 				// only set once such an accessor is actually defined. See
 				// arrayIndexAccessorSeen in object.go.
 				setterFound := false
-				if arrayIndexAccessorSeen && vm.ArrayPrototype.IsObject() {
+				if arrayIndexAccessorSeen.Load() && vm.ArrayPrototype.IsObject() {
 					idxKey := strconv.Itoa(idx)
 					setterKey := "s:" + idxKey // PropertyKey hash format for string keys
 					for cur := vm.ArrayPrototype.AsPlainObject(); cur != nil; {


### PR DESCRIPTION
Part 4 of the #39 split — the `arrayIndexAccessorSeen` concern from your review.

The latch is now an `atomic.Bool`. As you noted it was fail-safe (a stale `false` just restores the slow path), but it was still a data race under `-race` or with concurrent VM instances; `Store`/`Load` make the publication well-defined.

`noteAccessorKey` keeps its load-then-store shape rather than a CAS — the only transition is `false → true`, so a redundant store is harmless.

`go test -race ./pkg/vm/` passes.

### Where this sits in the #39 split

#39 bundled ~6 changes; per review it's split into four independent PRs, all branched off current `main`:

| | branch | contents |
|---|---|---|
| 1 | `perf/vm-numeric-compare-rem` | comparison fast path, integer `%`, drop unreachable per-op guards |
| 2 | `perf/vm-finally-nonalloc` | non-allocating finally-handler check |
| 3 | `perf/vm-dispatch-deadcode` | dead debug blocks, redundant `IsNaN` cleanup |
| 4 | `perf/vm-array-index-accessor-atomic` | `arrayIndexAccessorSeen` → `atomic.Bool` |

The other three pieces you flagged as unmentioned — the `IsObject()` range check, the `ToInteger()` fast path, and the `arrayIndexAccessorSeen` latch itself — already landed on `main` separately, so they aren't repeated here. Together these four are the remainder of #39.

The four merge onto `main` in sequence with no conflicts; the union passes `TestScripts`, `pkg/vm`, `pkg/compiler`, and `go test -race ./pkg/vm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
