### PR TITLE
docs: add Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## PASERATI
 
+> 💬 Come talk about Paserati in `#paserati` on [The Fixpoint](https://discord.gg/Ky535CQ9pj) Discord.
+
 ![Paserati](paserati.png)
 
 ### _"Sir, it's no V8 but we're doing what we can"_


### PR DESCRIPTION
Adds a link to The Fixpoint Discord server and points folks to `#paserati` for project discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)