### PR TITLE
builtins: make Array.prototype's generic methods actually generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Right now it prioritizes **correctness** over raw speed, but the architecture is
 
 ### Wins
 
-- **Test262 language suite: 96.7%**, **built-ins: 61.8%**, **TypeScript 6.0.3 conformance: 70.8%** (see details below)
+- **Test262 language suite: 96.7%**, **built-ins: 65.8%**, **TypeScript 6.0.3 conformance: 70.8%** (see details below)
 - **Native TS execution**: no `tsc`, no TS→JS transpilation
 - **TCO**: tail call optimization (elite feature)
 - **Shapes + ICs**: fast-ish property access without a JIT
@@ -87,7 +87,7 @@ go test ./tests/...
 | Suite | Passed | Failed | Skipped | Timeouts | Pass rate |
 | :-- | --: | --: | --: | --: | --: |
 | Test262 language | 22,753/23,523 | 770 | 0 | 0 | 96.7% |
-| Test262 built-ins | 14,395/23,294 | 8,899 | 0 | 0 | 61.8% |
+| Test262 built-ins | 15,334/23,294 | 7,960 | 0 | 0 | 65.8% |
 | TypeScript 6.0.3 conformance | 3,491/4,933 | 969 | 473 | 0 | 70.8% |
 <!-- compliance:end -->
 

--- a/docs/compliance.json
+++ b/docs/compliance.json
@@ -11,8 +11,8 @@
   "test262_builtins": {
     "name": "Test262 built-ins",
     "total": 23294,
-    "passed": 14395,
-    "failed": 8899,
+    "passed": 15334,
+    "failed": 7960,
     "skipped": 0,
     "timeout": 0,
     "version": ""

--- a/docs/compliance.svg
+++ b/docs/compliance.svg
@@ -23,13 +23,13 @@
 <text x="165" y="255" text-anchor="middle" class="caption">22,753/23,523</text>
 </g>
   <g aria-label="Test262 built-ins">
-<path d="M 340.00 135.00 L 298.14 180.73 A 62.00 62.00 0 1 0 340.00 73.00 Z" fill="#20a060" />
-<path d="M 340.00 135.00 L 340.00 73.00 A 62.00 62.00 0 0 0 298.14 180.73 Z" fill="#d64b4b" />
+<path d="M 340.00 135.00 L 288.01 168.78 A 62.00 62.00 0 1 0 340.00 73.00 Z" fill="#20a060" />
+<path d="M 340.00 135.00 L 340.00 73.00 A 62.00 62.00 0 0 0 288.01 168.78 Z" fill="#d64b4b" />
 <circle cx="340" cy="135" r="38" fill="#ffffff" />
-<text x="340" y="131" text-anchor="middle" class="percent">61.8%</text>
+<text x="340" y="131" text-anchor="middle" class="percent">65.8%</text>
 <text x="340" y="153" text-anchor="middle" class="caption">pass</text>
 <text x="340" y="233" text-anchor="middle" class="title">Test262 built-ins</text>
-<text x="340" y="255" text-anchor="middle" class="caption">14,395/23,294</text>
+<text x="340" y="255" text-anchor="middle" class="caption">15,334/23,294</text>
 </g>
   <g aria-label="TypeScript 6.0.3">
 <path d="M 690.00 135.00 L 630.18 151.29 A 62.00 62.00 0 1 0 690.00 73.00 Z" fill="#20a060" />

--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -1,0 +1,293 @@
+package builtins
+
+import (
+	"strconv"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// This file holds the shared "array-like" accessors used by Array.prototype's
+// generic methods (every, some, filter, map, forEach, indexOf, push, splice,
+// ...). Per ECMA-262, these methods are intentionally generic: their `this`
+// value only needs a "length" property and integer-indexed properties, not
+// an actual Array object (22.1.3: "the definition of these methods does not
+// require that its this value be an Array object").
+//
+// The methods used to implement that with a two-branch dance:
+//
+//	if arr := thisVal.AsArray(); arr != nil {
+//	    ... fast path ...
+//	} else if po := thisVal.AsPlainObject(); po != nil {
+//	    ... array-like fallback ...
+//	}
+//
+// but vm.Value.AsArray()/AsPlainObject() panic on a type mismatch instead of
+// returning nil - so the `!= nil` checks were dead code, and the panic fired
+// on the very first receiver that was neither a real Array nor a plain
+// Object (Arguments, TypedArray, Proxy, boxed primitives, Map/Set/...,
+// anything). See issue #46. Fixed for good by centralizing the three
+// operations these methods actually need - length, indexed get, indexed set
+// - into helpers that dispatch on the concrete type once, in one place, and
+// fall back to the VM's ordinary (correct-for-every-type) property-access
+// path for anything that isn't a real Array or PlainObject.
+
+// maxSafeInteger is ToLength's cap (2^53 - 1).
+const maxSafeInteger = 9007199254740991
+
+// maxArrayLength is the largest valid Array length (2^32 - 1, ECMA-262
+// 23.1.4.1's array index bound). ArrayCreate(len) and ArraySetLength both
+// throw a RangeError above this - critically, *before* doing any per-element
+// work. Array.prototype methods that build a result sized to an array-like's
+// declared length (map, toReversed, toSorted, toSpliced, with, the Array(len)
+// constructor) MUST check this up front: LengthOfArrayLike/ToLength allows
+// lengths up to 2^53-1 for an arbitrary array-like receiver (nothing stops
+// `{length: 2**32}.length` from being read), and a bare `for i := 0; i <
+// length; i++` loop over a multi-billion length hangs the process long
+// before finishing - the RangeError is the spec's mechanism for cutting
+// that off immediately rather than requiring a fast per-iteration no-op.
+const maxArrayLength = 4294967295
+
+// checkArrayCreateLength returns a RangeError if length exceeds the largest
+// valid Array length, matching ArrayCreate's own bounds check. Call this
+// immediately after computing a result array's target length and before any
+// loop over it - see maxArrayLength's comment for why this can't wait.
+func checkArrayCreateLength(vmInstance *vm.VM, length int) error {
+	if length > maxArrayLength {
+		return vmInstance.NewRangeError("Invalid array length")
+	}
+	return nil
+}
+
+// toLengthInt clamps a raw "length" value the way ToLength does: NaN or <= 0
+// becomes 0, anything above 2^53-1 is capped, otherwise truncated to an
+// integer. Returned as a plain int since no array-like this codebase deals
+// with can plausibly hold more than MaxInt elements anyway.
+func toLengthInt(v vm.Value) int {
+	n := v.ToFloat()
+	if n != n || n <= 0 { // NaN or <= 0
+		return 0
+	}
+	if n > maxSafeInteger {
+		n = maxSafeInteger
+	}
+	return int(n)
+}
+
+// arrayLikeLength returns LengthOfArrayLike(thisVal) (ECMA-262 7.3.20): the
+// real Length() for an Array, otherwise ToLength(Get(thisVal, "length")).
+// The PlainObject case goes through getOwnPlainObjectProperty so a "length"
+// defined as an accessor is invoked correctly rather than silently treated
+// as absent (see that helper's comment - this matters for real Test262
+// cases, not just theoretical ones). Everything else goes through the VM's
+// generic property get, which correctly handles TypedArray/Arguments/Proxy/
+// getters/etc.
+func arrayLikeLength(vmInstance *vm.VM, thisVal vm.Value) (int, error) {
+	switch thisVal.Type() {
+	case vm.TypeArray:
+		return thisVal.AsArray().Length(), nil
+	case vm.TypeObject:
+		lv, exists, err := getOwnPlainObjectProperty(vmInstance, thisVal.AsPlainObject(), thisVal, "length")
+		if err != nil {
+			return 0, err
+		}
+		if !exists {
+			return 0, nil
+		}
+		return toLengthInt(lv), nil
+	default:
+		lv, err := vmInstance.GetProperty(thisVal, "length")
+		if err != nil {
+			return 0, err
+		}
+		return toLengthInt(lv), nil
+	}
+}
+
+// getOwnPlainObjectProperty reads own property `key` of po (whose Value form
+// is `receiver`, used as `this` for an accessor getter), returning
+// (value, exists, error). This exists because PlainObject.GetOwn/Get have no
+// VM to invoke a getter with, so they silently can't distinguish "own
+// accessor property present" from "absent" - which several array-like
+// generic methods actually depend on. Test262 exploits this directly: more
+// than one near-integer-length test (Array.prototype.{unshift,reverse}, and
+// implicitly anything using arrayLikeGet's exists flag) places a *throwing
+// getter* at a specific index specifically to stop what would otherwise be
+// an iteration up near 2^53-1 after only a handful of steps. Treating that
+// accessor as "doesn't exist" (the bug this replaces) skips the getter
+// entirely and lets the loop run its full, computationally impossible
+// length instead of throwing - which manifested as an actual multi-gigabyte,
+// unbounded-runtime hang, not just a wrong answer.
+func getOwnPlainObjectProperty(vmInstance *vm.VM, po *vm.PlainObject, receiver vm.Value, key string) (vm.Value, bool, error) {
+	if g, _, _, _, ok := po.GetOwnAccessor(key); ok {
+		if g.Type() == vm.TypeUndefined {
+			return vm.Undefined, true, nil
+		}
+		v, err := vmInstance.Call(g, receiver, nil)
+		if err != nil {
+			return vm.Undefined, false, err
+		}
+		return v, true, nil
+	}
+	if v, ok := po.GetOwn(key); ok {
+		return v, true, nil
+	}
+	return vm.Undefined, false, nil
+}
+
+// arrayLikeGet returns (value, exists, error) for index i of an array-like
+// `this`. "exists" mirrors HasProperty so callers can skip holes in a sparse
+// Array or a PlainObject missing that key, matching spec semantics for
+// every/filter/forEach/etc. Real Arrays preserve the exact hole-checking the
+// previous fast path did; PlainObjects go through getOwnPlainObjectProperty
+// for correct accessor handling (see its comment); every other type
+// (TypedArray, Arguments, Proxy, boxed primitives, Map/Set/...) has no holes
+// to speak of, so a plain Get is both correct and simpler.
+func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, error) {
+	switch thisVal.Type() {
+	case vm.TypeArray:
+		arr := thisVal.AsArray()
+		if !arr.HasIndex(i) {
+			return vm.Undefined, false, nil
+		}
+		return arr.Get(i), true, nil
+	case vm.TypeObject:
+		return getOwnPlainObjectProperty(vmInstance, thisVal.AsPlainObject(), thisVal, strconv.Itoa(i))
+	default:
+		key := strconv.Itoa(i)
+		v, err := vmInstance.GetProperty(thisVal, key)
+		if err != nil {
+			return vm.Undefined, false, err
+		}
+		return v, true, nil
+	}
+}
+
+// arrayLikeSet writes index i of an array-like `this` to val - used by the
+// mutating generic methods (push, splice, copyWithin, fill, reverse, sort,
+// ...). Real Arrays write directly; PlainObjects invoke an own accessor
+// setter if present (mirroring arrayLikeGet's getter handling) before
+// falling back to a plain data-property write; anything else goes through
+// the VM's generic property set (correct for TypedArray element coercion,
+// Proxy set traps, setters, etc.).
+func arrayLikeSet(vmInstance *vm.VM, thisVal vm.Value, i int, val vm.Value) error {
+	switch thisVal.Type() {
+	case vm.TypeArray:
+		thisVal.AsArray().Set(i, val)
+		return nil
+	case vm.TypeObject:
+		po := thisVal.AsPlainObject()
+		key := strconv.Itoa(i)
+		if _, s, _, _, ok := po.GetOwnAccessor(key); ok && s.Type() != vm.TypeUndefined {
+			_, err := vmInstance.Call(s, thisVal, []vm.Value{val})
+			return err
+		}
+		po.SetOwn(key, val)
+		return nil
+	default:
+		return vmInstance.SetProperty(thisVal, strconv.Itoa(i), val)
+	}
+}
+
+// arrayLikeSetLength writes a new "length" onto an array-like `this` -
+// needed by push/splice/etc. when the receiver isn't a real Array (whose
+// length is derived, not stored).
+func arrayLikeSetLength(vmInstance *vm.VM, thisVal vm.Value, length int) error {
+	switch thisVal.Type() {
+	case vm.TypeArray:
+		// A real Array's length is spec-capped at 2^32-1 (ArraySetLength);
+		// an arbitrary object's "length" property has no such limit, so
+		// this check only applies to the TypeArray branch.
+		if err := checkArrayCreateLength(vmInstance, length); err != nil {
+			return err
+		}
+		thisVal.AsArray().SetLength(length)
+		return nil
+	case vm.TypeObject:
+		thisVal.AsPlainObject().SetOwn("length", vm.NumberValue(float64(length)))
+		return nil
+	default:
+		return vmInstance.SetProperty(thisVal, "length", vm.NumberValue(float64(length)))
+	}
+}
+
+// asPlainObjectOrNil is vm.Value.AsPlainObject() without the panic: nil for
+// anything that isn't exactly TypeObject, so it's safe to use in the
+// `if po := asPlainObjectOrNil(v); po != nil` idiom several call sites in
+// this file rely on (unlike AsPlainObject() itself, which panics on a type
+// mismatch before that nil check ever runs - see issue #46).
+func asPlainObjectOrNil(v vm.Value) *vm.PlainObject {
+	if v.Type() != vm.TypeObject {
+		return nil
+	}
+	return v.AsPlainObject()
+}
+
+// isArraySpec implements the IsArray abstract operation (ECMA-262 7.2.2)
+// backing Array.isArray: true for a real Array, recursing through a Proxy's
+// target (throwing if the proxy has been revoked), false for everything
+// else - except this engine's Array.prototype itself, which is represented
+// as a PlainObject rather than a real ArrayObject (see InitRuntime above),
+// so it needs an explicit identity check to satisfy "Array.prototype is an
+// Array exotic object" per spec.
+func isArraySpec(vmInstance *vm.VM, v vm.Value) (bool, error) {
+	switch v.Type() {
+	case vm.TypeArray:
+		return true, nil
+	case vm.TypeProxy:
+		proxy := v.AsProxy()
+		if proxy.Revoked {
+			return false, vmInstance.NewTypeError("Cannot perform 'IsArray' on a proxy that has been revoked")
+		}
+		return isArraySpec(vmInstance, proxy.Target())
+	case vm.TypeObject:
+		if vmInstance.ArrayPrototype.Type() == vm.TypeObject && v.AsPlainObject() == vmInstance.ArrayPrototype.AsPlainObject() {
+			return true, nil
+		}
+		return false, nil
+	default:
+		return false, nil
+	}
+}
+
+// isConcatSpreadable implements IsConcatSpreadable (ECMA-262 23.1.3.1.1):
+// non-objects are never spreadable; an object's own/inherited
+// @@isConcatSpreadable overrides everything if defined; otherwise an object
+// spreads iff it's a real Array. Used by Array.prototype.concat to decide
+// whether an argument (or the receiver itself) contributes its elements or
+// is appended as a single value.
+func isConcatSpreadable(vmInstance *vm.VM, v vm.Value) (bool, error) {
+	if !v.IsObject() && !v.IsCallable() {
+		return false, nil
+	}
+	spreadable, found, err := vmInstance.GetSymbolPropertyWithGetter(v, vmInstance.SymbolIsConcatSpreadable)
+	if err != nil {
+		return false, err
+	}
+	if found && !spreadable.IsUndefined() {
+		return spreadable.IsTruthy(), nil
+	}
+	// Fallback is IsArray(v), not a bare Type() check - a Proxy wrapping a
+	// real Array must still be recognized as spreadable (isArraySpec
+	// recurses through the proxy's target, per spec).
+	return isArraySpec(vmInstance, v)
+}
+
+// arrayLikeDelete removes index i from an array-like `this`, leaving a hole
+// - used by splice/pop/shift-style methods on a non-Array receiver where
+// spec semantics call for DeletePropertyOrThrow rather than writing
+// undefined (so a subsequent HasProperty/`in` check on that index is false).
+func arrayLikeDelete(vmInstance *vm.VM, thisVal vm.Value, i int) error {
+	switch thisVal.Type() {
+	case vm.TypeArray:
+		// Arrays don't track holes below their length via delete in this
+		// engine's element storage; writing Undefined matches this file's
+		// pre-existing behavior for Array receivers in these code paths.
+		thisVal.AsArray().Set(i, vm.Undefined)
+		return nil
+	case vm.TypeObject:
+		thisVal.AsPlainObject().DeleteOwn(strconv.Itoa(i))
+		return nil
+	default:
+		return vmInstance.SetProperty(thisVal, strconv.Itoa(i), vm.Undefined)
+	}
+}

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -246,14 +246,27 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NumberValue(0), nil
+		if thisVal.Type() == vm.TypeArray {
+			thisArray := thisVal.AsArray()
+			for i := 0; i < len(args); i++ {
+				thisArray.Append(args[i])
+			}
+			return vm.NumberValue(float64(thisArray.Length())), nil
 		}
-		for i := 0; i < len(args); i++ {
-			thisArray.Append(args[i])
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		return vm.NumberValue(float64(thisArray.Length())), nil
+		for _, arg := range args {
+			if err := arrayLikeSet(vmInstance, thisVal, length, arg); err != nil {
+				return vm.Undefined, err
+			}
+			length++
+		}
+		if err := arrayLikeSetLength(vmInstance, thisVal, length); err != nil {
+			return vm.Undefined, err
+		}
+		return vm.NumberValue(float64(length)), nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("pop", vm.NewNativeFunction(0, false, "pop", func(args []vm.Value) (vm.Value, error) {
@@ -261,14 +274,35 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil || thisArray.Length() == 0 {
-			return vm.Undefined, nil
+		if thisVal.Type() == vm.TypeArray {
+			thisArray := thisVal.AsArray()
+			if thisArray.Length() == 0 {
+				return vm.Undefined, nil
+			}
+			lastIndex := thisArray.Length() - 1
+			lastElement := thisArray.Get(lastIndex)
+			thisArray.SetLength(lastIndex)
+			return lastElement, nil
 		}
-		lastIndex := thisArray.Length() - 1
-		lastElement := thisArray.Get(lastIndex)
-		thisArray.SetLength(lastIndex)
-		return lastElement, nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		if length == 0 {
+			return vm.Undefined, arrayLikeSetLength(vmInstance, thisVal, 0)
+		}
+		newLen := length - 1
+		element, _, err := arrayLikeGet(vmInstance, thisVal, newLen)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		if err := arrayLikeDelete(vmInstance, thisVal, newLen); err != nil {
+			return vm.Undefined, err
+		}
+		if err := arrayLikeSetLength(vmInstance, thisVal, newLen); err != nil {
+			return vm.Undefined, err
+		}
+		return element, nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("shift", vm.NewNativeFunction(0, false, "shift", func(args []vm.Value) (vm.Value, error) {
@@ -276,18 +310,52 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil || thisArray.Length() == 0 {
-			return vm.Undefined, nil
+		if thisVal.Type() == vm.TypeArray {
+			thisArray := thisVal.AsArray()
+			if thisArray.Length() == 0 {
+				return vm.Undefined, nil
+			}
+			firstElement := thisArray.Get(0)
+			// Shift all elements left
+			newElements := make([]vm.Value, thisArray.Length()-1)
+			for i := 1; i < thisArray.Length(); i++ {
+				newElements[i-1] = thisArray.Get(i)
+			}
+			thisArray.SetElements(newElements)
+			return firstElement, nil
 		}
-		firstElement := thisArray.Get(0)
-		// Shift all elements left
-		newElements := make([]vm.Value, thisArray.Length()-1)
-		for i := 1; i < thisArray.Length(); i++ {
-			newElements[i-1] = thisArray.Get(i)
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		thisArray.SetElements(newElements)
-		return firstElement, nil
+		if length == 0 {
+			return vm.Undefined, arrayLikeSetLength(vmInstance, thisVal, 0)
+		}
+		first, _, err := arrayLikeGet(vmInstance, thisVal, 0)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for k := 1; k < length; k++ {
+			from, to := k, k-1
+			v, exists, err := arrayLikeGet(vmInstance, thisVal, from)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if exists {
+				if err := arrayLikeSet(vmInstance, thisVal, to, v); err != nil {
+					return vm.Undefined, err
+				}
+			} else if err := arrayLikeDelete(vmInstance, thisVal, to); err != nil {
+				return vm.Undefined, err
+			}
+		}
+		if err := arrayLikeDelete(vmInstance, thisVal, length-1); err != nil {
+			return vm.Undefined, err
+		}
+		if err := arrayLikeSetLength(vmInstance, thisVal, length-1); err != nil {
+			return vm.Undefined, err
+		}
+		return first, nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("unshift", vm.NewNativeFunction(1, true, "unshift", func(args []vm.Value) (vm.Value, error) {
@@ -295,22 +363,62 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NumberValue(0), nil
+		if thisVal.Type() == vm.TypeArray {
+			thisArray := thisVal.AsArray()
+			// Create new array with unshifted elements
+			newElements := make([]vm.Value, 0, thisArray.Length()+len(args))
+			// Add new elements first
+			for i := 0; i < len(args); i++ {
+				newElements = append(newElements, args[i])
+			}
+			// Add existing elements
+			for i := 0; i < thisArray.Length(); i++ {
+				newElements = append(newElements, thisArray.Get(i))
+			}
+			thisArray.SetElements(newElements)
+			return vm.NumberValue(float64(thisArray.Length())), nil
 		}
-		// Create new array with unshifted elements
-		newElements := make([]vm.Value, 0, thisArray.Length()+len(args))
-		// Add new elements first
-		for i := 0; i < len(args); i++ {
-			newElements = append(newElements, args[i])
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		// Add existing elements
-		for i := 0; i < thisArray.Length(); i++ {
-			newElements = append(newElements, thisArray.Get(i))
+		argCount := len(args)
+		if argCount > 0 {
+			// Per spec step 4a: throw TypeError before shifting anything if
+			// the new length would exceed 2^53-1 - length is already
+			// clamped to that bound by ToLength, but adding argCount on top
+			// of an already-maxed length can legitimately push past it, and
+			// without this check the shift loop below would attempt on the
+			// order of 2^53 iterations even when (as here) every access is
+			// individually cheap.
+			if length+argCount > maxSafeInteger {
+				return vm.Undefined, vmInstance.NewTypeError("Invalid array length")
+			}
+			for k := length; k > 0; k-- {
+				from, to := k-1, k+argCount-1
+				v, exists, err := arrayLikeGet(vmInstance, thisVal, from)
+				if err != nil {
+					return vm.Undefined, err
+				}
+				if exists {
+					if err := arrayLikeSet(vmInstance, thisVal, to, v); err != nil {
+						return vm.Undefined, err
+					}
+				} else if err := arrayLikeDelete(vmInstance, thisVal, to); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			for j, arg := range args {
+				if err := arrayLikeSet(vmInstance, thisVal, j, arg); err != nil {
+					return vm.Undefined, err
+				}
+			}
 		}
-		thisArray.SetElements(newElements)
-		return vm.NumberValue(float64(thisArray.Length())), nil
+		newLen := length + argCount
+		if err := arrayLikeSetLength(vmInstance, thisVal, newLen); err != nil {
+			return vm.Undefined, err
+		}
+		return vm.NumberValue(float64(newLen)), nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("slice", vm.NewNativeFunction(2, false, "slice", func(args []vm.Value) (vm.Value, error) {
@@ -318,11 +426,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NewArray(), nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		length := thisArray.Length()
 		start := 0
 		if len(args) >= 1 && !args[0].IsUndefined() {
 			var err error
@@ -364,9 +471,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if start >= end {
 			return vm.NewArray(), nil
 		}
-		elements := make([]vm.Value, end-start)
+		// ArraySpeciesCreate(O, count) throws before any copying if count
+		// exceeds the max valid Array length - critically before the make()
+		// below, which would otherwise try to allocate count elements (up
+		// to 2^53-1 for an arbitrary array-like's declared length).
+		count := end - start
+		if err := checkArrayCreateLength(vmInstance, count); err != nil {
+			return vm.Undefined, err
+		}
+		elements := make([]vm.Value, count)
 		for i := start; i < end; i++ {
-			elements[i-start] = thisArray.Get(i)
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			elements[i-start] = v
 		}
 		return vm.NewArrayWithArgs(elements), nil
 	}))
@@ -376,11 +495,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NewArray(), nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		length := thisArray.Length()
 		start := 0
 		if len(args) >= 1 {
 			var err error
@@ -416,56 +534,145 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 				deleteCount = length - start
 			}
 		}
+		var itemsToInsert []vm.Value
+		if len(args) >= 2 {
+			itemsToInsert = args[2:]
+		}
+		itemCount := len(itemsToInsert)
+
+		// ArraySpeciesCreate(O, actualDeleteCount) throws before any copying
+		// if actualDeleteCount exceeds the max valid Array length (see
+		// checkArrayCreateLength) - actualDeleteCount is bounded by
+		// length-start, which can itself be huge for an arbitrary
+		// array-like's declared length.
+		if err := checkArrayCreateLength(vmInstance, deleteCount); err != nil {
+			return vm.Undefined, err
+		}
+
+		// Per spec step 8: if the resulting length would exceed 2^53-1,
+		// throw a TypeError before doing any shifting - length is already
+		// clamped to that bound by ToLength, but adding itemCount on top of
+		// an already-maxed length can legitimately push newLength one past
+		// it. Without this check, the shift loops below would attempt on
+		// the order of 2^53 iterations.
+		newLength := length - deleteCount + itemCount
+		if newLength > maxSafeInteger {
+			return vm.Undefined, vmInstance.NewTypeError("Invalid array length")
+		}
+
 		// Create array with deleted elements
 		deleted := vm.NewArray()
+		deletedArr := deleted.AsArray()
 		for i := 0; i < deleteCount; i++ {
-			deleted.AsArray().Append(thisArray.Get(start + i))
+			v, _, err := arrayLikeGet(vmInstance, thisVal, start+i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			deletedArr.Append(v)
 		}
-		// Remove elements and insert new ones
-		// First collect items to insert
-		itemsToInsert := make([]vm.Value, 0)
-		for i := 2; i < len(args); i++ {
-			itemsToInsert = append(itemsToInsert, args[i])
+
+		if itemCount < deleteCount {
+			// Shift the tail left to close the gap
+			for i := start; i < length-deleteCount; i++ {
+				from, to := i+deleteCount, i+itemCount
+				v, exists, err := arrayLikeGet(vmInstance, thisVal, from)
+				if err != nil {
+					return vm.Undefined, err
+				}
+				if exists {
+					if err := arrayLikeSet(vmInstance, thisVal, to, v); err != nil {
+						return vm.Undefined, err
+					}
+				} else if err := arrayLikeDelete(vmInstance, thisVal, to); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			for i := length; i > newLength; i-- {
+				if err := arrayLikeDelete(vmInstance, thisVal, i-1); err != nil {
+					return vm.Undefined, err
+				}
+			}
+		} else if itemCount > deleteCount {
+			// Shift the tail right to make room
+			for i := length - deleteCount; i > start; i-- {
+				from, to := i+deleteCount-1, i+itemCount-1
+				v, exists, err := arrayLikeGet(vmInstance, thisVal, from)
+				if err != nil {
+					return vm.Undefined, err
+				}
+				if exists {
+					if err := arrayLikeSet(vmInstance, thisVal, to, v); err != nil {
+						return vm.Undefined, err
+					}
+				} else if err := arrayLikeDelete(vmInstance, thisVal, to); err != nil {
+					return vm.Undefined, err
+				}
+			}
 		}
-		// Perform splice operation manually
-		// Create new elements array
-		newElements := make([]vm.Value, 0)
-		// Add elements before start
-		for i := 0; i < start; i++ {
-			newElements = append(newElements, thisArray.Get(i))
+		for i, item := range itemsToInsert {
+			if err := arrayLikeSet(vmInstance, thisVal, start+i, item); err != nil {
+				return vm.Undefined, err
+			}
 		}
-		// Add items to insert
-		for _, item := range itemsToInsert {
-			newElements = append(newElements, item)
+		if err := arrayLikeSetLength(vmInstance, thisVal, newLength); err != nil {
+			return vm.Undefined, err
 		}
-		// Add elements after deleted section
-		for i := start + deleteCount; i < length; i++ {
-			newElements = append(newElements, thisArray.Get(i))
-		}
-		thisArray.SetElements(newElements)
 		return deleted, nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("concat", vm.NewNativeFunction(1, true, "concat", func(args []vm.Value) (vm.Value, error) {
-		thisArray := vmInstance.GetThis().AsArray()
-		if thisArray == nil {
-			return vm.NewArray(), nil
+		thisVal := vmInstance.GetThis()
+		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
+			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
 		result := vm.NewArray()
-		// Add elements from this array
-		for i := 0; i < thisArray.Length(); i++ {
-			result.AsArray().Append(thisArray.Get(i))
-		}
-		// Add elements from arguments
-		for i := 0; i < len(args); i++ {
-			if otherArray := args[i].AsArray(); otherArray != nil {
-				// If it's an array, add each element
-				for j := 0; j < otherArray.Length(); j++ {
-					result.AsArray().Append(otherArray.Get(j))
+		resultArr := result.AsArray()
+
+		// n tracks the total element count appended so far across every
+		// item, so the "would exceed 2^53-1" check below applies to the
+		// combined result, not just one item - per spec step 5.c.iii, this
+		// must be checked (and throw TypeError) *before* spreading a given
+		// item's elements, since a spreadable array-like can freely declare
+		// any "length" up to 2^53-1 and a bare loop over it would otherwise
+		// take on the order of 2^53 iterations.
+		n := 0
+		appendItem := func(item vm.Value) error {
+			spreadable, err := isConcatSpreadable(vmInstance, item)
+			if err != nil {
+				return err
+			}
+			if !spreadable {
+				if n+1 > maxSafeInteger {
+					return vmInstance.NewTypeError("Invalid array length")
 				}
-			} else {
-				// If it's not an array, add the element itself
-				result.AsArray().Append(args[i])
+				resultArr.Append(item)
+				n++
+				return nil
+			}
+			length, err := arrayLikeLength(vmInstance, item)
+			if err != nil {
+				return err
+			}
+			if n+length > maxSafeInteger {
+				return vmInstance.NewTypeError("Invalid array length")
+			}
+			for i := 0; i < length; i++ {
+				v, _, err := arrayLikeGet(vmInstance, item, i)
+				if err != nil {
+					return err
+				}
+				resultArr.Append(v)
+			}
+			n += length
+			return nil
+		}
+
+		if err := appendItem(thisVal); err != nil {
+			return vm.Undefined, err
+		}
+		for _, arg := range args {
+			if err := appendItem(arg); err != nil {
+				return vm.Undefined, err
 			}
 		}
 		return result, nil
@@ -476,21 +683,28 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NewString(""), nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 		separator := ","
 		if len(args) >= 1 {
 			separator = args[0].ToString()
 		}
-		// Build joined string
-		if thisArray.Length() == 0 {
+		if length == 0 {
 			return vm.NewString(""), nil
 		}
-		result := thisArray.Get(0).ToString()
-		for i := 1; i < thisArray.Length(); i++ {
-			result += separator + thisArray.Get(i).ToString()
+		first, _, err := arrayLikeGet(vmInstance, thisVal, 0)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		result := first.ToString()
+		for i := 1; i < length; i++ {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			result += separator + v.ToString()
 		}
 		return vm.NewString(result), nil
 	}))
@@ -501,17 +715,24 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		if length == 0 {
 			return vm.NewString(""), nil
 		}
-		// Build comma-separated string (same as join with default separator)
-		if thisArray.Length() == 0 {
-			return vm.NewString(""), nil
+		first, _, err := arrayLikeGet(vmInstance, thisVal, 0)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		result := thisArray.Get(0).ToString()
-		for i := 1; i < thisArray.Length(); i++ {
-			result += "," + thisArray.Get(i).ToString()
+		result := first.ToString()
+		for i := 1; i < length; i++ {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			result += "," + v.ToString()
 		}
 		return vm.NewString(result), nil
 	}))
@@ -521,20 +742,48 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
+		if thisVal.Type() == vm.TypeArray {
+			thisArray := thisVal.AsArray()
+			length := thisArray.Length()
+			for i := 0; i < length/2; i++ {
+				j := length - 1 - i
+				left := thisArray.Get(i)
+				right := thisArray.Get(j)
+				thisArray.Set(i, right)
+				thisArray.Set(j, left)
+			}
 			return thisVal, nil
 		}
-		length := thisArray.Length()
-		// Reverse elements in place
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
 		for i := 0; i < length/2; i++ {
 			j := length - 1 - i
-			left := thisArray.Get(i)
-			right := thisArray.Get(j)
-			thisArray.Set(i, right)
-			thisArray.Set(j, left)
+			left, leftExists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			right, rightExists, err := arrayLikeGet(vmInstance, thisVal, j)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if rightExists {
+				if err := arrayLikeSet(vmInstance, thisVal, i, right); err != nil {
+					return vm.Undefined, err
+				}
+			} else if err := arrayLikeDelete(vmInstance, thisVal, i); err != nil {
+				return vm.Undefined, err
+			}
+			if leftExists {
+				if err := arrayLikeSet(vmInstance, thisVal, j, left); err != nil {
+					return vm.Undefined, err
+				}
+			} else if err := arrayLikeDelete(vmInstance, thisVal, j); err != nil {
+				return vm.Undefined, err
+			}
 		}
-		return vmInstance.GetThis(), nil // Return the same array
+		return thisVal, nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("sort", vm.NewNativeFunction(1, false, "sort", func(args []vm.Value) (vm.Value, error) {
@@ -542,18 +791,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return thisVal, nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		length := thisArray.Length()
 		if length <= 1 {
-			return vmInstance.GetThis(), nil
+			return thisVal, nil
 		}
 		// Extract elements to slice
 		elements := make([]vm.Value, length)
 		for i := 0; i < length; i++ {
-			elements[i] = thisArray.Get(i)
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			elements[i] = v
 		}
 
 		// Get comparator function if provided
@@ -584,8 +836,16 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 		// Set sorted elements back
-		thisArray.SetElements(elements)
-		return vmInstance.GetThis(), nil // Return the same array
+		if thisVal.Type() == vm.TypeArray {
+			thisVal.AsArray().SetElements(elements)
+		} else {
+			for i, v := range elements {
+				if err := arrayLikeSet(vmInstance, thisVal, i, v); err != nil {
+					return vm.Undefined, err
+				}
+			}
+		}
+		return thisVal, nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("indexOf", vm.NewNativeFunction(1, false, "indexOf", func(args []vm.Value) (vm.Value, error) {
@@ -593,9 +853,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NumberValue(-1), nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 		// If no argument, search for undefined
 		var searchElement vm.Value
@@ -604,7 +864,6 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		} else {
 			searchElement = vm.Undefined
 		}
-		length := thisArray.Length()
 		if length == 0 {
 			return vm.NumberValue(-1), nil
 		}
@@ -628,11 +887,15 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// ECMAScript spec: indexOf uses Strict Equality (===), not SameValueZero
 		// This means NaN !== NaN, so indexOf(NaN) should return -1
 		for i := fromIndex; i < length; i++ {
-			// Skip holes in sparse arrays
-			if !thisArray.HasIndex(i) {
+			v, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			// Skip holes in sparse arrays/array-likes
+			if !exists {
 				continue
 			}
-			if thisArray.Get(i).StrictlyEquals(searchElement) {
+			if v.StrictlyEquals(searchElement) {
 				return vm.NumberValue(float64(i)), nil
 			}
 		}
@@ -644,9 +907,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.NumberValue(-1), nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 		// If no argument, search for undefined
 		var searchElement vm.Value
@@ -655,7 +918,6 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		} else {
 			searchElement = vm.Undefined
 		}
-		length := thisArray.Length()
 		if length == 0 {
 			return vm.NumberValue(-1), nil
 		}
@@ -678,11 +940,15 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// ECMAScript spec: lastIndexOf uses Strict Equality (===), not SameValueZero
 		// This means NaN !== NaN, so lastIndexOf(NaN) should return -1
 		for i := fromIndex; i >= 0; i-- {
-			// Skip holes in sparse arrays
-			if !thisArray.HasIndex(i) {
+			v, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			// Skip holes in sparse arrays/array-likes
+			if !exists {
 				continue
 			}
-			if thisArray.Get(i).StrictlyEquals(searchElement) {
+			if v.StrictlyEquals(searchElement) {
 				return vm.NumberValue(float64(i)), nil
 			}
 		}
@@ -694,9 +960,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil {
-			return vm.BooleanValue(false), nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 		// If no argument, search for undefined
 		var searchElement vm.Value
@@ -705,7 +971,6 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		} else {
 			searchElement = vm.Undefined
 		}
-		length := thisArray.Length()
 		if length == 0 {
 			return vm.BooleanValue(false), nil
 		}
@@ -729,7 +994,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// ECMAScript spec: includes uses SameValueZero, so NaN === NaN (Is() is correct)
 		// Note: includes DOES check holes and finds undefined in them (unlike indexOf)
 		for i := fromIndex; i < length; i++ {
-			if thisArray.Get(i).Is(searchElement) {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if v.Is(searchElement) {
 				return vm.BooleanValue(true), nil
 			}
 		}
@@ -741,9 +1010,12 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Array.prototype.find called on null or undefined")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil || len(args) < 1 {
+		if len(args) < 1 {
 			return vm.Undefined, nil
+		}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 		callback := args[0]
 		if !callback.IsCallable() {
@@ -756,9 +1028,12 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		} else {
 			thisArg = vm.Undefined
 		}
-		for i := 0; i < thisArray.Length(); i++ {
-			element := thisArray.Get(i)
-			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), vmInstance.GetThis())
+		for i := 0; i < length; i++ {
+			element, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -774,9 +1049,12 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Array.prototype.findIndex called on null or undefined")
 		}
-		thisArray := thisVal.AsArray()
-		if thisArray == nil || len(args) < 1 {
+		if len(args) < 1 {
 			return vm.NumberValue(-1), nil
+		}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 		callback := args[0]
 		if !callback.IsCallable() {
@@ -789,9 +1067,12 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		} else {
 			thisArg = vm.Undefined
 		}
-		for i := 0; i < thisArray.Length(); i++ {
-			element := thisArray.Get(i)
-			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), vmInstance.GetThis())
+		for i := 0; i < length; i++ {
+			element, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
 			if err != nil {
 				return vm.NumberValue(-1), err
 			}
@@ -810,16 +1091,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -846,36 +1120,23 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		result := vm.NewArray()
+		resultArr := result.AsArray()
 
-		// Support both arrays and array-like objects (with sparse array support)
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < length; i++ {
-				// Only call callback for indices that actually exist (sparse array support)
-				if arr.HasIndex(i) {
-					element := arr.Get(i)
-					test, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.NewArray(), err
-					}
-					if test.IsTruthy() {
-						result.AsArray().Append(element)
-					}
-				}
+		for i := 0; i < length; i++ {
+			// Only call callback for indices that actually exist (sparse array support)
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.NewArray(), err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				// Only call callback for indices that actually exist
-				if _, ok := po.GetOwn(key); ok {
-					elem, _ := po.Get(key)
-					test, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.NewArray(), err
-					}
-					if test.IsTruthy() {
-						result.AsArray().Append(elem)
-					}
-				}
+			if !exists {
+				continue
+			}
+			test, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.NewArray(), err
+			}
+			if test.IsTruthy() {
+				resultArr.Append(element)
 			}
 		}
 		return result, nil
@@ -889,16 +1150,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -924,44 +1178,35 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			thisArg = vm.Undefined
 		}
 
+		// ArraySpeciesCreate/ArrayCreate(len) throws before any iteration if
+		// len exceeds the max valid Array length - critically, this must
+		// happen before the loop below, not after: len can be up to 2^53-1
+		// (ToLength) for an arbitrary array-like receiver, and a bare loop
+		// over a multi-billion length would otherwise hang the process.
+		if err := checkArrayCreateLength(vmInstance, length); err != nil {
+			return vm.Undefined, err
+		}
+
 		// Create result array with same length (for sparse array support)
 		result := vm.NewArray()
 		resultArr := result.AsArray()
 		resultArr.SetLength(length)
 
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < length; i++ {
-				// Only call callback for indices that actually exist (sparse array support)
-				if arr.HasIndex(i) {
-					element := arr.Get(i)
-					mappedValue, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.Undefined, err
-					}
-					resultArr.Set(i, mappedValue)
-				}
+		for i := 0; i < length; i++ {
+			// Only call callback for indices that actually exist (sparse array support)
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-			return result, nil
-		}
-
-		// Array-like: { length: N, 0: ..., 1: ..., ... }
-		if po := thisVal.AsPlainObject(); po != nil {
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				// Only call callback for indices that actually exist
-				if _, ok := po.GetOwn(key); ok {
-					elem, _ := po.Get(key)
-					mappedValue, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.Undefined, err
-					}
-					resultArr.Set(i, mappedValue)
-				}
+			if !exists {
+				continue
 			}
-			return result, nil
+			mappedValue, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			resultArr.Set(i, mappedValue)
 		}
-
-		// Non-array-like: return empty array
 		return result, nil
 	}))
 
@@ -973,16 +1218,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1008,29 +1246,17 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			thisArg = vm.Undefined
 		}
 
-		// Support both arrays and array-like objects (with sparse array support)
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < length; i++ {
-				// Only call callback for indices that actually exist (sparse array support)
-				if arr.HasIndex(i) {
-					element := arr.Get(i)
-					_, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.Undefined, err
-					}
-				}
+		for i := 0; i < length; i++ {
+			// Only call callback for indices that actually exist (sparse array support)
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				// Only call callback for indices that actually exist
-				if _, ok := po.GetOwn(key); ok {
-					elem, _ := po.Get(key)
-					_, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.Undefined, err
-					}
-				}
+			if !exists {
+				continue
+			}
+			if _, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal); err != nil {
+				return vm.Undefined, err
 			}
 		}
 		return vm.Undefined, nil
@@ -1044,16 +1270,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1079,35 +1298,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			thisArg = vm.Undefined
 		}
 
-		// Support both arrays and array-like objects (with sparse array support)
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < length; i++ {
-				// Only call callback for indices that actually exist (sparse array support)
-				if arr.HasIndex(i) {
-					element := arr.Get(i)
-					result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.BooleanValue(false), err
-					}
-					if !result.IsTruthy() {
-						return vm.BooleanValue(false), nil
-					}
-				}
+		for i := 0; i < length; i++ {
+			// Only call callback for indices that actually exist (sparse array support)
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.BooleanValue(false), err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				// Only call callback for indices that actually exist
-				if _, ok := po.GetOwn(key); ok {
-					elem, _ := po.Get(key)
-					result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.BooleanValue(false), err
-					}
-					if !result.IsTruthy() {
-						return vm.BooleanValue(false), nil
-					}
-				}
+			if !exists {
+				continue
+			}
+			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.BooleanValue(false), err
+			}
+			if !result.IsTruthy() {
+				return vm.BooleanValue(false), nil
 			}
 		}
 		return vm.BooleanValue(true), nil
@@ -1121,16 +1326,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1156,35 +1354,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			thisArg = vm.Undefined
 		}
 
-		// Support both arrays and array-like objects (with sparse array support)
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < length; i++ {
-				// Only call callback for indices that actually exist (sparse array support)
-				if arr.HasIndex(i) {
-					element := arr.Get(i)
-					result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.BooleanValue(false), err
-					}
-					if result.IsTruthy() {
-						return vm.BooleanValue(true), nil
-					}
-				}
+		for i := 0; i < length; i++ {
+			// Only call callback for indices that actually exist (sparse array support)
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.BooleanValue(false), err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				// Only call callback for indices that actually exist
-				if _, ok := po.GetOwn(key); ok {
-					elem, _ := po.Get(key)
-					result, err := vmInstance.CallArgs3(callback, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-					if err != nil {
-						return vm.BooleanValue(false), err
-					}
-					if result.IsTruthy() {
-						return vm.BooleanValue(true), nil
-					}
-				}
+			if !exists {
+				continue
+			}
+			result, err := vmInstance.CallArgs3(callback, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.BooleanValue(false), err
+			}
+			if result.IsTruthy() {
+				return vm.BooleanValue(true), nil
 			}
 		}
 		return vm.BooleanValue(false), nil
@@ -1198,16 +1382,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1230,42 +1407,30 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("Reduce of empty array with no initial value")
 		}
 
-		accumulator := vm.Undefined
+		var accumulator vm.Value
 		startIndex := 0
 		if len(args) >= 2 {
 			accumulator = args[1]
-		} else if arr := thisVal.AsArray(); arr != nil {
-			accumulator = arr.Get(0)
-			startIndex = 1
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if v, ok := po.Get("0"); ok {
-				accumulator = v
+		} else {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, 0)
+			if err != nil {
+				return vm.Undefined, err
 			}
+			accumulator = v
 			startIndex = 1
 		}
 
-		// Iterate
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := startIndex; i < length; i++ {
-				element := arr.Get(i)
-				var err error
-				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, element, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
+		for i := startIndex; i < length; i++ {
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := startIndex; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				var elem vm.Value = vm.Undefined
-				if v, ok := po.Get(key); ok {
-					elem = v
-				}
-				var err error
-				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
+			if !exists {
+				continue
+			}
+			accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.Undefined, err
 			}
 		}
 		return accumulator, nil
@@ -1279,16 +1444,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 2. Let len be ? LengthOfArrayLike(O). - MUST access length BEFORE checking callback
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-				if length < 0 {
-					length = 0
-				}
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1311,43 +1469,30 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("Reduce of empty array with no initial value")
 		}
 
-		accumulator := vm.Undefined
+		var accumulator vm.Value
 		startIndex := length - 1
 		if len(args) >= 2 {
 			accumulator = args[1]
-		} else if arr := thisVal.AsArray(); arr != nil {
-			accumulator = arr.Get(length - 1)
-			startIndex = length - 2
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			key := fmt.Sprintf("%d", length-1)
-			if v, ok := po.Get(key); ok {
-				accumulator = v
+		} else {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, length-1)
+			if err != nil {
+				return vm.Undefined, err
 			}
+			accumulator = v
 			startIndex = length - 2
 		}
 
-		// Iterate backwards
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := startIndex; i >= 0; i-- {
-				element := arr.Get(i)
-				var err error
-				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, element, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
+		for i := startIndex; i >= 0; i-- {
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := startIndex; i >= 0; i-- {
-				key := fmt.Sprintf("%d", i)
-				var elem vm.Value = vm.Undefined
-				if v, ok := po.Get(key); ok {
-					elem = v
-				}
-				var err error
-				accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, elem, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
+			if !exists {
+				continue
+			}
+			accumulator, err = vmInstance.CallArgs4(callback, vm.Undefined, accumulator, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.Undefined, err
 			}
 		}
 		return accumulator, nil
@@ -1362,13 +1507,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Get length
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. Let relativeIndex be ? ToIntegerOrInfinity(index).
@@ -1398,15 +1539,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// 6. Return ? Get(O, ! ToString(k)).
-		if arr := thisVal.AsArray(); arr != nil {
-			return arr.Get(k), nil
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			key := fmt.Sprintf("%d", k)
-			if v, ok := po.Get(key); ok {
-				return v, nil
-			}
+		v, _, err := arrayLikeGet(vmInstance, thisVal, k)
+		if err != nil {
+			return vm.Undefined, err
 		}
-		return vm.Undefined, nil
+		return v, nil
 	}))
 
 	// Array.prototype.findLast - find from end
@@ -1437,35 +1574,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Get length and iterate backwards
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := arr.Length() - 1; i >= 0; i-- {
-				element := arr.Get(i)
-				result, err := vmInstance.CallArgs3(predicate, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
-				if result.IsTruthy() {
-					return element, nil
-				}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for i := length - 1; i >= 0; i-- {
+			element, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			length := 0
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
+			result, err := vmInstance.CallArgs3(predicate, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.Undefined, err
 			}
-			for i := length - 1; i >= 0; i-- {
-				key := fmt.Sprintf("%d", i)
-				var elem vm.Value = vm.Undefined
-				if v, ok := po.Get(key); ok {
-					elem = v
-				}
-				result, err := vmInstance.CallArgs3(predicate, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
-				if result.IsTruthy() {
-					return elem, nil
-				}
+			if result.IsTruthy() {
+				return element, nil
 			}
 		}
 		return vm.Undefined, nil
@@ -1499,35 +1622,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Get length and iterate backwards
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := arr.Length() - 1; i >= 0; i-- {
-				element := arr.Get(i)
-				result, err := vmInstance.CallArgs3(predicate, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.NumberValue(-1), err
-				}
-				if result.IsTruthy() {
-					return vm.NumberValue(float64(i)), nil
-				}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for i := length - 1; i >= 0; i-- {
+			element, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			length := 0
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
+			result, err := vmInstance.CallArgs3(predicate, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.NumberValue(-1), err
 			}
-			for i := length - 1; i >= 0; i-- {
-				key := fmt.Sprintf("%d", i)
-				var elem vm.Value = vm.Undefined
-				if v, ok := po.Get(key); ok {
-					elem = v
-				}
-				result, err := vmInstance.CallArgs3(predicate, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.NumberValue(-1), err
-				}
-				if result.IsTruthy() {
-					return vm.NumberValue(float64(i)), nil
-				}
+			if result.IsTruthy() {
+				return vm.NumberValue(float64(i)), nil
 			}
 		}
 		return vm.NumberValue(-1), nil
@@ -1541,13 +1650,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("Array.prototype.copyWithin called on null or undefined")
 		}
 
-		arr := thisVal.AsArray()
-		if arr == nil {
-			// For array-like objects, return unchanged
-			return thisVal, nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-
-		length := arr.Length()
 
 		// 3. Let relativeTarget be ? ToIntegerOrInfinity(target).
 		// Note: Must process arguments before any early returns, as they may throw
@@ -1638,16 +1744,30 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Copy the elements
 		if count > 0 {
+			copyOne := func(i int) error {
+				v, exists, err := arrayLikeGet(vmInstance, thisVal, from+i)
+				if err != nil {
+					return err
+				}
+				if exists {
+					return arrayLikeSet(vmInstance, thisVal, to+i, v)
+				}
+				return arrayLikeDelete(vmInstance, thisVal, to+i)
+			}
 			// Need to handle overlapping regions
 			if from < to && to < from+count {
 				// Copy backwards to avoid overwriting source
 				for i := count - 1; i >= 0; i-- {
-					arr.Set(to+i, arr.Get(from+i))
+					if err := copyOne(i); err != nil {
+						return vm.Undefined, err
+					}
 				}
 			} else {
 				// Copy forwards
 				for i := 0; i < count; i++ {
-					arr.Set(to+i, arr.Get(from+i))
+					if err := copyOne(i); err != nil {
+						return vm.Undefined, err
+					}
 				}
 			}
 		}
@@ -1663,12 +1783,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("Array.prototype.fill called on null or undefined")
 		}
 
-		arr := thisVal.AsArray()
-		if arr == nil {
-			return thisVal, nil
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
 		}
-
-		length := arr.Length()
 
 		// Get value to fill
 		value := vm.Undefined
@@ -1720,7 +1838,9 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Fill the array
 		for i := start; i < end; i++ {
-			arr.Set(i, value)
+			if err := arrayLikeSet(vmInstance, thisVal, i, value); err != nil {
+				return vm.Undefined, err
+			}
 		}
 
 		return thisVal, nil
@@ -1751,39 +1871,34 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		resultArr := result.AsArray()
 
 		// Helper function to flatten recursively
-		var flattenInto func(source vm.Value, currentDepth int)
-		flattenInto = func(source vm.Value, currentDepth int) {
-			var length int
-			var getElement func(i int) vm.Value
-
-			if arr := source.AsArray(); arr != nil {
-				length = arr.Length()
-				getElement = func(i int) vm.Value { return arr.Get(i) }
-			} else if po := source.AsPlainObject(); po != nil {
-				if lv, ok := po.Get("length"); ok {
-					length = int(lv.ToFloat())
-				}
-				getElement = func(i int) vm.Value {
-					if v, ok := po.Get(fmt.Sprintf("%d", i)); ok {
-						return v
-					}
-					return vm.Undefined
-				}
-			} else {
-				return
+		var flattenInto func(source vm.Value, currentDepth int) error
+		flattenInto = func(source vm.Value, currentDepth int) error {
+			length, err := arrayLikeLength(vmInstance, source)
+			if err != nil {
+				return err
 			}
-
 			for i := 0; i < length; i++ {
-				element := getElement(i)
-				if currentDepth > 0 && element.IsArray() {
-					flattenInto(element, currentDepth-1)
+				element, exists, err := arrayLikeGet(vmInstance, source, i)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					continue
+				}
+				if currentDepth > 0 && element.Type() == vm.TypeArray {
+					if err := flattenInto(element, currentDepth-1); err != nil {
+						return err
+					}
 				} else {
 					resultArr.Append(element)
 				}
 			}
+			return nil
 		}
 
-		flattenInto(thisVal, depth)
+		if err := flattenInto(thisVal, depth); err != nil {
+			return vm.Undefined, err
+		}
 		return result, nil
 	}))
 
@@ -1818,44 +1933,30 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		resultArr := result.AsArray()
 
 		// Get length and iterate
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < arr.Length(); i++ {
-				element := arr.Get(i)
-				mapped, err := vmInstance.CallArgs3(mapper, thisArg, element, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
-				// Flatten by one level
-				if mappedArr := mapped.AsArray(); mappedArr != nil {
-					for j := 0; j < mappedArr.Length(); j++ {
-						resultArr.Append(mappedArr.Get(j))
-					}
-				} else {
-					resultArr.Append(mapped)
-				}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for i := 0; i < length; i++ {
+			element, exists, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			length := 0
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
+			if !exists {
+				continue
 			}
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				var elem vm.Value = vm.Undefined
-				if v, ok := po.Get(key); ok {
-					elem = v
+			mapped, err := vmInstance.CallArgs3(mapper, thisArg, element, vm.NumberValue(float64(i)), thisVal)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			// Flatten by one level
+			if mapped.Type() == vm.TypeArray {
+				mappedArr := mapped.AsArray()
+				for j := 0; j < mappedArr.Length(); j++ {
+					resultArr.Append(mappedArr.Get(j))
 				}
-				mapped, err := vmInstance.CallArgs3(mapper, thisArg, elem, vm.NumberValue(float64(i)), thisVal)
-				if err != nil {
-					return vm.Undefined, err
-				}
-				if mappedArr := mapped.AsArray(); mappedArr != nil {
-					for j := 0; j < mappedArr.Length(); j++ {
-						resultArr.Append(mappedArr.Get(j))
-					}
-				} else {
-					resultArr.Append(mapped)
-				}
+			} else {
+				resultArr.Append(mapped)
 			}
 		}
 
@@ -1879,27 +1980,26 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		// ArrayCreate(len) throws before any iteration if len exceeds the
+		// max valid Array length (see checkArrayCreateLength).
+		if err := checkArrayCreateLength(vmInstance, length); err != nil {
+			return vm.Undefined, err
+		}
+
 		// Create a copy
 		result := vm.NewArray()
 		resultArr := result.AsArray()
 
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < arr.Length(); i++ {
-				resultArr.Append(arr.Get(i))
+		for i := 0; i < length; i++ {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			length := 0
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-			}
-			for i := 0; i < length; i++ {
-				key := fmt.Sprintf("%d", i)
-				if v, ok := po.Get(key); ok {
-					resultArr.Append(v)
-				} else {
-					resultArr.Append(vm.Undefined)
-				}
-			}
+			resultArr.Append(v)
 		}
 
 		// Sort the copy using the same logic as sort
@@ -1951,13 +2051,14 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Get source length
-		var sourceLength int
-		if arr := thisVal.AsArray(); arr != nil {
-			sourceLength = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				sourceLength = int(lv.ToFloat())
-			}
+		sourceLength, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		// ArrayCreate(len) throws before any iteration if len exceeds the
+		// max valid Array length (see checkArrayCreateLength).
+		if err := checkArrayCreateLength(vmInstance, sourceLength); err != nil {
+			return vm.Undefined, err
 		}
 
 		// Parse start argument (? ToIntegerOrInfinity)
@@ -2015,21 +2116,13 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		result := vm.NewArray()
 		resultArr := result.AsArray()
 
-		// Helper to get element
-		getElement := func(i int) vm.Value {
-			if arr := thisVal.AsArray(); arr != nil {
-				return arr.Get(i)
-			} else if po := thisVal.AsPlainObject(); po != nil {
-				if v, ok := po.Get(fmt.Sprintf("%d", i)); ok {
-					return v
-				}
-			}
-			return vm.Undefined
-		}
-
 		// Copy elements before start
 		for i := 0; i < actualStart; i++ {
-			resultArr.Append(getElement(i))
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			resultArr.Append(v)
 		}
 
 		// Insert new elements
@@ -2039,7 +2132,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Copy remaining elements after deleted section
 		for i := actualStart + actualDeleteCount; i < sourceLength; i++ {
-			resultArr.Append(getElement(i))
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			resultArr.Append(v)
 		}
 
 		return result, nil
@@ -2054,13 +2151,14 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Get length
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		// ArrayCreate(len) throws before any iteration if len exceeds the
+		// max valid Array length (see checkArrayCreateLength).
+		if err := checkArrayCreateLength(vmInstance, length); err != nil {
+			return vm.Undefined, err
 		}
 
 		// 3. Let relativeIndex be ? ToIntegerOrInfinity(index).
@@ -2097,27 +2195,16 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		result := vm.NewArray()
 		resultArr := result.AsArray()
 
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := 0; i < length; i++ {
-				if i == actualIndex {
-					resultArr.Append(value)
-				} else {
-					resultArr.Append(arr.Get(i))
-				}
+		for i := 0; i < length; i++ {
+			if i == actualIndex {
+				resultArr.Append(value)
+				continue
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := 0; i < length; i++ {
-				if i == actualIndex {
-					resultArr.Append(value)
-				} else {
-					key := fmt.Sprintf("%d", i)
-					if v, ok := po.Get(key); ok {
-						resultArr.Append(v)
-					} else {
-						resultArr.Append(vm.Undefined)
-					}
-				}
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
+			resultArr.Append(v)
 		}
 
 		return result, nil
@@ -2132,32 +2219,26 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Get length
-		var length int
-		if arr := thisVal.AsArray(); arr != nil {
-			length = arr.Length()
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			if lv, ok := po.Get("length"); ok {
-				length = int(lv.ToFloat())
-			}
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		// ArrayCreate(len) throws before any iteration if len exceeds the
+		// max valid Array length (see checkArrayCreateLength).
+		if err := checkArrayCreateLength(vmInstance, length); err != nil {
+			return vm.Undefined, err
 		}
 
 		// Create reversed copy
 		result := vm.NewArray()
 		resultArr := result.AsArray()
 
-		if arr := thisVal.AsArray(); arr != nil {
-			for i := length - 1; i >= 0; i-- {
-				resultArr.Append(arr.Get(i))
+		for i := length - 1; i >= 0; i-- {
+			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
+			if err != nil {
+				return vm.Undefined, err
 			}
-		} else if po := thisVal.AsPlainObject(); po != nil {
-			for i := length - 1; i >= 0; i-- {
-				key := fmt.Sprintf("%d", i)
-				if v, ok := po.Get(key); ok {
-					resultArr.Append(v)
-				} else {
-					resultArr.Append(vm.Undefined)
-				}
-			}
+			resultArr.Append(v)
 		}
 
 		return result, nil
@@ -2186,13 +2267,19 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		case len(args) == 0:
 			result = vm.NewArray()
 		case len(args) == 1 && args[0].IsNumber():
-			length := int(args[0].ToFloat())
-			if length < 0 {
-				result = vm.NewArray() // Should throw RangeError in real JS
-			} else {
-				result = vm.NewArray()
-				result.AsArray().SetLength(length)
+			// Per spec (23.1.1.1), the single-number-argument form requires
+			// an exact array index: a non-negative integer that fits in the
+			// ArrayCreate bound. Anything else - negative, fractional, or
+			// >= 2^32 - throws RangeError rather than silently truncating
+			// or (for a huge length) hanging the process on the eventual
+			// element loop some other method would run over it.
+			lengthFloat := args[0].ToFloat()
+			length := int(lengthFloat)
+			if lengthFloat < 0 || float64(length) != lengthFloat || length > maxArrayLength {
+				return vm.Undefined, vmInstance.NewRangeError("Invalid array length")
 			}
+			result = vm.NewArray()
+			result.AsArray().SetLength(length)
 		default:
 			result = vm.NewArrayWithArgs(args)
 		}
@@ -2211,19 +2298,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if len(args) < 1 {
 			return vm.BooleanValue(false), nil
 		}
-		arg := args[0]
-		// Check if it's an Array type
-		if arg.Type() == vm.TypeArray {
-			return vm.BooleanValue(true), nil
+		isArr, err := isArraySpec(vmInstance, args[0])
+		if err != nil {
+			return vm.Undefined, err
 		}
-		// Per ECMAScript, Array.prototype is an Array exotic object and isArray should return true
-		// Check if arg is the Array.prototype object
-		if arg.IsObject() && vmInstance.ArrayPrototype.IsObject() {
-			if arg.AsPlainObject() == vmInstance.ArrayPrototype.AsPlainObject() {
-				return vm.BooleanValue(true), nil
-			}
-		}
-		return vm.BooleanValue(false), nil
+		return vm.BooleanValue(isArr), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {
@@ -2440,7 +2519,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if A.IsArray() {
 				arr := A.AsArray()
 				arr.Set(k, kValue)
-			} else if A.IsObject() {
+			} else if A.Type() == vm.TypeObject {
 				po := A.AsPlainObject()
 				// Check if we can create/update this property
 				// CreateDataPropertyOrThrow fails if:
@@ -2462,7 +2541,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// 8. Perform ? Set(A, "length", len, true).
 		if A.IsArray() {
 			// Already set by Set
-		} else if A.IsObject() {
+		} else if A.Type() == vm.TypeObject {
 			po := A.AsPlainObject()
 			lengthVal := vm.NumberValue(float64(len))
 			// Check if there's a setter for "length" and call it
@@ -2633,7 +2712,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 						var done bool = false
 						var value vm.Value = vm.Undefined
 
-						if result.IsObject() {
+						if result.Type() == vm.TypeObject {
 							obj := result.AsPlainObject()
 							if obj != nil {
 								if doneVal, ok := obj.GetOwn("done"); ok {
@@ -2649,7 +2728,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 							// Set length and resolve
 							if A.IsArray() {
 								// Length is automatically updated for arrays
-							} else if A.IsObject() {
+							} else if A.Type() == vm.TypeObject {
 								A.AsPlainObject().SetOwn("length", vm.NumberValue(float64(k)))
 							}
 							resolveWithArray(A)
@@ -2678,7 +2757,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 										// Add to result array
 										if A.IsArray() {
 											A.AsArray().Set(k, v)
-										} else if A.IsObject() {
+										} else if A.Type() == vm.TypeObject {
 											A.AsPlainObject().SetOwn(fmt.Sprintf("%d", k), v)
 										}
 										k++
@@ -2699,7 +2778,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 							// Add to result array
 							if A.IsArray() {
 								A.AsArray().Set(k, mappedValue)
-							} else if A.IsObject() {
+							} else if A.Type() == vm.TypeObject {
 								A.AsPlainObject().SetOwn(fmt.Sprintf("%d", k), mappedValue)
 							}
 							k++
@@ -2746,21 +2825,19 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 				iterateNext()
 			} else {
-				// Array-like: use length property
-				var length int = 0
-
-				if asyncItems.IsArray() {
-					length = asyncItems.AsArray().Length()
-				} else if asyncItems.IsObject() {
-					obj := asyncItems.AsPlainObject()
-					if obj != nil {
-						if lenVal, ok := obj.GetOwn("length"); ok {
-							length = int(lenVal.ToFloat())
-						}
-					}
-				} else {
-					// For primitives, treat as empty
+				// Array-like: use length property. Covers real Arrays,
+				// PlainObjects, and everything else with a "length" (Arguments,
+				// TypedArray, Proxy, ...) via the same generic accessor the
+				// synchronous Array.prototype methods use.
+				if !asyncItems.IsObject() && !asyncItems.IsCallable() {
+					// Primitives with no [Symbol.asyncIterator]/[Symbol.iterator]
+					// and nothing shaped like an array-like: treat as empty.
 					resolveWithArray(A)
+					return
+				}
+				length, lenErr := arrayLikeLength(vmInstance, asyncItems)
+				if lenErr != nil {
+					rejectWithError(lenErr)
 					return
 				}
 
@@ -2777,7 +2854,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 						// Set length and resolve
 						if A.IsArray() {
 							// Length is auto-updated
-						} else if A.IsObject() {
+						} else if A.Type() == vm.TypeObject {
 							A.AsPlainObject().SetOwn("length", vm.NumberValue(float64(k)))
 						}
 						resolveWithArray(A)
@@ -2785,16 +2862,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 					}
 
 					// Get element at k
-					var kValue vm.Value = vm.Undefined
-					if asyncItems.IsArray() {
-						kValue = asyncItems.AsArray().Get(k)
-					} else if asyncItems.IsObject() {
-						obj := asyncItems.AsPlainObject()
-						if obj != nil {
-							if v, ok := obj.GetOwn(fmt.Sprintf("%d", k)); ok {
-								kValue = v
-							}
-						}
+					kValue, _, elemErr := arrayLikeGet(vmInstance, asyncItems, k)
+					if elemErr != nil {
+						rejectWithError(elemErr)
+						return
 					}
 
 					// Handle the value (might be a promise)
@@ -2819,7 +2890,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 									// Add to result array
 									if A.IsArray() {
 										A.AsArray().Set(k, v)
-									} else if A.IsObject() {
+									} else if A.Type() == vm.TypeObject {
 										A.AsPlainObject().SetOwn(fmt.Sprintf("%d", k), v)
 									}
 									k++
@@ -2840,7 +2911,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 						// Add to result array
 						if A.IsArray() {
 							A.AsArray().Set(k, mappedValue)
-						} else if A.IsObject() {
+						} else if A.Type() == vm.TypeObject {
 							A.AsPlainObject().SetOwn(fmt.Sprintf("%d", k), mappedValue)
 						}
 						k++
@@ -2892,13 +2963,15 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return createArgumentsIterator(vmInstance, argsObj), nil
 		}
 
-		// Handle generic array-like objects with length property
+		// Handle generic array-like objects with length property (Map/Set,
+		// TypedArray, Proxy, boxed primitives, ...) - arrayLikeLength returns
+		// 0 for anything with no "length" property rather than erroring, so
+		// this covers exactly the same "has a length property" test the old
+		// PlainObject-only check did, without panicking on anything that
+		// isn't a plain Object.
 		if thisVal.IsObject() {
-			obj := thisVal.AsPlainObject()
-			if obj != nil {
-				if lenVal, ok := obj.GetOwn("length"); ok && lenVal.IsNumber() {
-					return createArrayLikeIterator(vmInstance, thisVal), nil
-				}
+			if _, err := arrayLikeLength(vmInstance, thisVal); err == nil {
+				return createArrayLikeIterator(vmInstance, thisVal), nil
 			}
 		}
 
@@ -2939,13 +3012,13 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Add Symbol.asyncIterator implementation for arrays (for await...of support)
 	// This wraps the sync iterator in an async iterator (returns promises)
 	asyncIterFn := vm.NewNativeFunction(0, false, "[Symbol.asyncIterator]", func(args []vm.Value) (vm.Value, error) {
-		thisArray := vmInstance.GetThis().AsArray()
-		if thisArray == nil {
-			return vm.Undefined, nil
+		thisVal := vmInstance.GetThis()
+		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
+			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
 
-		// Create an async array iterator object (wraps sync iterator)
-		return createAsyncArrayIterator(vmInstance, thisArray), nil
+		// Create an async array iterator object (wraps sync iteration)
+		return createAsyncArrayIterator(vmInstance, thisVal), nil
 	})
 	// Make it writable and configurable like standard JavaScript
 	w2, e2, c2 := true, false, true
@@ -3052,7 +3125,7 @@ func createArrayLikeIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 	iterator := vm.NewObject(vmInstance.ArrayIteratorPrototype).AsPlainObject()
 	iteratorVal := vm.NewValueFromPlainObject(iterator)
 
-	state := &vm.BuiltinIterState{Kind: vm.IterKindLikeValues, Like: arrayLike.AsPlainObject()}
+	state := &vm.BuiltinIterState{Kind: vm.IterKindLikeValues, Like: asPlainObjectOrNil(arrayLike)}
 	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
 	// Add [Symbol.iterator] that returns the iterator itself
@@ -3074,7 +3147,7 @@ func createArrayKeysIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value {
 	if arrayLike.Type() == vm.TypeArray {
 		state.Arr = arrayLike.AsArray()
 	} else {
-		state.Like = arrayLike.AsPlainObject() // nil-safe: nil source iterates as length 0
+		state.Like = asPlainObjectOrNil(arrayLike) // nil source (or non-PlainObject array-like) iterates as length 0
 	}
 	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
@@ -3097,7 +3170,7 @@ func createArrayEntriesIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value 
 	if arrayLike.Type() == vm.TypeArray {
 		state.Arr = arrayLike.AsArray()
 	} else {
-		state.Like = arrayLike.AsPlainObject() // nil-safe: nil source iterates as length 0
+		state.Like = asPlainObjectOrNil(arrayLike) // nil source (or non-PlainObject array-like) iterates as length 0
 	}
 	iterator.SetOwnNonEnumerable("next", makeBuiltinIterNext(vmInstance, state))
 
@@ -3113,7 +3186,13 @@ func createArrayEntriesIterator(vmInstance *vm.VM, arrayLike vm.Value) vm.Value 
 
 // createAsyncArrayIterator creates an async iterator object for array iteration
 // This wraps array iteration to return promises (for await...of support)
-func createAsyncArrayIterator(vmInstance *vm.VM, array *vm.ArrayObject) vm.Value {
+// createAsyncArrayIterator wraps thisVal's synchronous iteration (via the
+// same arrayLikeLength/arrayLikeGet generic accessors every other
+// Array.prototype method uses) in an async iterator whose next() resolves a
+// Promise<{value, done}> - not just for real Arrays, but for anything
+// [Symbol.asyncIterator] can legally be called on via .call()/.apply()
+// (Arguments, TypedArray, Proxy, array-likes, ...).
+func createAsyncArrayIterator(vmInstance *vm.VM, thisVal vm.Value) vm.Value {
 	// Create iterator object inheriting from Object.prototype
 	iterator := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 
@@ -3125,13 +3204,20 @@ func createAsyncArrayIterator(vmInstance *vm.VM, array *vm.ArrayObject) vm.Value
 		// Create iterator result object {value, done}
 		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 
-		if currentIndex >= array.Length() {
+		length, err := arrayLikeLength(vmInstance, thisVal)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		if currentIndex >= length {
 			// Iterator is exhausted
 			result.SetOwnNonEnumerable("value", vm.Undefined)
 			result.SetOwnNonEnumerable("done", vm.BooleanValue(true))
 		} else {
 			// Return current element and advance
-			val := array.Get(currentIndex)
+			val, _, err := arrayLikeGet(vmInstance, thisVal, currentIndex)
+			if err != nil {
+				return vm.Undefined, err
+			}
 			result.SetOwnNonEnumerable("value", val)
 			result.SetOwnNonEnumerable("done", vm.BooleanValue(false))
 			currentIndex++

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -806,16 +806,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		default:
 			// Check for numeric string index
 			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
-				// For mapped arguments, write directly to the register
-				if idx < argObj.numMapped && argObj.mappedRegs != nil {
-					argObj.mappedRegs[idx] = *valueToSet
-				} else {
-					// Expand args array if needed
-					for len(argObj.args) <= idx {
-						argObj.args = append(argObj.args, Undefined)
-					}
-					argObj.args[idx] = *valueToSet
-				}
+				argObj.SetIndexed(idx, *valueToSet)
 			} else {
 				// Store in overflow named properties
 				argObj.SetNamedProp(propName, *valueToSet)

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2599,6 +2599,27 @@ func (a *ArgumentsObject) Set(index int, value Value) {
 	a.args[index] = value
 }
 
+// SetIndexed writes value at index, expanding the backing args slice as
+// needed - unlike Set (which is a no-op past the current length), this
+// mirrors how an arguments object behaves as a plain object with numeric
+// keys: `arguments[10] = x` on a 2-argument call creates the property.
+// Mapped (sloppy-mode) arguments still write through to the live parameter
+// register. Shared by op_setprop.go's OpSetProp handling and VM.SetProperty
+// so both stay in sync.
+func (a *ArgumentsObject) SetIndexed(index int, value Value) {
+	if index < 0 {
+		return
+	}
+	if index < a.numMapped && a.mappedRegs != nil {
+		a.mappedRegs[index] = value
+		return
+	}
+	for len(a.args) <= index {
+		a.args = append(a.args, Undefined)
+	}
+	a.args[index] = value
+}
+
 // Callee returns the function that created this arguments object
 func (a *ArgumentsObject) Callee() Value {
 	return a.callee

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -449,8 +449,12 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			if err != nil {
 				return Undefined, err
 			}
-			// ECMAScript 10.5.8 invariant validation
-			if targetObj := proxy.target.AsPlainObject(); targetObj != nil {
+			// ECMAScript 10.5.8 invariant validation. Only PlainObject targets
+			// go through this check - proxy.target can legally be any object
+			// type (Array, TypedArray, another Proxy, ...), and AsPlainObject()
+			// panics on anything that isn't exactly TypeObject.
+			if proxy.target.Type() == TypeObject {
+				targetObj := proxy.target.AsPlainObject()
 				// Check for non-configurable accessor with get=undefined
 				if g, _, _, c, isAccessor := targetObj.GetOwnAccessor(propName); isAccessor && !c {
 					if g.Type() == TypeUndefined && !result.IsUndefined() {
@@ -888,16 +892,32 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		// Arguments objects: check length, numeric indices, and named properties
 		args := obj.AsArguments()
 		if args != nil {
-			// Check for 'length' property
+			// 'length'/'callee' can be overridden by an explicit assignment
+			// (stored in the overflow named-property map, since the real
+			// a.length/a.callee fields back the live argument count/callee
+			// instead) - an override must win over the live value. See
+			// op_setprop.go's TypeArguments case, which is the write side
+			// of this same convention.
 			if propName == "length" {
+				if v, ok := args.GetNamedProp("length"); ok {
+					return v, nil
+				}
 				return NumberValue(float64(args.Length())), nil
 			}
 			// Check for 'callee' property (only in non-strict mode)
 			if propName == "callee" && !args.IsStrict() {
+				if v, ok := args.GetNamedProp("callee"); ok {
+					return v, nil
+				}
 				return args.Callee(), nil
 			}
-			// Check for numeric index access
-			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 && idx < args.Length() {
+			// Check for numeric index access. Bounds-check via Get() itself
+			// (which checks the live args slice, then namedProps) rather
+			// than args.Length() here - Length() is the *original* argument
+			// count and doesn't grow when SetIndexed() extends the backing
+			// slice past it (e.g. after `arguments[10] = x` or a generic
+			// Array.prototype method writing past the end via .call()).
+			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
 				return args.Get(idx), nil
 			}
 			// Check for named properties (like value, writable, get, set, etc.)
@@ -1024,10 +1044,60 @@ func (vm *VM) SetProperty(obj Value, propName string, value Value) error {
 		regexObj.Properties.SetOwn(propName, value)
 		return nil
 
+	case TypeArray:
+		arr := obj.AsArray()
+		if propName == "length" {
+			arr.SetLength(toLengthIntForSetProperty(value))
+			return nil
+		}
+		if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
+			arr.Set(idx, value)
+			return nil
+		}
+		// Non-index properties on an Array (e.g. an ad-hoc named property)
+		// aren't represented on ArrayObject in this engine; silently
+		// dropping matches this function's pre-existing "no-op for
+		// anything it doesn't model" convention rather than panicking.
+		return nil
+
+	case TypeArguments:
+		// Mirrors op_setprop.go's TypeArguments case (the bytecode
+		// OpSetProp handler) so native Go callers of SetProperty see the
+		// same semantics as compiled `arguments.x = v` / `arguments[i] = v`.
+		args := obj.AsArguments()
+		switch propName {
+		case "callee":
+			args.SetNamedProp("callee", value)
+		case "length":
+			args.SetNamedProp("length", value)
+		default:
+			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
+				args.SetIndexed(idx, value)
+			} else {
+				args.SetNamedProp(propName, value)
+			}
+		}
+		return nil
+
 	default:
 		// For non-objects, this is a no-op (or could throw in strict mode)
 		return nil
 	}
+}
+
+// toLengthIntForSetProperty mirrors builtins.toLengthInt (ToLength clamping)
+// without creating an import cycle - SetProperty needs the same clamping
+// when a caller writes an Array's "length" property to an arbitrary value.
+func toLengthIntForSetProperty(v Value) int {
+	n := v.ToFloat()
+	if n != n || n <= 0 {
+		return 0
+	}
+	const maxSafeInteger = 9007199254740991
+	if n > maxSafeInteger {
+		n = maxSafeInteger
+	}
+	return int(n)
 }
 
 // GetSymbolPropertyWithGetter gets a symbol property from an object value, handling getters and prototype chain


### PR DESCRIPTION
## Summary

Closes #46 (the `Array.prototype` portion — the remaining `AsArray()`/`AsPlainObject()` panic pattern elsewhere in the codebase is out of scope for this PR).

Per ECMA-262, `Array.prototype`'s methods are intentionally generic — they don't require `this` to be an actual Array. Every method here was instead written as `if arr := thisVal.AsArray(); arr != nil { ... } else if po := thisVal.AsPlainObject(); po != nil { ... }`, or (for about a third of them: `push`, `pop`, `shift`, `unshift`, `join`, `toString`, `reverse`, `sort`, ...) with no fallback at all. Both shapes have the same bug: `AsArray()`/`AsPlainObject()` **panic** on a type mismatch instead of returning `nil`, so the `!= nil` checks were dead code and the panic fired on the very first receiver that wasn't exactly a real Array or plain Object — Arguments, TypedArray, Proxy, boxed primitives, Map/Set/…, anything. That's ordinary, spec-legal code like `Array.prototype.push.call(arguments, x)`.

## What changed

New `pkg/builtins/array_generic.go` centralizes the three operations these methods actually need — array-like length, indexed get, indexed set — into shared helpers (`arrayLikeLength`/`arrayLikeGet`/`arrayLikeSet`/`arrayLikeSetLength`/`arrayLikeDelete`), then `array_init.go` threads them through every method. Real Arrays keep their existing fast paths; everything else routes through the VM's ordinary property access.

Also fixed along the way (same underlying `IsObject()`-passed-to-`AsPlainObject()` defect, just at other call sites): `Array.isArray`, `Array.of`, `concat`'s spreadability check (now also Proxy-through-Array aware), `Array.fromAsync`, the `values`/`[Symbol.asyncIterator]`/`keys`/`entries` iterator machinery, and `flat`/`flatMap`'s handling of a mapper's return value.

## Two correctness bugs the generic rewrite surfaced (both caught by Test262)

1. **Accessor properties silently treated as absent.** The PlainObject fast path used `PlainObject.GetOwn/Get/SetOwn` directly, which have no VM to invoke a getter/setter — an own accessor property looked like "doesn't exist." Several Test262 tests place a *throwing getter* a few indices from a `length` near `Number.MAX_SAFE_INTEGER` specifically to verify an implementation doesn't try to iterate the full range; missing the getter meant genuinely looping toward 2^53. Fixed with a new `getOwnPlainObjectProperty` helper that checks `GetOwnAccessor` first.
2. **Missing `ArrayCreate`/`ArraySetLength` bounds checks.** `ToLength` permits a declared `length` up to 2^53-1 for an arbitrary object, but methods that build a result sized to that length (`map`, `toReversed`, `toSorted`, `toSpliced`, `with`, the `Array(len)` constructor, `slice`, `splice`/`concat`/`unshift`'s computed new length) must throw `RangeError`/`TypeError` *before* iterating — that's precisely why the spec has those checks. Missing them is what actually hung the whole Test262 runner during development (an object like `{length: 2**32}` handed to `map` tried to build and iterate a four-billion-element array — 18GB+ RSS, no forward progress). Fixed with `checkArrayCreateLength` and matching inline checks, verified against Test262's full near-integer-limit test family across every affected method.

## Known gaps (not fixed here, flagged rather than left silently broken)

- `Object.defineProperty` on a real Array converting an index to an accessor panics via the identical `IsObject()`/`AsPlainObject()` shape inside `objectDefinePropertyWithVM` (whose own comment already says "on plain objects only for now"). Pre-existing, unrelated to this rewrite — `with/no-get-replaced-index.js` fails on this setup step, not on `with` itself.
- `reverse/length-exceeding-integer-limit-with-proxy.js` times out (cleanly — the per-test timeout reclaims it, not a hang) because its stopping exception has to cross two nested native/direct-call boundaries (a Proxy `get` trap, then the getter it invokes) instead of one. Filed as a new reproducer on #61, which already diagnoses this exact class of bug.

## Verification

- Test262 `built-ins/` (exact set-diff against baseline, not just counts): **+938 passes, 0 regressions**.
- Test262 `language/` (checked explicitly since this touches shared VM property-access code): unchanged at 96.7%.
- Full `built-ins` suite completes in ~55s (previously hung indefinitely before the `checkArrayCreateLength` fixes), 12 timeouts, none new regressions — mostly pre-existing/unrelated (Iterator helpers, `decodeURI`) plus the two Array-specific ones called out above.
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean.
- `go test ./tests -run TestScripts`, `./pkg/vm/...`, `./pkg/builtins/...` green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
