### PR TITLE
parser: disambiguate 'using of' in a classic for-loop head

### DIFF
--- a/pkg/parser/parse_using.go
+++ b/pkg/parser/parse_using.go
@@ -38,6 +38,15 @@ func (p *Parser) startsUsingDeclaration() bool {
 	return p.peekTokenIs(lexer.IDENT) || p.isKeywordThatCanBeIdentifier(p.peekToken.Type)
 }
 
+// isUsingOfDisambiguator reports whether a token following `using of` (or
+// `await using of`) in a for-loop head proves that `of` is being used as a
+// binding name, not the for-of separator: a for-of iterable expression can
+// never start with `=` or `:` (a TS type annotation on the binding), so
+// either one unambiguously means this is a using-declaration.
+func isUsingOfDisambiguator(t lexer.TokenType) bool {
+	return t == lexer.ASSIGN || t == lexer.COLON
+}
+
 // startsUsingDeclarationForLoop is startsUsingDeclaration's for-loop-head
 // counterpart: a for-of/for-in head unambiguously expects a binding target,
 // so `for (using {} of xs)` does commit to a using declaration even though
@@ -52,7 +61,12 @@ func (p *Parser) startsUsingDeclarationForLoop() bool {
 		return false
 	}
 	if p.peekTokenIs(lexer.OF) {
-		return false
+		// `using of` is ambiguous between a for-of loop over a variable named
+		// `using` (`for (using of xs)`) and a using-declaration whose binding
+		// name is literally `of` in a classic for-statement
+		// (`for (using of = e;;)`) - `of` isn't restricted as a for-loop
+		// binding name outside the for-of/for-in head itself.
+		return isUsingOfDisambiguator(p.lookAhead(1).Type)
 	}
 	return p.peekTokenIs(lexer.IDENT) || p.isKeywordThatCanBeIdentifier(p.peekToken.Type) ||
 		p.peekTokenIs(lexer.LBRACKET) || p.peekTokenIs(lexer.LBRACE)
@@ -64,15 +78,19 @@ func (p *Parser) startsUsingDeclarationForLoop() bool {
 //
 // Requires `using` followed by a binding name, so `for (using of xs)` (a for-of
 // over a variable named `using`) and `for (await foo; ...)` (an await
-// expression) are both correctly left alone.
+// expression) are both correctly left alone - except `using of =`, see
+// startsUsingDeclarationForLoop.
 func (p *Parser) startsUsingDeclarationAt(at int) bool {
 	tok := p.lookAhead(at)
 	if tok.Type != lexer.IDENT || tok.Literal != "using" {
 		return false
 	}
 	name := p.lookAhead(at + 1)
-	if name.Line != tok.Line || name.Type == lexer.OF {
+	if name.Line != tok.Line {
 		return false
+	}
+	if name.Type == lexer.OF {
+		return isUsingOfDisambiguator(p.lookAhead(at + 2).Type)
 	}
 	return name.Type == lexer.IDENT || p.isKeywordThatCanBeIdentifier(name.Type) ||
 		name.Type == lexer.LBRACKET || name.Type == lexer.LBRACE
@@ -89,8 +107,12 @@ func (p *Parser) startsAwaitUsingDeclaration() bool {
 		return false
 	}
 	// Look past `using` for a binding name; `of` would make this a for-of over
-	// a variable named `using`.
-	return !p.peekTokenIs2(lexer.OF)
+	// a variable named `using` - unless followed by `=`/`:`, see
+	// startsUsingDeclarationForLoop.
+	if p.peekTokenIs2(lexer.OF) {
+		return isUsingOfDisambiguator(p.lookAhead(2).Type)
+	}
+	return true
 }
 
 // parseUsingStatement parses `using x = expr, y = expr;`. Current token is the

--- a/tests/scripts/using_for_of_ambiguity.ts
+++ b/tests/scripts/using_for_of_ambiguity.ts
@@ -1,0 +1,59 @@
+// no-typecheck
+// Test disambiguation of `using` immediately followed by `of` in a for-loop
+// head. This is genuinely ambiguous:
+//   for (using of xs)       - for-of loop over a variable named `using`
+//   for (using of = e;;)    - classic for-loop, `using` declares a variable
+//                             literally named `of` (an initializer expression
+//                             can never start with `=`, so this is the only
+//                             unambiguous signal)
+// `of` is not restricted as a `using` binding name outside the for-of/for-in
+// head itself - only the for-of reading of `using of` is.
+// expect: using/of ambiguity checks passed
+
+// Classic for-loop: `using` declares a variable named `of`.
+let ranClassic = false;
+for (using of = { [Symbol.dispose]: () => {} };;) {
+  ranClassic = true;
+  break;
+}
+if (!ranClassic) throw new Error("for (using of = e;;) did not run its body");
+
+// Real for-of loop: plain identifier `using` iterates over the array.
+let seen: number[] = [];
+for (using of [1, 2, 3]) {
+  seen.push(using);
+}
+if (seen.join(",") !== "1,2,3") throw new Error("for (using of xs) regressed to a using-declaration");
+
+// A normal `using x = e;;` for-loop still works (the already-working case
+// this fix must not disturb).
+let ranNamed = false;
+for (using x = { [Symbol.dispose]: () => {} };;) {
+  ranNamed = true;
+  break;
+}
+if (!ranNamed) throw new Error("for (using x = e;;) regressed");
+
+// The `await using` sibling predicate must agree with the plain `using` one:
+// `await using of = e;;` also declares a variable named `of`.
+let ranAwaitOf = false;
+for (await using of = { [Symbol.dispose]: () => {} };;) {
+  ranAwaitOf = true;
+  break;
+}
+if (!ranAwaitOf) throw new Error("for (await using of = e;;) did not run its body");
+
+// `await using x = e;;` (already-working case) must still work too.
+let ranAwaitNamed = false;
+for (await using x = { [Symbol.dispose]: () => {} };;) {
+  ranAwaitNamed = true;
+  break;
+}
+if (!ranAwaitNamed) throw new Error("for (await using x = e;;) regressed");
+
+// A type-annotated `using of: T = e;;` is disambiguated the same way as `=`.
+for (using of: any = { [Symbol.dispose]: () => {} };;) {
+  break;
+}
+
+"using/of ambiguity checks passed";


### PR DESCRIPTION
## Summary

`using` is a contextual keyword: it only introduces a declaration immediately before a binding name. `using of` is inherently ambiguous in a for-loop head — it could be a for-of loop over a variable literally named `using` (`for (using of xs)`), or a using-declaration whose binding name is literally `of` in a classic for-statement (`for (using of = e;;)` — `of` is not a restricted binding name outside the for-of/for-in head itself).

The parser resolved this by always excluding `using of` from being a declaration, regardless of which shape followed — correct for the for-of case, but wrong for the classic for-statement one, which then fell through the general identifier-handling path, misread `using of` as introducing a for-of loop, and produced a parse error once what actually followed `of` didn't fit that shape.

## Fix

The token right after `of` resolves it unambiguously: a for-of iterable expression can never start with `=` or `:` (a TS type annotation on the binding), so seeing either one there proves this is a using-declaration. Applied consistently across all three of the parser's using-declaration lookahead predicates — `startsUsingDeclarationForLoop`, `startsUsingDeclarationAt`, and `startsAwaitUsingDeclaration` — the last one needed the same fix since it independently excluded `using of` the same way and would otherwise now disagree with the other two.

## Scope

Left out, both pre-existing and unaffected by this change:
- `await using of of xs` (`using` declares `of`, first `of` is the real for-of separator, second `of` is the iterable) — a different disambiguation (`of` followed by `of`, not by `=`/`:`) that this fix doesn't attempt. Confirmed failing identically before this change.
- The statement-level (non-for-loop) `using of` exclusion in `startsUsingDeclaration` is untouched — no test262 coverage was found for a bare `using of = e;` statement, so it's left alone rather than guessed at.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./tests -run TestScripts` green, including a new `tests/scripts/using_for_of_ambiguity.ts` covering the classic for-loop `using of = e` declaration, a real for-of loop over a plain `using` variable, the already-working `using x = e;;` case, both `await` variants, and a type-annotated `using of: T = e;;` for-loop.
- test262 `language` suite: 23086/23523 → 23087/23523 (1 test — this is a narrow parser fix). Verified via a true per-test identity diff against the pre-change binary: 1 new pass, 0 regressions.
- test262 `built-ins` suite diffed against the committed `baseline.txt`: net change +0 (one apparent flake, a RegExp property-escapes generated test that times out right at the 0.2s cutoff — reproduced identically on the pre-change binary in an earlier session, unrelated to this change).

## Survey notes from this round

While looking for the next cluster to fix, I surveyed several candidates and deliberately steered away from two that turned out to be traps, worth recording so the next attempt doesn't rediscover them:

- The `dstr` "index out of range" VM panics recurring across generators/async-generators/class destructuring (~36 tests total) are the unresolved half of #61 — already investigated and reverted once with documented -463 regressions from the straightforward fix (see that issue's last comment).
- Direct-eval `var` declarations that introduce a name not already present in the caller's scope currently become script globals instead of locals of the enclosing function (`eval-code/direct`'s `var-env-*` cluster, ~12 tests, plus siblings in `compound-assignment` and an `eval-var-scope-syntax-err` pattern recurring across ~8 more suites, ~35+ tests total — the single largest remaining cluster in `language/`). Fixing it properly needs a dynamic-fallback environment for functions containing a direct eval, since their locals are otherwise fixed at compile time to specific registers — a real architecture piece, not a quick patch.
