### PR TITLE
fix(string,regexp): index by UTF-16 code unit, not UTF-8 byte

### DIFF
--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -339,17 +339,21 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		isSticky := regex.IsSticky()
 
 		if isGlobal || isSticky {
-			// Use lastIndex for stateful matching
+			// lastIndex is JS-visible, so it is held in UTF-16 code units and
+			// converted to a byte offset only to cut the string. Storing the byte
+			// offset instead made `re.lastIndex` report a number the caller could
+			// not use — 6 where the spec says 5 on a string holding one `é`.
 			baseIndex := regex.GetLastIndex()
 			if baseIndex < 0 {
 				baseIndex = 0
 			}
-			if baseIndex > len(str) {
+			if baseIndex > utf16Len(str) {
 				// lastIndex beyond string length - no match possible
 				regex.SetLastIndex(0)
 				return vm.BooleanValue(false), nil
 			}
-			searchStr := str[baseIndex:]
+			baseByte := utf16ToByteOffset(str, baseIndex)
+			searchStr := str[baseByte:]
 			loc := regex.FindStringIndex(searchStr)
 
 			// For sticky flag, match must occur at exactly position 0 of searchStr
@@ -359,7 +363,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 			if loc != nil {
 				// Update lastIndex
-				regex.SetLastIndex(baseIndex + loc[1])
+				regex.SetLastIndex(byteToUTF16Offset(str, baseByte+loc[1]))
 				return vm.BooleanValue(true), nil
 			} else {
 				// No match - reset lastIndex
@@ -409,23 +413,26 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if baseIndex < 0 {
 				baseIndex = 0
 			}
-			if baseIndex > len(str) {
+			if baseIndex > utf16Len(str) {
 				// lastIndex beyond string length - no match possible
 				regex.SetLastIndex(0)
 				return vm.Null, nil
 			}
 
+			// lastIndex is in code units; the finder wants a byte offset.
+			baseByte := utf16ToByteOffset(str, baseIndex)
+
 			// Search from baseIndex position (preserves lookbehind context for regexp2)
-			loc = regex.FindStringSubmatchIndexAt(str, baseIndex)
+			loc = regex.FindStringSubmatchIndexAt(str, baseByte)
 
 			// For sticky, match must occur exactly at baseIndex
-			if isSticky && loc != nil && loc[0] != baseIndex {
+			if isSticky && loc != nil && loc[0] != baseByte {
 				loc = nil
 			}
 
 			if loc != nil {
 				// Update lastIndex
-				regex.SetLastIndex(loc[1])
+				regex.SetLastIndex(byteToUTF16Offset(str, loc[1]))
 			} else {
 				// No match - reset lastIndex
 				regex.SetLastIndex(0)
@@ -454,8 +461,9 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 				arr.Append(vm.NewString(str[start:end]))
 			}
 		}
-		// Set required properties: index, input, groups
-		arr.SetExecMeta(loc[0], str)
+		// Set required properties: index, input, groups. The index is JS-visible,
+		// so it is reported in code units even though loc speaks bytes.
+		arr.SetExecMeta(byteToUTF16Offset(str, loc[0]), str)
 		return result, nil
 	}))
 
@@ -623,18 +631,20 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
-		// If lastIndex > string length, fail
-		if searchStart > len(str) {
+		// If lastIndex > string length, fail. searchStart came from lastIndex and
+		// is therefore in code units; everything below it speaks bytes.
+		if searchStart > utf16Len(str) {
 			if isSticky || isGlobal {
 				regex.SetLastIndex(0)
 			}
 			return vm.Null, nil
 		}
+		searchStartByte := utf16ToByteOffset(str, searchStart)
 
 		// Execute match - search from searchStart position (preserves lookbehind context)
 		var loc []int
-		if searchStart > 0 {
-			loc = regex.FindStringSubmatchIndexAt(str, searchStart)
+		if searchStartByte > 0 {
+			loc = regex.FindStringSubmatchIndexAt(str, searchStartByte)
 		} else {
 			loc = regex.FindStringSubmatchIndex(str)
 		}
@@ -647,14 +657,14 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// For sticky, match must start exactly at lastIndex
-		if isSticky && loc[0] != searchStart {
+		if isSticky && loc[0] != searchStartByte {
 			regex.SetLastIndex(0)
 			return vm.Null, nil
 		}
 
 		// Update lastIndex for global/sticky
 		if isSticky || isGlobal {
-			regex.SetLastIndex(loc[1])
+			regex.SetLastIndex(byteToUTF16Offset(str, loc[1]))
 		}
 
 		// Build result array
@@ -668,7 +678,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 				arr.Append(vm.NewString(str[start:end]))
 			}
 		}
-		arr.SetExecMeta(loc[0], str)
+		arr.SetExecMeta(byteToUTF16Offset(str, loc[0]), str)
 
 		return result, nil
 	}
@@ -693,7 +703,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if rx.IsRegExp() {
 			regex := rx.AsRegExpObject()
 			if regex != nil && !regex.HasCompileError() {
-					if regex.IsGlobal() {
+				if regex.IsGlobal() {
 					// Global match: find all matches, return array of matched strings
 					regex.SetLastIndex(0)
 					matches := regex.FindAllString(str, -1)
@@ -722,7 +732,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 						arr.Append(vm.NewString(str[start:end]))
 					}
 				}
-				arr.SetOwn("index", vm.NumberValue(float64(loc[0])))
+				arr.SetOwn("index", vm.NumberValue(float64(byteToUTF16Offset(str, loc[0]))))
 				arr.SetOwn("input", vm.NewString(str))
 				arr.SetOwn("groups", vm.Undefined)
 				return result, nil
@@ -929,7 +939,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 									callArgs = append(callArgs, vm.Undefined)
 								}
 							}
-							callArgs = append(callArgs, vm.NumberValue(float64(match[0])))
+							callArgs = append(callArgs, vm.NumberValue(float64(byteToUTF16Offset(str, match[0]))))
 							callArgs = append(callArgs, vm.NewString(str))
 							vmInstance.EnterHelperCall()
 							res, err := vmInstance.Call(replaceValue, vm.Undefined, callArgs)
@@ -959,7 +969,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 									callArgs = append(callArgs, vm.Undefined)
 								}
 							}
-							callArgs = append(callArgs, vm.NumberValue(float64(match[0])))
+							callArgs = append(callArgs, vm.NumberValue(float64(byteToUTF16Offset(str, match[0]))))
 							callArgs = append(callArgs, vm.NewString(str))
 							vmInstance.EnterHelperCall()
 							res, err := vmInstance.Call(replaceValue, vm.Undefined, callArgs)
@@ -1055,13 +1065,16 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 			// Step 13c: Get position
 			positionVal, _ := vmInstance.GetProperty(result, "index")
+			// `index` is JS-visible and therefore in code units, while every
+			// slice of str below is in bytes. Keep both, and never mix them.
 			position := int(positionVal.ToFloat())
 			if position < 0 {
 				position = 0
 			}
-			if position > len(str) {
-				position = len(str)
+			if position > utf16Len(str) {
+				position = utf16Len(str)
 			}
+			positionByte := utf16ToByteOffset(str, position)
 
 			// Step 13d-e: Get capture groups
 			captures := make([]vm.Value, nCaptures)
@@ -1098,13 +1111,13 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 				}
 				replacement = replResult.ToString()
 			} else {
-				replacement = processReplacementPatternEx(str, matched, position, captures, namedCaptures, replaceValue.ToString())
+				replacement = processReplacementPatternEx(str, matched, positionByte, captures, namedCaptures, replaceValue.ToString())
 			}
 
 			// Step 13l-m: Update accumulated result
-			if position >= nextSourcePosition {
-				accumulatedResult += str[nextSourcePosition:position] + replacement
-				nextSourcePosition = position + len(matched)
+			if positionByte >= nextSourcePosition {
+				accumulatedResult += str[nextSourcePosition:positionByte] + replacement
+				nextSourcePosition = positionByte + len(matched)
 			}
 		}
 

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -1646,7 +1646,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			vmInstance.EnterHelperCall()
 			res, err := vmInstance.Call(replaceArg, vm.Undefined, []vm.Value{
 				vm.NewString(searchValue),
-				vm.NumberValue(float64(idx)),
+				vm.NumberValue(float64(byteToUTF16Offset(thisStr, idx))),
 				vm.NewString(thisStr),
 			})
 			vmInstance.ExitHelperCall()
@@ -1787,7 +1787,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				vmInstance.EnterHelperCall()
 				res, err := vmInstance.Call(replaceArg, vm.Undefined, []vm.Value{
 					vm.NewString(searchValue),
-					vm.NumberValue(float64(idx)),
+					vm.NumberValue(float64(byteToUTF16Offset(thisStr, idx))),
 					vm.NewString(thisStr),
 				})
 				vmInstance.ExitHelperCall()
@@ -2420,8 +2420,8 @@ func createMatchAllIterator(vmInstance *vm.VM, str string, allMatches [][]int) v
 				}
 			}
 
-			// Add index property
-			arr.SetOwn("index", vm.NumberValue(float64(matchIndices[0])))
+			// Add index property, in code units — matchIndices speaks bytes.
+			arr.SetOwn("index", vm.NumberValue(float64(byteToUTF16Offset(str, matchIndices[0]))))
 			// Add input property
 			arr.SetOwn("input", vm.NewString(str))
 

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -20,6 +20,65 @@ var ErrVMUnwinding = errors.New("VM unwinding")
 
 // requireObjectCoercible checks if a value can be converted to an object (not null or undefined).
 // Returns an error if the value is null or undefined, nil otherwise.
+// ECMAScript indexes a string by UTF-16 code unit. Go indexes it by byte. The
+// two agree for ASCII and nowhere else, so every method below that reached for
+// len(s) or s[i:j] was returning byte offsets into a UTF-8 buffer: one `é` was
+// enough for "abcédef".substring(4) to start mid-character and hand back the
+// continuation byte 0xA9, and for indexOf to report 5 where the spec says 4.
+//
+// The engine already had the right primitive — String.prototype.length and
+// charAt go through vm.StringToUTF16 — so this is about routing the rest of the
+// surface through the same coordinate system rather than inventing one.
+//
+// Offsets are converted rather than working in []uint16 throughout: conversion
+// is a linear scan, where materializing every string as UTF-16 to slice it would
+// allocate on every call for the ASCII case that dominates.
+
+// utf16Len is the string's length in UTF-16 code units — what .length reports.
+func utf16Len(s string) int {
+	n := 0
+	for _, r := range s {
+		n++
+		if r > 0xFFFF {
+			n++ // astral characters occupy a surrogate pair
+		}
+	}
+	return n
+}
+
+// utf16ToByteOffset maps a UTF-16 code unit offset to a byte offset, clamped to
+// the string. An offset landing between the halves of a surrogate pair rounds
+// up to the end of that character: a UTF-8 buffer cannot hold half of one, and
+// rounding up keeps the result a valid string rather than a broken sequence.
+func utf16ToByteOffset(s string, u16 int) int {
+	if u16 <= 0 {
+		return 0
+	}
+	n := 0
+	for i, r := range s {
+		if n >= u16 {
+			return i
+		}
+		n++
+		if r > 0xFFFF {
+			n++
+		}
+	}
+	return len(s)
+}
+
+// byteToUTF16Offset is the inverse, for reporting an index found by a byte-wise
+// search back to the caller in the units the caller thinks in.
+func byteToUTF16Offset(s string, b int) int {
+	if b <= 0 {
+		return 0
+	}
+	if b > len(s) {
+		b = len(s)
+	}
+	return utf16Len(s[:b])
+}
+
 func requireObjectCoercible(vmInstance *vm.VM, val vm.Value, methodName string) error {
 	if val.Type() == vm.TypeNull {
 		return vmInstance.NewTypeError(fmt.Sprintf("String.prototype.%s called on null or undefined", methodName))
@@ -573,7 +632,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		length := len(thisStr)
+		length := utf16Len(thisStr)
 
 		// Convert start argument via ToInteger (which calls ToPrimitive for objects)
 		// ToInteger(undefined) = 0
@@ -632,7 +691,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if start >= end {
 			return vm.NewString(""), nil
 		}
-		return vm.NewString(thisStr[start:end]), nil
+		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("substring", vm.NewNativeFunction(2, false, "substring", func(args []vm.Value) (vm.Value, error) {
@@ -645,7 +704,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		length := len(thisStr)
+		length := utf16Len(thisStr)
 		if len(args) < 1 || args[0].Type() == vm.TypeUndefined {
 			return vm.NewString(thisStr), nil
 		}
@@ -668,7 +727,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if start > end {
 			start, end = end, start
 		}
-		return vm.NewString(thisStr[start:end]), nil
+		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("substr", vm.NewNativeFunction(2, false, "substr", func(args []vm.Value) (vm.Value, error) {
@@ -681,7 +740,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		length := len(thisStr)
+		length := utf16Len(thisStr)
 		if len(args) < 1 || args[0].Type() == vm.TypeUndefined {
 			return vm.NewString(thisStr), nil
 		}
@@ -705,7 +764,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if end > length {
 			end = length
 		}
-		return vm.NewString(thisStr[start:end]), nil
+		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("indexOf", vm.NewNativeFunction(1, false, "indexOf", func(args []vm.Value) (vm.Value, error) {
@@ -748,14 +807,17 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				position = 0
 			}
 		}
-		if position >= len(thisStr) {
+		if position >= utf16Len(thisStr) {
 			return vm.NumberValue(-1), nil
 		}
-		index := strings.Index(thisStr[position:], searchStr)
+		// Search over bytes, report in code units: strings.Index is the fast path
+		// and the offsets it speaks are not the ones the caller asked in.
+		startByte := utf16ToByteOffset(thisStr, position)
+		index := strings.Index(thisStr[startByte:], searchStr)
 		if index == -1 {
 			return vm.NumberValue(-1), nil
 		}
-		return vm.NumberValue(float64(position + index)), nil
+		return vm.NumberValue(float64(byteToUTF16Offset(thisStr, startByte+index))), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("lastIndexOf", vm.NewNativeFunction(1, false, "lastIndexOf", func(args []vm.Value) (vm.Value, error) {
@@ -777,7 +839,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				return vm.Undefined, err
 			}
 		}
-		position := len(thisStr)
+		// position is a code unit index; endPos below is a BYTE cut into the
+		// haystack, so the two are kept in their own units and converted once.
+		position := utf16Len(thisStr)
 		if len(args) >= 2 && args[1].Type() != vm.TypeUndefined {
 			// Convert position - throws TypeError for Symbols
 			positionF, err := toNumberWithVM(vmInstance, args[1])
@@ -787,17 +851,20 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			position = int(positionF)
 			if position < 0 {
 				position = 0
-			} else if position > len(thisStr) {
-				position = len(thisStr)
+			} else if position > utf16Len(thisStr) {
+				position = utf16Len(thisStr)
 			}
 		}
 		// Ensure we don't go past the end of the string
-		endPos := position + len(searchStr)
+		endPos := utf16ToByteOffset(thisStr, position) + len(searchStr)
 		if endPos > len(thisStr) {
 			endPos = len(thisStr)
 		}
 		index := strings.LastIndex(thisStr[:endPos], searchStr)
-		return vm.NumberValue(float64(index)), nil
+		if index == -1 {
+			return vm.NumberValue(-1), nil
+		}
+		return vm.NumberValue(float64(byteToUTF16Offset(thisStr, index))), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("includes", vm.NewNativeFunction(1, false, "includes", func(args []vm.Value) (vm.Value, error) {
@@ -839,10 +906,10 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if searchStr == "" {
 			return vm.BooleanValue(true), nil
 		}
-		if position >= len(thisStr) {
+		if position >= utf16Len(thisStr) {
 			return vm.BooleanValue(false), nil
 		}
-		return vm.BooleanValue(strings.Contains(thisStr[position:], searchStr)), nil
+		return vm.BooleanValue(strings.Contains(thisStr[utf16ToByteOffset(thisStr, position):], searchStr)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("startsWith", vm.NewNativeFunction(1, false, "startsWith", func(args []vm.Value) (vm.Value, error) {
@@ -880,10 +947,10 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				position = 0
 			}
 		}
-		if position >= len(thisStr) {
+		if position >= utf16Len(thisStr) {
 			return vm.BooleanValue(false), nil
 		}
-		return vm.BooleanValue(strings.HasPrefix(thisStr[position:], searchStr)), nil
+		return vm.BooleanValue(strings.HasPrefix(thisStr[utf16ToByteOffset(thisStr, position):], searchStr)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("endsWith", vm.NewNativeFunction(1, false, "endsWith", func(args []vm.Value) (vm.Value, error) {
@@ -909,7 +976,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		length := len(thisStr)
+		length := utf16Len(thisStr)
 		if len(args) >= 2 && args[1].Type() != vm.TypeUndefined {
 			// Convert position - throws TypeError for Symbols
 			lengthF, err := toNumberWithVM(vmInstance, args[1])
@@ -919,14 +986,17 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			length = int(lengthF)
 			if length < 0 {
 				length = 0
-			} else if length > len(thisStr) {
-				length = len(thisStr)
+			} else if length > utf16Len(thisStr) {
+				length = utf16Len(thisStr)
 			}
 		}
-		if length < len(searchStr) {
+		// endPos is where the caller's `length` lands in bytes; the comparison
+		// below is byte-wise because searchStr is measured the same way.
+		endPos := utf16ToByteOffset(thisStr, length)
+		if endPos < len(searchStr) {
 			return vm.BooleanValue(false), nil
 		}
-		return vm.BooleanValue(strings.HasSuffix(thisStr[:length], searchStr)), nil
+		return vm.BooleanValue(strings.HasSuffix(thisStr[:endPos], searchStr)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("toLowerCase", vm.NewNativeFunction(0, false, "toLowerCase", func(args []vm.Value) (vm.Value, error) {

--- a/tests/scripts/regex_index_utf16.ts
+++ b/tests/scripts/regex_index_utf16.ts
@@ -1,0 +1,49 @@
+// Regex-reported indices are UTF-16 code unit offsets, not UTF-8 byte offsets.
+//
+// Companion to string_utf16_indexing.ts. The String methods were fixed first;
+// every index the regex path hands back went on being a byte offset, so on a
+// string holding one `é` the match was reported one past where it happened —
+// and `lastIndex` advanced by a number the caller could not use to slice.
+//
+// `index` is read through a helper because the checker types a match result as
+// `null | string[]`, where `.index` is not a member. That is its own gap, and
+// narrowing it here would only hide what this test is about.
+
+const s = "abcédef"; // 7 code units, 8 UTF-8 bytes; 'd' sits at 4
+
+function indexOfMatch(m: any): number {
+  return m === null ? -1 : (m.index as number);
+}
+
+const search = s.search(/d/) === 4;
+const matchIdx = indexOfMatch(s.match(/d/)) === 4;
+
+const re = /d/g;
+const execIdx = indexOfMatch(re.exec(s)) === 4;
+const lastIdx = re.lastIndex === 5;
+
+// Walking a global regex must visit every code unit exactly once, with no gap
+// where the multi-byte character sits.
+const all: number[] = [];
+const re2 = /./g;
+let x: any = re2.exec(s);
+while (x !== null) {
+  all.push(x.index as number);
+  x = re2.exec(s);
+}
+const walk = all.join(",") === "0,1,2,3,4,5,6";
+
+// The offset handed to a replacer callback is the same coordinate.
+let seen = -1;
+s.replace(/d/, function (mm: string, off: number) {
+  seen = off;
+  return mm;
+});
+const replaceOff = seen === 4;
+
+// ...and the replacement itself still lands in the right place.
+const replaced = s.replace(/d/, "X") === "abcéXef";
+
+search && matchIdx && execIdx && lastIdx && walk && replaceOff && replaced;
+
+// expect: true

--- a/tests/scripts/string_utf16_indexing.ts
+++ b/tests/scripts/string_utf16_indexing.ts
@@ -1,0 +1,41 @@
+// String methods index by UTF-16 code unit, not by UTF-8 byte.
+//
+// `length`, `charAt` and `split("")` already went through the code-unit path
+// while `substring`, `slice`, `substr`, `indexOf`, `lastIndexOf`, `startsWith`
+// and `endsWith` sliced the underlying Go string by byte. One non-ASCII
+// character was enough to split it: "abcédef".substring(4) started inside `é`
+// and returned its continuation byte 0xA9 as a character.
+//
+// This is what made Octane's RegExp workload fail its own checksum — its
+// computeInputVariants rebuilds a string around one rotated character with
+// substring, so every variant of a non-ASCII input came out short.
+
+const s = "abcédef"; // 7 code units, 8 UTF-8 bytes
+
+// Slicing lands on character boundaries, and nothing leaks a partial byte.
+const sub = s.substring(4) === "def";
+const subRange = s.substring(2, 5) === "céd";
+const sliced = s.slice(4) === "def";
+const slicedNeg = s.slice(-3) === "def";
+const substr = s.substr(4, 2) === "de";
+
+// Indices are reported in the same units the caller passed in.
+const idx = s.indexOf("d") === 4;
+const lastIdx = s.lastIndexOf("f") === 6;
+const starts = s.startsWith("d", 4) === true;
+const ends = s.endsWith("é", 4) === true;
+
+// The methods that were already correct stay correct.
+const len = s.length === 7;
+const at = s.charAt(4) === "d";
+const parts = s.split("").length === 7;
+
+// An astral character occupies two code units, so indices past it shift by two.
+const astral = "a😀b";
+const astralLen = astral.length === 4;
+const astralTail = astral.substring(3) === "b";
+
+sub && subRange && sliced && slicedNeg && substr && idx && lastIdx && starts &&
+  ends && len && at && parts && astralLen && astralTail;
+
+// expect: true


### PR DESCRIPTION
Fixes #54.

Seven `String.prototype` methods and every match position the regex path
reports took their offsets straight into the backing Go string, which is
UTF-8, while `length`, `charAt` and `split("")` go through
`vm.StringToUTF16` and report code units. The two coordinate systems agree
on ASCII and nowhere else, so one accented character splits them:
`"abcédef"` reports `length === 7` and returns a 4-unit `substring(4)` of
its last 3 characters, starting mid-`é`.

`lastIndex` is the load-bearing case. It is both JS-visible and the
engine's own cursor, so it was holding a byte offset in a property the spec
defines in code units — a number the caller cannot use to slice the string
it came from. Walking `/./g` over that string visited `0,1,2,3,5,6,7`,
skipping an index that exists and naming one that does not.

## What changed

Offsets convert at the boundary rather than materializing strings as
`[]uint16`, so the ASCII path stays allocation-free and byte-wise searches
still run through `strings.Index` with their results mapped back before
they reach the caller. An offset landing between the halves of a surrogate
pair rounds up to the end of that character, since a UTF-8 buffer cannot
hold half of one.

- `String.prototype`: `substring`, `slice`, `substr`, `indexOf`,
  `lastIndexOf`, `startsWith`, `endsWith`.
- Match positions, eight sites: both `exec` paths, `Symbol.match`'s fast
  path, `Symbol.replace`'s two fast paths and its spec path, `matchAll`,
  and the two `String.replace` callbacks that pass a position for a string
  search.

Converting `exec()`'s `index` is not sufficient on its own. `Symbol.replace`
reads that property back and uses it to slice `str`, so one number was
serving as both a JS index and a byte offset. They are now separate
variables, `position` for what the callback sees and `positionByte` for
every cut into `str`; their absence is what caused the original bug.

The two halves are one commit each, so they can be reviewed separately.

## Verification

`tests/scripts/string_utf16_indexing.ts` and
`tests/scripts/regex_index_utf16.ts` are new, and cover each fixed method
against a non-ASCII string.

On Test262, `built-ins/RegExp` drops two failures,
`prototype/exec/u-lastindex-value.js` and `S15.10.2.7_A2_T1.js`, with no
regressions. `built-ins/String` is unchanged, with an identical failing
set. `language` shows no attributable change; a batch run of that suite is
not repeatable to better than a few tests here, with and without the patch
alike, so a small number either way is not signal.

Octane's RegExp workload is the thread that led here: `computeInputVariants`
rebuilds a string around one rotated character using `substring`, so every
variant of a non-ASCII input came out two bytes short. This fix accounts
for all of block 6's drift against V8 and all but 1 of block 1's. The
workload's checksum still fails, by less: blocks 0 and 2 have a separate
cause, which is that `\s` and `.` do not carry their ECMAScript meanings
under RE2.
