### PR TITLE
tests: rename BenchmarkFibPlaceholderRun to BenchmarkFactorial

### DIFF
--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -349,7 +349,7 @@
         }
       ]
     },
-    "github.com/nooga/paserati/tests.BenchmarkFibPlaceholderRun": {
+    "github.com/nooga/paserati/tests.BenchmarkFactorial": {
       "ns_per_op": 1194928877.0000002,
       "allocs_per_op": 3,
       "bytes_per_op": 544,

--- a/docs/perf/index.html
+++ b/docs/perf/index.html
@@ -212,7 +212,7 @@ function labelFor(s) {
     const fam = (name.split(".Benchmark")[1] || "").split("/")[0];
     if (fam === "GetOwn") return "GetOwn";
     if (fam.startsWith("Prototype")) return "Prototype";   // MethodAccess + CacheHitRate
-    return "Workloads";                                    // Fib, Matrix
+    return "Workloads";                                    // Factorial, Matrix
   }
   const GROUPS = ["GetOwn", "Prototype", "Workloads", "Test262"];
   const members = {};                                      // group -> [series]

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -29,9 +29,11 @@ func compileFile(tb testing.TB, filename string) *vm.Chunk {
 	return chunk
 }
 
-// BenchmarkFib runs the (currently placeholder) fib.ts script.
-// Renamed to match BenchmarkXxx pattern.
-func BenchmarkFibPlaceholderRun(b *testing.B) {
+// BenchmarkFactorial runs scripts/factorial.ts: recursive calls plus a fused
+// `--` on a parameter. Previously named BenchmarkFibPlaceholderRun, which
+// described neither the workload (it compiles factorial.ts, not fib.ts) nor
+// its status (it's a real, live benchmark, not a placeholder) - see #53.
+func BenchmarkFactorial(b *testing.B) {
 	// Compile once outside the loop.
 	// Use the correct filename provided by the user.
 	chunk := compileFile(b, "scripts/factorial.ts")


### PR DESCRIPTION
## Summary

Closes #53.

`BenchmarkFibPlaceholderRun` compiled and ran `scripts/factorial.ts`, not `scripts/fib.ts` - and it wasn't a placeholder, it was a real, live benchmark that's been running all along. As #53 notes, the timed region and workload were always sound (recursion, a fused `--` on a parameter, ~5M calls/iteration, flat in `b.N`); only the label was wrong, and it was actively misleading - #43's regression got attributed to the wrong workload (an array-index guard, per #52) in part because of this name.

Renamed to `BenchmarkFactorial` rather than repointing it at `fib.ts`: repointing would silently swap the workload underneath a name that timeline tooling already tracks, and the recursion-plus-fused-decrement shape is worth keeping on its own since nothing else in the suite covers it - exactly the direction #53 suggested.

Also renamed the corresponding key in `docs/perf/baseline.json` (`...BenchmarkFibPlaceholderRun` → `...BenchmarkFactorial`) instead of leaving the old entry orphaned. `cmd/bench-ratchet`'s `check` treats a baseline entry that's missing from the current run as a failure by default (`-allow-incomplete` is needed to tolerate it), so simply dropping the key would have broken the next ratchet run over a benchmark that still exists and still passes, just under its correct name. This does still cost the timeline a naming discontinuity, as #53 anticipated - the historical samples move with the rename rather than being lost.

## Verification

- `go build ./...`, `go vet ./tests/...`, `golangci-lint run ./...` clean.
- `go test ./tests -run TestScripts` green.
- `go test ./tests -bench '^BenchmarkFactorial$'` runs correctly; `-bench '^BenchmarkFibPlaceholderRun$'` now matches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
