### PR TITLE
compiler: give eval its own lexical TDZ for top-level let/const

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1016,25 +1016,84 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 	// --- Hoist let/const declarations with TDZ (Temporal Dead Zone) marker ---
 	// Let/const declarations are initialized with the Uninitialized marker at script start.
 	// This ensures that accessing them before their declaration line throws a ReferenceError.
-	// Skip TDZ hoisting for eval code - eval has different scoping rules.
-	if c.enclosing == nil && !c.isIndirectEval && c.callerScopeDesc == nil {
-		letConstNames := collectLetConstDeclarations(program.Statements)
-		debugPrintf("[Compile] TDZ hoisting %d top-level let/const declarations\n", len(letConstNames))
-		for _, name := range letConstNames {
-			// Skip if already defined (e.g., by a hoisted function with the same name - error in strict mode but allowed in sloppy)
-			if _, _, found := c.currentSymbolTable.Resolve(name); found {
-				debugPrintf("[Compile TDZHoist] Skipping '%s' - already defined\n", name)
-				continue
+	if c.enclosing == nil {
+		isEvalTopLevel := c.isIndirectEval || c.callerScopeDesc != nil
+		if !isEvalTopLevel {
+			letConstNames := collectLetConstDeclarations(program.Statements)
+			debugPrintf("[Compile] TDZ hoisting %d top-level let/const declarations\n", len(letConstNames))
+			for _, name := range letConstNames {
+				// Skip if already defined (e.g., by a hoisted function with the same name - error in strict mode but allowed in sloppy)
+				if _, _, found := c.currentSymbolTable.Resolve(name); found {
+					debugPrintf("[Compile TDZHoist] Skipping '%s' - already defined\n", name)
+					continue
+				}
+				// Define as global with Uninitialized value (TDZ)
+				globalIdx := c.GetOrAssignGlobalIndex(name)
+				c.currentSymbolTable.DefineGlobal(name, globalIdx)
+				// Emit code to initialize to Uninitialized (TDZ marker)
+				tempReg := c.regAlloc.Alloc()
+				c.emitLoadUninitialized(tempReg, 0)
+				c.emitSetGlobal(globalIdx, tempReg, 0)
+				c.regAlloc.Free(tempReg)
+				debugPrintf("[Compile TDZHoist] TDZ hoisted let/const '%s' at global index %d\n", name, globalIdx)
 			}
-			// Define as global with Uninitialized value (TDZ)
-			globalIdx := c.GetOrAssignGlobalIndex(name)
-			c.currentSymbolTable.DefineGlobal(name, globalIdx)
-			// Emit code to initialize to Uninitialized (TDZ marker)
-			tempReg := c.regAlloc.Alloc()
-			c.emitLoadUninitialized(tempReg, 0)
-			c.emitSetGlobal(globalIdx, tempReg, 0)
-			c.regAlloc.Free(tempReg)
-			debugPrintf("[Compile TDZHoist] TDZ hoisted let/const '%s' at global index %d\n", name, globalIdx)
+		} else {
+			// Eval code creates its own fresh lexical Environment Record for let/const
+			// (ECMAScript EvalDeclarationInstantiation) - distinct from, and discarded
+			// after, the calling context's environment. It must never leak into the
+			// caller's or global scope, but still needs local TDZ: referencing one of
+			// these names before its declaration line - even from within the eval
+			// string itself - must throw a ReferenceError rather than silently falling
+			// through to an outer/global binding of the same name.
+			for _, stmt := range program.Statements {
+				switch s := stmt.(type) {
+				case *parser.LetStatement:
+					if s.Name == nil {
+						continue
+					}
+					// A caller-local of the same name must be *shadowed*, not
+					// deferred to: the eval's own let/const always introduces a
+					// fresh binding in its own lexical environment. Only skip
+					// when this scope already has a real (non-caller-local)
+					// definition for the name (e.g. already hoisted above).
+					if existing, ok := c.currentSymbolTable.store[s.Name.Value]; ok && !existing.IsCallerLocal {
+						continue
+					}
+					if reg, ok := c.regAlloc.TryAllocForVariable(); ok {
+						c.currentSymbolTable.DefineTDZ(s.Name.Value, reg)
+						c.regAlloc.Pin(reg)
+						c.emitLoadUninitialized(reg, s.Token.Line)
+					} else {
+						spillIdx := c.AllocSpillSlot()
+						c.currentSymbolTable.DefineTDZSpilled(s.Name.Value, spillIdx)
+						tempReg := c.regAlloc.Alloc()
+						c.emitLoadUninitialized(tempReg, s.Token.Line)
+						c.emitStoreSpill(spillIdx, tempReg, s.Token.Line)
+						c.regAlloc.Free(tempReg)
+					}
+				case *parser.ConstStatement:
+					if s.Name == nil {
+						continue
+					}
+					// See the LetStatement case above: shadow caller-locals,
+					// only skip a real existing definition in this scope.
+					if existing, ok := c.currentSymbolTable.store[s.Name.Value]; ok && !existing.IsCallerLocal {
+						continue
+					}
+					if reg, ok := c.regAlloc.TryAllocForVariable(); ok {
+						c.currentSymbolTable.DefineConstTDZ(s.Name.Value, reg)
+						c.regAlloc.Pin(reg)
+						c.emitLoadUninitialized(reg, s.Token.Line)
+					} else {
+						spillIdx := c.AllocSpillSlot()
+						c.currentSymbolTable.DefineConstTDZSpilled(s.Name.Value, spillIdx)
+						tempReg := c.regAlloc.Alloc()
+						c.emitLoadUninitialized(tempReg, s.Token.Line)
+						c.emitStoreSpill(spillIdx, tempReg, s.Token.Line)
+						c.regAlloc.Free(tempReg)
+					}
+				}
+			}
 		}
 	}
 	// --- END let/const TDZ hoisting ---

--- a/tests/scripts/eval_lexical_tdz.ts
+++ b/tests/scripts/eval_lexical_tdz.ts
@@ -1,0 +1,80 @@
+// no-typecheck
+// Test that let/const declared inside eval() get their own fresh lexical
+// environment with proper TDZ (Temporal Dead Zone) tracking, per ECMAScript
+// EvalDeclarationInstantiation - referencing the name before its declaration
+// line, even from within the eval string itself, must throw a ReferenceError.
+// The binding must also stay local to the eval call: it must never leak into
+// the calling scope.
+// expect: eval TDZ checks passed
+
+let letTdzThrew = false;
+try {
+  eval("typeof x; let x;");
+} catch (e) {
+  letTdzThrew = e instanceof ReferenceError;
+}
+if (!letTdzThrew) throw new Error("expected ReferenceError for TDZ access to eval-local let");
+
+let constTdzThrew = false;
+try {
+  eval("typeof y; const y = 1;");
+} catch (e) {
+  constTdzThrew = e instanceof ReferenceError;
+}
+if (!constTdzThrew) throw new Error("expected ReferenceError for TDZ access to eval-local const");
+
+// Normal (post-declaration) access still works.
+if (eval("let z = 5; z + 1;") !== 6) throw new Error("normal eval-local let usage regressed");
+
+// A closure created inside the eval must capture the eval-local binding itself.
+if (eval("let a = 1; (function() { return a; })();") !== 1)
+  throw new Error("closure over eval-local let regressed");
+
+// The eval's own let/const must shadow an identically-named binding from the
+// calling scope, not defer to it (per EvalDeclarationInstantiation, eval gets
+// its own fresh lexical environment).
+function shadowsCallerVar() {
+  var x = 1;
+  let threw = false;
+  try {
+    eval("typeof x; let x;");
+  } catch (e) {
+    threw = e instanceof ReferenceError;
+  }
+  return threw && x === 1;
+}
+if (!shadowsCallerVar()) throw new Error("eval-local let did not shadow caller's var binding");
+
+function shadowsCallerLet() {
+  let x = 1;
+  let threw = false;
+  try {
+    eval("typeof x; let x;");
+  } catch (e) {
+    threw = e instanceof ReferenceError;
+  }
+  return threw && x === 1;
+}
+if (!shadowsCallerLet()) throw new Error("eval-local let did not shadow caller's let binding");
+
+// The binding must not leak outside the eval call.
+eval("let leaked = 1;");
+let leakThrew = false;
+try {
+  // @ts-ignore - intentionally referencing a name that must not exist here
+  leaked;
+} catch (e) {
+  leakThrew = e instanceof ReferenceError;
+}
+if (!leakThrew) throw new Error("eval-local let leaked into the calling scope");
+
+// const reassignment inside eval still throws.
+let constReassignThrew = false;
+try {
+  eval("const w = 1; w = 2;");
+} catch (e) {
+  constReassignThrew = e instanceof TypeError;
+}
+if (!constReassignThrew) throw new Error("expected TypeError reassigning eval-local const");
+
+"eval TDZ checks passed";


### PR DESCRIPTION
## Summary

Direct and indirect eval code creates a fresh Environment Record for its own `let`/`const`/`class` declarations (`EvalDeclarationInstantiation`), separate from the calling context's — the names are hoisted with TDZ before the eval body runs, and the whole environment is discarded once eval returns.

Top-level TDZ hoisting was unconditionally skipped for eval code (it only ran for `c.enclosing == nil && !isIndirectEval && callerScopeDesc == nil`), because reusing the real top-level hoist path would have hoisted the names into global slots, permanently leaking eval-local `let`/`const` into the calling/global scope. But no eval-local equivalent was ever added, so referencing a not-yet-declared `let`/`const` inside eval code — even from within the eval string itself — silently fell through instead of hitting the TDZ and throwing a `ReferenceError`.

## Changes

- Adds an eval-mode branch that mirrors the existing per-block TDZ predefine pattern (pinned local registers, or spill slots under register pressure) instead of global slots, so the bindings stay local to the eval call.
- Skips a caller-local of the same name rather than deferring to it: eval's own `let`/`const` must *shadow* an identically-named caller binding, not resolve through it.

## Scope

- Only `LetStatement` / `ConstStatement` at the eval's own top level are covered — the destructuring-declaration forms that the per-block predefine handles are left as pre-existing gaps (nothing was predefined for eval before this, so it's not a regression).
- Top-level `class` TDZ is broken independently of eval (reproduces outside eval too) and is out of scope here.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./tests -run TestScripts` green, including a new `tests/scripts/eval_lexical_tdz.ts` covering: TDZ access, normal post-declaration access, closure capture of an eval-local binding, no leakage into the calling scope, const reassignment, and shadowing of an identically-named caller `var`/`let` binding.
- test262 `language` suite: 23082/23523 → 23086/23523. Verified via a true per-test identity diff against the pre-change binary: **4 new passes, 0 regressions**.
- test262 `built-ins` suite diffed against the committed `baseline.txt`: **net change +0** (one apparent flake, `RegExp/property-escapes/generated/Radical.js`, reproduced identically on the pre-change binary — a timing-sensitive 0.2s-timeout borderline case, unrelated to this change).