### PR TITLE
TypedArray ctor fixes + dedup, FinalizationRegistry, Float16 support

### DIFF
--- a/pkg/builtins/atomics_init.go
+++ b/pkg/builtins/atomics_init.go
@@ -69,8 +69,8 @@ func (a *AtomicsInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Check for valid TypedArray types (not Float32, Float64, or Uint8Clamped)
 		elemType := ta.GetElementType()
-		if elemType == vm.TypedArrayFloat32 || elemType == vm.TypedArrayFloat64 || elemType == vm.TypedArrayUint8Clamped {
-			return nil, 0, vmInstance.NewTypeError("Atomics operations are not allowed on Float32Array, Float64Array, or Uint8ClampedArray")
+		if elemType == vm.TypedArrayFloat16 || elemType == vm.TypedArrayFloat32 || elemType == vm.TypedArrayFloat64 || elemType == vm.TypedArrayUint8Clamped {
+			return nil, 0, vmInstance.NewTypeError("Atomics operations are not allowed on Float16Array, Float32Array, Float64Array, or Uint8ClampedArray")
 		}
 
 		// ValidateIntegerTypedArray: an already out-of-bounds view (detached,

--- a/pkg/builtins/bigint64array_init.go
+++ b/pkg/builtins/bigint64array_init.go
@@ -1,8 +1,6 @@
 package builtins
 
 import (
-	"math/big"
-
 	"github.com/nooga/paserati/pkg/types"
 	"github.com/nooga/paserati/pkg/vm"
 )
@@ -45,150 +43,18 @@ func (i *BigInt64ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "BigInt64Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 8)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 8); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 8)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 8); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				v := arr.Get(i)
-				// Convert to BigInt if not already
-				if !v.IsBigInt() {
-					v = vm.NewBigInt(big.NewInt(int64(v.ToFloat())))
-				}
-				vals[i] = v
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayBigInt64, l, 0, 0), nil
-	})
+	bigInt64EK := TypedArrayElementKind{Kind: vm.TypedArrayBigInt64, ElementSize: 8, IsBigInt: true}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "BigInt64Array", NumericTypedArrayCtorBody(vmInstance, bigInt64EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, bigInt64ArrayProto, 8)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				v := sourceArray.Get(i)
-				// Convert to BigInt if not already
-				if !v.IsBigInt() {
-					v = vm.NewBigInt(big.NewInt(int64(v.ToFloat())))
-				}
-				values[i] = v
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigInt64, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayBigInt64, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(bigInt64EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		values := make([]vm.Value, len(args))
-		for i, v := range args {
-			// Convert to BigInt if not already
-			if !v.IsBigInt() {
-				v = vm.NewBigInt(big.NewInt(int64(v.ToFloat())))
-			}
-			values[i] = v
-		}
-		return vm.NewTypedArray(vm.TypedArrayBigInt64, values, 0, 0), nil
+		return TypedArrayOfValues(bigInt64EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/biguint64array_init.go
+++ b/pkg/builtins/biguint64array_init.go
@@ -1,8 +1,6 @@
 package builtins
 
 import (
-	"math/big"
-
 	"github.com/nooga/paserati/pkg/types"
 	"github.com/nooga/paserati/pkg/vm"
 )
@@ -45,150 +43,18 @@ func (i *BigUint64ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "BigUint64Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 8)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 8); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 8)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 8); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				v := arr.Get(i)
-				// Convert to BigInt if not already
-				if !v.IsBigInt() {
-					v = vm.NewBigInt(new(big.Int).SetUint64(uint64(v.ToFloat())))
-				}
-				vals[i] = v
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayBigUint64, l, 0, 0), nil
-	})
+	bigUint64EK := TypedArrayElementKind{Kind: vm.TypedArrayBigUint64, ElementSize: 8, IsBigInt: true, Unsigned: true}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "BigUint64Array", NumericTypedArrayCtorBody(vmInstance, bigUint64EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, bigUint64ArrayProto, 8)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				v := sourceArray.Get(i)
-				// Convert to BigInt if not already
-				if !v.IsBigInt() {
-					v = vm.NewBigInt(new(big.Int).SetUint64(uint64(v.ToFloat())))
-				}
-				values[i] = v
-			}
-			return vm.NewTypedArray(vm.TypedArrayBigUint64, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayBigUint64, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(bigUint64EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		values := make([]vm.Value, len(args))
-		for i, v := range args {
-			// Convert to BigInt if not already
-			if !v.IsBigInt() {
-				v = vm.NewBigInt(new(big.Int).SetUint64(uint64(v.ToFloat())))
-			}
-			values[i] = v
-		}
-		return vm.NewTypedArray(vm.TypedArrayBigUint64, values, 0, 0), nil
+		return TypedArrayOfValues(bigUint64EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/dataview_init.go
+++ b/pkg/builtins/dataview_init.go
@@ -30,6 +30,7 @@ func (d *DataViewInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("getUint16", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.Number, []bool{false, true})).
 		WithProperty("getInt32", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.Number, []bool{false, true})).
 		WithProperty("getUint32", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.Number, []bool{false, true})).
+		WithProperty("getFloat16", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.Number, []bool{false, true})).
 		WithProperty("getFloat32", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.Number, []bool{false, true})).
 		WithProperty("getFloat64", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.Number, []bool{false, true})).
 		WithProperty("getBigInt64", types.NewOptionalFunction([]types.Type{types.Number, types.Boolean}, types.BigInt, []bool{false, true})).
@@ -40,6 +41,7 @@ func (d *DataViewInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("setUint16", types.NewOptionalFunction([]types.Type{types.Number, types.Number, types.Boolean}, types.Undefined, []bool{false, false, true})).
 		WithProperty("setInt32", types.NewOptionalFunction([]types.Type{types.Number, types.Number, types.Boolean}, types.Undefined, []bool{false, false, true})).
 		WithProperty("setUint32", types.NewOptionalFunction([]types.Type{types.Number, types.Number, types.Boolean}, types.Undefined, []bool{false, false, true})).
+		WithProperty("setFloat16", types.NewOptionalFunction([]types.Type{types.Number, types.Number, types.Boolean}, types.Undefined, []bool{false, false, true})).
 		WithProperty("setFloat32", types.NewOptionalFunction([]types.Type{types.Number, types.Number, types.Boolean}, types.Undefined, []bool{false, false, true})).
 		WithProperty("setFloat64", types.NewOptionalFunction([]types.Type{types.Number, types.Number, types.Boolean}, types.Undefined, []bool{false, false, true})).
 		WithProperty("setBigInt64", types.NewOptionalFunction([]types.Type{types.Number, types.BigInt, types.Boolean}, types.Undefined, []bool{false, false, true})).
@@ -257,6 +259,20 @@ func (d *DataViewInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vm.Number(float64(val)), nil
 	}))
 
+	// getFloat16
+	dataViewProto.SetOwnNonEnumerable("getFloat16", vm.NewNativeFunction(1, false, "getFloat16", func(args []vm.Value) (vm.Value, error) {
+		if len(args) < 1 {
+			return vm.Undefined, vmInstance.NewTypeError("getFloat16 requires 1 argument")
+		}
+		dv, byteOffset, err := validateDataViewAccess(vmInstance.GetThis(), args[0], 2)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		littleEndian := len(args) > 1 && args[1].IsTruthy()
+		val, _ := dv.GetFloat16(byteOffset, littleEndian)
+		return vm.Number(val), nil
+	}))
+
 	// getFloat32
 	dataViewProto.SetOwnNonEnumerable("getFloat32", vm.NewNativeFunction(1, false, "getFloat32", func(args []vm.Value) (vm.Value, error) {
 		if len(args) < 1 {
@@ -398,6 +414,21 @@ func (d *DataViewInitializer) InitRuntime(ctx *RuntimeContext) error {
 		value := uint32(vmInstance.ToNumber(args[1]))
 		littleEndian := len(args) > 2 && args[2].IsTruthy()
 		dv.SetUint32(byteOffset, value, littleEndian)
+		return vm.Undefined, nil
+	}))
+
+	// setFloat16
+	dataViewProto.SetOwnNonEnumerable("setFloat16", vm.NewNativeFunction(2, false, "setFloat16", func(args []vm.Value) (vm.Value, error) {
+		if len(args) < 2 {
+			return vm.Undefined, vmInstance.NewTypeError("setFloat16 requires 2 arguments")
+		}
+		dv, byteOffset, err := validateDataViewAccess(vmInstance.GetThis(), args[0], 2)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		value := vmInstance.ToNumber(args[1])
+		littleEndian := len(args) > 2 && args[2].IsTruthy()
+		dv.SetFloat16(byteOffset, value, littleEndian)
 		return vm.Undefined, nil
 	}))
 

--- a/pkg/builtins/finalizationregistry_init.go
+++ b/pkg/builtins/finalizationregistry_init.go
@@ -1,0 +1,174 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+type FinalizationRegistryInitializer struct{}
+
+func (f *FinalizationRegistryInitializer) Name() string {
+	return "FinalizationRegistry"
+}
+
+func (f *FinalizationRegistryInitializer) Priority() int {
+	return 416 // After WeakRef (415)
+}
+
+func (f *FinalizationRegistryInitializer) InitTypes(ctx *TypeContext) error {
+	// Create generic type parameter T for FinalizationRegistry's held value.
+	tParam := &types.TypeParameter{Name: "T", Index: 0}
+	tType := &types.TypeParameterType{Parameter: tParam}
+
+	finalizationRegistryType := &types.GenericType{
+		Name:           "FinalizationRegistry",
+		TypeParameters: []*types.TypeParameter{tParam},
+		Body:           nil, // set below
+	}
+
+	instanceType := types.NewObjectType().
+		WithProperty("register", types.NewOptionalFunction(
+			[]types.Type{types.NewObjectType(), tType, types.Any},
+			types.Undefined,
+			[]bool{false, false, true},
+		)).
+		WithProperty("unregister", types.NewSimpleFunction([]types.Type{types.Any}, types.Boolean))
+
+	finalizationRegistryType.Body = instanceType
+	ctx.SetPrimitivePrototype("finalizationregistry", instanceType)
+
+	ctorType := &types.GenericType{
+		Name:           "FinalizationRegistry",
+		TypeParameters: []*types.TypeParameter{tParam},
+		Body: types.NewSimpleFunction(
+			[]types.Type{types.NewSimpleFunction([]types.Type{tType}, types.Undefined)},
+			finalizationRegistryType,
+		),
+	}
+
+	if err := ctx.DefineGlobal("FinalizationRegistry", ctorType); err != nil {
+		return err
+	}
+	return ctx.DefineTypeAlias("FinalizationRegistry", finalizationRegistryType)
+}
+
+func (f *FinalizationRegistryInitializer) InitRuntime(ctx *RuntimeContext) error {
+	vmInstance := ctx.VM
+	objectProto := vmInstance.ObjectPrototype
+
+	proto := vm.NewObject(objectProto).AsPlainObject()
+
+	// FinalizationRegistry.prototype.register(target, heldValue, unregisterToken?)
+	// Per https://tc39.es/ecma262/#sec-finalization-registry.prototype.register
+	proto.SetOwnNonEnumerable("register", vm.NewNativeFunction(2, false, "register", func(args []vm.Value) (vm.Value, error) {
+		thisVal := vmInstance.GetThis()
+		fr := thisVal.AsFinalizationRegistry()
+		if fr == nil {
+			return vm.Undefined, vmInstance.NewTypeError("Method FinalizationRegistry.prototype.register called on incompatible receiver")
+		}
+
+		target := vm.Undefined
+		if len(args) > 0 {
+			target = args[0]
+		}
+		if !target.CanBeHeldWeakly() {
+			return vm.Undefined, vmInstance.NewTypeError("target must be an object or a non-registered symbol")
+		}
+
+		heldValue := vm.Undefined
+		if len(args) > 1 {
+			heldValue = args[1]
+		}
+		if target.StrictlyEquals(heldValue) {
+			return vm.Undefined, vmInstance.NewTypeError("target and heldValue must not be the same value")
+		}
+
+		hasToken := false
+		var token vm.Value
+		if len(args) > 2 && !args[2].IsUndefined() {
+			token = args[2]
+			if !token.CanBeHeldWeakly() {
+				return vm.Undefined, vmInstance.NewTypeError("unregisterToken must be an object or a non-registered symbol")
+			}
+			hasToken = true
+		}
+
+		fr.Register(target, heldValue, hasToken, token)
+		return vm.Undefined, nil
+	}))
+	if v, ok := proto.GetOwn("register"); ok {
+		w, e, c := true, false, true
+		proto.DefineOwnProperty("register", v, &w, &e, &c)
+	}
+
+	// FinalizationRegistry.prototype.unregister(unregisterToken)
+	// Per https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister
+	proto.SetOwnNonEnumerable("unregister", vm.NewNativeFunction(1, false, "unregister", func(args []vm.Value) (vm.Value, error) {
+		thisVal := vmInstance.GetThis()
+		fr := thisVal.AsFinalizationRegistry()
+		if fr == nil {
+			return vm.Undefined, vmInstance.NewTypeError("Method FinalizationRegistry.prototype.unregister called on incompatible receiver")
+		}
+
+		token := vm.Undefined
+		if len(args) > 0 {
+			token = args[0]
+		}
+		if !token.CanBeHeldWeakly() {
+			return vm.Undefined, vmInstance.NewTypeError("unregisterToken must be an object or a non-registered symbol")
+		}
+
+		return vm.BooleanValue(fr.Unregister(token)), nil
+	}))
+	if v, ok := proto.GetOwn("unregister"); ok {
+		w, e, c := true, false, true
+		proto.DefineOwnProperty("unregister", v, &w, &e, &c)
+	}
+
+	// @@toStringTag: { writable: false, enumerable: false, configurable: true }
+	if vmInstance.SymbolToStringTag.Type() == vm.TypeSymbol {
+		falseVal, trueVal := false, true
+		proto.DefineOwnPropertyByKey(
+			vm.NewSymbolKey(vmInstance.SymbolToStringTag),
+			vm.NewString("FinalizationRegistry"),
+			&falseVal, &falseVal, &trueVal,
+		)
+	}
+
+	// Constructor: new FinalizationRegistry(cleanupCallback)
+	// Per https://tc39.es/ecma262/#sec-finalization-registry-cleanupCallback
+	ctor := vm.NewConstructorWithProps(1, false, "FinalizationRegistry", func(args []vm.Value) (vm.Value, error) {
+		newTarget := vmInstance.GetNewTarget()
+		if newTarget.IsUndefined() {
+			return vm.Undefined, vmInstance.NewTypeError("Constructor FinalizationRegistry requires 'new'")
+		}
+
+		cleanupCallback := vm.Undefined
+		if len(args) > 0 {
+			cleanupCallback = args[0]
+		}
+		if !cleanupCallback.IsCallable() {
+			return vm.Undefined, vmInstance.NewTypeError("cleanupCallback must be callable")
+		}
+
+		prototype, err := vmInstance.GetPrototypeFromConstructor(newTarget, "%FinalizationRegistryPrototype%")
+		if err != nil {
+			return vm.Undefined, err
+		}
+
+		return vm.NewFinalizationRegistry(cleanupCallback, prototype), nil
+	})
+
+	w, e, c := false, false, false
+	ctor.AsNativeFunctionWithProps().Properties.DefineOwnProperty("prototype", vm.NewValueFromPlainObject(proto), &w, &e, &c)
+
+	proto.SetOwnNonEnumerable("constructor", ctor)
+	if v, ok := proto.GetOwn("constructor"); ok {
+		w2, e2, c2 := true, false, true
+		proto.DefineOwnProperty("constructor", v, &w2, &e2, &c2)
+	}
+
+	vmInstance.FinalizationRegistryPrototype = vm.NewValueFromPlainObject(proto)
+
+	return ctx.DefineGlobal("FinalizationRegistry", ctor)
+}

--- a/pkg/builtins/float16array_init.go
+++ b/pkg/builtins/float16array_init.go
@@ -1,0 +1,54 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// Float16ArrayInitializer registers Float16Array (ES2024), the half-precision
+// (IEEE 754 binary16) typed array. Its element storage/conversion lives in
+// pkg/vm/typed_array.go (vm.Float64ToFloat16Bits/vm.Float16BitsToFloat64,
+// shared with Math.f16round and DataView.prototype.{get,set}Float16).
+type Float16ArrayInitializer struct{}
+
+func (f *Float16ArrayInitializer) Name() string  { return "Float16Array" }
+func (f *Float16ArrayInitializer) Priority() int { return 424 } // After Float64Array
+
+func (f *Float16ArrayInitializer) InitTypes(ctx *TypeContext) error {
+	protoType := typedArrayInstanceType(types.Number)
+
+	ctorType := types.NewObjectType().
+		WithSimpleCallSignature([]types.Type{types.Number}, protoType).
+		WithSimpleCallSignature([]types.Type{types.Any}, protoType).
+		WithSimpleCallSignature([]types.Type{&types.ArrayType{ElementType: types.Number}}, protoType).
+		WithProperty("BYTES_PER_ELEMENT", types.Number).
+		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, protoType)).
+		WithProperty("of", types.NewSimpleFunction([]types.Type{}, protoType)).
+		WithProperty("prototype", protoType)
+
+	return ctx.DefineGlobal("Float16Array", ctorType)
+}
+
+func (f *Float16ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
+	vmInstance := ctx.VM
+	proto := vm.NewObject(vmInstance.TypedArrayPrototype).AsPlainObject()
+
+	SetupTypedArrayPrototypeProperties(proto, vmInstance, 2)
+
+	ek := TypedArrayElementKind{Kind: vm.TypedArrayFloat16, ElementSize: 2}
+	ctor := vm.NewConstructorWithProps(3, true, "Float16Array", NumericTypedArrayCtorBody(vmInstance, ek))
+	SetupTypedArrayConstructorProperties(ctor, proto, 2)
+
+	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
+		return TypedArrayFromArrayLike(ek, args), nil
+	}))
+	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
+		return TypedArrayOfValues(ek, args), nil
+	}))
+
+	proto.SetOwnNonEnumerable("constructor", ctor)
+	ctor.AsNativeFunctionWithProps().Properties.SetPrototype(vmInstance.TypedArrayConstructor)
+
+	vmInstance.Float16ArrayPrototype = vm.NewValueFromPlainObject(proto)
+	return ctx.DefineGlobal("Float16Array", ctor)
+}

--- a/pkg/builtins/float32array_init.go
+++ b/pkg/builtins/float32array_init.go
@@ -43,132 +43,18 @@ func (f *Float32ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "Float32Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 4)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 4); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 4)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 4); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayFloat32, l, 0, 0), nil
-	})
+	float32EK := TypedArrayElementKind{Kind: vm.TypedArrayFloat32, ElementSize: 4}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "Float32Array", NumericTypedArrayCtorBody(vmInstance, float32EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, float32ArrayProto, 4)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayFloat32, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				values[i] = sourceArray.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat32, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayFloat32, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(float32EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayFloat32, args, 0, 0), nil
+		return TypedArrayOfValues(float32EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/float64array_init.go
+++ b/pkg/builtins/float64array_init.go
@@ -43,132 +43,18 @@ func (u *Float64ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "Float64Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 8)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 8); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 8)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 8); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayFloat64, l, 0, 0), nil
-	})
+	float64EK := TypedArrayElementKind{Kind: vm.TypedArrayFloat64, ElementSize: 8}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "Float64Array", NumericTypedArrayCtorBody(vmInstance, float64EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, float64ArrayProto, 8)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayFloat64, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				values[i] = sourceArray.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayFloat64, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayFloat64, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(float64EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayFloat64, args, 0, 0), nil
+		return TypedArrayOfValues(float64EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/int16array_init.go
+++ b/pkg/builtins/int16array_init.go
@@ -34,129 +34,17 @@ func (i *Int16ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctor := vm.NewConstructorWithProps(3, true, "Int16Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmx, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmx, args[1], 2)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmx, buf, off, 2); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmx, args[1], 2)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmx, sab, off, 2); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmx, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmx); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayInt16, l, 0, 0), nil
-	})
+	int16EK := TypedArrayElementKind{Kind: vm.TypedArrayInt16, ElementSize: 2}
+	ctor := vm.NewConstructorWithProps(3, true, "Int16Array", NumericTypedArrayCtorBody(vmx, int16EK))
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctor, proto, 2)
 
 	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayInt16, 0, 0, 0), nil
-		}
-		src := args[0]
-		if a := src.AsArray(); a != nil {
-			vals := make([]vm.Value, a.Length())
-			for i := 0; i < a.Length(); i++ {
-				vals[i] = a.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt16, vals, 0, 0), nil
-		}
-		return vm.NewTypedArray(vm.TypedArrayInt16, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(int16EK, args), nil
 	}))
 
 	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayInt16, args, 0, 0), nil
+		return TypedArrayOfValues(int16EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/int32array_init.go
+++ b/pkg/builtins/int32array_init.go
@@ -43,132 +43,18 @@ func (i *Int32ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// Create Int32Array constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "Int32Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 4)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 4); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 4)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 4); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayInt32, l, 0, 0), nil
-	})
+	int32EK := TypedArrayElementKind{Kind: vm.TypedArrayInt32, ElementSize: 4}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "Int32Array", NumericTypedArrayCtorBody(vmInstance, int32EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, int32ArrayProto, 4)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayInt32, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				values[i] = sourceArray.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt32, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayInt32, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(int32EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayInt32, args, 0, 0), nil
+		return TypedArrayOfValues(int32EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/int8array_init.go
+++ b/pkg/builtins/int8array_init.go
@@ -34,126 +34,16 @@ func (i *Int8ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctor := vm.NewConstructorWithProps(3, true, "Int8Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmx, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmx, args[1], 1)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmx, buf, off, 1); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmx, args[1], 1)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmx, sab, off, 1); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmx, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmx); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayInt8, l, 0, 0), nil
-	})
+	int8EK := TypedArrayElementKind{Kind: vm.TypedArrayInt8, ElementSize: 1}
+	ctor := vm.NewConstructorWithProps(3, true, "Int8Array", NumericTypedArrayCtorBody(vmx, int8EK))
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctor, proto, 1)
 	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayInt8, 0, 0, 0), nil
-		}
-		src := args[0]
-		if a := src.AsArray(); a != nil {
-			vals := make([]vm.Value, a.Length())
-			for i := 0; i < a.Length(); i++ {
-				vals[i] = a.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayInt8, vals, 0, 0), nil
-		}
-		return vm.NewTypedArray(vm.TypedArrayInt8, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(int8EK, args), nil
 	}))
-	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) { return vm.NewTypedArray(vm.TypedArrayInt8, args, 0, 0), nil }))
+	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
+		return TypedArrayOfValues(int8EK, args), nil
+	}))
 
 	proto.SetOwnNonEnumerable("constructor", ctor)
 

--- a/pkg/builtins/math_init.go
+++ b/pkg/builtins/math_init.go
@@ -34,115 +34,13 @@ func toInt32(n float64) int32 {
 	return int32(u)
 }
 
-// float64ToFloat16ToFloat64 converts a float64 to half-precision (float16) and back
-// This implements the rounding behavior specified for Math.f16round
+// float64ToFloat16ToFloat64 converts a float64 to half-precision (float16) and
+// back, implementing the rounding behavior specified for Math.f16round. The
+// actual bit-level conversion lives in pkg/vm (vm.Float64ToFloat16Bits /
+// vm.Float16BitsToFloat64) since Float16Array and DataView.prototype.
+// {get,set}Float16 need the same round-trip.
 func float64ToFloat16ToFloat64(x float64) float64 {
-	// Get the bits of the float64
-	bits := math.Float64bits(x)
-	sign := bits >> 63
-	exp := int((bits >> 52) & 0x7FF)
-	frac := bits & 0xFFFFFFFFFFFFF
-
-	// float16 parameters
-	const f16ExpBias = 15
-	const f64ExpBias = 1023
-	const f16MaxExp = 30   // Biased max exponent (31 is for inf/nan)
-	const f16MinExp = 1    // Biased min normal exponent
-	const f16FracBits = 10 // Mantissa bits in float16
-
-	// Compute unbiased exponent
-	unbiasedExp := exp - f64ExpBias
-
-	var f16Bits uint16
-
-	if exp == 0x7FF {
-		// Infinity or NaN - already handled before calling this function
-		if frac == 0 {
-			// Infinity
-			f16Bits = uint16(sign<<15) | 0x7C00
-		} else {
-			// NaN - preserve sign, set NaN pattern
-			f16Bits = uint16(sign<<15) | 0x7E00
-		}
-	} else if exp == 0 {
-		// Denormal or zero in float64 - becomes zero in float16
-		f16Bits = uint16(sign << 15)
-	} else if unbiasedExp > 15 {
-		// Overflow to infinity
-		f16Bits = uint16(sign<<15) | 0x7C00
-	} else if unbiasedExp < -24 {
-		// Underflow to zero
-		f16Bits = uint16(sign << 15)
-	} else if unbiasedExp < -14 {
-		// Denormal in float16
-		// Shift the mantissa right to create a denormal
-		shift := uint(-14 - unbiasedExp)
-		// Add implicit 1 bit
-		frac16 := (frac >> 42) | 0x400 // 10 bits + implicit 1
-		frac16 = frac16 >> shift
-		// Round to nearest even
-		roundBit := (frac >> (42 + shift - 1)) & 1
-		if roundBit == 1 {
-			frac16++
-		}
-		f16Bits = uint16(sign<<15) | uint16(frac16&0x3FF)
-	} else {
-		// Normal number
-		f16Exp := uint16(unbiasedExp + f16ExpBias)
-		// Take top 10 bits of mantissa, round to nearest even
-		frac16 := frac >> 42 // Top 10 bits
-		// Check for rounding
-		roundBits := (frac >> 41) & 1 // 11th bit
-		if roundBits == 1 {
-			// Round up, but check for tie (round to even)
-			lowerBits := frac & 0x1FFFFFFFFFF // bits 0-40
-			if lowerBits != 0 || (frac16&1) == 1 {
-				frac16++
-				if frac16 > 0x3FF {
-					// Overflow to next exponent
-					frac16 = 0
-					f16Exp++
-					if f16Exp > 30 {
-						// Overflow to infinity
-						f16Bits = uint16(sign<<15) | 0x7C00
-						goto convert
-					}
-				}
-			}
-		}
-		f16Bits = uint16(sign<<15) | (f16Exp << 10) | uint16(frac16&0x3FF)
-	}
-
-convert:
-	// Convert float16 bits back to float64
-	f16Sign := (f16Bits >> 15) & 1
-	f16Exp := (f16Bits >> 10) & 0x1F
-	f16Frac := f16Bits & 0x3FF
-
-	var result float64
-	if f16Exp == 0x1F {
-		// Infinity or NaN
-		if f16Frac == 0 {
-			result = math.Inf(1)
-		} else {
-			result = math.NaN()
-		}
-	} else if f16Exp == 0 {
-		if f16Frac == 0 {
-			result = 0
-		} else {
-			// Denormal
-			result = float64(f16Frac) / 1024.0 * math.Pow(2, -14)
-		}
-	} else {
-		// Normal
-		result = (1.0 + float64(f16Frac)/1024.0) * math.Pow(2, float64(f16Exp)-15)
-	}
-
-	if f16Sign == 1 {
-		result = -result
-	}
-	return result
+	return vm.Float16BitsToFloat64(vm.Float64ToFloat16Bits(x))
 }
 
 type MathInitializer struct{}

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1397,7 +1397,21 @@ func lookupSymbolProp(vmInstance *vm.VM, val vm.Value, symKey vm.PropertyKey, sy
 	case vm.TypeSharedArrayBuffer:
 		return lookupSymbolPropFromProto(vmInstance, vmInstance.SharedArrayBufferPrototype, symKey, symObj, depth)
 	case vm.TypeTypedArray:
-		return lookupSymbolPropFromProto(vmInstance, vmInstance.ObjectPrototype, symKey, symObj, depth)
+		// Resolve the concrete per-kind prototype (or a per-instance override,
+		// e.g. from subclassing) rather than ObjectPrototype: well-known symbol
+		// properties like @@toStringTag live on the specific XxxArray.prototype
+		// (via %TypedArray%.prototype) as an ACCESSOR (its getter reads
+		// ta.GetElementType(), varying per concrete subtype). Call
+		// lookupSymbolPropInPlainObj directly (rather than going through
+		// lookupSymbolPropFromProto -> lookupSymbolProp, which would re-dispatch
+		// on the *prototype's* type and lose the original TypedArray as
+		// receiver) so the getter is invoked with the TypedArray instance as
+		// `this`, not the prototype object.
+		proto := typedArrayEffectivePrototype(vmInstance, val)
+		if proto.Type() != vm.TypeObject {
+			return vm.Undefined, nil
+		}
+		return lookupSymbolPropInPlainObj(vmInstance, val, proto.AsPlainObject(), symKey, symObj, depth)
 	case vm.TypeArguments:
 		// Check own symbol properties first
 		argObj := val.AsArguments()
@@ -2122,6 +2136,8 @@ func objectGetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			return vmInstance.Uint32ArrayPrototype, nil
 		case vm.TypedArrayInt32:
 			return vmInstance.Int32ArrayPrototype, nil
+		case vm.TypedArrayFloat16:
+			return vmInstance.Float16ArrayPrototype, nil
 		case vm.TypedArrayFloat32:
 			return vmInstance.Float32ArrayPrototype, nil
 		case vm.TypedArrayFloat64:

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1968,6 +1968,15 @@ func objectGetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 	if obj.Type() == vm.TypeNull || obj.Type() == vm.TypeUndefined {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 	}
+
+	// Exotic-type instances (subclassing a native constructor, or a custom
+	// newTarget.prototype via Reflect.construct/GetPrototypeFromConstructor)
+	// carry a per-instance [[Prototype]] override that takes precedence over
+	// the type-switch below's intrinsic defaults; see InstancePrototypeOverride.
+	if override, ok := vmInstance.InstancePrototypeOverride(obj); ok {
+		return override, nil
+	}
+
 	// Handle primitive types by returning their prototype directly
 	if obj.IsNumber() {
 		return vmInstance.NumberPrototype, nil

--- a/pkg/builtins/standard.go
+++ b/pkg/builtins/standard.go
@@ -75,6 +75,7 @@ func GetStandardInitializers() []BuiltinInitializer {
 	initializers = append(initializers, &Int32ArrayInitializer{})
 	initializers = append(initializers, &Float32ArrayInitializer{})
 	initializers = append(initializers, &Float64ArrayInitializer{})
+	initializers = append(initializers, &Float16ArrayInitializer{})
 	initializers = append(initializers, &BigInt64ArrayInitializer{})
 	initializers = append(initializers, &BigUint64ArrayInitializer{})
 	initializers = append(initializers, &AtomicsInitializer{})

--- a/pkg/builtins/standard.go
+++ b/pkg/builtins/standard.go
@@ -35,6 +35,7 @@ func GetStandardInitializers() []BuiltinInitializer {
 	initializers = append(initializers, &WeakMapInitializer{})
 	initializers = append(initializers, &WeakSetInitializer{})
 	initializers = append(initializers, &WeakRefInitializer{})
+	initializers = append(initializers, &FinalizationRegistryInitializer{})
 	initializers = append(initializers, &RegExpInitializer{})
 	initializers = append(initializers, &ErrorInitializer{})
 	initializers = append(initializers, &TypeErrorInitializer{})

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -183,6 +183,48 @@ func TypedArrayGPFC(vmInstance *vm.VM, defaultProtoIntrinsic string) (vm.Value, 
 	return vmInstance.GetPrototypeFromConstructor(newTarget, defaultProtoIntrinsic)
 }
 
+// typedArrayEffectivePrototype resolves the prototype a TypedArray instance
+// actually uses: its per-instance override if one was set (subclassing, or a
+// custom newTarget via Reflect.construct), else the intrinsic prototype for
+// its element kind. Returns vm.Undefined if val isn't a TypedArray.
+func typedArrayEffectivePrototype(vmInstance *vm.VM, val vm.Value) vm.Value {
+	ta := val.AsTypedArray()
+	if ta == nil {
+		return vm.Undefined
+	}
+	if p := ta.GetPrototype(); p.IsObject() {
+		return p
+	}
+	switch ta.GetElementType() {
+	case vm.TypedArrayInt8:
+		return vmInstance.Int8ArrayPrototype
+	case vm.TypedArrayUint8:
+		return vmInstance.Uint8ArrayPrototype
+	case vm.TypedArrayUint8Clamped:
+		return vmInstance.Uint8ClampedArrayPrototype
+	case vm.TypedArrayInt16:
+		return vmInstance.Int16ArrayPrototype
+	case vm.TypedArrayUint16:
+		return vmInstance.Uint16ArrayPrototype
+	case vm.TypedArrayInt32:
+		return vmInstance.Int32ArrayPrototype
+	case vm.TypedArrayUint32:
+		return vmInstance.Uint32ArrayPrototype
+	case vm.TypedArrayFloat16:
+		return vmInstance.Float16ArrayPrototype
+	case vm.TypedArrayFloat32:
+		return vmInstance.Float32ArrayPrototype
+	case vm.TypedArrayFloat64:
+		return vmInstance.Float64ArrayPrototype
+	case vm.TypedArrayBigInt64:
+		return vmInstance.BigInt64ArrayPrototype
+	case vm.TypedArrayBigUint64:
+		return vmInstance.BigUint64ArrayPrototype
+	default:
+		return vmInstance.TypedArrayPrototype
+	}
+}
+
 // typedArrayIntrinsicProtoName maps a TypedArrayKind to its %Foo.prototype%
 // intrinsic name, for GetPrototypeFromConstructor's cross-realm default.
 func typedArrayIntrinsicProtoName(kind vm.TypedArrayKind) string {
@@ -201,6 +243,8 @@ func typedArrayIntrinsicProtoName(kind vm.TypedArrayKind) string {
 		return "%Uint32Array.prototype%"
 	case vm.TypedArrayInt32:
 		return "%Int32Array.prototype%"
+	case vm.TypedArrayFloat16:
+		return "%Float16Array.prototype%"
 	case vm.TypedArrayFloat32:
 		return "%Float32Array.prototype%"
 	case vm.TypedArrayFloat64:

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -315,11 +315,9 @@ func TypedArrayLengthToIndex(vmInstance *vm.VM, arg vm.Value) (int, error) {
 // alignment (length omitted) or a bounds check (length given). Returns
 // length == -1 when the resulting view should auto/length-track the buffer.
 func computeBufferViewOffsetLength(vmInstance *vm.VM, buf *vm.ArrayBufferObject, args []vm.Value, elementSize int) (off int, length int, err error) {
-	byteOffsetArg := vm.Value{}
+	byteOffsetArg := vm.Undefined
 	if len(args) > 1 {
 		byteOffsetArg = args[1]
-	} else {
-		byteOffsetArg = vm.Undefined
 	}
 	off, err = ValidateTypedArrayByteOffset(vmInstance, byteOffsetArg, elementSize)
 	if err != nil {
@@ -351,11 +349,9 @@ func computeBufferViewOffsetLength(vmInstance *vm.VM, buf *vm.ArrayBufferObject,
 // computeBufferViewOffsetLength. SharedArrayBuffers cannot be detached, so
 // there is no post-coercion detach recheck.
 func computeSharedBufferViewOffsetLength(vmInstance *vm.VM, sab *vm.SharedArrayBufferObject, args []vm.Value, elementSize int) (off int, length int, err error) {
-	byteOffsetArg := vm.Value{}
+	byteOffsetArg := vm.Undefined
 	if len(args) > 1 {
 		byteOffsetArg = args[1]
-	} else {
-		byteOffsetArg = vm.Undefined
 	}
 	off, err = ValidateTypedArrayByteOffsetShared(vmInstance, byteOffsetArg, elementSize)
 	if err != nil {

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/nooga/paserati/pkg/types"
 	"github.com/nooga/paserati/pkg/vm"
@@ -167,16 +168,60 @@ func ValidateTypedArrayBufferAlignmentShared(vmInstance *vm.VM, buffer *vm.Share
 	return nil
 }
 
-// TypedArrayGPFC calls GetPrototypeFromConstructor if newTarget is set.
-// This implements the GPFC portion of AllocateTypedArray.
-func TypedArrayGPFC(vmInstance *vm.VM) error {
-	if newTarget := vmInstance.GetNewTarget(); !newTarget.IsUndefined() {
-		_, gpfcErr := vmInstance.GetPrototypeFromConstructor(newTarget, "%ObjectPrototype%")
-		if gpfcErr != nil {
-			return gpfcErr
-		}
+// TypedArrayGPFC implements the shared first steps of every %TypedArray%
+// subclass constructor overload (22.2.5.1 step 1: "If NewTarget is undefined,
+// throw a TypeError exception", then AllocateTypedArray's
+// GetPrototypeFromConstructor(newTarget, defaultProto) step). The caller must
+// apply the returned prototype to the newly created typed array itself
+// (GetPrototypeFromConstructor only computes [[Prototype]]; it doesn't know
+// where to install it).
+func TypedArrayGPFC(vmInstance *vm.VM, defaultProtoIntrinsic string) (vm.Value, error) {
+	newTarget := vmInstance.GetNewTarget()
+	if newTarget.IsUndefined() {
+		return vm.Undefined, vmInstance.NewTypeError("Constructor TypedArray requires 'new'")
 	}
-	return nil
+	return vmInstance.GetPrototypeFromConstructor(newTarget, defaultProtoIntrinsic)
+}
+
+// typedArrayIntrinsicProtoName maps a TypedArrayKind to its %Foo.prototype%
+// intrinsic name, for GetPrototypeFromConstructor's cross-realm default.
+func typedArrayIntrinsicProtoName(kind vm.TypedArrayKind) string {
+	switch kind {
+	case vm.TypedArrayUint8:
+		return "%Uint8Array.prototype%"
+	case vm.TypedArrayUint8Clamped:
+		return "%Uint8ClampedArray.prototype%"
+	case vm.TypedArrayInt8:
+		return "%Int8Array.prototype%"
+	case vm.TypedArrayInt16:
+		return "%Int16Array.prototype%"
+	case vm.TypedArrayUint16:
+		return "%Uint16Array.prototype%"
+	case vm.TypedArrayUint32:
+		return "%Uint32Array.prototype%"
+	case vm.TypedArrayInt32:
+		return "%Int32Array.prototype%"
+	case vm.TypedArrayFloat32:
+		return "%Float32Array.prototype%"
+	case vm.TypedArrayFloat64:
+		return "%Float64Array.prototype%"
+	case vm.TypedArrayBigInt64:
+		return "%BigInt64Array.prototype%"
+	case vm.TypedArrayBigUint64:
+		return "%BigUint64Array.prototype%"
+	default:
+		return "%TypedArrayPrototype%"
+	}
+}
+
+// applyGPFCPrototype installs the prototype computed by TypedArrayGPFC onto
+// a freshly created typed array value (a per-instance override; see
+// TypedArrayObject.SetPrototype).
+func applyGPFCPrototype(result vm.Value, proto vm.Value) vm.Value {
+	if ta := result.AsTypedArray(); ta != nil {
+		ta.SetPrototype(proto)
+	}
+	return result
 }
 
 // TypedArrayToIndex validates a non-object argument for TypedArray constructors.
@@ -194,6 +239,243 @@ func TypedArrayToIndex(vmInstance *vm.VM, arg vm.Value) (int, error) {
 		return 0, vmInstance.NewRangeError("Invalid typed array length")
 	}
 	return l, nil
+}
+
+// TypedArrayLengthToIndex validates the optional "length" argument of a
+// TypedArray-from-buffer constructor (22.2.5.1.4/1.5 step "newLength = ?
+// ToIndex(length)"). Unlike TypedArrayToIndex, the argument here may be an
+// object (e.g. `new Int8Array(buffer, 0, {valueOf(){...}})`), so this goes
+// through the VM-aware toIntegerOrInfinityWithVM (which calls ToPrimitive and
+// properly propagates an exception thrown from valueOf/toString) rather than
+// the bare Value.ToFloat() used by TypedArrayToIndex's non-object callers.
+func TypedArrayLengthToIndex(vmInstance *vm.VM, arg vm.Value) (int, error) {
+	if arg.Type() == vm.TypeBigInt {
+		return 0, vmInstance.NewTypeError("Cannot convert a BigInt value to a number")
+	}
+	n, err := toIntegerOrInfinityWithVM(vmInstance, arg)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 {
+		return 0, vmInstance.NewRangeError("Invalid typed array length")
+	}
+	return n, nil
+}
+
+// computeBufferViewOffsetLength implements the byteOffset/length portion of
+// InitializeTypedArrayFromArrayBuffer (22.2.5.1.4) shared by every
+// %TypedArray% subclass constructor's ArrayBuffer overload: ToIndex(byteOffset)
+// and its alignment check, then ToIndex(length) if given. Per spec the
+// detached-buffer check happens AFTER both coercions (either of which may run
+// arbitrary user code via valueOf/toString that detaches buf), followed by
+// alignment (length omitted) or a bounds check (length given). Returns
+// length == -1 when the resulting view should auto/length-track the buffer.
+func computeBufferViewOffsetLength(vmInstance *vm.VM, buf *vm.ArrayBufferObject, args []vm.Value, elementSize int) (off int, length int, err error) {
+	byteOffsetArg := vm.Value{}
+	if len(args) > 1 {
+		byteOffsetArg = args[1]
+	} else {
+		byteOffsetArg = vm.Undefined
+	}
+	off, err = ValidateTypedArrayByteOffset(vmInstance, byteOffsetArg, elementSize)
+	if err != nil {
+		return 0, 0, err
+	}
+	length = -1
+	if len(args) > 2 && !args[2].IsUndefined() {
+		length, err = TypedArrayLengthToIndex(vmInstance, args[2])
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	if buf.IsDetached() {
+		return 0, 0, vmInstance.NewTypeError("Cannot perform operation on a detached ArrayBuffer")
+	}
+	if length == -1 {
+		if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, elementSize); err != nil {
+			return 0, 0, err
+		}
+		return off, -1, nil
+	}
+	if off+length*elementSize > len(buf.GetData()) {
+		return 0, 0, vmInstance.NewRangeError("Invalid typed array length")
+	}
+	return off, length, nil
+}
+
+// computeSharedBufferViewOffsetLength is the SharedArrayBuffer counterpart of
+// computeBufferViewOffsetLength. SharedArrayBuffers cannot be detached, so
+// there is no post-coercion detach recheck.
+func computeSharedBufferViewOffsetLength(vmInstance *vm.VM, sab *vm.SharedArrayBufferObject, args []vm.Value, elementSize int) (off int, length int, err error) {
+	byteOffsetArg := vm.Value{}
+	if len(args) > 1 {
+		byteOffsetArg = args[1]
+	} else {
+		byteOffsetArg = vm.Undefined
+	}
+	off, err = ValidateTypedArrayByteOffsetShared(vmInstance, byteOffsetArg, elementSize)
+	if err != nil {
+		return 0, 0, err
+	}
+	length = -1
+	if len(args) > 2 && !args[2].IsUndefined() {
+		length, err = TypedArrayLengthToIndex(vmInstance, args[2])
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	if length == -1 {
+		if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, elementSize); err != nil {
+			return 0, 0, err
+		}
+		return off, -1, nil
+	}
+	if off+length*elementSize > len(sab.GetData()) {
+		return 0, 0, vmInstance.NewRangeError("Invalid typed array length")
+	}
+	return off, length, nil
+}
+
+// TypedArrayElementKind describes what differs between numeric %TypedArray%
+// subclass constructors (Int8Array, ..., BigInt64Array, BigUint64Array); the
+// shared body in NumericTypedArrayCtorBody implements everything else once.
+type TypedArrayElementKind struct {
+	Kind        vm.TypedArrayKind
+	ElementSize int
+	IsBigInt    bool
+	Unsigned    bool // for IsBigInt only: BigUint64Array vs BigInt64Array
+}
+
+// coerceTypedArrayElement converts a plain JS value (as found in a source
+// array/iterable) to the representation a typed array of this element kind
+// stores: BigInt arrays require an actual BigInt, converting a Number via
+// truncation (matching the pre-existing per-file behavior, signed or
+// unsigned per Kind); everything else is stored as-is.
+func (ek TypedArrayElementKind) coerceElement(v vm.Value) vm.Value {
+	if ek.IsBigInt && !v.IsBigInt() {
+		if ek.Unsigned {
+			return vm.NewBigInt(new(big.Int).SetUint64(uint64(v.ToFloat())))
+		}
+		return vm.NewBigInt(big.NewInt(int64(v.ToFloat())))
+	}
+	return v
+}
+
+// NumericTypedArrayCtorBody returns the native constructor function body
+// shared by every numeric/BigInt %TypedArray% subclass, dispatching on the
+// first argument per ECMAScript 23.2.5 %TypedArray%(...): no args, a length,
+// an ArrayBuffer/SharedArrayBuffer (with optional byteOffset/length), an
+// array-like, or a coercible primitive.
+func NumericTypedArrayCtorBody(vmInstance *vm.VM, ek TypedArrayElementKind) func(args []vm.Value) (vm.Value, error) {
+	kind := ek.Kind
+	elementSize := ek.ElementSize
+	protoName := typedArrayIntrinsicProtoName(kind)
+	return func(args []vm.Value) (vm.Value, error) {
+		if len(args) == 0 {
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, 0, 0, 0), proto), nil
+		}
+		arg := args[0]
+		if arg.IsNumber() {
+			l, err := TypedArrayToIndex(vmInstance, arg)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, l, 0, 0), proto), nil
+		}
+		if buf := arg.AsArrayBuffer(); buf != nil {
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			off, ln, err := computeBufferViewOffsetLength(vmInstance, buf, args, elementSize)
+			if err != nil {
+				if err == ErrVMUnwinding {
+					return vm.Undefined, nil
+				}
+				return vm.Undefined, err
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, buf, off, ln), proto), nil
+		}
+		if sab := arg.AsSharedArrayBuffer(); sab != nil {
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			off, ln, err := computeSharedBufferViewOffsetLength(vmInstance, sab, args, elementSize)
+			if err != nil {
+				if err == ErrVMUnwinding {
+					return vm.Undefined, nil
+				}
+				return vm.Undefined, err
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, sab, off, ln), proto), nil
+		}
+		if arr := arg.AsArray(); arr != nil {
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			vals := make([]vm.Value, arr.Length())
+			for i := 0; i < arr.Length(); i++ {
+				vals[i] = ek.coerceElement(arr.Get(i))
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, vals, 0, 0), proto), nil
+		}
+		if arg.IsObject() {
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, 0, 0, 0), proto), nil
+		}
+		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
+		l, err := TypedArrayToIndex(vmInstance, arg)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		proto, err := TypedArrayGPFC(vmInstance, protoName)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		return applyGPFCPrototype(vm.NewTypedArray(kind, l, 0, 0), proto), nil
+	}
+}
+
+// TypedArrayFromArrayLike implements the shared body of the legacy (non-spec,
+// array-only) %TypedArray%.from used by each subclass's own "from" method.
+func TypedArrayFromArrayLike(ek TypedArrayElementKind, args []vm.Value) vm.Value {
+	if len(args) == 0 {
+		return vm.NewTypedArray(ek.Kind, 0, 0, 0)
+	}
+	source := args[0]
+	if sourceArray := source.AsArray(); sourceArray != nil {
+		values := make([]vm.Value, sourceArray.Length())
+		for i := 0; i < sourceArray.Length(); i++ {
+			values[i] = ek.coerceElement(sourceArray.Get(i))
+		}
+		return vm.NewTypedArray(ek.Kind, values, 0, 0)
+	}
+	return vm.NewTypedArray(ek.Kind, 0, 0, 0)
+}
+
+// TypedArrayOfValues implements the shared body of each subclass's "of" method.
+func TypedArrayOfValues(ek TypedArrayElementKind, args []vm.Value) vm.Value {
+	if !ek.IsBigInt {
+		return vm.NewTypedArray(ek.Kind, args, 0, 0)
+	}
+	values := make([]vm.Value, len(args))
+	for i, v := range args {
+		values[i] = ek.coerceElement(v)
+	}
+	return vm.NewTypedArray(ek.Kind, values, 0, 0)
 }
 
 // SetupTypedArrayConstructorProperties sets up the constructor properties with correct descriptors.

--- a/pkg/builtins/uint16array_init.go
+++ b/pkg/builtins/uint16array_init.go
@@ -43,132 +43,18 @@ func (u *Uint16ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "Uint16Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 2)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 2); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 2)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 2); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayUint16, l, 0, 0), nil
-	})
+	uint16EK := TypedArrayElementKind{Kind: vm.TypedArrayUint16, ElementSize: 2}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "Uint16Array", NumericTypedArrayCtorBody(vmInstance, uint16EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, uint16ArrayProto, 2)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayUint16, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				values[i] = sourceArray.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint16, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayUint16, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(uint16EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayUint16, args, 0, 0), nil
+		return TypedArrayOfValues(uint16EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/uint32array_init.go
+++ b/pkg/builtins/uint32array_init.go
@@ -34,129 +34,17 @@ func (u *Uint32ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctor := vm.NewConstructorWithProps(3, true, "Uint32Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmx, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmx, args[1], 4)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmx, buf, off, 4); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmx, args[1], 4)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmx, sab, off, 4); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmx); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmx, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmx); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayUint32, l, 0, 0), nil
-	})
+	uint32EK := TypedArrayElementKind{Kind: vm.TypedArrayUint32, ElementSize: 4}
+	ctor := vm.NewConstructorWithProps(3, true, "Uint32Array", NumericTypedArrayCtorBody(vmx, uint32EK))
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctor, proto, 4)
 
 	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayUint32, 0, 0, 0), nil
-		}
-		src := args[0]
-		if a := src.AsArray(); a != nil {
-			vals := make([]vm.Value, a.Length())
-			for i := 0; i < a.Length(); i++ {
-				vals[i] = a.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint32, vals, 0, 0), nil
-		}
-		return vm.NewTypedArray(vm.TypedArrayUint32, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(uint32EK, args), nil
 	}))
 
 	ctor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayUint32, args, 0, 0), nil
+		return TypedArrayOfValues(uint32EK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/builtins/uint8array_init.go
+++ b/pkg/builtins/uint8array_init.go
@@ -255,132 +255,18 @@ func (u *Uint8ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}))
 
 	// Create Uint8Array constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "Uint8Array", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 1)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 1); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 1)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 1); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayUint8, l, 0, 0), nil
-	})
+	uint8EK := TypedArrayElementKind{Kind: vm.TypedArrayUint8, ElementSize: 1}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "Uint8Array", NumericTypedArrayCtorBody(vmInstance, uint8EK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, uint8ArrayProto, 1)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayUint8, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				values[i] = sourceArray.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayUint8, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(uint8EK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayUint8, args, 0, 0), nil
+		return TypedArrayOfValues(uint8EK, args), nil
 	}))
 
 	// ES2024: Uint8Array.fromBase64(string, options?)

--- a/pkg/builtins/uint8clampedarray_init.go
+++ b/pkg/builtins/uint8clampedarray_init.go
@@ -43,132 +43,18 @@ func (u *Uint8ClampedArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Note: set, fill, subarray, slice, and Symbol.toStringTag are inherited from %TypedArray%.prototype
 
 	// constructor (length is 3 per ECMAScript spec)
-	ctorWithProps := vm.NewConstructorWithProps(3, true, "Uint8ClampedArray", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, 0, 0, 0), nil
-		}
-		arg := args[0]
-		if arg.IsNumber() {
-			l, err := TypedArrayToIndex(vmInstance, arg)
-			if err != nil {
-				return vm.Undefined, err
-			}
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, l, 0, 0), nil
-		}
-		if buf := arg.AsArrayBuffer(); buf != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffset(vmInstance, args[1], 1)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			// If length is auto-calculated, validate buffer alignment
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignment(vmInstance, buf, off, 1); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, buf, off, ln), nil
-		}
-		if sab := arg.AsSharedArrayBuffer(); sab != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			off := 0
-			if len(args) > 1 {
-				var err error
-				off, err = ValidateTypedArrayByteOffsetShared(vmInstance, args[1], 1)
-				if err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			ln := -1
-			if len(args) > 2 && !args[2].IsUndefined() {
-				ln = int(args[2].ToFloat())
-			}
-			if ln == -1 {
-				if err := ValidateTypedArrayBufferAlignmentShared(vmInstance, sab, off, 1); err != nil {
-					if err == ErrVMUnwinding {
-						return vm.Undefined, nil
-					}
-					return vm.Undefined, err
-				}
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, sab, off, ln), nil
-		}
-		if arr := arg.AsArray(); arr != nil {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			vals := make([]vm.Value, arr.Length())
-			for i := 0; i < arr.Length(); i++ {
-				vals[i] = arr.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, vals, 0, 0), nil
-		}
-		if arg.IsObject() {
-			if err := TypedArrayGPFC(vmInstance); err != nil {
-				return vm.Undefined, err
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, 0, 0, 0), nil
-		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
-		l, err := TypedArrayToIndex(vmInstance, arg)
-		if err != nil {
-			return vm.Undefined, err
-		}
-		if err := TypedArrayGPFC(vmInstance); err != nil {
-			return vm.Undefined, err
-		}
-		return vm.NewTypedArray(vm.TypedArrayUint8Clamped, l, 0, 0), nil
-	})
+	uint8ClampedEK := TypedArrayElementKind{Kind: vm.TypedArrayUint8Clamped, ElementSize: 1}
+	ctorWithProps := vm.NewConstructorWithProps(3, true, "Uint8ClampedArray", NumericTypedArrayCtorBody(vmInstance, uint8ClampedEK))
 
 	// Set up constructor properties with correct descriptors (BYTES_PER_ELEMENT, prototype)
 	SetupTypedArrayConstructorProperties(ctorWithProps, uint8ClampedArrayProto, 1)
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
-		if len(args) == 0 {
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, 0, 0, 0), nil
-		}
-
-		source := args[0]
-		if sourceArray := source.AsArray(); sourceArray != nil {
-			values := make([]vm.Value, sourceArray.Length())
-			for i := 0; i < sourceArray.Length(); i++ {
-				values[i] = sourceArray.Get(i)
-			}
-			return vm.NewTypedArray(vm.TypedArrayUint8Clamped, values, 0, 0), nil
-		}
-
-		return vm.NewTypedArray(vm.TypedArrayUint8Clamped, 0, 0, 0), nil
+		return TypedArrayFromArrayLike(uint8ClampedEK, args), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("of", vm.NewNativeFunction(0, true, "of", func(args []vm.Value) (vm.Value, error) {
-		return vm.NewTypedArray(vm.TypedArrayUint8Clamped, args, 0, 0), nil
+		return TypedArrayOfValues(uint8ClampedEK, args), nil
 	}))
 
 	// Set constructor property on prototype

--- a/pkg/vm/dataview.go
+++ b/pkg/vm/dataview.go
@@ -203,6 +203,24 @@ func (dv *DataViewObject) GetUint32(byteOffset int, littleEndian bool) (uint32, 
 	return binary.BigEndian.Uint32(data), true
 }
 
+// GetFloat16 reads a 16-bit half-precision float at the specified byte offset
+func (dv *DataViewObject) GetFloat16(byteOffset int, littleEndian bool) (float64, bool) {
+	if byteOffset < 0 || byteOffset+2 > dv.effectiveByteLength() {
+		return 0, false
+	}
+	if dv.buffer.IsDetached() {
+		return 0, false
+	}
+	data := dv.buffer.GetData()[dv.byteOffset+byteOffset:]
+	var bits uint16
+	if littleEndian {
+		bits = binary.LittleEndian.Uint16(data)
+	} else {
+		bits = binary.BigEndian.Uint16(data)
+	}
+	return Float16BitsToFloat64(bits), true
+}
+
 // GetFloat32 reads a 32-bit float at the specified byte offset
 func (dv *DataViewObject) GetFloat32(byteOffset int, littleEndian bool) (float32, bool) {
 	if byteOffset < 0 || byteOffset+4 > dv.effectiveByteLength() {
@@ -370,6 +388,24 @@ func (dv *DataViewObject) SetUint32(byteOffset int, value uint32, littleEndian b
 }
 
 // SetFloat32 writes a 32-bit float at the specified byte offset
+// SetFloat16 writes a 16-bit half-precision float at the specified byte offset
+func (dv *DataViewObject) SetFloat16(byteOffset int, value float64, littleEndian bool) bool {
+	if byteOffset < 0 || byteOffset+2 > dv.effectiveByteLength() {
+		return false
+	}
+	if dv.buffer.IsDetached() {
+		return false
+	}
+	data := dv.buffer.GetData()[dv.byteOffset+byteOffset:]
+	bits := Float64ToFloat16Bits(value)
+	if littleEndian {
+		binary.LittleEndian.PutUint16(data, bits)
+	} else {
+		binary.BigEndian.PutUint16(data, bits)
+	}
+	return true
+}
+
 func (dv *DataViewObject) SetFloat32(byteOffset int, value float32, littleEndian bool) bool {
 	if byteOffset < 0 || byteOffset+4 > dv.effectiveByteLength() {
 		return false

--- a/pkg/vm/isobject_bench_test.go
+++ b/pkg/vm/isobject_bench_test.go
@@ -45,7 +45,7 @@ func TestIsObjectExhaustive(t *testing.T) {
 		TypeGenerator: true, TypeAsyncGenerator: true, TypePromise: true, TypeRegExp: true,
 		TypeTypedArray: true, TypeDataView: true, TypeArrayBuffer: true, TypeSharedArrayBuffer: true,
 		TypeProxy: true, TypeMap: true, TypeSet: true, TypeWeakMap: true, TypeWeakSet: true,
-		TypeWeakRef: true,
+		TypeWeakRef: true, TypeFinalizationRegistry: true,
 	}
 	for typ := TypeUndefined; typ <= TypeUninitialized; typ++ {
 		got := (Value{typ: typ}).IsObject()

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1382,6 +1382,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			proto = vm.Int32ArrayPrototype
 		case TypedArrayUint32:
 			proto = vm.Uint32ArrayPrototype
+		case TypedArrayFloat16:
+			proto = vm.Float16ArrayPrototype
 		case TypedArrayFloat32:
 			proto = vm.Float32ArrayPrototype
 		case TypedArrayFloat64:

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -761,6 +761,39 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 		return true, InterpretOK, *dest
 	}
 
+	// 10b''. FinalizationRegistry objects - consult the instance's stored
+	// prototype (set by the constructor via GetPrototypeFromConstructor for
+	// cross-realm support), falling back to vm.FinalizationRegistryPrototype.
+	if objVal.Type() == TypeFinalizationRegistry {
+		fr := objVal.AsFinalizationRegistry()
+		proto := fr.GetPrototype()
+		if !proto.IsObject() {
+			proto = vm.FinalizationRegistryPrototype
+		}
+		if proto.IsObject() {
+			po := proto.AsPlainObject()
+			if v, ok := po.GetOwn(propName); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+			current := po.prototype
+			for current.typ != TypeNull && current.typ != TypeUndefined {
+				if current.IsObject() {
+					cpo := current.AsPlainObject()
+					if v, ok := cpo.GetOwn(propName); ok {
+						*dest = v
+						return true, InterpretOK, *dest
+					}
+					current = cpo.prototype
+				} else {
+					break
+				}
+			}
+		}
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+
 	// 10c. SharedArrayBuffer objects - check own properties first, then prototype chain
 	if objVal.Type() == TypeSharedArrayBuffer {
 		sab := objVal.AsSharedArrayBuffer()
@@ -1726,6 +1759,42 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		proto := wr.GetPrototype()
 		if !proto.IsObject() {
 			proto = vm.WeakRefPrototype
+		}
+		if proto.IsObject() {
+			po := proto.AsPlainObject()
+			if v, ok := po.GetOwnByKey(NewSymbolKey(symKey)); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+			current := po.prototype
+			for current.typ != TypeNull && current.typ != TypeUndefined {
+				if current.IsObject() {
+					if proto2 := current.AsPlainObject(); proto2 != nil {
+						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
+							*dest = v
+							return true, InterpretOK, *dest
+						}
+						current = proto2.prototype
+					} else if dict := current.AsDictObject(); dict != nil {
+						current = dict.prototype
+					} else {
+						break
+					}
+				} else {
+					break
+				}
+			}
+		}
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+
+	// FinalizationRegistry: consult the instance's stored prototype for symbol properties
+	if base.Type() == TypeFinalizationRegistry {
+		fr := base.AsFinalizationRegistry()
+		proto := fr.GetPrototype()
+		if !proto.IsObject() {
+			proto = vm.FinalizationRegistryPrototype
 		}
 		if proto.IsObject() {
 			po := proto.AsPlainObject()

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -618,6 +618,15 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 						}
 					}
 				}
+			case TypedArrayFloat16:
+				if ctor, ok := vm.GetGlobal("Float16Array"); ok {
+					if ctor.Type() == TypeNativeFunctionWithProps {
+						fn := ctor.AsNativeFunctionWithProps()
+						if p, hit := fn.Properties.GetOwn("prototype"); hit {
+							prototype = p.AsPlainObject()
+						}
+					}
+				}
 			case TypedArrayFloat32:
 				if ctor, ok := vm.GetGlobal("Float32Array"); ok {
 					if ctor.Type() == TypeNativeFunctionWithProps {

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -545,6 +545,14 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 			if val, ok := ta.GetOwnProperty(propName); ok {
 				return val, true
 			}
+			// A per-instance [[Prototype]] override (subclassing a native
+			// TypedArray constructor, or a custom newTarget.prototype via
+			// Reflect.construct/GetPrototypeFromConstructor) takes precedence
+			// over the intrinsic default resolved below.
+			if ta.GetPrototype().Type() == TypeObject {
+				prototype = ta.GetPrototype().AsPlainObject()
+				break
+			}
 			// Resolve prototype dynamically via global constructors to avoid missing VM fields
 			switch ta.GetElementType() {
 			case TypedArrayUint8:

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -727,6 +727,13 @@ func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 			}
 		}
 		return vm.WeakRefPrototype
+	case TypeFinalizationRegistry:
+		if fr := objVal.AsFinalizationRegistry(); fr != nil {
+			if proto := fr.GetPrototype(); proto.IsObject() {
+				return proto
+			}
+		}
+		return vm.FinalizationRegistryPrototype
 	}
 	return Undefined
 }

--- a/pkg/vm/realm.go
+++ b/pkg/vm/realm.go
@@ -26,6 +26,7 @@ type Realm struct {
 	WeakMapPrototype              Value
 	WeakSetPrototype              Value
 	WeakRefPrototype              Value
+	FinalizationRegistryPrototype Value
 	GeneratorPrototype            Value
 	AsyncGeneratorPrototype       Value
 	IteratorPrototype             Value // %Iterator.prototype% - base for all iterators
@@ -158,6 +159,7 @@ func (r *Realm) InitializePrototypes() {
 	r.WeakMapPrototype = NewObject(r.ObjectPrototype)
 	r.WeakSetPrototype = NewObject(r.ObjectPrototype)
 	r.WeakRefPrototype = NewObject(r.ObjectPrototype)
+	r.FinalizationRegistryPrototype = NewObject(r.ObjectPrototype)
 	r.PromisePrototype = NewObject(r.ObjectPrototype)
 	r.ArrayBufferPrototype = NewObject(r.ObjectPrototype)
 	r.SharedArrayBufferPrototype = NewObject(r.ObjectPrototype)

--- a/pkg/vm/realm.go
+++ b/pkg/vm/realm.go
@@ -61,6 +61,7 @@ type Realm struct {
 	Uint16ArrayPrototype       Value
 	Uint32ArrayPrototype       Value
 	Int32ArrayPrototype        Value
+	Float16ArrayPrototype      Value
 	Float32ArrayPrototype      Value
 	Float64ArrayPrototype      Value
 	BigInt64ArrayPrototype     Value
@@ -188,6 +189,7 @@ func (r *Realm) InitializePrototypes() {
 	r.Uint16ArrayPrototype = NewObject(r.TypedArrayPrototype)
 	r.Uint32ArrayPrototype = NewObject(r.TypedArrayPrototype)
 	r.Int32ArrayPrototype = NewObject(r.TypedArrayPrototype)
+	r.Float16ArrayPrototype = NewObject(r.TypedArrayPrototype)
 	r.Float32ArrayPrototype = NewObject(r.TypedArrayPrototype)
 	r.Float64ArrayPrototype = NewObject(r.TypedArrayPrototype)
 	r.BigInt64ArrayPrototype = NewObject(r.TypedArrayPrototype)

--- a/pkg/vm/subclass.go
+++ b/pkg/vm/subclass.go
@@ -53,6 +53,10 @@ func (vm *VM) applySubclassPrototype(instance Value, newTarget Value) {
 		instance.AsTypedArray().SetPrototype(proto)
 	case TypePromise:
 		instance.AsPromise().SetPrototype(proto)
+	case TypeWeakRef:
+		instance.AsWeakRef().SetPrototype(proto)
+	case TypeFinalizationRegistry:
+		instance.AsFinalizationRegistry().SetPrototype(proto)
 	case TypeFunction:
 		instance.AsFunction().subclassPrototype = proto
 	}
@@ -77,6 +81,8 @@ func (vm *VM) InstancePrototypeOverride(v Value) (Value, bool) {
 		p = v.AsWeakSet().GetPrototype()
 	case TypeWeakRef:
 		p = v.AsWeakRef().GetPrototype()
+	case TypeFinalizationRegistry:
+		p = v.AsFinalizationRegistry().GetPrototype()
 	case TypeRegExp:
 		p = v.AsRegExpObject().GetPrototype()
 	case TypeArrayBuffer:

--- a/pkg/vm/typed_array.go
+++ b/pkg/vm/typed_array.go
@@ -29,6 +29,7 @@ const (
 	TypedArrayUint16
 	TypedArrayInt32
 	TypedArrayUint32
+	TypedArrayFloat16
 	TypedArrayFloat32
 	TypedArrayFloat64
 	TypedArrayBigInt64
@@ -423,6 +424,8 @@ func (kind TypedArrayKind) BytesPerElement() int {
 		return 1
 	case TypedArrayInt16, TypedArrayUint16:
 		return 2
+	case TypedArrayFloat16:
+		return 2
 	case TypedArrayInt32, TypedArrayUint32, TypedArrayFloat32:
 		return 4
 	case TypedArrayFloat64, TypedArrayBigInt64, TypedArrayBigUint64:
@@ -449,6 +452,8 @@ func (kind TypedArrayKind) Name() string {
 		return "Int32Array"
 	case TypedArrayUint32:
 		return "Uint32Array"
+	case TypedArrayFloat16:
+		return "Float16Array"
 	case TypedArrayFloat32:
 		return "Float32Array"
 	case TypedArrayFloat64:
@@ -488,6 +493,9 @@ func (ta *TypedArrayObject) GetElement(index int) Value {
 		return Number(float64(int32(binary.LittleEndian.Uint32(data))))
 	case TypedArrayUint32:
 		return Number(float64(binary.LittleEndian.Uint32(data)))
+	case TypedArrayFloat16:
+		bits := binary.LittleEndian.Uint16(data)
+		return Number(Float16BitsToFloat64(bits))
 	case TypedArrayFloat32:
 		bits := binary.LittleEndian.Uint32(data)
 		return Number(float64(math.Float32frombits(bits)))
@@ -550,6 +558,102 @@ func JSWrapInt(num float64, bits uint) uint64 {
 	return uint64(mod)
 }
 
+// Float64ToFloat16Bits converts x to the bit pattern of the nearest IEEE 754
+// binary16 (half-precision) value, round-to-nearest-even. Shared by
+// Math.f16round, Float16Array element storage, and
+// DataView.prototype.setFloat16 so the rounding behavior (and its edge
+// cases: subnormals, overflow to infinity, NaN payload) lives in one place.
+func Float64ToFloat16Bits(x float64) uint16 {
+	bits := math.Float64bits(x)
+	sign := bits >> 63
+	exp := int((bits >> 52) & 0x7FF)
+	frac := bits & 0xFFFFFFFFFFFFF
+
+	const f16ExpBias = 15
+	const f64ExpBias = 1023
+
+	unbiasedExp := exp - f64ExpBias
+
+	if exp == 0x7FF {
+		// Infinity or NaN
+		if frac == 0 {
+			return uint16(sign<<15) | 0x7C00
+		}
+		return uint16(sign<<15) | 0x7E00
+	}
+	if exp == 0 {
+		// Denormal or zero in float64 - becomes zero in float16
+		return uint16(sign << 15)
+	}
+	if unbiasedExp > 15 {
+		// Overflow to infinity
+		return uint16(sign<<15) | 0x7C00
+	}
+	if unbiasedExp < -24 {
+		// Underflow to zero
+		return uint16(sign << 15)
+	}
+	if unbiasedExp < -14 {
+		// Denormal in float16: shift the mantissa right to create a denormal
+		shift := uint(-14 - unbiasedExp)
+		frac16 := (frac >> 42) | 0x400 // top 10 bits + implicit 1
+		frac16 = frac16 >> shift
+		// Round to nearest even
+		if (frac>>(42+shift-1))&1 == 1 {
+			frac16++
+		}
+		return uint16(sign<<15) | uint16(frac16&0x3FF)
+	}
+
+	// Normal number: take the top 10 bits of the mantissa, round to nearest even
+	f16Exp := uint16(unbiasedExp + f16ExpBias)
+	frac16 := frac >> 42
+	if (frac>>41)&1 == 1 { // 11th bit: round?
+		lowerBits := frac & 0x1FFFFFFFFFF // bits 0-40
+		if lowerBits != 0 || (frac16&1) == 1 {
+			frac16++
+			if frac16 > 0x3FF {
+				frac16 = 0
+				f16Exp++
+				if f16Exp > 30 {
+					return uint16(sign<<15) | 0x7C00 // overflow to infinity
+				}
+			}
+		}
+	}
+	return uint16(sign<<15) | (f16Exp << 10) | uint16(frac16&0x3FF)
+}
+
+// Float16BitsToFloat64 converts an IEEE 754 binary16 bit pattern to float64.
+func Float16BitsToFloat64(bits uint16) float64 {
+	sign := (bits >> 15) & 1
+	exp := (bits >> 10) & 0x1F
+	frac := bits & 0x3FF
+
+	var result float64
+	switch {
+	case exp == 0x1F:
+		if frac == 0 {
+			result = math.Inf(1)
+		} else {
+			result = math.NaN()
+		}
+	case exp == 0:
+		if frac == 0 {
+			result = 0
+		} else {
+			result = float64(frac) / 1024.0 * math.Pow(2, -14) // denormal
+		}
+	default:
+		result = (1.0 + float64(frac)/1024.0) * math.Pow(2, float64(exp)-15)
+	}
+
+	if sign == 1 {
+		result = -result
+	}
+	return result
+}
+
 // SetTypedArrayElement sets an element at the given index
 func (ta *TypedArrayObject) SetElement(index int, value Value) {
 	// GetLength() returns 0 when out of bounds (detached, or shrunk past this
@@ -579,6 +683,8 @@ func (ta *TypedArrayObject) SetElement(index int, value Value) {
 		binary.LittleEndian.PutUint16(data, uint16(JSWrapInt(num, 16)))
 	case TypedArrayInt32, TypedArrayUint32:
 		binary.LittleEndian.PutUint32(data, uint32(JSWrapInt(num, 32)))
+	case TypedArrayFloat16:
+		binary.LittleEndian.PutUint16(data, Float64ToFloat16Bits(num))
 	case TypedArrayFloat32:
 		binary.LittleEndian.PutUint32(data, math.Float32bits(float32(num)))
 	case TypedArrayFloat64:

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -1308,6 +1308,8 @@ func (v Value) ToString() string {
 				return "[object Int32Array]"
 			case TypedArrayUint32:
 				return "[object Uint32Array]"
+			case TypedArrayFloat16:
+				return "[object Float16Array]"
 			case TypedArrayFloat32:
 				return "[object Float32Array]"
 			case TypedArrayFloat64:
@@ -1708,6 +1710,8 @@ func (v Value) inspectWithDepth(nested bool, depth int, maxDepth int) string {
 				typeName = "Int32Array"
 			case TypedArrayUint32:
 				typeName = "Uint32Array"
+			case TypedArrayFloat16:
+				typeName = "Float16Array"
 			case TypedArrayFloat32:
 				typeName = "Float32Array"
 			case TypedArrayFloat64:

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -76,6 +76,7 @@ const (
 	TypeWeakMap
 	TypeWeakSet
 	TypeWeakRef
+	TypeFinalizationRegistry
 	TypeArrayBuffer
 	TypeSharedArrayBuffer
 	TypeTypedArray
@@ -136,6 +137,8 @@ func (vt ValueType) String() string {
 		return "weakset"
 	case TypeWeakRef:
 		return "weakref"
+	case TypeFinalizationRegistry:
+		return "finalizationregistry"
 	case TypeArrayBuffer:
 		return "arraybuffer"
 	case TypeSharedArrayBuffer:
@@ -158,10 +161,13 @@ type SymbolObject struct {
 	HasDescription bool // true when Symbol was created with an explicit description argument
 }
 
-// CanBeHeldWeakly returns true if this value can be used as a WeakMap/WeakSet key.
-// Per ECMAScript spec: objects and non-registered symbols can be held weakly.
+// CanBeHeldWeakly returns true if this value can be used as a WeakMap/WeakSet
+// key or a WeakRef/FinalizationRegistry target. Per ECMAScript spec: objects
+// (which functions are too - v.IsObject()'s [TypeObject,TypeProxy] range
+// predates the function ValueTypes in the enum, so check IsCallable()
+// alongside it) and non-registered symbols can be held weakly.
 func (v Value) CanBeHeldWeakly() bool {
-	if v.IsObject() {
+	if v.IsObject() || v.IsCallable() {
 		return true
 	}
 	if v.typ == TypeSymbol {
@@ -341,6 +347,77 @@ type WeakRefObject struct {
 	targetWeak weak.Pointer[byte] // Weak reference to the target object
 	targetType ValueType          // Original ValueType of the target, restored on Deref
 	prototype  Value              // [[Prototype]] for cross-realm support
+}
+
+// finalizationRegistryCell mirrors the spec's per-registration Record:
+// { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] }. The target is
+// held weakly (via Go's weak package, matching WeakRef/WeakMap/WeakSet)
+// though nothing currently dereferences it: this runtime has no host GC
+// hook, so cleanupCallback is never invoked - register()/unregister() are a
+// pure bookkeeping API per Test262 (no test depends on actual reclamation).
+type finalizationRegistryCell struct {
+	targetWeak weak.Pointer[byte]
+	heldValue  Value
+	hasToken   bool
+	tokenPtr   uintptr // pointer identity of [[UnregisterToken]], for unregister() matching
+}
+
+// FinalizationRegistryObject implements ECMAScript FinalizationRegistry.
+type FinalizationRegistryObject struct {
+	Object
+	cleanupCallback Value
+	cells           []*finalizationRegistryCell
+	prototype       Value
+}
+
+func (fr *FinalizationRegistryObject) GetPrototype() Value  { return fr.prototype }
+func (fr *FinalizationRegistryObject) SetPrototype(p Value) { fr.prototype = p }
+
+// Register appends a new cell. hasToken/token mirror the optional third
+// "unregisterToken" argument (empty when hasToken is false).
+func (fr *FinalizationRegistryObject) Register(target, heldValue Value, hasToken bool, token Value) {
+	cell := &finalizationRegistryCell{
+		targetWeak: weak.Make((*byte)(target.obj)),
+		heldValue:  heldValue,
+		hasToken:   hasToken,
+	}
+	if hasToken {
+		cell.tokenPtr = uintptr(token.obj)
+	}
+	fr.cells = append(fr.cells, cell)
+}
+
+// Unregister removes every cell whose [[UnregisterToken]] matches token
+// (SameValue, via pointer identity), returning true if any were removed.
+func (fr *FinalizationRegistryObject) Unregister(token Value) bool {
+	tokenPtr := uintptr(token.obj)
+	removed := false
+	kept := fr.cells[:0]
+	for _, cell := range fr.cells {
+		if cell.hasToken && cell.tokenPtr == tokenPtr {
+			removed = true
+			continue
+		}
+		kept = append(kept, cell)
+	}
+	fr.cells = kept
+	return removed
+}
+
+// NewFinalizationRegistry creates a new FinalizationRegistry with the given
+// cleanup callback and prototype (never Undefined - callers pass the
+// resolved GetPrototypeFromConstructor result, defaulting to the realm's
+// FinalizationRegistryPrototype).
+func NewFinalizationRegistry(cleanupCallback Value, prototype Value) Value {
+	frObj := &FinalizationRegistryObject{cleanupCallback: cleanupCallback, prototype: prototype}
+	return Value{typ: TypeFinalizationRegistry, obj: unsafe.Pointer(frObj)}
+}
+
+func (v Value) AsFinalizationRegistry() *FinalizationRegistryObject {
+	if v.typ != TypeFinalizationRegistry {
+		return nil
+	}
+	return (*FinalizationRegistryObject)(v.obj)
 }
 
 type ProxyObject struct {
@@ -704,6 +781,9 @@ func (wr *WeakRefObject) GetPrototype() Value {
 	return wr.prototype
 }
 
+// SetPrototype overrides the per-instance [[Prototype]] (for subclassing).
+func (wr *WeakRefObject) SetPrototype(p Value) { wr.prototype = p }
+
 // Deref returns the target object if it's still alive, or undefined if collected.
 // The returned Value preserves the target's original ValueType (array, function,
 // etc.) — load .Value() exactly once so a concurrent GC between the nil-check
@@ -891,7 +971,8 @@ func (v Value) TypeName() string {
 		return "object"
 	case TypeObject, TypeDictObject, TypeArray, TypeArguments, TypeRegExp, TypeTypedArray,
 		TypeDataView, TypeGenerator, TypeAsyncGenerator, TypePromise, TypeMap, TypeSet,
-		TypeArrayBuffer, TypeSharedArrayBuffer, TypeWeakMap, TypeWeakSet, TypeWeakRef:
+		TypeArrayBuffer, TypeSharedArrayBuffer, TypeWeakMap, TypeWeakSet, TypeWeakRef,
+		TypeFinalizationRegistry:
 		return "object"
 	default:
 		return fmt.Sprintf("<unknown type: %d>", v.typ)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -228,6 +228,7 @@ type VM struct {
 	WeakMapPrototype              Value
 	WeakSetPrototype              Value
 	WeakRefPrototype              Value
+	FinalizationRegistryPrototype Value
 	GeneratorPrototype            Value
 	AsyncGeneratorPrototype       Value
 	IteratorPrototype             Value // %Iterator.prototype% - base for all iterators
@@ -660,6 +661,8 @@ func (vm *VM) GetPrototypeFromConstructor(constructor Value, intrinsicDefault st
 		return realm.WeakSetPrototype, nil
 	case "%WeakRefPrototype%":
 		return realm.WeakRefPrototype, nil
+	case "%FinalizationRegistryPrototype%":
+		return realm.FinalizationRegistryPrototype, nil
 	case "%ErrorPrototype%":
 		return realm.ErrorPrototype, nil
 	case "%TypeErrorPrototype%":
@@ -740,6 +743,7 @@ func (vm *VM) syncPrototypesFromRealm() {
 	vm.WeakMapPrototype = r.WeakMapPrototype
 	vm.WeakSetPrototype = r.WeakSetPrototype
 	vm.WeakRefPrototype = r.WeakRefPrototype
+	vm.FinalizationRegistryPrototype = r.FinalizationRegistryPrototype
 	vm.PromisePrototype = r.PromisePrototype
 	vm.SymbolPrototype = r.SymbolPrototype
 	vm.DatePrototype = r.DatePrototype
@@ -835,6 +839,7 @@ func (vm *VM) SyncPrototypesToRealm() {
 	r.WeakMapPrototype = vm.WeakMapPrototype
 	r.WeakSetPrototype = vm.WeakSetPrototype
 	r.WeakRefPrototype = vm.WeakRefPrototype
+	r.FinalizationRegistryPrototype = vm.FinalizationRegistryPrototype
 	r.PromisePrototype = vm.PromisePrototype
 	r.SymbolPrototype = vm.SymbolPrototype
 	r.DatePrototype = vm.DatePrototype
@@ -3152,6 +3157,12 @@ startExecution:
 						current = p
 					} else {
 						current = vm.WeakRefPrototype
+					}
+				case TypeFinalizationRegistry:
+					if p := objVal.AsFinalizationRegistry().GetPrototype(); p.IsObject() {
+						current = p
+					} else {
+						current = vm.FinalizationRegistryPrototype
 					}
 				case TypeArguments:
 					current = vm.ObjectPrototype // Arguments objects inherit from Object.prototype

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -301,6 +301,7 @@ type VM struct {
 	Uint16ArrayPrototype       Value
 	Uint32ArrayPrototype       Value
 	Int32ArrayPrototype        Value
+	Float16ArrayPrototype      Value
 	Float32ArrayPrototype      Value
 	Float64ArrayPrototype      Value
 	BigInt64ArrayPrototype     Value
@@ -707,6 +708,8 @@ func (vm *VM) GetPrototypeFromConstructor(constructor Value, intrinsicDefault st
 		return realm.Uint32ArrayPrototype, nil
 	case "%Int32Array.prototype%":
 		return realm.Int32ArrayPrototype, nil
+	case "%Float16Array.prototype%":
+		return realm.Float16ArrayPrototype, nil
 	case "%Float32Array.prototype%":
 		return realm.Float32ArrayPrototype, nil
 	case "%Float64Array.prototype%":
@@ -779,6 +782,7 @@ func (vm *VM) syncPrototypesFromRealm() {
 	vm.Uint16ArrayPrototype = r.Uint16ArrayPrototype
 	vm.Uint32ArrayPrototype = r.Uint32ArrayPrototype
 	vm.Int32ArrayPrototype = r.Int32ArrayPrototype
+	vm.Float16ArrayPrototype = r.Float16ArrayPrototype
 	vm.Float32ArrayPrototype = r.Float32ArrayPrototype
 	vm.Float64ArrayPrototype = r.Float64ArrayPrototype
 	vm.BigInt64ArrayPrototype = r.BigInt64ArrayPrototype
@@ -875,6 +879,7 @@ func (vm *VM) SyncPrototypesToRealm() {
 	r.Uint16ArrayPrototype = vm.Uint16ArrayPrototype
 	r.Uint32ArrayPrototype = vm.Uint32ArrayPrototype
 	r.Int32ArrayPrototype = vm.Int32ArrayPrototype
+	r.Float16ArrayPrototype = vm.Float16ArrayPrototype
 	r.Float32ArrayPrototype = vm.Float32ArrayPrototype
 	r.Float64ArrayPrototype = vm.Float64ArrayPrototype
 	r.BigInt64ArrayPrototype = vm.BigInt64ArrayPrototype

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -688,6 +688,30 @@ func (vm *VM) GetPrototypeFromConstructor(constructor Value, intrinsicDefault st
 		return realm.PromisePrototype, nil
 	case "%DatePrototype%":
 		return realm.DatePrototype, nil
+	case "%TypedArrayPrototype%":
+		return realm.TypedArrayPrototype, nil
+	case "%Uint8Array.prototype%":
+		return realm.Uint8ArrayPrototype, nil
+	case "%Uint8ClampedArray.prototype%":
+		return realm.Uint8ClampedArrayPrototype, nil
+	case "%Int8Array.prototype%":
+		return realm.Int8ArrayPrototype, nil
+	case "%Int16Array.prototype%":
+		return realm.Int16ArrayPrototype, nil
+	case "%Uint16Array.prototype%":
+		return realm.Uint16ArrayPrototype, nil
+	case "%Uint32Array.prototype%":
+		return realm.Uint32ArrayPrototype, nil
+	case "%Int32Array.prototype%":
+		return realm.Int32ArrayPrototype, nil
+	case "%Float32Array.prototype%":
+		return realm.Float32ArrayPrototype, nil
+	case "%Float64Array.prototype%":
+		return realm.Float64ArrayPrototype, nil
+	case "%BigInt64Array.prototype%":
+		return realm.BigInt64ArrayPrototype, nil
+	case "%BigUint64Array.prototype%":
+		return realm.BigUint64ArrayPrototype, nil
 	default:
 		// Fallback to ObjectPrototype
 		return realm.ObjectPrototype, nil

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -582,6 +582,8 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				proto = vm.Int32ArrayPrototype
 			case TypedArrayUint32:
 				proto = vm.Uint32ArrayPrototype
+			case TypedArrayFloat16:
+				proto = vm.Float16ArrayPrototype
 			case TypedArrayFloat32:
 				proto = vm.Float32ArrayPrototype
 			case TypedArrayFloat64:


### PR DESCRIPTION
## Summary

Three related built-ins fixes/additions, in dependency order:

1. **TypedArray constructor fix + dedup** (`4283643`) — fixes spec-incorrect `length`/`byteOffset` validation ordering (detached-buffer recheck must happen *after* argument coercion, since coercion can run user `valueOf`/`toString` that detaches the buffer), a missing `new`-required check, and two prototype-resolution bugs (missing `%Foo.prototype%` intrinsics in `GetPrototypeFromConstructor`; two legacy prototype-lookup paths that ignored per-instance `[[Prototype]]` overrides from subclassing/`Reflect.construct`). Replaces ~1000+ lines of duplicated per-type constructor bodies across all 11 numeric TypedArray types with one shared, correct implementation in `typedarray_common.go`. The prototype-override fix also fixed 4 unrelated WeakRef tests as a side effect (same root-cause pattern).

2. **FinalizationRegistry (ES2021)** (`1debecb`) — full implementation (`register`/`unregister`, `@@toStringTag`) following the existing WeakRef/WeakMap/WeakSet architectural pattern. No host GC hook exists in this runtime (and none of the 47 Test262 tests require one), so this is pure spec-conformant bookkeeping. Also fixes `CanBeHeldWeakly()` to accept callables, not just objects — a general bug affecting WeakMap/WeakSet/WeakRef too, caught by a FinalizationRegistry test that registers a function as a target.

3. **Float16 support** (`fa2a3a4`) — `Float16Array` and `DataView.prototype.{get,set}Float16`, sharing one canonical IEEE 754 binary16 bit-conversion (promoted from `Math.f16round`'s previous private implementation) across all three consumers. Along the way, found and fixed a pre-existing bug affecting *every* numeric TypedArray type (not just Float16): `Object.prototype.toString.call(anyTypedArray)` returned `"[object Object]"` instead of the correct tag, because the `@@toStringTag` lookup for TypedArrays lost the original instance as receiver when recursing through the wrong helper.

A candidate 4th area (`Array.prototype` `@@species` support for `slice`/`filter`/`map`/`concat`) was investigated but deliberately dropped: those methods are written directly against `AsArray()`/element-slice manipulation, so adding species support means rewriting them to be generic over `Get`/`length`/`Set` — a rewrite, not a fix, and out of scope for this PR.

## Verification

- `go test ./tests -run TestScripts` (smoke test) green throughout, after every commit.
- `go build ./...` / `go vet ./...` clean throughout.
- Test262 `built-ins/` (main vs this branch, full set-diff not just counts): 134 tests newly passing, 1 newly failing — and that one is not a regression: it's `DataView/prototype/setFloat16/return-abrupt-from-tonumber-value-symbol.js`, which only vacuously "passed" on main because `setFloat16` didn't exist yet (calling it threw "not a function", which happened to satisfy the test's "must throw" assertion for the wrong reason). Now that `setFloat16` is real, it correctly surfaces a pre-existing, disclosed gap: `ToNumber` doesn't reject `Symbol` arguments, which equally affects `setFloat32`/`setInt32`/etc. Not fixed here — flagged as out of scope.
- Test262 `language/` (full run, not touched by per-commit verification since these changes touch shared VM machinery — `ValueType` enum, `CanBeHeldWeakly`, `lookupSymbolProp`, prototype resolution): 98.4% (23156/23523), unchanged from the pre-existing baseline — no regressions from the shared-machinery edits.
- Float16 bit-conversion manually verified round-trip-exact for the smallest and largest subnormals (2⁻²⁴, 2⁻¹⁴−2⁻²⁴), max normal (65504), and `-0`, not just typical values.

## Test262 impact (built-ins)

| Area | Before | After |
|---|---|---|
| `built-ins/TypedArrayConstructors` | 74.1%/71.7% | 86.5% (637/736) |
| `built-ins/FinalizationRegistry` | 0% | 100% (47/47) |
| `built-ins/DataView` | — | +28 tests |
| `built-ins/` (overall) | 17347/23294 | 17480/23294 (+133, +0.57pp) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
