### PR TITLE
vm: enforce private field/method/accessor brand-check semantics

### DIFF
--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -1226,6 +1226,11 @@ func (c *Compiler) compileAssignmentExpression(node *parser.AssignmentExpression
 				debugPrintf("// DEBUG Assign Store Private Field: Emitting SetPrivateField R%d[%d] = R%d\n", memberInfo.objectReg, memberInfo.nameConstIdx, hint)
 				if memberInfo.isPrivateSetter {
 					c.emitCallPrivateSetter(memberInfo.objectReg, hint, memberInfo.nameConstIdx, line)
+				} else if node.IsFieldInitializer {
+					// Class field initializer: this is the (only) definition of the
+					// private field, not a later assignment - use PrivateFieldAdd
+					// semantics so re-running it on an already-initialized object throws.
+					c.emitDefinePrivateField(memberInfo.objectReg, hint, memberInfo.nameConstIdx, line)
 				} else {
 					c.emitSetPrivateField(memberInfo.objectReg, hint, memberInfo.nameConstIdx, line)
 				}
@@ -1720,11 +1725,28 @@ func (c *Compiler) compileMemberExpressionAssignment(memberExpr *parser.MemberEx
 
 	// MemberExpression is always non-computed (obj.prop), not obj[prop]
 	// For computed access, the parser creates an IndexExpression
-	propName, ok := memberExpr.Property.(*parser.Identifier)
-	if !ok {
+	propName := c.extractPropertyName(memberExpr.Property)
+	if len(propName) == 0 {
 		return NewCompileError(memberExpr, "member expression property must be an identifier")
 	}
-	propIdx := c.chunk.AddConstant(vm.String(propName.Value))
+
+	// Check for private field (starts with #) - this target is reached from
+	// destructuring assignment patterns (e.g. `[obj.#x] = arr`), which must
+	// honor the same private-field brand checks as plain assignment.
+	if propName[0] == '#' {
+		fieldName := propName[1:]
+		brandedKey := c.getPrivateFieldKey(fieldName)
+		nameConstIdx := c.chunk.AddConstant(vm.String(brandedKey))
+
+		if kind, _, ok := c.getPrivateMemberKind(fieldName); ok && (kind == PrivateMemberSetter || kind == PrivateMemberAccessor || kind == PrivateMemberGetter) {
+			c.emitCallPrivateSetter(objReg, valueReg, nameConstIdx, line)
+		} else {
+			c.emitSetPrivateField(objReg, valueReg, nameConstIdx, line)
+		}
+		return nil
+	}
+
+	propIdx := c.chunk.AddConstant(vm.String(propName))
 	c.emitSetProp(objReg, valueReg, propIdx, line)
 
 	return nil

--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -1459,12 +1459,12 @@ func (c *Compiler) addStaticProperty(property *parser.PropertyDefinition, constr
 
 	// Check if this is a private field (ECMAScript # field)
 	if len(propertyName) > 0 && propertyName[0] == '#' {
-		// Private static field - strip the # and use OpSetPrivateField
+		// Private static field - strip the # and use OpDefinePrivateField
 		fieldName := propertyName[1:]
 		// Use branded key to distinguish private fields with same name in different classes
 		brandedKey := c.getPrivateFieldKey(fieldName)
 		propertyNameIdx := c.chunk.AddConstant(vm.String(brandedKey))
-		c.emitSetPrivateField(constructorReg, valueReg, propertyNameIdx, property.Token.Line)
+		c.emitDefinePrivateField(constructorReg, valueReg, propertyNameIdx, property.Token.Line)
 		debugPrintf("// DEBUG addStaticProperty: Static private field '%s' added to constructor\n", propertyName)
 	} else if _, isComputed := property.Key.(*parser.ComputedPropertyName); isComputed {
 		// Computed property key - use the pre-computed key from preEvaluateComputedFieldKeys

--- a/pkg/compiler/emit.go
+++ b/pkg/compiler/emit.go
@@ -576,6 +576,17 @@ func (c *Compiler) emitSetPrivateField(obj, val Register, nameConstIdx uint16, l
 	c.emitUint16(nameConstIdx)
 }
 
+// emitDefinePrivateField emits OpDefinePrivateField ObjReg, ValueReg, NameConstIdx(Uint16)
+// For ECMAScript private field initialization (PrivateFieldAdd): throws TypeError if
+// the private field already exists on the object (e.g. double construction of the
+// same instance via a base constructor that returns a pre-existing object).
+func (c *Compiler) emitDefinePrivateField(obj, val Register, nameConstIdx uint16, line int) {
+	c.emitOpCode(vm.OpDefinePrivateField, line)
+	c.emitByte(byte(obj))
+	c.emitByte(byte(val))
+	c.emitUint16(nameConstIdx)
+}
+
 // emitSetPrivateMethod emits OpSetPrivateMethod ObjReg, ValueReg, NameConstIdx(Uint16)
 // For ECMAScript private method definition: obj.#method = func (not writable)
 func (c *Compiler) emitSetPrivateMethod(obj, val Register, nameConstIdx uint16, line int) {

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -209,6 +209,10 @@ const (
 	// Ry is not an array. Bit-identical to what the built-in array iterator's Step
 	// yields, so it stands in for one next() on the fast destructuring path.
 	OpArrayRawGetInt OpCode = 175
+	// Rx Ry NameIdx(16bit): Rx.#field = Ry (private field initialization / PrivateFieldAdd -
+	// throws TypeError if the private field already exists on Rx; unlike OpSetPrivateField,
+	// which requires the field to already exist)
+	OpDefinePrivateField OpCode = 176
 
 	// --- NEW: Global Variable Operations ---
 	OpGetGlobal     OpCode = 46 // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
@@ -469,6 +473,8 @@ func (op OpCode) String() string {
 		return "OpGetPrivateField"
 	case OpSetPrivateField:
 		return "OpSetPrivateField"
+	case OpDefinePrivateField:
+		return "OpDefinePrivateField"
 	case OpSetPrivateMethod:
 		return "OpSetPrivateMethod"
 	case OpHasPrivateField:
@@ -1102,6 +1108,8 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 	case OpGetPrivateField:
 		return c.registerRegisterConstantInstruction(builder, instruction.String(), offset, "NameIdx")
 	case OpSetPrivateField:
+		return c.registerRegisterConstantInstruction(builder, instruction.String(), offset, "NameIdx")
+	case OpDefinePrivateField:
 		return c.registerRegisterConstantInstruction(builder, instruction.String(), offset, "NameIdx")
 	case OpSetPrivateMethod:
 		return c.registerRegisterConstantInstruction(builder, instruction.String(), offset, "NameIdx")

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -9215,17 +9215,17 @@ startExecution:
 					return InterpretRuntimeError, Undefined
 				}
 			} else {
-				// Regular private data field - set it (this also handles initial field creation)
-				// ECMAScript spec PrivateFieldAdd: If O.[[Extensible]] is false, throw a TypeError
-				// This only applies when ADDING a new field, not when updating an existing one
-				if !obj.HasPrivateField(fieldName) && !obj.IsExtensible() {
-					// Extract display name without brand prefix for error message
+				// Regular private data field assignment (PrivateFieldSet):
+				// the field must already exist on this exact object - assignment
+				// never implicitly creates a private field. If it's missing, the
+				// object's class simply never declared this private name on it.
+				if !obj.HasPrivateField(fieldName) {
 					displayName := fieldName
 					if colonIdx := strings.Index(fieldName, ":"); colonIdx >= 0 {
 						displayName = fieldName[colonIdx+1:]
 					}
 					frame.ip = ip
-					vm.ThrowTypeError(fmt.Sprintf("Cannot add private field #%s to a non-extensible object", displayName))
+					vm.ThrowTypeError(fmt.Sprintf("Cannot write private member #%s to an object whose class did not declare it", displayName))
 					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						return InterpretRuntimeError, vm.currentException
 					}
@@ -9240,6 +9240,96 @@ startExecution:
 				}
 				obj.SetPrivateField(fieldName, registers[valReg])
 			}
+
+		case OpDefinePrivateField:
+			// Private field initialization (PrivateFieldAdd): Rx.#field = Ry
+			// Used only for the initial definition of a private field (class field
+			// initializers). Throws TypeError if the field already exists on the
+			// object (e.g. a base constructor returned a pre-existing instance) or
+			// if the object is non-extensible.
+			objReg := code[ip]
+			valReg := code[ip+1]
+			nameConstIdxHi := code[ip+2]
+			nameConstIdxLo := code[ip+3]
+			nameConstIdx := uint16(nameConstIdxHi)<<8 | uint16(nameConstIdxLo)
+			ip += 4
+
+			if int(nameConstIdx) >= len(constants) {
+				frame.ip = ip
+				status := vm.runtimeError("Invalid constant index %d for private field name.", nameConstIdx)
+				return status, Undefined
+			}
+			nameVal := constants[nameConstIdx]
+			if !IsString(nameVal) {
+				frame.ip = ip
+				status := vm.runtimeError("Internal Error: Private field name constant %d is not a string.", nameConstIdx)
+				return status, Undefined
+			}
+			fieldName := AsString(nameVal)
+
+			objVal := registers[objReg]
+
+			var obj *PlainObject
+			if objVal.Type() == TypeObject {
+				obj = objVal.AsPlainObject()
+			} else if objVal.Type() == TypeFunction {
+				fn := objVal.AsFunction()
+				if fn.Properties == nil {
+					fn.Properties = &PlainObject{prototype: Undefined, shape: RootShape}
+				}
+				obj = fn.Properties
+			} else if objVal.Type() == TypeClosure {
+				cl := objVal.AsClosure()
+				if cl.Properties == nil {
+					cl.Properties = &PlainObject{prototype: Undefined, shape: RootShape}
+				}
+				obj = cl.Properties
+			} else {
+				frame.ip = ip
+				status := vm.runtimeError("Cannot add private field '%s' of %s", fieldName, objVal.TypeName())
+				return status, Undefined
+			}
+
+			displayName := fieldName
+			if colonIdx := strings.Index(fieldName, ":"); colonIdx >= 0 {
+				displayName = fieldName[colonIdx+1:]
+			}
+
+			// PrivateFieldAdd: throw if the entry already exists on this object.
+			if obj.HasPrivateField(fieldName) || obj.IsPrivateMethod(fieldName) || obj.IsPrivateAccessor(fieldName) {
+				frame.ip = ip
+				vm.ThrowTypeError(fmt.Sprintf("Cannot add private member #%s, already exists on the object", displayName))
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				frame = &vm.frames[vm.frameCount-1]
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
+				continue
+			}
+
+			// PrivateFieldAdd: throw if the object is non-extensible.
+			if !obj.IsExtensible() {
+				frame.ip = ip
+				vm.ThrowTypeError(fmt.Sprintf("Cannot add private field #%s to a non-extensible object", displayName))
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				frame = &vm.frames[vm.frameCount-1]
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
+				continue
+			}
+
+			obj.SetPrivateField(fieldName, registers[valReg])
 
 		case OpCallPrivateSetter:
 			// Call a private setter - throws TypeError if the setter doesn't exist
@@ -9393,6 +9483,30 @@ startExecution:
 				frame.ip = ip
 				status := vm.runtimeError("Cannot set private method '%s' of %s", methodName, objVal.TypeName())
 				return status, Undefined
+			}
+
+			// ECMAScript spec PrivateMethodOrAccessorAdd: throw a TypeError if this
+			// object already has an entry for this private name (e.g. a base
+			// constructor returned a pre-existing instance, and construction runs
+			// a second time).
+			if obj.IsPrivateMethod(methodName) || obj.IsPrivateAccessor(methodName) || obj.HasPrivateField(methodName) {
+				displayName := methodName
+				if colonIdx := strings.Index(methodName, ":"); colonIdx >= 0 {
+					displayName = methodName[colonIdx+1:]
+				}
+				frame.ip = ip
+				vm.ThrowTypeError(fmt.Sprintf("Cannot add private member #%s, already exists on the object", displayName))
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				frame = &vm.frames[vm.frameCount-1]
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
+				continue
 			}
 
 			// ECMAScript spec PrivateFieldAdd: If O.[[Extensible]] is false, throw a TypeError
@@ -9549,6 +9663,28 @@ startExecution:
 				frame.ip = ip
 				status := vm.runtimeError("Cannot set private accessor '%s' on %s", fieldName, objVal.TypeName())
 				return status, Undefined
+			}
+
+			// ECMAScript spec PrivateMethodOrAccessorAdd: throw a TypeError if this
+			// object already has an entry for this private name.
+			if obj.IsPrivateMethod(fieldName) || obj.IsPrivateAccessor(fieldName) || obj.HasPrivateField(fieldName) {
+				displayName := fieldName
+				if colonIdx := strings.Index(fieldName, ":"); colonIdx >= 0 {
+					displayName = fieldName[colonIdx+1:]
+				}
+				frame.ip = ip
+				vm.ThrowTypeError(fmt.Sprintf("Cannot add private member #%s, already exists on the object", displayName))
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				frame = &vm.frames[vm.frameCount-1]
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
+				continue
 			}
 
 			// ECMAScript spec PrivateFieldAdd: If O.[[Extensible]] is false, throw a TypeError

--- a/tests/scripts/class_private_brand_checks.ts
+++ b/tests/scripts/class_private_brand_checks.ts
@@ -1,0 +1,137 @@
+// no-typecheck
+// Test ECMAScript private field/method/accessor brand-check semantics:
+// - PrivateFieldAdd (initialization) throws if the entry already exists.
+// - PrivateFieldSet (assignment) throws if the entry does NOT exist.
+// - PrivateMethodOrAccessorAdd throws if the entry already exists.
+// expect: all private brand checks passed
+
+// --- Double construction via a base constructor that returns a pre-existing object ---
+// Per spec, re-running InitializeInstanceFields on the same object must throw.
+
+class Base {
+  constructor(o: any) {
+    return o;
+  }
+}
+
+class WithPrivateField extends Base {
+  #x = 1;
+}
+
+let shared1 = {};
+new WithPrivateField(shared1);
+let fieldDoubleInitThrew = false;
+try {
+  new WithPrivateField(shared1);
+} catch (e) {
+  fieldDoubleInitThrew = e instanceof TypeError;
+}
+if (!fieldDoubleInitThrew) throw new Error("expected TypeError on double private field init");
+
+class WithPrivateMethod extends Base {
+  #m() {
+    return 1;
+  }
+}
+
+let shared2 = {};
+new WithPrivateMethod(shared2);
+let methodDoubleInitThrew = false;
+try {
+  new WithPrivateMethod(shared2);
+} catch (e) {
+  methodDoubleInitThrew = e instanceof TypeError;
+}
+if (!methodDoubleInitThrew) throw new Error("expected TypeError on double private method init");
+
+class WithPrivateAccessor extends Base {
+  get #p() {
+    return 1;
+  }
+  set #p(v: any) {}
+}
+
+let shared3 = {};
+new WithPrivateAccessor(shared3);
+let accessorDoubleInitThrew = false;
+try {
+  new WithPrivateAccessor(shared3);
+} catch (e) {
+  accessorDoubleInitThrew = e instanceof TypeError;
+}
+if (!accessorDoubleInitThrew) throw new Error("expected TypeError on double private accessor init");
+
+// --- Assigning to a private field on an object that never had it declared ---
+// Per spec, PrivateFieldSet must throw when the entry is missing - it must
+// never silently create the field.
+
+class HasPrivateField {
+  #field: number = 0;
+  setDirect() {
+    this.#field = 1;
+  }
+  setViaArrayDestructure() {
+    [this.#field] = [1];
+  }
+  setViaObjectDestructure() {
+    ({ a: this.#field } = { a: 1 });
+  }
+  setViaSpread() {
+    ({ ...this.#field } = {});
+  }
+}
+
+let proto: any = HasPrivateField.prototype;
+
+let directThrew = false;
+try {
+  proto.setDirect.call({});
+} catch (e) {
+  directThrew = e instanceof TypeError;
+}
+if (!directThrew) throw new Error("expected TypeError assigning private field to foreign object");
+
+let arrayDestructureThrew = false;
+try {
+  proto.setViaArrayDestructure.call({});
+} catch (e) {
+  arrayDestructureThrew = e instanceof TypeError;
+}
+if (!arrayDestructureThrew)
+  throw new Error("expected TypeError destructuring-assigning private field (array) to foreign object");
+
+let objectDestructureThrew = false;
+try {
+  proto.setViaObjectDestructure.call({});
+} catch (e) {
+  objectDestructureThrew = e instanceof TypeError;
+}
+if (!objectDestructureThrew)
+  throw new Error("expected TypeError destructuring-assigning private field (object) to foreign object");
+
+let spreadThrew = false;
+try {
+  proto.setViaSpread.call({});
+} catch (e) {
+  spreadThrew = e instanceof TypeError;
+}
+if (!spreadThrew) throw new Error("expected TypeError object-spread-assigning private field to foreign object");
+
+// --- Regression guard: normal (same-instance) private field/method usage still works ---
+
+class Counter {
+  #count = 0;
+  #step() {
+    this.#count++;
+  }
+  bump(): number {
+    this.#step();
+    [this.#count] = [this.#count + 1];
+    return this.#count;
+  }
+}
+
+let counter = new Counter();
+if (counter.bump() !== 2) throw new Error("normal private field/method usage regressed");
+
+"all private brand checks passed";


### PR DESCRIPTION
## Summary

The VM implemented `#x = v` (initialization) and `this.#x = v` (assignment) as a single generic "set-or-create" opcode, so neither of the two distinct ECMAScript private-member invariants was enforced:

- **PrivateFieldAdd** (initialization) must throw a `TypeError` if the entry already exists on the object (e.g. a base constructor returns a pre-existing instance and the derived constructor's field initialization re-runs on it).
- **PrivateFieldSet** (later assignment) must throw a `TypeError` if the entry does **not** exist — it must never silently create the field.

## Changes

- Adds `OpDefinePrivateField` for the Add path (used by instance field initializers and static field initialization): throws if the field/method/accessor already exists, or the object is non-extensible.
- `OpSetPrivateField` (assignment) now requires the private field to already exist, matching `PrivateFieldSet`, instead of silently creating it.
- `OpSetPrivateMethod` / `OpSetPrivateAccessor` now throw if the private name is already installed on the target object (`PrivateMethodOrAccessorAdd`).
- Fixes `compileMemberExpressionAssignment` (used by destructuring-assignment targets like `[this.#x] = arr`), which never recognized `#`-prefixed properties as private at all — it silently wrote a plain public property literally named `"#x"` instead of routing through the private field path.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./tests -run TestScripts` green, including a new `tests/scripts/class_private_brand_checks.ts` covering double-init (field/method/accessor) and foreign-object assignment (direct, array-destructure, object-destructure, spread), plus a same-instance regression guard.
- test262 `language` suite: 23064/23523 → 23082/23523 passing (98.05% → 98.11%). Verified via a true per-test identity diff against the pre-change binary: **18 new passes, 0 regressions**.
- test262 `built-ins` suite diffed against the committed `baseline.txt`: **net change +0**.
- Manually confirmed two of the newly-passing tests run to true completion (not a silent abort at a native-exception boundary, per the known test262-runner false-pass gap).

## Scoped out (diagnosed, not fixed here)

- `privatefieldset-typeerror-4`: private-name resolution across two evaluations of the same class factory shares a brand key (`getPrivateFieldKey` is per-definition-site) — same root cause as the still-failing `*-multiple-evaluations-of-class*` family.
- `privatefieldset-typeerror-10`: `[...this.#field] = []` (rest-element destructuring target) routes through a different, not-yet-updated code path.
- All four private-member opcodes throw an uncatchable `vm.runtimeError` (not a catchable `TypeError`) for non-object receivers — pre-existing style, only one instance added here.