### PR TITLE
vm: implement mapped arguments property descriptors (ES 10.4.4.7)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -368,19 +368,25 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			keyVal = resolved
 		}
 		if keyVal.Type() == vm.TypeSymbol {
+			// Guard on Type() before AsX() - AsPlainObject()/AsDictObject()/
+			// AsArray() panic instead of returning nil for a mismatched type,
+			// so calling AsPlainObject() unconditionally here (as this used
+			// to) panicked for every non-plain-object `this`, including
+			// arguments objects (which do have own symbol properties, e.g.
+			// Symbol.iterator - see language/arguments-object/mapped/
+			// Symbol.iterator.js).
 			key := vm.NewSymbolKey(keyVal)
-			if po := thisValue.AsPlainObject(); po != nil {
-				if _, _, en, _, ok := po.GetOwnDescriptorByKey(key); ok {
+			switch thisValue.Type() {
+			case vm.TypeObject:
+				if _, _, en, _, ok := thisValue.AsPlainObject().GetOwnDescriptorByKey(key); ok {
 					return vm.BooleanValue(en), nil
 				}
-				return vm.BooleanValue(false), nil
-			}
-			if dict := thisValue.AsDictObject(); dict != nil {
-				// DictObject doesn’t support symbol keys
-				return vm.BooleanValue(false), nil
-			}
-			if arr := thisValue.AsArray(); arr != nil {
-				return vm.BooleanValue(false), nil
+			case vm.TypeArguments:
+				// Symbol.iterator is the only own symbol property arguments
+				// objects have, and it's non-enumerable per spec.
+				if thisValue.AsArguments().HasOwnSymbolProp(keyVal.AsSymbolObject()) {
+					return vm.BooleanValue(false), nil
+				}
 			}
 			return vm.BooleanValue(false), nil
 		}
@@ -443,14 +449,14 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.BooleanValue(false), nil
 		case vm.TypeArguments:
 			argsObj := thisValue.AsArguments()
-			// Per spec: length and callee are non-enumerable, numeric indices are enumerable
+			// Per spec: length and callee are non-enumerable
 			if propName == "length" || propName == "callee" {
 				return vm.BooleanValue(false), nil
 			}
-			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 && idx < argsObj.Length() {
-				return vm.BooleanValue(true), nil
-			}
-			return vm.BooleanValue(false), nil
+			// Numeric indices: consult any defineProperty override instead of
+			// assuming the CreateMappedArgumentsObject default of true.
+			own := argsObj.ArgumentsOwnProperty(propName)
+			return vm.BooleanValue(own.Exists && own.Enumerable), nil
 		case vm.TypeProxy:
 			// Per spec, propertyIsEnumerable uses [[GetOwnProperty]] which goes through the proxy protocol
 			desc, err := objectGetOwnPropertyDescriptorWithVM(vmInstance, []vm.Value{thisValue, keyVal})
@@ -3351,6 +3357,20 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		return obj, nil
 	}
 
+	// Arguments objects: implement ES 10.4.4.7 for numeric-index keys (the
+	// mapped-argument write-through/severance semantics). "length"/"callee"
+	// and symbol keys aren't covered yet - falls through to the no-op below,
+	// same pre-existing behavior as before this case existed.
+	if obj.Type() == vm.TypeArguments && !keyIsSymbol {
+		if _, isIndex := vm.ParseArgumentsIndex(propName); isIndex {
+			argsObj := obj.AsArguments()
+			if err := vmInstance.ArgumentsDefineOwnProperty(argsObj, propName, hasValue, value, writablePtr, enumerablePtr, configurablePtr, hasGetter, getter, hasSetter, setter); err != nil {
+				return vm.Undefined, err
+			}
+			return obj, nil
+		}
+	}
+
 	// Define the property with attributes (on plain objects only for now)
 	if obj.Type() == vm.TypeObject {
 	if plainObj := obj.AsPlainObject(); plainObj != nil {
@@ -4027,13 +4047,33 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			descriptor.SetOwn("configurable", vm.BooleanValue(true))
 			return vm.NewValueFromPlainObject(descriptor), nil
 		}
-		// Check for numeric index
-		if index, err := strconv.Atoi(propName); err == nil && index >= 0 && index < argsObj.Length() {
+		// Check for numeric index - consult any Object.defineProperty
+		// override (attributes and, once the mapping's been severed, the
+		// stored value) instead of always synthesizing the
+		// CreateMappedArgumentsObject default. See arguments_props.go.
+		if _, isIndex := vm.ParseArgumentsIndex(propName); isIndex {
+			own := argsObj.ArgumentsOwnProperty(propName)
+			if !own.Exists {
+				return vm.Undefined, nil
+			}
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-			descriptor.SetOwn("value", argsObj.Get(index))
-			descriptor.SetOwn("writable", vm.BooleanValue(true))
-			descriptor.SetOwn("enumerable", vm.BooleanValue(true))
-			descriptor.SetOwn("configurable", vm.BooleanValue(true))
+			if own.IsAccessor {
+				if own.HasGetter {
+					descriptor.SetOwn("get", own.Getter)
+				} else {
+					descriptor.SetOwn("get", vm.Undefined)
+				}
+				if own.HasSetter {
+					descriptor.SetOwn("set", own.Setter)
+				} else {
+					descriptor.SetOwn("set", vm.Undefined)
+				}
+			} else {
+				descriptor.SetOwn("value", own.Value)
+				descriptor.SetOwn("writable", vm.BooleanValue(own.Writable))
+			}
+			descriptor.SetOwn("enumerable", vm.BooleanValue(own.Enumerable))
+			descriptor.SetOwn("configurable", vm.BooleanValue(own.Configurable))
 			return vm.NewValueFromPlainObject(descriptor), nil
 		}
 		// Handle callee property

--- a/pkg/vm/arguments_props.go
+++ b/pkg/vm/arguments_props.go
@@ -1,0 +1,374 @@
+package vm
+
+import "strconv"
+
+// This file centralizes the arguments exotic object's [[GetOwnProperty]],
+// [[DefineOwnProperty]], [[Get]], [[Set]], and [[Delete]] behavior (ES
+// 10.4.4), so every call site (bytecode fast paths, the native GetProperty/
+// SetProperty API, and Object.defineProperty/getOwnPropertyDescriptor) shares
+// one source of truth instead of independently re-deriving per-index
+// defaults. Before this file existed, six different call sites each
+// hardcoded {writable:true, enumerable:true, configurable:true} for numeric
+// indices and none of them consulted (or even could record) a
+// defineProperty override - see language/arguments-object/mapped/*.
+
+// ArgOwnResult is the resolved own-property state for one key on an
+// arguments object, before any user code (a getter) has been invoked.
+type ArgOwnResult struct {
+	Exists       bool
+	IsAccessor   bool
+	Value        Value // meaningful when !IsAccessor
+	Getter       Value
+	Setter       Value
+	HasGetter    bool
+	HasSetter    bool
+	Writable     bool // meaningful when !IsAccessor
+	Enumerable   bool
+	Configurable bool
+}
+
+// isLiveMappedIndex reports whether index is still write-through-linked to
+// its parameter register - i.e. it's a mapped index whose binding hasn't
+// been severed by a prior defineProperty (writable:false or an accessor
+// conversion; ES 10.4.4.7 step 6).
+func (a *ArgumentsObject) isLiveMappedIndex(index int, override *ArgDescriptor) bool {
+	if index < 0 || index >= a.numMapped || a.mappedRegs == nil {
+		return false
+	}
+	if override != nil && override.Unmapped {
+		return false
+	}
+	return true
+}
+
+// ArgumentsOwnProperty resolves the current own-property descriptor for key,
+// without invoking any user code. Numeric-index keys default to
+// {writable:true, enumerable:true, configurable:true} per
+// CreateMappedArgumentsObject; "length" and "callee" are handled by their
+// own dedicated call sites and are intentionally not covered here.
+func (a *ArgumentsObject) ArgumentsOwnProperty(key string) ArgOwnResult {
+	if a.deletedProps != nil && a.deletedProps[key] {
+		return ArgOwnResult{Exists: false}
+	}
+
+	var override *ArgDescriptor
+	if a.argDescs != nil {
+		override = a.argDescs[key]
+	}
+
+	index, isIndex := tryParseArgIndex(key)
+
+	if override != nil {
+		if override.IsAccessor {
+			return ArgOwnResult{
+				Exists: true, IsAccessor: true,
+				Getter: override.Getter, Setter: override.Setter,
+				HasGetter: override.HasGetter, HasSetter: override.HasSetter,
+				Enumerable: override.Enumerable, Configurable: override.Configurable,
+			}
+		}
+		value := override.Value
+		if isIndex && a.isLiveMappedIndex(index, override) {
+			// Still mapped: the live register is authoritative, not the
+			// (possibly stale) stored value - a plain `arguments[i] = x` or
+			// `a = x` assignment writes the register directly and doesn't
+			// go through argDescs.
+			value = a.mappedRegs[index]
+		}
+		return ArgOwnResult{
+			Exists: true, Value: value,
+			Writable: override.Writable, Enumerable: override.Enumerable, Configurable: override.Configurable,
+		}
+	}
+
+	// No override recorded: synthesize the default descriptor for whichever
+	// kind of key this is.
+	if isIndex {
+		if index < a.numMapped && a.mappedRegs != nil {
+			return ArgOwnResult{Exists: true, Value: a.mappedRegs[index], Writable: true, Enumerable: true, Configurable: true}
+		}
+		if index < len(a.args) {
+			return ArgOwnResult{Exists: true, Value: a.args[index], Writable: true, Enumerable: true, Configurable: true}
+		}
+		if a.namedProps != nil {
+			if v, ok := a.namedProps[key]; ok {
+				return ArgOwnResult{Exists: true, Value: v, Writable: true, Enumerable: true, Configurable: true}
+			}
+		}
+		return ArgOwnResult{Exists: false}
+	}
+
+	// Non-index overflow property added via SetNamedProp without ever going
+	// through defineProperty (e.g. `arguments.foo = 1`).
+	if a.namedProps != nil {
+		if v, ok := a.namedProps[key]; ok {
+			return ArgOwnResult{Exists: true, Value: v, Writable: true, Enumerable: true, Configurable: true}
+		}
+	}
+	return ArgOwnResult{Exists: false}
+}
+
+// tryParseArgIndex parses key as a non-negative array index. Mirrors
+// tryParseArrayIndex's contract but lives here to keep this file
+// self-contained.
+func tryParseArgIndex(key string) (int, bool) {
+	idx, err := strconv.Atoi(key)
+	if err != nil || idx < 0 {
+		return 0, false
+	}
+	return idx, true
+}
+
+// ParseArgumentsIndex is the exported form of tryParseArgIndex, for callers
+// outside this package (e.g. pkg/builtins) that need to tell whether a
+// property key is a numeric-index key on an arguments object before
+// invoking ArgumentsDefineOwnProperty.
+func ParseArgumentsIndex(key string) (int, bool) { return tryParseArgIndex(key) }
+
+// argumentsGet resolves key's value for [[Get]], calling the getter if key
+// was converted to an accessor property.
+func (vm *VM) argumentsGet(a *ArgumentsObject, key string) (Value, error) {
+	own := a.ArgumentsOwnProperty(key)
+	if !own.Exists {
+		return Undefined, nil
+	}
+	if own.IsAccessor {
+		if !own.HasGetter || own.Getter.Type() == TypeUndefined {
+			return Undefined, nil
+		}
+		return vm.Call(own.Getter, NewValueFromArguments(a), nil)
+	}
+	return own.Value, nil
+}
+
+// argumentsSet implements [[Set]] for a numeric-index or overflow-named key,
+// including write-through to the live parameter register while still
+// mapped. strict controls whether a rejected write (non-writable, or a
+// data-only accessor with no setter) throws or silently no-ops.
+func (vm *VM) argumentsSet(a *ArgumentsObject, key string, value Value, strict bool) error {
+	own := a.ArgumentsOwnProperty(key)
+
+	if own.Exists && own.IsAccessor {
+		if own.HasSetter && own.Setter.Type() != TypeUndefined {
+			_, err := vm.Call(own.Setter, NewValueFromArguments(a), []Value{value})
+			return err
+		}
+		if strict {
+			return vm.NewTypeError("Cannot set property " + key + " of arguments which has only a getter")
+		}
+		return nil
+	}
+
+	if own.Exists && !own.Writable {
+		if strict {
+			return vm.NewTypeError("Cannot assign to read only property '" + key + "' of object '[object Arguments]'")
+		}
+		return nil
+	}
+
+	index, isIndex := tryParseArgIndex(key)
+	var override *ArgDescriptor
+	if a.argDescs != nil {
+		override = a.argDescs[key]
+	}
+
+	if isIndex && a.isLiveMappedIndex(index, override) {
+		a.mappedRegs[index] = value
+		// Keep a same override's stored value in sync too, purely so a
+		// later read that (incorrectly) bypassed isLiveMappedIndex still
+		// sees something sane; ArgumentsOwnProperty itself always prefers
+		// the live register while mapped.
+		if override != nil {
+			override.Value = value
+		}
+		return nil
+	}
+
+	if override != nil {
+		override.Value = value
+		return nil
+	}
+
+	if isIndex {
+		a.SetIndexed(index, value)
+		return nil
+	}
+	a.SetNamedProp(key, value)
+	return nil
+}
+
+// argumentsDefineOwnProperty implements ES 10.4.4.7 ArgumentsExoticObjects
+// [[DefineOwnProperty]] for a numeric-index key: validates the change
+// against the current descriptor exactly like OrdinaryDefineOwnProperty,
+// then applies ES step 6's mapped-argument side effects (write-through the
+// new value while still mapped; sever the mapping if the property becomes
+// non-writable or is converted to an accessor).
+func (vm *VM) ArgumentsDefineOwnProperty(
+	a *ArgumentsObject, key string,
+	hasValue bool, value Value,
+	writablePtr, enumerablePtr, configurablePtr *bool,
+	hasGetter bool, getter Value,
+	hasSetter bool, setter Value,
+) error {
+	current := a.ArgumentsOwnProperty(key)
+	becomingAccessor := hasGetter || hasSetter
+
+	if current.Exists && !current.Configurable {
+		if configurablePtr != nil && *configurablePtr {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if enumerablePtr != nil && *enumerablePtr != current.Enumerable {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if current.IsAccessor && (hasValue || writablePtr != nil) {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if !current.IsAccessor && becomingAccessor {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if !current.IsAccessor && !becomingAccessor {
+			if !current.Writable && writablePtr != nil && *writablePtr {
+				return vm.NewTypeError("Cannot redefine property: " + key)
+			}
+			if !current.Writable && hasValue && !value.Is(current.Value) {
+				return vm.NewTypeError("Cannot redefine property: " + key)
+			}
+		}
+	} else if !current.Exists {
+		if a.argDescs == nil {
+			a.argDescs = make(map[string]*ArgDescriptor)
+		}
+	}
+
+	// Merge onto the resolved current state - missing fields are preserved,
+	// matching OrdinaryDefineOwnProperty's "fields not present in Desc keep
+	// the current value" rule (defaulting to the ES defaults when the
+	// property is being created for the first time).
+	writable := current.Writable
+	if !current.Exists {
+		writable = true
+	}
+	if writablePtr != nil {
+		writable = *writablePtr
+	}
+	enumerable := current.Enumerable
+	if !current.Exists {
+		enumerable = true
+	}
+	if enumerablePtr != nil {
+		enumerable = *enumerablePtr
+	}
+	configurable := current.Configurable
+	if !current.Exists {
+		configurable = true
+	}
+	if configurablePtr != nil {
+		configurable = *configurablePtr
+	}
+
+	newDesc := &ArgDescriptor{
+		Enumerable: enumerable, Configurable: configurable,
+	}
+
+	index, isIndex := tryParseArgIndex(key)
+	existingOverride := a.argDescIfPresent(key)
+	wasLiveMapped := isIndex && a.isLiveMappedIndex(index, existingOverride)
+
+	// Once a mapped index's binding is severed it stays severed - this
+	// defineProperty call may not even touch writable/accessor-ness (e.g. a
+	// second call only setting configurable:false), in which case the
+	// "wasLiveMapped" branches below never run at all and mustn't leave
+	// Unmapped at its bool zero value (false), silently un-severing a
+	// mapping a prior call already removed.
+	if isIndex {
+		if existingOverride != nil {
+			newDesc.Unmapped = existingOverride.Unmapped
+		} else {
+			newDesc.Unmapped = !(index < a.numMapped && a.mappedRegs != nil)
+		}
+	}
+
+	if becomingAccessor {
+		newDesc.IsAccessor = true
+		if hasGetter {
+			newDesc.Getter = getter
+			newDesc.HasGetter = true
+		} else if current.IsAccessor {
+			newDesc.Getter = current.Getter
+			newDesc.HasGetter = current.HasGetter
+		}
+		if hasSetter {
+			newDesc.Setter = setter
+			newDesc.HasSetter = true
+		} else if current.IsAccessor {
+			newDesc.Setter = current.Setter
+			newDesc.HasSetter = current.HasSetter
+		}
+		if wasLiveMapped {
+			// ES 10.4.4.7 step 6a: converting a mapped index to an accessor
+			// severs the binding entirely.
+			newDesc.Unmapped = true
+		}
+	} else {
+		newDesc.Value = current.Value
+		if hasValue {
+			newDesc.Value = value
+		}
+		newDesc.Writable = writable
+		if wasLiveMapped {
+			if hasValue {
+				// Step 6b(i): write the new value through to the parameter.
+				a.mappedRegs[index] = value
+			}
+			if writablePtr != nil && !*writablePtr {
+				// Step 6b(ii): making it non-writable severs the mapping.
+				newDesc.Unmapped = true
+				newDesc.Value = a.mappedRegs[index]
+			} else {
+				newDesc.Unmapped = false
+			}
+		}
+	}
+
+	if a.argDescs == nil {
+		a.argDescs = make(map[string]*ArgDescriptor)
+	}
+	a.argDescs[key] = newDesc
+	if a.deletedProps != nil {
+		delete(a.deletedProps, key)
+	}
+	return nil
+}
+
+// argDescIfPresent returns the raw override for key without synthesizing
+// defaults, or nil if none is recorded.
+func (a *ArgumentsObject) argDescIfPresent(key string) *ArgDescriptor {
+	if a.argDescs == nil {
+		return nil
+	}
+	return a.argDescs[key]
+}
+
+// argumentsDelete implements [[Delete]] for a key on an arguments object:
+// returns false (without deleting) if the property exists and is
+// non-configurable, matching ES OrdinaryDelete via Reflect.deleteProperty /
+// the `delete` operator's semantics. Deleting a still-mapped index also
+// severs its binding, per the note in ES 10.4.4.7 that a deleted mapped
+// argument's map entry is removed.
+func (a *ArgumentsObject) argumentsDelete(key string) bool {
+	own := a.ArgumentsOwnProperty(key)
+	if !own.Exists {
+		return true
+	}
+	if !own.Configurable {
+		return false
+	}
+	if a.deletedProps == nil {
+		a.deletedProps = make(map[string]bool)
+	}
+	a.deletedProps[key] = true
+	if a.argDescs != nil {
+		delete(a.argDescs, key)
+	}
+	return true
+}

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -804,9 +804,22 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			// Store override in named props so reads check there first
 			argObj.SetNamedProp("length", *valueToSet)
 		default:
-			// Check for numeric string index
-			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
-				argObj.SetIndexed(idx, *valueToSet)
+			// Check for numeric string index. Goes through argumentsSet (see
+			// arguments_props.go) so a defineProperty-installed accessor,
+			// non-writable rejection, or write-through-while-mapped is
+			// respected instead of always writing the raw slot. Strict-mode
+			// throwing isn't wired up here (this opcode doesn't have the
+			// calling frame's strictness on hand) - non-writable writes
+			// silently no-op, matching this switch's other cases.
+			if _, isIndex := ParseArgumentsIndex(propName); isIndex {
+				if err := vm.argumentsSet(argObj, propName, *valueToSet, false); err != nil {
+					if excErr, ok := err.(ExceptionError); ok {
+						vm.throwException(excErr.GetExceptionValue())
+						return false, InterpretRuntimeError, Undefined
+					}
+					vm.ThrowTypeError(err.Error())
+					return false, InterpretRuntimeError, Undefined
+				}
 			} else {
 				// Store in overflow named properties
 				argObj.SetNamedProp(propName, *valueToSet)

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -219,6 +219,40 @@ type ArgumentsObject struct {
 	namedProps  map[string]Value        // Overflow storage for arbitrary named properties
 	mappedRegs  []Value                 // Shared slice into frame registers for mapped arguments (sloppy mode)
 	numMapped   int                     // Number of mapped parameters (0 = unmapped)
+
+	// argDescs/deletedProps back the arguments exotic object's own property
+	// descriptors (ES 10.4.4) once anything has touched them via
+	// Object.defineProperty or delete - see arguments_props.go. Absent from
+	// argDescs (and not in deletedProps) means "use the
+	// CreateMappedArgumentsObject default for this key": a data property
+	// {writable:true, enumerable:true, configurable:true} for numeric
+	// indices below the original argument count, live-linked to the
+	// parameter register when index < numMapped.
+	argDescs     map[string]*ArgDescriptor
+	deletedProps map[string]bool
+}
+
+// ArgDescriptor overrides an arguments object's default per-key attributes
+// once Object.defineProperty (or an equivalent internal operation) has
+// touched that key. See arguments_props.go for how these are resolved,
+// applied, and kept in sync with the live parameter binding.
+type ArgDescriptor struct {
+	IsAccessor bool
+	Value      Value // data value; authoritative only once Unmapped (or key was never a live-mapped index)
+	Getter     Value
+	Setter     Value
+	HasGetter  bool
+	HasSetter  bool
+
+	Writable     bool // meaningful only when !IsAccessor
+	Enumerable   bool
+	Configurable bool
+
+	// Unmapped is set once ES 10.4.4.7 [[DefineOwnProperty]] step 6 has
+	// severed this index's live binding to the parameter register (by
+	// setting writable:false or by converting to an accessor). Only
+	// meaningful for numeric-index keys.
+	Unmapped bool
 }
 
 // GeneratorState represents the execution state of a generator
@@ -1058,6 +1092,13 @@ func (v Value) AsArguments() *ArgumentsObject {
 		panic("value is not an arguments object")
 	}
 	return (*ArgumentsObject)(v.obj)
+}
+
+// NewValueFromArguments wraps an existing *ArgumentsObject back into a
+// Value, e.g. to use as the `this` binding when calling an accessor getter/
+// setter defined on it via Object.defineProperty.
+func NewValueFromArguments(a *ArgumentsObject) Value {
+	return Value{typ: TypeArguments, obj: unsafe.Pointer(a)}
 }
 
 func (v Value) AsGenerator() *GeneratorObject {
@@ -2654,6 +2695,17 @@ func (a *ArgumentsObject) HasOwnSymbolProp(sym *SymbolObject) bool {
 	}
 	_, ok := a.symbolProps[sym]
 	return ok
+}
+
+// DeleteSymbolProp removes a symbol-keyed property (e.g. Symbol.iterator,
+// which is configurable per spec) and reports whether it was present.
+func (a *ArgumentsObject) DeleteSymbolProp(sym *SymbolObject) bool {
+	if a.symbolProps == nil {
+		return false
+	}
+	_, existed := a.symbolProps[sym]
+	delete(a.symbolProps, sym)
+	return existed
 }
 
 // SetCallee sets the callee property on the arguments object

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6990,8 +6990,23 @@ startExecution:
 					if idx < 0 {
 						registers[destReg] = Undefined // Negative index -> undefined
 					} else {
-						// Use Get() which checks args array and namedProps
-						registers[destReg] = args.Get(idx)
+						// Goes through argumentsGet (arguments_props.go) so a
+						// defineProperty-installed accessor or deletion is
+						// respected, not just the raw mapped/args slot.
+						v, err := vm.argumentsGet(args, strconv.Itoa(idx))
+						if err != nil {
+							frame.ip = ip
+							if excErr, ok := err.(ExceptionError); ok {
+								vm.throwException(excErr.GetExceptionValue())
+							} else {
+								vm.ThrowTypeError(err.Error())
+							}
+							if vm.frameCount == 0 || vm.unwindingCrossedNative {
+								return InterpretRuntimeError, vm.currentException
+							}
+							goto reloadFrame
+						}
+						registers[destReg] = v
 					}
 				case TypeString:
 					key := AsString(indexVal)
@@ -7008,8 +7023,20 @@ startExecution:
 					default:
 						// Try parsing as array index
 						if idx, ok := tryParseArrayIndex(key); ok {
-							// Use Get() which checks args array and namedProps
-							registers[destReg] = args.Get(idx)
+							v, err := vm.argumentsGet(args, strconv.Itoa(idx))
+							if err != nil {
+								frame.ip = ip
+								if excErr, ok := err.(ExceptionError); ok {
+									vm.throwException(excErr.GetExceptionValue())
+								} else {
+									vm.ThrowTypeError(err.Error())
+								}
+								if vm.frameCount == 0 || vm.unwindingCrossedNative {
+									return InterpretRuntimeError, vm.currentException
+								}
+								goto reloadFrame
+							}
+							registers[destReg] = v
 						} else {
 							// Delegate to Array.prototype for other string properties
 							if vm.ArrayPrototype.Type() == TypeObject {
@@ -7718,16 +7745,21 @@ startExecution:
 						status := vm.runtimeError("Arguments index cannot be negative, got %d", idx)
 						return status, Undefined
 					}
-					// For mapped arguments, write directly to the register
-					if idx < argObj.numMapped && argObj.mappedRegs != nil {
-						argObj.mappedRegs[idx] = valueVal
-					} else if idx < len(argObj.args) {
-						// Within original bounds - update the args array
-						argObj.args[idx] = valueVal
-					} else {
-						// Beyond original length - store as named property (DO NOT extend length)
-						// Per ECMAScript, arguments objects have fixed length based on actual arguments
-						argObj.SetNamedProp(strconv.Itoa(idx), valueVal)
+					// Goes through argumentsSet (arguments_props.go) so a
+					// defineProperty-installed accessor, non-writable
+					// rejection, or write-through-while-mapped is respected
+					// instead of always writing the raw slot.
+					if err := vm.argumentsSet(argObj, strconv.Itoa(idx), valueVal, false); err != nil {
+						frame.ip = ip
+						if excErr, ok := err.(ExceptionError); ok {
+							vm.throwException(excErr.GetExceptionValue())
+						} else {
+							vm.ThrowTypeError(err.Error())
+						}
+						if vm.frameCount == 0 || vm.unwindingCrossedNative {
+							return InterpretRuntimeError, vm.currentException
+						}
+						goto reloadFrame
 					}
 				} else if indexVal.Type() == TypeSymbol {
 					// Symbol key access on arguments object
@@ -7752,16 +7784,18 @@ startExecution:
 						argObj.SetNamedProp("length", valueVal)
 					default:
 						// Check for numeric string index
-						if idx, err := strconv.Atoi(key); err == nil && idx >= 0 {
-							// For mapped arguments, write directly to the register
-							if idx < argObj.numMapped && argObj.mappedRegs != nil {
-								argObj.mappedRegs[idx] = valueVal
-							} else if idx < len(argObj.args) {
-								// Within original bounds - update the args array
-								argObj.args[idx] = valueVal
-							} else {
-								// Beyond original length - store as named property (DO NOT extend length)
-								argObj.SetNamedProp(key, valueVal)
+						if _, isIndex := ParseArgumentsIndex(key); isIndex {
+							if err := vm.argumentsSet(argObj, key, valueVal, false); err != nil {
+								frame.ip = ip
+								if excErr, ok := err.(ExceptionError); ok {
+									vm.throwException(excErr.GetExceptionValue())
+								} else {
+									vm.ThrowTypeError(err.Error())
+								}
+								if vm.frameCount == 0 || vm.unwindingCrossedNative {
+									return InterpretRuntimeError, Undefined
+								}
+								goto reloadFrame
 							}
 						} else {
 							// Store in overflow named properties
@@ -12843,11 +12877,18 @@ startExecution:
 					keys[i] = strconv.Itoa(i)
 				}
 			case TypeArguments:
-				// Arguments objects enumerate their indices as strings
+				// Arguments objects enumerate their indices as strings, skipping
+				// any made non-enumerable (or deleted) via Object.defineProperty/
+				// delete - see arguments_props.go. Consulting ArgumentsOwnProperty
+				// per index (rather than assuming the CreateMappedArgumentsObject
+				// default of enumerable:true) is what verifyProperty's for-in-based
+				// isEnumerable() check in propertyHelper.js relies on.
 				argsObj := objValue.AsArguments()
-				keys = make([]string, argsObj.length)
 				for i := 0; i < argsObj.length; i++ {
-					keys[i] = strconv.Itoa(i)
+					key := strconv.Itoa(i)
+					if own := argsObj.ArgumentsOwnProperty(key); own.Exists && own.Enumerable {
+						keys = append(keys, key)
+					}
 				}
 			case TypeFunction:
 				// Enumerate own enumerable properties on the function's Properties object
@@ -14668,7 +14709,50 @@ startExecution:
 			}
 
 			var success bool
-			if obj.IsObject() {
+			if obj.Type() == TypeArguments {
+				// See arguments_props.go: [[Delete]] fails (returns false)
+				// for a non-configurable own property instead of always
+				// succeeding, and severs a still-mapped index's live
+				// parameter binding on a successful delete.
+				keyStr := key.ToString()
+				if key.Type() == TypeSymbol {
+					// Symbol-keyed properties on arguments (e.g. Symbol.iterator)
+					// are always configurable per spec - actually remove it so a
+					// following hasOwnProperty check (propertyHelper.js's
+					// isConfigurable) sees it gone, not just report success.
+					obj.AsArguments().DeleteSymbolProp(key.AsSymbolObject())
+					success = true
+				} else {
+					success = obj.AsArguments().argumentsDelete(keyStr)
+				}
+				if !success && function.Chunk.IsStrict {
+					frame.ip = ip
+					vm.ThrowTypeError("Cannot delete property '" + keyStr + "' of [object Arguments]")
+					if !vm.unwinding {
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					if vm.unwindingCrossedNative || vm.frameCount == 0 {
+						return InterpretRuntimeError, vm.currentException
+					}
+					frame = &vm.frames[vm.frameCount-1]
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					registers = frame.registers
+					ip = frame.ip
+					continue
+				}
+				registers[destReg] = BooleanValue(success)
+				continue
+			} else if obj.Type() == TypeObject {
 				if po := obj.AsPlainObject(); po != nil {
 					if key.Type() == TypeSymbol {
 						// Check if property is non-configurable
@@ -14788,16 +14872,24 @@ startExecution:
 							}
 						}
 					}
-				} else if d := obj.AsDictObject(); d != nil {
-					if key.Type() == TypeSymbol {
-						success = false
-					} else {
-						success = d.DeleteOwn(key.ToString())
-					}
-				} else if a := obj.AsArray(); a != nil {
-					// Not supporting element deletion yet
-					success = false
 				}
+			} else if obj.Type() == TypeDictObject {
+				// Note: this branch (and the TypeArray one below) used to be
+				// nested inside the TypeObject case above via `obj.AsPlainObject()`
+				// falling through to an `else if` - but AsPlainObject() panics
+				// for any non-TypeObject value instead of returning nil, so
+				// they were unreachable dead code and `delete dictObj[computed]`/
+				// `delete arr[computed]` panicked instead. Promoted to their own
+				// top-level branches, guarded by Type() like every other case
+				// here, so they're actually reached instead of panicking.
+				if key.Type() == TypeSymbol {
+					success = false
+				} else {
+					success = obj.AsDictObject().DeleteOwn(key.ToString())
+				}
+			} else if obj.Type() == TypeArray {
+				// Not supporting element deletion yet
+				success = false
 			} else if obj.Type() == TypeString {
 				// String primitives: indices within length are non-configurable
 				// indices beyond length don't exist, so delete returns true

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -911,14 +911,13 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				}
 				return args.Callee(), nil
 			}
-			// Check for numeric index access. Bounds-check via Get() itself
-			// (which checks the live args slice, then namedProps) rather
-			// than args.Length() here - Length() is the *original* argument
-			// count and doesn't grow when SetIndexed() extends the backing
-			// slice past it (e.g. after `arguments[10] = x` or a generic
-			// Array.prototype method writing past the end via .call()).
-			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
-				return args.Get(idx), nil
+			// Check for numeric index access. Goes through argumentsGet (see
+			// arguments_props.go) rather than the raw Get()/mappedRegs fast
+			// path so a defineProperty-installed accessor or an explicit
+			// deletion is respected instead of always reading the live
+			// value straight through.
+			if _, isIndex := ParseArgumentsIndex(propName); isIndex {
+				return vm.argumentsGet(args, propName)
 			}
 			// Check for named properties (like value, writable, get, set, etc.)
 			if v, ok := args.GetNamedProp(propName); ok {
@@ -1071,11 +1070,13 @@ func (vm *VM) SetProperty(obj Value, propName string, value Value) error {
 		case "length":
 			args.SetNamedProp("length", value)
 		default:
-			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 {
-				args.SetIndexed(idx, value)
-			} else {
-				args.SetNamedProp(propName, value)
+			if _, isIndex := ParseArgumentsIndex(propName); isIndex {
+				// Non-strict: rejected writes (non-writable, accessor with
+				// no setter) silently no-op rather than erroring, matching
+				// this function's other cases.
+				return vm.argumentsSet(args, propName, value, false)
 			}
+			args.SetNamedProp(propName, value)
 		}
 		return nil
 


### PR DESCRIPTION
Continues the "repair the language score" work from #66. `Object.defineProperty` on a mapped `arguments` index was a total no-op - no case for `TypeArguments` existed in `objectDefinePropertyWithVM` at all - so setting `configurable`/`writable`/`enumerable`, or converting an index to an accessor, silently did nothing. Meanwhile six-plus independent read paths (GetProperty, OpGetIndex, getOwnPropertyDescriptor, propertyIsEnumerable, for-in, hasOwnProperty) each hardcoded the `CreateMappedArgumentsObject` default `{writable:true, enumerable:true, configurable:true}` with no way to record or see an override.

## What's here

`pkg/vm/arguments_props.go` is the new single source of truth: `ArgOwnResult`/`ArgDescriptor` model an arguments object's resolved own-property state, and `VM.ArgumentsDefineOwnProperty` implements ES 10.4.4.7's mapped-argument side effects - write a new value through to the still-mapped parameter register, and permanently sever the mapping when a property becomes non-writable or is converted to an accessor. Wired into every read/write/enumerate/define/delete call site that used to hardcode the default independently.

Also fixed three latent panics this cluster's own tests exercise - same "`AsPlainObject()`/`AsDictObject()` panics instead of returning nil for the wrong type" shape as #64's `defineProperty` fix:
- `OpDeleteIndex` (`delete obj[computed]`) called `obj.AsPlainObject()` unconditionally for anything `IsObject()`-true, panicking for arguments/dict/array alike. Restructured into type-guarded branches - `delete dictObj[k]`/`delete arr[k]` by computed key now actually work instead of panicking too, as a side benefit.
- `Object.prototype.propertyIsEnumerable`'s symbol-key branch had the identical bug.

## Verification

- `language/arguments-object/mapped`: 3/43 → 43/43.
- `language/arguments-object` (full): 214/263 → 257/263. Remaining 6 are pre-existing and out of scope (length/callee defineProperty support - different default-attribute shape, not touched here).
- Full Test262 diff, each suite run **alone** (not concurrently - a prior run in this session showed concurrent language+built-ins runs produce timeout-driven noise): **language +49/-0**, **built-ins +56/-1**. The one new built-ins failure (`RegExp/property-escapes/generated/Radical.js`) is a timing flake, confirmed by running it alone (150ms, well under the 200ms budget).
- Smoke suite (`go test ./tests -run TestScripts`) green, `golangci-lint run` clean, `go vet` clean.

No regressions found in either suite.
