### PR TITLE
vm: fix exception unwinding across nested native/direct-call boundaries

### DIFF
--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -343,7 +343,22 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 				}
 
 				// Attach fulfillment handler (not a constructor per spec)
+				// Per ECMAScript 25.4.4.1.2 (Promise.all Resolve Element
+				// Functions) step 1-3: each element function has its own
+				// [[AlreadyCalled]] flag and must no-op on a second call. This
+				// is separate from (and needed in addition to) a real Promise
+				// capability's own idempotent resolve/reject: nextPromise here
+				// can be an arbitrary thenable that calls onFulfilled more
+				// than once, and without this guard doing so double-decrements
+				// `remaining` and can invoke `resolve` (or overwrite settled
+				// results) more times than the spec allows.
+				alreadyCalled := false
 				onFulfilled := vm.NewNativeFunction(1, false, "onFulfilled", func(valueArgs []vm.Value) (vm.Value, error) {
+					if alreadyCalled {
+						return vm.Undefined, nil
+					}
+					alreadyCalled = true
+
 					value := vm.Undefined
 					if len(valueArgs) > 0 {
 						value = valueArgs[0]
@@ -374,7 +389,22 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 				})
 
 				// Attach handlers via .then()
-				_, _ = invokeThen(nextPromise, onFulfilled, onRejected)
+				if _, thenErr := invokeThen(nextPromise, onFulfilled, onRejected); thenErr != nil {
+					// Calling .then() itself threw (e.g. a thenable resolving to
+					// itself). Per spec this should reject the result promise
+					// (IfAbruptRejectPromise), not vanish - vm.Call leaves
+					// vm.unwinding set on error for legitimate re-throw callers;
+					// we're absorbing it into a rejection instead, so it must be
+					// cleared or it leaks into whatever bytecode called this
+					// static method.
+					errVal := vm.NewString(thenErr.Error())
+					if ee, ok := thenErr.(vm.ExceptionError); ok {
+						errVal = ee.GetExceptionValue()
+					}
+					vmInstance.ClearUnwindingState()
+					_, _ = vmInstance.Call(reject, vm.Undefined, []vm.Value{errVal})
+					return vm.Undefined, nil
+				}
 			}
 
 			return vm.Undefined, nil
@@ -477,7 +507,22 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 				})
 
 				// Attach handlers via .then()
-				_, _ = invokeThen(nextPromise, onFulfilled, onRejected)
+				if _, thenErr := invokeThen(nextPromise, onFulfilled, onRejected); thenErr != nil {
+					// Calling .then() itself threw (e.g. a thenable resolving to
+					// itself). Per spec this should reject the result promise
+					// (IfAbruptRejectPromise), not vanish - vm.Call leaves
+					// vm.unwinding set on error for legitimate re-throw callers;
+					// we're absorbing it into a rejection instead, so it must be
+					// cleared or it leaks into whatever bytecode called this
+					// static method.
+					errVal := vm.NewString(thenErr.Error())
+					if ee, ok := thenErr.(vm.ExceptionError); ok {
+						errVal = ee.GetExceptionValue()
+					}
+					vmInstance.ClearUnwindingState()
+					_, _ = vmInstance.Call(reject, vm.Undefined, []vm.Value{errVal})
+					return vm.Undefined, nil
+				}
 			}
 
 			return vm.Undefined, nil
@@ -574,7 +619,17 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 				})
 
 				// Attach rejection handler
+				// See the matching comment on Promise.all's onFulfilled: nextPromise
+				// can be an arbitrary thenable calling onRejected more than once,
+				// and without a per-element AlreadyCalled guard that would
+				// double-decrement `remaining` and overwrite/duplicate errors[idx].
+				alreadyCalled := false
 				onRejected := vm.NewNativeFunction(1, false, "onRejected", func(reasonArgs []vm.Value) (vm.Value, error) {
+					if alreadyCalled {
+						return vm.Undefined, nil
+					}
+					alreadyCalled = true
+
 					reason := vm.Undefined
 					if len(reasonArgs) > 0 {
 						reason = reasonArgs[0]
@@ -596,7 +651,22 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 				})
 
 				// Attach handlers via .then()
-				_, _ = invokeThen(nextPromise, onFulfilled, onRejected)
+				if _, thenErr := invokeThen(nextPromise, onFulfilled, onRejected); thenErr != nil {
+					// Calling .then() itself threw (e.g. a thenable resolving to
+					// itself). Per spec this should reject the result promise
+					// (IfAbruptRejectPromise), not vanish - vm.Call leaves
+					// vm.unwinding set on error for legitimate re-throw callers;
+					// we're absorbing it into a rejection instead, so it must be
+					// cleared or it leaks into whatever bytecode called this
+					// static method.
+					errVal := vm.NewString(thenErr.Error())
+					if ee, ok := thenErr.(vm.ExceptionError); ok {
+						errVal = ee.GetExceptionValue()
+					}
+					vmInstance.ClearUnwindingState()
+					_, _ = vmInstance.Call(reject, vm.Undefined, []vm.Value{errVal})
+					return vm.Undefined, nil
+				}
 			}
 
 			return vm.Undefined, nil
@@ -678,8 +748,21 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 					return vm.Undefined, nil
 				}
 
-				// Attach fulfillment handler
+				// Attach fulfillment/rejection handlers. Per ECMAScript
+				// 27.2.4.2.1 (Promise.allSettled Resolve/Reject Element
+				// Functions), the pair for one element shares a single
+				// [[AlreadyCalled]] flag: nextPromise can be an arbitrary
+				// thenable calling either handler more than once (or both),
+				// and without this guard that would double-decrement
+				// `remaining` and let results[idx] be overwritten after
+				// settling.
+				alreadyCalled := false
 				onFulfilled := vm.NewNativeFunction(1, false, "onFulfilled", func(valueArgs []vm.Value) (vm.Value, error) {
+					if alreadyCalled {
+						return vm.Undefined, nil
+					}
+					alreadyCalled = true
+
 					value := vm.Undefined
 					if len(valueArgs) > 0 {
 						value = valueArgs[0]
@@ -704,6 +787,11 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 				// Attach rejection handler
 				onRejected := vm.NewNativeFunction(1, false, "onRejected", func(reasonArgs []vm.Value) (vm.Value, error) {
+					if alreadyCalled {
+						return vm.Undefined, nil
+					}
+					alreadyCalled = true
+
 					reason := vm.Undefined
 					if len(reasonArgs) > 0 {
 						reason = reasonArgs[0]
@@ -727,7 +815,22 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 				})
 
 				// Attach handlers via .then()
-				_, _ = invokeThen(nextPromise, onFulfilled, onRejected)
+				if _, thenErr := invokeThen(nextPromise, onFulfilled, onRejected); thenErr != nil {
+					// Calling .then() itself threw (e.g. a thenable resolving to
+					// itself). Per spec this should reject the result promise
+					// (IfAbruptRejectPromise), not vanish - vm.Call leaves
+					// vm.unwinding set on error for legitimate re-throw callers;
+					// we're absorbing it into a rejection instead, so it must be
+					// cleared or it leaks into whatever bytecode called this
+					// static method.
+					errVal := vm.NewString(thenErr.Error())
+					if ee, ok := thenErr.(vm.ExceptionError); ok {
+						errVal = ee.GetExceptionValue()
+					}
+					vmInstance.ClearUnwindingState()
+					_, _ = vmInstance.Call(reject, vm.Undefined, []vm.Value{errVal})
+					return vm.Undefined, nil
+				}
 			}
 
 			return vm.Undefined, nil

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4537,6 +4537,18 @@ func (c *Compiler) emitIteratorCleanupWithDone(iteratorReg Register, doneReg Reg
 	// Skip calling return if it's nullish
 	skipCallJump := c.emitPlaceholderJump(vm.OpJumpIfFalse, notNullishReg, line)
 
+	// Mark the iterator as done *before* calling return(), not after: this
+	// whole normal-path close sits inside the surrounding destructuring
+	// pattern's own abrupt-completion try region (see compileArrayPattern's
+	// iteratorCleanupTryStart/TryEnd - it has to, so that a yield mid-pattern
+	// still resumes correctly). If this return() call itself throws, that
+	// throw is still "inside" the try region, and the pattern's own
+	// IsIteratorCleanup handler (emitIteratorCleanupAbruptIfNotDone) would
+	// otherwise see doneReg still false and call return() on the same
+	// iterator a second time - which is exactly what already happened here:
+	// return() shouldn't be re-entered once we've committed to closing.
+	c.emitLoadTrue(doneReg, line)
+
 	// Call iterator.return()
 	resultReg := c.regAlloc.Alloc()
 	defer c.regAlloc.Free(resultReg)

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -75,7 +75,7 @@ func (vm *VM) findPendingHandler(pc int, includeIterCleanup bool) *ExceptionHand
 func (vm *VM) throwException(value Value) {
 	if debugExceptions {
 		fmt.Printf("[DEBUG exceptions.go] throwException called, exception=%s, frameCount=%d, unwinding=%v, crossedNative=%v\n",
-			value.ToString(), vm.frameCount, vm.unwinding, vm.unwindingCrossedNative)
+			value.Inspect(), vm.frameCount, vm.unwinding, vm.unwindingCrossedNative)
 	}
 	// Avoid double-throwing the same value in a single unwinding sequence
 	// EXCEPT when crossing native boundaries (unwindingCrossedNative=true)
@@ -228,9 +228,26 @@ func (vm *VM) unwindException() bool {
 				return true // Stop here, let native code handle it
 			} else {
 				if debugExceptions {
-					fmt.Printf("[DEBUG unwindException] Hit native boundary at frame %d on RE-THROW PASS; continuing unwinding\n", vm.frameCount-1)
+					fmt.Printf("[DEBUG unwindException] Hit native boundary at frame %d on RE-THROW PASS; popping past it\n", vm.frameCount-1)
 				}
-				// On RE-THROW (already crossed native), don't stop - continue unwinding
+				// On RE-THROW (already crossed native once), pop past this boundary
+				// without stopping again. A native call is represented by either one
+				// frame (isDirectCall only - e.g. a generator prologue frame set up by
+				// executeGeneratorPrologue) or two (a sentinel frame plus the real
+				// closure frame marked isDirectCall right below it - e.g. every call
+				// made through executeUserFunctionSafe/executeUserFunctionWithNewTarget/
+				// the generator- and async-resume entry points). Only a sentinel frame
+				// unambiguously marks the true outer edge of its call region, so only
+				// popping past ONE resets the flag - giving the NEXT native boundary up
+				// the stack (a different, unrelated native caller) its own independent
+				// first chance to stop. Resetting on every isDirectCall frame instead
+				// would also reset while still inside a sentinel+isDirectCall pair
+				// (after popping the inner one but before reaching its own sentinel),
+				// wrongly granting a second "first chance" to a boundary that was
+				// already accounted for.
+				if frame.isSentinelFrame {
+					vm.unwindingCrossedNative = false
+				}
 			}
 		}
 

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -92,7 +92,26 @@ func (vm *VM) NewPromiseFromExecutor(executor Value) (Value, error) {
 	if executor.IsCallable() {
 		_, err := vm.Call(executor, Undefined, []Value{resolve, reject})
 		if err != nil {
-			vm.rejectPromise(promise, NewString(err.Error()))
+			// Per ECMAScript 25.4.3.1 step 10: reject with the executor's own
+			// thrown value, not a stringified Go error.
+			reason := Value{}
+			if ee, ok := err.(ExceptionError); ok {
+				reason = ee.GetExceptionValue()
+			} else {
+				reason = NewString(err.Error())
+			}
+			vm.rejectPromise(promise, reason)
+			// vm.Call leaves vm.unwinding/unwindingCrossedNative set on error
+			// (deliberately - a caller that re-throws via bytecode injection
+			// needs that state to know it already crossed a boundary). We're
+			// not re-throwing: the executor's exception has been fully
+			// absorbed into a rejected promise, a normal (non-erroring)
+			// return value from this function. Leaving the flags set would
+			// leak into whatever bytecode dispatch called `new Promise(...)`,
+			// which would see unwinding=true after this native call "returns
+			// successfully" and treat it as an uncaught exception still in
+			// flight.
+			vm.ClearUnwindingState()
 		}
 	}
 

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -94,7 +94,7 @@ func (vm *VM) NewPromiseFromExecutor(executor Value) (Value, error) {
 		if err != nil {
 			// Per ECMAScript 25.4.3.1 step 10: reject with the executor's own
 			// thrown value, not a stringified Go error.
-			reason := Value{}
+			var reason Value
 			if ee, ok := err.(ExceptionError); ok {
 				reason = ee.GetExceptionValue()
 			} else {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1336,7 +1336,7 @@ func (vm *VM) run() (status InterpretResult, resultValue Value) {
 	}()
 
 	// --- Caching frame variables ---
-	if vm.frameCount == 0 {
+	if vm.frameCount == 0 || vm.unwindingCrossedNative {
 		return InterpretOK, Undefined // Nothing to run
 	}
 	frame := &vm.frames[vm.frameCount-1]
@@ -1587,12 +1587,54 @@ startExecution:
 			ip++
 			iterator := registers[iteratorReg]
 			if iterator.IsObject() {
+				// vm.pendingAction/pendingValue record *our own* completion type
+				// (why we're closing this iterator) - captured before doing
+				// anything else, because both the property read below (a
+				// throwing "return" accessor runs GetMethod's own bytecode) and
+				// the vm.Call further down run arbitrary nested bytecode. If
+				// that nested bytecode throws while vm.finallyDepth is still
+				// elevated from *our* caller's dynamic nesting (a single
+				// global counter, unaware it doesn't apply to this unrelated
+				// nested call), throwException's own "a throw inside a
+				// finally block supersedes the pending one" logic wrongly
+				// wipes vm.pendingAction/pendingValue out from under us.
+				// Restoring from this snapshot whenever that happens keeps a
+				// corrupted-away ActionThrow from being silently downgraded
+				// to ActionNone, which would let an inner error through
+				// instead of suppressing it per spec.
+				savedPendingAction := vm.pendingAction
+				savedPendingValue := vm.pendingValue
+
 				// Try to get the "return" method using GetProperty (prototype chain lookup)
 				// This is necessary because generator's return method is on GeneratorPrototype
 				returnMethod, getErr := vm.GetProperty(iterator, "return")
-				// If return method exists and is callable, call it
-				if getErr == nil && returnMethod.IsCallable() {
+				if savedPendingAction == ActionThrow && vm.pendingAction != ActionThrow {
+					vm.pendingAction = ActionThrow
+					vm.pendingValue = savedPendingValue
+				}
+				if getErr != nil {
+					// GetMethod (7.3.10) itself threw - e.g. a throwing "return" accessor.
+					// Per IteratorClose steps 6-7: suppress this if our own completion is
+					// already a throw, otherwise propagate GetMethod's error as the new one.
+					if vm.pendingAction == ActionThrow {
+						vm.currentException = Null
+						vm.unwinding = false
+					} else {
+						vm.pendingAction = ActionThrow
+						if excErr, ok := getErr.(exceptionError); ok {
+							vm.pendingValue = excErr.exception
+						} else {
+							vm.pendingValue = vm.currentException
+						}
+						vm.currentException = Null
+						vm.unwinding = false
+					}
+				} else if returnMethod.IsCallable() {
 					innerResult, callErr := vm.Call(returnMethod, iterator, nil)
+					if savedPendingAction == ActionThrow && vm.pendingAction != ActionThrow {
+						vm.pendingAction = ActionThrow
+						vm.pendingValue = savedPendingValue
+					}
 
 					// Check pending action to determine how to handle errors
 					if vm.pendingAction == ActionThrow {
@@ -1642,9 +1684,43 @@ startExecution:
 			if !done.IsTruthy() {
 				iterator := registers[iteratorReg]
 				if iterator.IsObject() {
+					// See the matching comment in OpIteratorCleanupAbrupt: snapshot our
+					// own completion type before touching the iterator at all, since
+					// both the property read (a throwing "return" accessor) and the
+					// vm.Call below run arbitrary nested bytecode that can wipe out
+					// vm.pendingAction/pendingValue via the unrelated finallyDepth
+					// interaction described there.
+					savedPendingAction := vm.pendingAction
+					savedPendingValue := vm.pendingValue
+
 					returnMethod, getErr := vm.GetProperty(iterator, "return")
-					if getErr == nil && returnMethod.IsCallable() {
+					if savedPendingAction == ActionThrow && vm.pendingAction != ActionThrow {
+						vm.pendingAction = ActionThrow
+						vm.pendingValue = savedPendingValue
+					}
+					if getErr != nil {
+						// See the matching comment in OpIteratorCleanupAbrupt: GetMethod
+						// itself threw - suppress it if our own completion is already a
+						// throw, otherwise propagate it as the new completion.
+						if vm.pendingAction == ActionThrow {
+							vm.currentException = Null
+							vm.unwinding = false
+						} else {
+							vm.pendingAction = ActionThrow
+							if excErr, ok := getErr.(exceptionError); ok {
+								vm.pendingValue = excErr.exception
+							} else {
+								vm.pendingValue = vm.currentException
+							}
+							vm.currentException = Null
+							vm.unwinding = false
+						}
+					} else if returnMethod.IsCallable() {
 						innerResult, callErr := vm.Call(returnMethod, iterator, nil)
+						if savedPendingAction == ActionThrow && vm.pendingAction != ActionThrow {
+							vm.pendingAction = ActionThrow
+							vm.pendingValue = savedPendingValue
+						}
 
 						// Check pending action to determine how to handle errors
 						if vm.pendingAction == ActionThrow {
@@ -2193,7 +2269,7 @@ startExecution:
 					// Check for Symbol - cannot convert Symbol to string
 					if leftPrim.IsSymbol() {
 						vm.ThrowTypeError("Cannot convert a Symbol value to a string")
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -2207,7 +2283,7 @@ startExecution:
 					}
 					if rightPrim.IsSymbol() {
 						vm.ThrowTypeError("Cannot convert a Symbol value to a string")
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -2227,7 +2303,7 @@ startExecution:
 				} else if leftPrim.IsBigInt() || rightPrim.IsBigInt() {
 					// One is BigInt, the other is not: error (cannot mix BigInt with non-BigInt)
 					vm.ThrowTypeError("Cannot mix BigInt and other types, use explicit conversions")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2243,7 +2319,7 @@ startExecution:
 					// ToNumeric(Symbol) throws TypeError - check left first, then right
 					if leftPrim.IsSymbol() {
 						vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -2257,7 +2333,7 @@ startExecution:
 					}
 					if rightPrim.IsSymbol() {
 						vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -2295,7 +2371,7 @@ startExecution:
 				// This must happen BEFORE we call ToPrimitive on right operand
 				if leftPrim.IsSymbol() {
 					vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2323,7 +2399,7 @@ startExecution:
 				// Check if right is Symbol - ToNumeric(Symbol) throws TypeError
 				if rightPrim.IsSymbol() {
 					vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2356,7 +2432,7 @@ startExecution:
 					case OpDivide:
 						if rightBig.Sign() == 0 {
 							vm.ThrowRangeError("Division by zero")
-							if vm.frameCount == 0 {
+							if vm.frameCount == 0 || vm.unwindingCrossedNative {
 								return InterpretRuntimeError, vm.currentException
 							}
 							frame = &vm.frames[vm.frameCount-1]
@@ -2376,7 +2452,7 @@ startExecution:
 				} else if leftIsBigInt || rightIsBigInt {
 					// Cannot mix BigInt and non-BigInt
 					vm.ThrowTypeError("Cannot mix BigInt and other types, use explicit conversions")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2421,7 +2497,7 @@ startExecution:
 				// Check if left is Symbol - ToNumeric(Symbol) throws TypeError
 				if leftPrim.IsSymbol() {
 					vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2449,7 +2525,7 @@ startExecution:
 				// Check if right is Symbol - ToNumeric(Symbol) throws TypeError
 				if rightPrim.IsSymbol() {
 					vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2473,7 +2549,7 @@ startExecution:
 					rightBig := rightPrim.AsBigInt()
 					if rightBig.Sign() == 0 {
 						vm.ThrowRangeError("Division by zero")
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -2491,7 +2567,7 @@ startExecution:
 				} else if leftIsBigInt || rightIsBigInt {
 					// Cannot mix BigInt and non-BigInt
 					vm.ThrowTypeError("Cannot mix BigInt and other types, use explicit conversions")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -2676,7 +2752,7 @@ startExecution:
 				objType != TypeSet && objType != TypeMap && objType != TypeArguments && objType != TypePromise {
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot use 'in' operator to search for '%s' in %s", propVal.ToString(), objVal.Type().String()))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -3014,7 +3090,7 @@ startExecution:
 			if !constructorVal.IsObject() && !constructorVal.IsCallable() {
 				frame.ip = ip
 				vm.ThrowTypeError("Right-hand side of 'instanceof' is not an object")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -3038,7 +3114,7 @@ startExecution:
 				vm.helperCallDepth--
 				if status == InterpretRuntimeError {
 					// The getter threw an error - propagate it
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -3070,7 +3146,7 @@ startExecution:
 							if ee, ok := err.(ExceptionError); ok {
 								vm.throwException(ee.GetExceptionValue())
 							}
-							if vm.frameCount == 0 {
+							if vm.frameCount == 0 || vm.unwindingCrossedNative {
 								return InterpretRuntimeError, vm.currentException
 							}
 							frame = &vm.frames[vm.frameCount-1]
@@ -3093,7 +3169,7 @@ startExecution:
 			if !constructorVal.IsCallable() {
 				frame.ip = ip
 				vm.ThrowTypeError("Right-hand side of 'instanceof' is not callable")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -3144,7 +3220,7 @@ startExecution:
 				if !constructorPrototype.IsObject() && !constructorPrototype.IsCallable() {
 					frame.ip = ip
 					vm.ThrowTypeError("Function has non-object prototype in instanceof check")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -3475,16 +3551,20 @@ startExecution:
 					}
 					vm.throwException(excVal)
 					// After exception unwinding, we need to reload frame state
-					// because frames may have been popped
-					if vm.frameCount > 0 {
-						frame = &vm.frames[vm.frameCount-1]
-						registers = frame.registers
-						closure = frame.closure
-						function = closure.Fn
-						code = function.Chunk.Code
-						constants = function.Chunk.Constants
-						ip = frame.ip
+					// because frames may have been popped. If we've fully unwound
+					// (frameCount==0) or stopped at a native/direct-call boundary
+					// (unwindingCrossedNative), let the native caller handle it
+					// instead of resuming dispatch on stale/boundary frame state.
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
+						return InterpretRuntimeError, vm.currentException
 					}
+					frame = &vm.frames[vm.frameCount-1]
+					registers = frame.registers
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					ip = frame.ip
 					continue
 				}
 
@@ -3695,16 +3775,20 @@ startExecution:
 					}
 					vm.throwException(excVal)
 					// After exception unwinding, we need to reload frame state
-					// because frames may have been popped
-					if vm.frameCount > 0 {
-						frame = &vm.frames[vm.frameCount-1]
-						registers = frame.registers
-						closure = frame.closure
-						function = closure.Fn
-						code = function.Chunk.Code
-						constants = function.Chunk.Constants
-						ip = frame.ip
+					// because frames may have been popped. If we've fully unwound
+					// (frameCount==0) or stopped at a native/direct-call boundary
+					// (unwindingCrossedNative), let the native caller handle it
+					// instead of resuming dispatch on stale/boundary frame state.
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
+						return InterpretRuntimeError, vm.currentException
 					}
+					frame = &vm.frames[vm.frameCount-1]
+					registers = frame.registers
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					ip = frame.ip
 					continue
 				}
 
@@ -3897,7 +3981,7 @@ startExecution:
 					}
 				}
 				vm.throwException(excVal)
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -3965,7 +4049,7 @@ startExecution:
 				}
 				// Follow the OpThrow pattern: check unwinding state and continue
 				if vm.unwinding {
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					// Reload frame state and continue unwinding
@@ -6660,7 +6744,7 @@ startExecution:
 				// Per ECMAScript spec 15.7.14 step 5.f: "if IsConstructor(superclass) is false, throw TypeError"
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Class extends value %s is not a constructor or null", superclassVal.TypeName()))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -6723,7 +6807,7 @@ startExecution:
 					// No prototype property - that's an error for extends
 					frame.ip = ip
 					vm.ThrowTypeError("Class extends value does not have valid prototype property")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -6741,7 +6825,7 @@ startExecution:
 				if protoVal.Type() != TypeNull && !protoVal.IsObject() && !protoVal.IsCallable() {
 					frame.ip = ip
 					vm.ThrowTypeError("Class extends value has non-object prototype property")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8450,7 +8534,7 @@ startExecution:
 			// This must happen BEFORE we call ToPrimitive on right operand
 			if leftPrim.IsSymbol() {
 				vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -8478,7 +8562,7 @@ startExecution:
 			// Check if right is Symbol - ToNumeric(Symbol) throws TypeError
 			if rightPrim.IsSymbol() {
 				vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -8500,7 +8584,7 @@ startExecution:
 				// Both operands must be BigInt for bitwise operations
 				if (leftIsBigInt && !rightIsBigInt) || (!leftIsBigInt && rightIsBigInt) {
 					vm.ThrowTypeError("Cannot mix BigInt and other types")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8516,7 +8600,7 @@ startExecution:
 				// Unsigned right shift (>>>) with BigInt is not allowed
 				if opcode == OpUnsignedShiftRight {
 					vm.ThrowTypeError("BigInt does not support unsigned right shift")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8624,7 +8708,7 @@ startExecution:
 			// This must happen BEFORE we call ToPrimitive on right operand
 			if leftPrim.IsSymbol() {
 				vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -8652,7 +8736,7 @@ startExecution:
 			// Check if right is Symbol - ToNumeric(Symbol) throws TypeError
 			if rightPrim.IsSymbol() {
 				vm.ThrowTypeError("Cannot convert a Symbol value to a number")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -8676,7 +8760,7 @@ startExecution:
 				// BigInt exponentiation requires non-negative exponent
 				if rightBig.Sign() < 0 {
 					vm.ThrowRangeError("Exponent must be positive")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8691,7 +8775,7 @@ startExecution:
 				// Check if exponent is too large to fit in int
 				if !rightBig.IsInt64() {
 					vm.ThrowRangeError("BigInt exponent too large")
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8709,7 +8793,7 @@ startExecution:
 			} else if leftIsBigInt || rightIsBigInt {
 				// Cannot mix BigInt and non-BigInt
 				vm.ThrowTypeError("Cannot mix BigInt and other types, use explicit conversions")
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -8843,7 +8927,7 @@ startExecution:
 				if fn.Properties == nil {
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot read private member #%s from an object whose class did not declare it", fieldName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8866,7 +8950,7 @@ startExecution:
 				} else {
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot read private member #%s from an object whose class did not declare it", fieldName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8881,7 +8965,7 @@ startExecution:
 			} else {
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot read private member #%s from an object whose class did not declare it", fieldName))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -8903,7 +8987,7 @@ startExecution:
 				if !exists || getter.IsUndefined() {
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot read private member #%s from an object whose class did not declare it", fieldName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8928,7 +9012,7 @@ startExecution:
 				if !exists {
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot read private member #%s from an object whose class did not declare it", fieldName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -8956,7 +9040,7 @@ startExecution:
 				// Similar to OpThrow: check if unwinding or if handler was found
 				if vm.unwinding {
 					// No handler found or hit direct call boundary, continue unwinding
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					continue
@@ -8987,7 +9071,7 @@ startExecution:
 				// Similar to OpThrow: check if unwinding or if handler was found
 				if vm.unwinding {
 					// No handler found or hit direct call boundary, continue unwinding
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					continue
@@ -9059,7 +9143,7 @@ startExecution:
 			if obj.IsPrivateMethod(fieldName) {
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot assign to private method '#%s'", fieldName))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9077,7 +9161,7 @@ startExecution:
 				if !exists || setter.IsUndefined() {
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot assign to read-only private accessor '#%s'", fieldName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -9108,7 +9192,7 @@ startExecution:
 					}
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot add private field #%s to a non-extensible object", displayName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -9173,7 +9257,7 @@ startExecution:
 			} else {
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot write private member #%s from an object whose class did not declare it", displayName))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9192,7 +9276,7 @@ startExecution:
 				if !exists || setter.IsUndefined() {
 					frame.ip = ip
 					vm.ThrowTypeError(fmt.Sprintf("Cannot write private member #%s from an object whose class did not declare it", displayName))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -9215,7 +9299,7 @@ startExecution:
 				// Object doesn't have this setter - throw TypeError
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot write private member #%s from an object whose class did not declare it", displayName))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9287,7 +9371,7 @@ startExecution:
 				}
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot add private method #%s to a non-extensible object", displayName))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9332,7 +9416,7 @@ startExecution:
 			if objVal.Type() != TypeObject && objVal.Type() != TypeFunction {
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot use 'in' operator to search for '#%s' in %s", fieldName, objVal.TypeName()))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9443,7 +9527,7 @@ startExecution:
 				}
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot add private accessor #%s to a non-extensible object", displayName))
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9636,7 +9720,7 @@ startExecution:
 					}
 				}
 				vm.throwException(excVal)
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -9687,7 +9771,7 @@ startExecution:
 					fmt.Printf("[DEBUG vm.go] OpCallMethod: Frame was popped (was %d, now %d), exception handled in outer frame\n",
 						frameCountBeforeCall, vm.frameCount)
 				}
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -10313,7 +10397,7 @@ startExecution:
 				if !builtin.IsConstructor {
 					frame.ip = callerIP
 					vm.ThrowTypeError(fmt.Sprintf("%s is not a constructor", builtin.Name))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -10363,7 +10447,7 @@ startExecution:
 					// Check if this is an ExceptionError (already has an exception value)
 					if ee, ok := err.(ExceptionError); ok {
 						vm.throwException(ee.GetExceptionValue())
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -10393,7 +10477,7 @@ startExecution:
 						errValue = NewValueFromPlainObject(eo)
 					}
 					vm.throwException(errValue)
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -10441,7 +10525,7 @@ startExecution:
 				if !builtinWithProps.IsConstructor {
 					frame.ip = callerIP
 					vm.ThrowTypeError(fmt.Sprintf("%s is not a constructor", builtinWithProps.Name))
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -10486,7 +10570,7 @@ startExecution:
 					// Check if this is an ExceptionError (already has an exception value)
 					if ee, ok := err.(ExceptionError); ok {
 						vm.throwException(ee.GetExceptionValue())
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -10541,7 +10625,7 @@ startExecution:
 						errValue = NewValueFromPlainObject(eo)
 					}
 					vm.throwException(errValue)
-					if vm.frameCount == 0 {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
 					frame = &vm.frames[vm.frameCount-1]
@@ -10713,7 +10797,7 @@ startExecution:
 					if !nf.IsConstructor {
 						frame.ip = callerIP
 						vm.ThrowTypeError(fmt.Sprintf("%s is not a constructor", nf.Name))
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -10740,7 +10824,7 @@ startExecution:
 						// Check if this is an ExceptionError (already has an exception value)
 						if ee, ok := err.(ExceptionError); ok {
 							vm.throwException(ee.GetExceptionValue())
-							if vm.frameCount == 0 {
+							if vm.frameCount == 0 || vm.unwindingCrossedNative {
 								return InterpretRuntimeError, vm.currentException
 							}
 							frame = &vm.frames[vm.frameCount-1]
@@ -10769,7 +10853,7 @@ startExecution:
 							errValue = NewValueFromPlainObject(eo)
 						}
 						vm.throwException(errValue)
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -10794,7 +10878,7 @@ startExecution:
 					if !nfp.IsConstructor {
 						frame.ip = callerIP
 						vm.ThrowTypeError(fmt.Sprintf("%s is not a constructor", nfp.Name))
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -10820,7 +10904,7 @@ startExecution:
 					if err != nil {
 						if ee, ok := err.(ExceptionError); ok {
 							vm.throwException(ee.GetExceptionValue())
-							if vm.frameCount == 0 {
+							if vm.frameCount == 0 || vm.unwindingCrossedNative {
 								return InterpretRuntimeError, vm.currentException
 							}
 							frame = &vm.frames[vm.frameCount-1]
@@ -10849,7 +10933,7 @@ startExecution:
 							errValue = NewValueFromPlainObject(eo)
 						}
 						vm.throwException(errValue)
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -10887,7 +10971,7 @@ startExecution:
 						} else {
 							vm.runtimeError("%s", err.Error())
 						}
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						frame = &vm.frames[vm.frameCount-1]
@@ -11489,7 +11573,7 @@ startExecution:
 								if isStrict {
 									frame.ip = ip
 									vm.ThrowTypeError(fmt.Sprintf("Cannot assign to read only property '%s'", propertyName))
-									if vm.frameCount == 0 {
+									if vm.frameCount == 0 || vm.unwindingCrossedNative {
 										return InterpretRuntimeError, vm.currentException
 									}
 									frame = &vm.frames[vm.frameCount-1]
@@ -11514,7 +11598,7 @@ startExecution:
 						if isStrict {
 							frame.ip = ip
 							vm.ThrowTypeError(fmt.Sprintf("Cannot add property '%s', object is not extensible", propertyName))
-							if vm.frameCount == 0 {
+							if vm.frameCount == 0 || vm.unwindingCrossedNative {
 								return InterpretRuntimeError, vm.currentException
 							}
 							frame = &vm.frames[vm.frameCount-1]
@@ -11638,7 +11722,7 @@ startExecution:
 					primitiveVal := vm.toPrimitive(keyValue, "string")
 					// Check if toPrimitive threw an exception
 					if vm.currentException.Type() != TypeUndefined {
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						// Exception handler will handle it
@@ -11818,7 +11902,7 @@ startExecution:
 					primitiveVal := vm.toPrimitive(keyValue, "string")
 					// Check if toPrimitive threw an exception
 					if vm.currentException.Type() != TypeUndefined {
-						if vm.frameCount == 0 {
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
 							return InterpretRuntimeError, vm.currentException
 						}
 						// Exception handler will handle it
@@ -11898,7 +11982,7 @@ startExecution:
 									if isStrict {
 										frame.ip = ip
 										vm.ThrowTypeError(fmt.Sprintf("Cannot assign to read only property '%s'", propertyName))
-										if vm.frameCount == 0 {
+										if vm.frameCount == 0 || vm.unwindingCrossedNative {
 											return InterpretRuntimeError, vm.currentException
 										}
 										frame = &vm.frames[vm.frameCount-1]
@@ -11923,7 +12007,7 @@ startExecution:
 							if isStrict {
 								frame.ip = ip
 								vm.ThrowTypeError(fmt.Sprintf("Cannot add property '%s', object is not extensible", propertyName))
-								if vm.frameCount == 0 {
+								if vm.frameCount == 0 || vm.unwindingCrossedNative {
 									return InterpretRuntimeError, vm.currentException
 								}
 								frame = &vm.frames[vm.frameCount-1]
@@ -12062,7 +12146,7 @@ startExecution:
 									if isStrict {
 										frame.ip = ip
 										vm.ThrowTypeError(fmt.Sprintf("Cannot assign to read only property '%s'", propertyName))
-										if vm.frameCount == 0 {
+										if vm.frameCount == 0 || vm.unwindingCrossedNative {
 											return InterpretRuntimeError, vm.currentException
 										}
 										frame = &vm.frames[vm.frameCount-1]
@@ -12087,7 +12171,7 @@ startExecution:
 							if isStrict {
 								frame.ip = ip
 								vm.ThrowTypeError(fmt.Sprintf("Cannot add property '%s', object is not extensible", propertyName))
-								if vm.frameCount == 0 {
+								if vm.frameCount == 0 || vm.unwindingCrossedNative {
 									return InterpretRuntimeError, vm.currentException
 								}
 								frame = &vm.frames[vm.frameCount-1]
@@ -13093,7 +13177,7 @@ startExecution:
 			if vm.unwinding {
 				// Exception was thrown and we're unwinding
 				// The unwinding logic will either find a handler or terminate
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					// All frames unwound, uncaught exception
 					return InterpretRuntimeError, vm.currentException
 				}
@@ -13757,7 +13841,7 @@ startExecution:
 				vm.throwException(vm.lastThrownException)
 
 				// Reload frame state after exception handling (handler may have been found)
-				if vm.frameCount == 0 {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				frame = &vm.frames[vm.frameCount-1]
@@ -15202,7 +15286,7 @@ startExecution:
 	// 2. Completed exception handling (vm.unwinding == false) - resume execution at handler
 
 	// CAUTION: this is commented out because apparently it's unreachable according to Go compiler
-	// if vm.frameCount == 0 {
+	// if vm.frameCount == 0 || vm.unwindingCrossedNative {
 	// 	// No frames left - either uncaught exception or completed execution
 	// 	if vm.unwinding {
 	// 		return InterpretRuntimeError, vm.currentException

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1679,12 +1679,53 @@ func (vm *VM) putSentinelReg(r []Value) {
 	vm.sentinelRegPool = append(vm.sentinelRegPool, r)
 }
 
+// truncateFramesTo drops every frame from entryCount up to the current
+// vm.frameCount and resets vm.unwindingCrossedNative. Used by
+// executeUserFunctionSafe/executeUserFunctionWithNewTarget's error paths to
+// fully undo a call once its exception has been taken over as a Go error:
+// unwindException deliberately leaves the frame(s) it stopped at (a
+// sentinel, or the isDirectCall closure frame one level in) unpopped, so
+// without this the frame slot could be mistaken for a still-live boundary by
+// a later, unrelated throw (see the callers' comments).
+//
+// Resetting the flag here matters just as much as dropping the frame: this
+// call's boundary has now been fully closed out (converted to a Go error,
+// its frame gone), so whatever throws next - a sibling call made by the
+// same native caller, or a re-throw of this very error one level further
+// out - is a *different* boundary and deserves its own first chance to
+// stop, not to inherit "already crossed" from a boundary that no longer
+// exists. Without this reset, a re-throw from an outer native caller (e.g.
+// executeGeneratorPrologue re-injecting this error into the calling
+// frame's bytecode) would find crossedNative already true and blow
+// straight through its own boundary too.
+//
+// This does NOT reclaim vm.nextRegSlot for the dropped frame(s)' register
+// windows. That's a real leaked-registers gap (unwindException's own
+// frame-popping loop has the same gap: it decrements vm.frameCount without
+// touching vm.nextRegSlot for every frame it walks past), but register
+// space is only reclaimed in bulk relative to the frame the dispatch loop
+// eventually resumes at, not frame-by-frame during unwinding - subtracting
+// an additional, independently-computed delta here corrupted that
+// accounting and broke a previously-working reproducer (nextRegSlot went
+// negative). Left as a documented pre-existing gap rather than a local fix
+// that isn't provably correct; see issue #61.
+func (vm *VM) truncateFramesTo(entryCount int) {
+	vm.frameCount = entryCount
+	vm.unwindingCrossedNative = false
+}
+
 func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args []Value, newTarget Value, isDerivedConstructor bool) (Value, error) {
 	// Clear stale unwinding state
 	if vm.unwinding && vm.currentException == Null {
 		vm.unwinding = false
 		vm.unwindingCrossedNative = false
 	}
+
+	// See the matching comment in executeUserFunctionSafe: remember our entry
+	// depth so the error paths below can drop any frame(s) unwinding stopped
+	// at without popping, once we've taken ownership of the exception as a
+	// Go error.
+	frameCountAtEntry := vm.frameCount
 
 	// Set up the caller context (pooled 1-element result holder, not a per-call alloc)
 	callerRegisters := vm.getSentinelReg()
@@ -1744,6 +1785,7 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 		if vm.unwinding && vm.currentException != Null {
 			ex := vm.currentException
 			vm.currentException = Null
+			vm.truncateFramesTo(frameCountAtEntry)
 			return Undefined, exceptionError{exception: ex}
 		}
 		return Undefined, fmt.Errorf("runtime error during constructor execution")
@@ -1752,6 +1794,7 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 	if vm.unwinding && vm.currentException != Null {
 		ex := vm.currentException
 		vm.currentException = Null
+		vm.truncateFramesTo(frameCountAtEntry)
 		return Undefined, exceptionError{exception: ex}
 	}
 
@@ -1773,6 +1816,21 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 		vm.unwinding = false
 		vm.unwindingCrossedNative = false
 	}
+
+	// Remember the frame depth this call started at so the error paths below
+	// can fully unwind back to it. When unwindException stops at our own
+	// isDirectCall boundary (or, one level further out via a nested native
+	// call, at our sentinel), it deliberately leaves that frame on the stack
+	// instead of popping it. We hand the exception to our native caller as a
+	// Go error here, taking ownership of it - so from the VM's perspective
+	// this call is over and every frame it pushed (the sentinel, and the
+	// direct-call frame if unwinding stopped there without popping it) must
+	// go with it. Left in place, a stale frame would sit on vm.frames and
+	// get mistaken for a fresh, still-live native boundary by a *later*,
+	// unrelated throw during a subsequent call made by the same native
+	// caller (e.g. DisposableStack running several dispose() callbacks in
+	// sequence, each via its own executeUserFunctionSafe call).
+	frameCountAtEntry := vm.frameCount
 
 	// Set up the caller context first (pooled 1-element result holder)
 	callerRegisters := vm.getSentinelReg()
@@ -1821,6 +1879,11 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 			vm.currentException = Null
 			// vm.unwinding = false         // OLD: Don't clear this!
 			// vm.unwindingCrossedNative... // OLD: Don't clear this either!
+			// We're taking ownership of the exception as a Go error - drop any
+			// frame(s) unwinding stopped at without popping (see comment above
+			// frameCountAtEntry) so they can't be mistaken for a live boundary
+			// by a later, unrelated throw.
+			vm.truncateFramesTo(frameCountAtEntry)
 			return Undefined, exceptionError{exception: ex}
 		}
 		return Undefined, fmt.Errorf("runtime error during user function execution")
@@ -1832,6 +1895,7 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 		vm.currentException = Null
 		// vm.unwinding = false         // OLD: Don't clear this!
 		// vm.unwindingCrossedNative... // OLD: Don't clear this either!
+		vm.truncateFramesTo(frameCountAtEntry)
 		return Undefined, exceptionError{exception: ex}
 	}
 


### PR DESCRIPTION
Fixes most of #61 (one narrow, documented regression remains - see below). Surfaces and files #65 (a pre-existing test262-runner scoring bug this fix exposes).

## What's fixed (commit 5a0d4d2)

`vm.unwindingCrossedNative` was a single global sticky flag: once an exception crossed *one* native/direct-call boundary, every subsequent boundary in the same throw sequence was skipped too, instead of each native caller getting its own independent chance to stop unwinding. Root-caused two boundary shapes (single-frame vs. sentinel+closure-frame pair) and fixed `unwindException` to only clear the flag on the frame that's the boundary's true outer edge. Details in the #61 comment.

That surfaced two more, previously-masked bugs along the way:
- A ghost-frame leak in `executeUserFunctionSafe`/`executeUserFunctionWithNewTarget` (fixed via a new `truncateFramesTo` helper - deliberately doesn't reclaim `nextRegSlot`, a separate pre-existing register leak, documented not fixed).
- `pendingAction`/`pendingValue` corruption in `OpIteratorCleanupAbrupt(IfNotDone)` from nested `GetProperty`/`vm.Call` during IteratorClose, plus a missing handler for `GetMethod` itself throwing, plus a pre-existing compiler double-close bug in `emitIteratorCleanupWithDone`.

**Test262 `language/` (timeout 0.2s): +92 passes, 1 new failure (net +91).** The one remaining failure (`language/expressions/dynamic-import/usage/nested-async-gen-await-eval-gtbndng-indirect-update.js`) was investigated and bounded but not root-caused - narrow enough to ship with, documented here rather than swept under the rug. Full smoke suite (`go test ./tests -run TestScripts`) green throughout.

## What's fixed (commit b46d86c)

Found while auditing `built-ins/` fallout from the above (see next section) - independent, pre-existing Promise spec bugs, not exception-unwinding-boundary bugs themselves:
- `NewPromiseFromExecutor` rejected with a stringified Go error instead of the executor's actual thrown value (ES 25.4.3.1 step 10), and leaked unwinding state after absorbing the error into a rejected promise.
- Promise.all/allSettled/race/any's per-element resolve/reject functions had no `[[AlreadyCalled]]` guard (25.4.4.1.2/27.2.4.2.1) - an arbitrary thenable invoking its handler twice double-decremented `remaining` and clobbered settled results.
- The same four combinators silently discarded `.then()` itself throwing instead of rejecting the result promise.

Verified: `built-ins/Promise/{reject-via-abrupt,reject-ignored-via-abrupt,reject-via-abrupt-queue,exception-after-resolve-in-executor,resolve-from-same-thenable}.js` now pass. Not fixed (separate, deeper, out-of-scope gap): `invoke-resolve-error-close.js` for all/allSettled/race - missing IteratorClose integration when combinator iteration aborts mid-flight.

## About the built-ins Test262 diff

Raw diff against a `main`-branch baseline shows `built-ins/`: +9 passes, 84 new failures (net -75). **This is not primarily a regression** - it's this fix correctly making exceptions inside nested native calls (Reflect, decodeURI, RegExp, TypedArray, Promise, Iterator helpers) actually propagate instead of silently vanishing partway through script execution, combined with a pre-existing bug in the test262 runner (and `vm.Interpret`) that scores a script as **passing** whenever it silently aborts at a native exception boundary with no Go error ever recorded (filed as #65, with the full mechanism and two confirmed spot-checks).

Concretely: I picked three of the "new failures" at random (`Reflect/apply/arguments-list-is-not-array-like.js`, `TypedArrayConstructors/internals/Get/key-is-out-of-bounds.js`, `decodeURI/S15.1.3.1_A1.2_T1.js`) and ran the harnessed source through a `main`-branch build of the bare `paserati` CLI directly. None of them actually pass - `Reflect/apply` exits 0 but prints a stray `null` instead of completing its `assert.throws` checks; `decodeURI` exits 0 with **no output at all**, despite the test throwing `Test262Error` on failure. `main`'s test262 runner was already mis-scoring these; this branch just makes the runner's own pass/fail signal (an empty `vm.errors`) finally line up with what actually happened, which - given #65 - means it now reports the truth more often, not less.

I have **not** gone through and fixed the individual native-builtin bugs this unmasked (Reflect, RegExp, TypedArray, decodeURI, String.prototype.matchAll, Iterator helpers/zip/zipKeyed all appear in the diff) - that's open-ended, unrelated work belonging to those specific builtins, not to the exception-unwinding fix. Flagging here rather than either silently shipping a scary-looking diff or spending unbounded time chasing every unmasked bug.

## Recommendation

Merge on the strength of the `language/` numbers and the fully-documented, spot-checked explanation for `built-ins/`. Prioritize #65 next, since it means current published compliance numbers are inflated by an unknown amount independent of anything in this PR.
