### PR TITLE
builtins: fix BigInt prototype methods panicking on a primitive receiver

### DIFF
--- a/pkg/builtins/bigint_init.go
+++ b/pkg/builtins/bigint_init.go
@@ -42,6 +42,35 @@ func (b *BigIntInitializer) InitTypes(ctx *TypeContext) error {
 	return ctx.DefineGlobal("BigInt", bigintCtorType)
 }
 
+// thisBigIntValue implements the spec's ThisBigIntValue: a primitive BigInt is
+// its own value, and a BigInt object wrapper yields its wrapped primitive.
+// Any other receiver reports false.
+//
+// The slot is spelled "[[PrimitiveValue]]" because that is what actually
+// creates BigInt wrappers here (object_init.go's Object(bigint) case); the
+// spec's name for it is [[BigIntData]]. Number/String/Boolean/Symbol wrappers
+// share the same slot name, so the TypeBigInt check on the stored value is
+// what keeps this from unwrapping one of those.
+//
+// This lives in one place on purpose. Each call site previously inlined the
+// unwrap guarded by `Type() == TypeBigInt` and then called AsPlainObject() on
+// it — but AsPlainObject panics unless the value is TypeObject, and a wrapper
+// is TypeObject, never TypeBigInt. So the wrapper branch was unreachable and
+// every primitive receiver panicked.
+func thisBigIntValue(v vm.Value) (vm.Value, bool) {
+	switch v.Type() {
+	case vm.TypeBigInt:
+		return v, true
+	case vm.TypeObject:
+		if po := v.AsPlainObject(); po != nil {
+			if data, exists := po.GetOwn("[[PrimitiveValue]]"); exists && data.Type() == vm.TypeBigInt {
+				return data, true
+			}
+		}
+	}
+	return vm.Undefined, false
+}
+
 func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 	vmInstance := ctx.VM
 
@@ -56,19 +85,8 @@ func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisBigInt := vmInstance.GetThis()
 
 		// Get the primitive BigInt value
-		var primitiveBigInt vm.Value
-		if thisBigInt.Type() == vm.TypeBigInt {
-			// For BigInt object wrappers, extract the primitive value from [[BigIntData]]
-			if po := thisBigInt.AsPlainObject(); po != nil {
-				if dataVal, exists := po.GetOwn("[[BigIntData]]"); exists {
-					primitiveBigInt = dataVal
-				} else {
-					primitiveBigInt = thisBigInt
-				}
-			} else {
-				primitiveBigInt = thisBigInt
-			}
-		} else {
+		primitiveBigInt, ok := thisBigIntValue(thisBigInt)
+		if !ok {
 			// For non-BigInts, try to convert or throw error
 			return vm.NewString(thisBigInt.ToString()), nil
 		}
@@ -95,19 +113,8 @@ func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisBigInt := vmInstance.GetThis()
 
 		// Get the primitive BigInt value
-		var primitiveBigInt vm.Value
-		if thisBigInt.Type() == vm.TypeBigInt {
-			// For BigInt object wrappers, extract the primitive value from [[BigIntData]]
-			if po := thisBigInt.AsPlainObject(); po != nil {
-				if dataVal, exists := po.GetOwn("[[BigIntData]]"); exists {
-					primitiveBigInt = dataVal
-				} else {
-					primitiveBigInt = thisBigInt
-				}
-			} else {
-				primitiveBigInt = thisBigInt
-			}
-		} else {
+		primitiveBigInt, ok := thisBigIntValue(thisBigInt)
+		if !ok {
 			// For non-BigInts, try to convert or throw error
 			return vm.NewString(thisBigInt.ToString()), nil
 		}
@@ -121,14 +128,8 @@ func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisBigInt := vmInstance.GetThis()
 
 		// Return the primitive BigInt value
-		if thisBigInt.Type() == vm.TypeBigInt {
-			// For BigInt object wrappers, extract the primitive value from [[BigIntData]]
-			if po := thisBigInt.AsPlainObject(); po != nil {
-				if dataVal, exists := po.GetOwn("[[BigIntData]]"); exists {
-					return dataVal, nil
-				}
-			}
-			return thisBigInt, nil
+		if primitiveBigInt, ok := thisBigIntValue(thisBigInt); ok {
+			return primitiveBigInt, nil
 		}
 
 		// Cannot convert other types to BigInt
@@ -157,17 +158,10 @@ func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		arg := args[0]
 
-		// If argument is already a BigInt, return it (handles both primitive and object wrapper cases)
-		if arg.Type() == vm.TypeBigInt {
-			// Check if it's already an object wrapper
-			if po := arg.AsPlainObject(); po != nil {
-				if _, exists := po.GetOwn("[[BigIntData]]"); exists {
-					// Already an object wrapper, return as-is
-					return arg, nil
-				}
-			}
-			// It's a primitive BigInt, return as-is
-			return arg, nil
+		// If argument is already a BigInt, return its primitive value. This
+		// covers both a primitive and an object wrapper, per ToBigInt.
+		if primitive, ok := thisBigIntValue(arg); ok {
+			return primitive, nil
 		}
 
 		// Convert argument to primitive BigInt

--- a/pkg/builtins/bigint_init.go
+++ b/pkg/builtins/bigint_init.go
@@ -91,13 +91,19 @@ func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.NewString(thisBigInt.ToString()), nil
 		}
 
+		// Radix per BigInt.prototype.toString: undefined means 10, otherwise
+		// ToIntegerOrInfinity (which throws on a Symbol or a BigInt-returning
+		// ToPrimitive), then RangeError outside 2..36.
 		var radix int = 10
-		if len(args) > 0 {
-			radix = int(args[0].ToFloat())
-			if radix < 2 || radix > 36 {
-				// In real JS this would throw RangeError, for now use default
-				radix = 10
+		if len(args) > 0 && args[0].Type() != vm.TypeUndefined {
+			r, err := toIntegerOrInfinityWithVM(vmInstance, args[0])
+			if err != nil {
+				return vm.Undefined, err
 			}
+			if r < 2 || r > 36 {
+				return vm.Undefined, vmInstance.NewRangeError("toString() radix must be between 2 and 36")
+			}
+			radix = r
 		}
 
 		bigIntVal := primitiveBigInt.AsBigInt()

--- a/tests/scripts/bigint_prototype_methods.ts
+++ b/tests/scripts/bigint_prototype_methods.ts
@@ -1,0 +1,52 @@
+// BigInt.prototype methods and the BigInt() constructor must accept a primitive
+// BigInt receiver. Regression: each site guarded its object-wrapper unwrap with
+// `Type() == TypeBigInt` and then called AsPlainObject(), which panics unless
+// the value is TypeObject. A wrapper is TypeObject and never TypeBigInt, so the
+// wrapper branch was unreachable and every primitive receiver panicked — the
+// process exited 0 with no output and no error.
+//
+// Method calls go through `any` because the checker does not yet support
+// property access on a bigint receiver at all ("property access is not
+// supported on type bigint"), and it rejects unary '-' on bigint. Both are
+// pre-existing checker gaps, separate from the runtime bug covered here.
+// expect: 10|a|-ff|bigint|10|10|bigint|10|10|10|10n|10n|str|num
+let out: string[] = [];
+const b: any = 10n;
+const neg: any = BigInt("-255");
+const wrapper: any = Object(10n);
+
+// toString, including a radix and a negative value
+out.push(b.toString());
+out.push(b.toString(16));
+out.push(neg.toString(16));
+
+// valueOf returns the primitive BigInt, not a wrapper
+out.push(typeof b.valueOf());
+out.push(String(b.valueOf()));
+
+// toLocaleString
+out.push(b.toLocaleString());
+
+// BigInt() applied to something that is already a BigInt
+out.push(typeof BigInt(10n));
+out.push(String(BigInt(10n)));
+
+// An object wrapper receiver unwraps to its primitive. This is the arm the
+// helper exists for, and it only works if the slot name matches the one
+// Object(bigint) actually writes.
+out.push(wrapper.toString());
+out.push(wrapper.toLocaleString());
+out.push(String((BigInt.prototype as any).valueOf.call(wrapper)) + "n");
+out.push(String(BigInt(wrapper)) + "n");
+
+// Non-BigInt receivers keep their existing fallbacks: toString stringifies,
+// valueOf throws.
+out.push((BigInt.prototype as any).toString.call("str"));
+try {
+  (BigInt.prototype as any).valueOf.call(5);
+  out.push("no-throw");
+} catch (e) {
+  out.push("num");
+}
+
+out.join("|");

--- a/tests/scripts/bigint_prototype_methods.ts
+++ b/tests/scripts/bigint_prototype_methods.ts
@@ -9,7 +9,7 @@
 // property access on a bigint receiver at all ("property access is not
 // supported on type bigint"), and it rejects unary '-' on bigint. Both are
 // pre-existing checker gaps, separate from the runtime bug covered here.
-// expect: 10|a|-ff|bigint|10|10|bigint|10|10|10|10n|10n|str|num
+// expect: 10|a|-ff|bigint|10|10|bigint|10|10|10|10n|10n|str|num|range|10
 let out: string[] = [];
 const b: any = 10n;
 const neg: any = BigInt("-255");
@@ -48,5 +48,15 @@ try {
 } catch (e) {
   out.push("num");
 }
+
+// An out-of-range radix is a RangeError, not a silent clamp to 10, and an
+// explicit undefined radix still means 10.
+try {
+  b.toString(1);
+  out.push("no-throw");
+} catch (e) {
+  out.push("range");
+}
+out.push(b.toString(undefined));
 
 out.join("|");


### PR DESCRIPTION
`10n.toString()` prints nothing and exits 0. So do `valueOf()`, `toLocaleString()`, and `BigInt(10n)` — every BigInt prototype method is unusable on a primitive receiver.

Two commits: the panic fix, and a separable radix fix that the first one makes reachable.

## 1. The panic

All four sites inlined the same object-wrapper unwrap:

```go
if v.Type() == vm.TypeBigInt {
    // For BigInt object wrappers, extract the primitive value from [[BigIntData]]
    if po := v.AsPlainObject(); po != nil {
```

`AsPlainObject` panics unless the value is `TypeObject` (`value.go:968-971`), and a BigInt object wrapper *is* `TypeObject` — never `TypeBigInt`. The guard admits exactly the values the body cannot handle: the wrapper branch was unreachable, and every primitive receiver panicked.

It reads as a silent stop rather than a crash because `VM.run`'s recover discards the panic and returns `InterpretOK` — filed separately as #44.

Replaced all four copies with one `thisBigIntValue` helper implementing ThisBigIntValue. Four hand-inlined copies of a subtle unwrap is what produced four identical bugs.

**The slot name matters here.** The spec calls it `[[BigIntData]]`, and that is what the old code looked up — but nothing in this repo ever writes that name. `Object(bigint)` stores `[[PrimitiveValue]]` (`object_init.go:944`), so searching for the spec name would have left the wrapper arm dead in a new place. The helper uses `[[PrimitiveValue]]` and checks the stored value's type, since Number/String/Boolean/Symbol wrappers share that slot.

## 2. The radix

`toString`'s radix was coerced with a bare `ToFloat` and clamped into 2..36, with a comment noting real JS throws. Now runs the package's existing `toIntegerOrInfinityWithVM` and throws `RangeError` outside 2..36.

Separable, but included because commit 1 is what makes these paths reachable — see the test262 accounting below. Happy to split it out if you'd rather.

## Verification

Primitive and wrapper receivers, all matching Node:

```
10n.toString()                          10
10n.toString(16)                        a
BigInt("-255").toString(16)             -ff
10n.valueOf()                           10n   (typeof bigint)
10n.toLocaleString()                    10
BigInt(10n)                             10n
Object(10n).toString()                  10
Object(10n).toLocaleString()            10
BigInt.prototype.valueOf.call(Object(10n))  10n
BigInt(Object(10n))                     10n
```

Non-BigInt receiver fallbacks are unchanged: `toString`/`toLocaleString` stringify, `valueOf` throws `TypeError`.

`tests/scripts/bigint_prototype_methods.ts` covers all of the above. With commit 1 reverted it fails with `"undefined"` — the script produces nothing at all.

`go build`/`vet`/`gofmt` clean; `TestScripts`, `pkg/vm`, `pkg/builtins`, `pkg/compiler` pass.

### test262

`built-ins/BigInt`: **41 → 41**, and `language`: 23222/23648 with zero per-test diffs.

The count is flat but the composition changed, so the per-test diff is worth stating plainly:

- **+1** `prototype/valueOf/cross-realm.js` — genuinely fixed by the wrapper unwrap.
- **−1** `prototype/toString/radix-tointegerorinfinity-throws-toprimitive-or-bigint.js` — this was a false pass. The panic ended the script before its assertion ran, and the harness scored the silence as green. It now fails for a real, pre-existing reason: `toIntegerOrInfinityWithVM` doesn't reject a BigInt returned from `ToPrimitive`. That helper is shared with Array, so fixing it belongs in its own change where the Array impact can be measured — deliberately not touched here.

Two other radix tests (`radix-err.js`, `radix-tointegerorinfinity-throws-symbol.js`) were false passes for the same reason; commit 2 turns those into genuine passes, which is why the total lands back at 41 rather than 38.

## Note on the test

It calls through `any`. The checker rejects property access on a bigint receiver outright ("property access is not supported on type bigint"), rejects unary `-` on bigint, and types a bigint literal as a number literal (`const b: bigint = 10n` fails). All pre-existing and unrelated to this PR — happy to file separately if you want them tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
