### PR TITLE
fix(regex): give \s, \S and . their ECMAScript meanings under RE2

### DIFF
--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -64,7 +64,12 @@ func NewRegExp(pattern, flags string) (Value, error) {
 		return Undefined, err
 	}
 
-	// Compile the Go regex
+	// Deliberately NO regexp2 fallback here. RE2 rejecting a pattern is how
+	// this path reports the SyntaxError that ECMAScript requires for the
+	// modifier and named-group early errors; routing those to regexp2, which
+	// accepts them, silently loses 27 test262 cases. Constructs RE2 cannot
+	// express (lookahead, backreferences) therefore still throw from the
+	// constructor while working in a literal — see the ticket.
 	compiledRegex, err := regexp.Compile(goPattern)
 	if err != nil {
 		return Undefined, err
@@ -602,6 +607,107 @@ func parseHex(s string) int {
 }
 
 // translateJSFlagsToGo converts JavaScript regex flags to Go inline flag syntax
+// ECMAScript WhiteSpace ∪ LineTerminator, spelled as RE2 character-class
+// members. \p{Zs} carries SP, U+00A0 and the rest of the Unicode space
+// separators; the explicit codepoints are the members outside that category.
+const ecmaSpaceMembers = `\t\n\v\f\r\x{2028}\x{2029}\x{feff}\p{Zs}`
+
+// The complement of ecmaSpaceMembers, written out as ranges. RE2 has no set
+// complement INSIDE a character class, so `[a\S]` cannot be spelled with a
+// negation and needs the ranges enumerated instead. Kept adjacent to the set
+// above: the two must be edited together.
+const ecmaNonSpaceMembers = `\x{0}-\x{8}\x{e}-\x{1f}\x{21}-\x{9f}\x{a1}-\x{167f}` +
+	`\x{1681}-\x{1fff}\x{200b}-\x{2027}\x{202a}-\x{202e}\x{2030}-\x{205e}` +
+	`\x{2060}-\x{2fff}\x{3001}-\x{fefe}\x{ff00}-\x{10ffff}`
+
+// LineTerminator — the set `.` must never match unless the s flag is set.
+const ecmaLineTerminators = `\n\r\x{2028}\x{2029}`
+
+// hasInlineDotAll reports whether the pattern turns dotAll on for part of
+// itself with an inline modifier group — `(?s:...)`, `(?ims:...)`, `(?s-i:...)`.
+//
+// The `.` rewrite is scope-blind, so on these patterns it would clamp a `.`
+// that the modifier had just widened. Rewriting is skipped wholesale rather
+// than tracked per group: the modifiers nest, and getting the scope subtly
+// wrong is worse than leaving Go's semantics in place for a rare construct.
+func hasInlineDotAll(pattern string) bool {
+	for i := 0; i+2 < len(pattern); i++ {
+		if pattern[i] != '(' || pattern[i+1] != '?' {
+			continue
+		}
+		for j := i + 2; j < len(pattern); j++ {
+			c := pattern[j]
+			if c == 's' {
+				return true
+			}
+			// The modifier run is letters and one optional '-'; anything else
+			// ends it, and this was some other (?...) construct.
+			if !(c >= 'a' && c <= 'z') && c != '-' {
+				break
+			}
+		}
+	}
+	return false
+}
+
+// rewriteECMAClasses gives \s, \S and . their ECMAScript meanings under RE2.
+//
+// Go's \s is [\t\n\f\r ] and Go's . is "anything but \n". ECMAScript's \s also
+// carries U+00A0, U+FEFF and every Zs, and its . additionally excludes U+2028
+// and U+2029. The danger is that RE2 ACCEPTS such a pattern and compiles it to
+// the wrong language silently, so this rewrites rather than rejects.
+//
+// The rewrite is total — it never rejects — because this path has no fallback
+// engine: RE2 refusing a pattern is how the caller reports a SyntaxError, so a
+// rewrite that gave up here would turn a valid regex into a thrown error.
+//
+// Operates on bytes: every construct it inspects is ASCII, and UTF-8
+// continuation bytes are >= 0x80, so multi-byte runes copy through untouched.
+func rewriteECMAClasses(pattern string, dotAll bool) string {
+	var b strings.Builder
+	b.Grow(len(pattern))
+	inClass := false
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' && i+1 < len(pattern) {
+			switch pattern[i+1] {
+			case 's':
+				if inClass {
+					b.WriteString(ecmaSpaceMembers)
+				} else {
+					b.WriteString("[" + ecmaSpaceMembers + "]")
+				}
+			case 'S':
+				if inClass {
+					b.WriteString(ecmaNonSpaceMembers)
+				} else {
+					b.WriteString("[^" + ecmaSpaceMembers + "]")
+				}
+			default:
+				// Any other escape passes through with its operand, which is
+				// also what keeps \\ from being read as an escaping backslash.
+				b.WriteByte(c)
+				b.WriteByte(pattern[i+1])
+			}
+			i++
+			continue
+		}
+		switch {
+		case c == '[' && !inClass:
+			inClass = true
+			b.WriteByte(c)
+		case c == ']' && inClass:
+			inClass = false
+			b.WriteByte(c)
+		case c == '.' && !inClass && !dotAll:
+			b.WriteString("[^" + ecmaLineTerminators + "]")
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
 func translateJSFlagsToGo(pattern, flags string) (string, error) {
 	// Preprocess Unicode escapes (\uXXXX, \xXX) that Go's regexp doesn't support
 	pattern = preprocessUnicodeEscapes(pattern)
@@ -615,7 +721,10 @@ func translateJSFlagsToGo(pattern, flags string) (string, error) {
 		}
 	}
 
-	goPattern := pattern
+	// Give \s, \S and . ECMAScript semantics before RE2 sees them. Under the s
+	// flag `.` already matches every character, so it needs no rewrite.
+	dotAll := strings.Contains(flags, "s") || hasInlineDotAll(pattern)
+	goPattern := rewriteECMAClasses(pattern, dotAll)
 
 	// Apply flags as Go inline flags (prepended to pattern)
 	var flagPrefixes []string

--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -23,8 +23,8 @@ type cachedCompiledRegex struct {
 // Uses Go's standard regexp (RE2) for simple patterns, falls back to regexp2 for
 // advanced features like lookahead and backreferences.
 type RegExpObject struct {
-	Object                        // Embed the base Object for properties and prototype
-	compiledRegex  *regexp.Regexp // Go's compiled regex engine (fast, RE2)
+	Object                         // Embed the base Object for properties and prototype
+	compiledRegex  *regexp.Regexp  // Go's compiled regex engine (fast, RE2)
 	compiledRegex2 *regexp2.Regexp // Fallback regex engine (slower, full ECMAScript support)
 	source         string          // Original pattern string (without slashes)
 	flags          string          // JavaScript flags (g, i, m, s, u, y)
@@ -623,31 +623,46 @@ const ecmaNonSpaceMembers = `\x{0}-\x{8}\x{e}-\x{1f}\x{21}-\x{9f}\x{a1}-\x{167f}
 // LineTerminator — the set `.` must never match unless the s flag is set.
 const ecmaLineTerminators = `\n\r\x{2028}\x{2029}`
 
-// hasInlineDotAll reports whether the pattern turns dotAll on for part of
-// itself with an inline modifier group — `(?s:...)`, `(?ims:...)`, `(?s-i:...)`.
+// modifierRun reads an inline modifier run starting at the '(' of a `(?...`
+// construct: `(?s:`, `(?ims:`, `(?s-i:`, `(?-s)`. It returns the run's letters,
+// whether the construct opens a group (the `:` form rather than the `)` form),
+// and the run's length, or ok=false when this is some other `(?` construct —
+// `(?:`, `(?=`, `(?!`, `(?<name>`.
 //
-// The `.` rewrite is scope-blind, so on these patterns it would clamp a `.`
-// that the modifier had just widened. Rewriting is skipped wholesale rather
-// than tracked per group: the modifiers nest, and getting the scope subtly
-// wrong is worse than leaving Go's semantics in place for a rare construct.
-func hasInlineDotAll(pattern string) bool {
-	for i := 0; i+2 < len(pattern); i++ {
-		if pattern[i] != '(' || pattern[i+1] != '?' {
+// `(?:` reads as an empty run that opens a group, which is exactly right: a
+// plain non-capturing group changes no modifiers and still scopes the ones
+// inside it.
+func modifierRun(pattern string, i int) (run string, opensGroup bool, n int, ok bool) {
+	if i+1 >= len(pattern) || pattern[i] != '(' || pattern[i+1] != '?' {
+		return "", false, 0, false
+	}
+	j := i + 2
+	for j < len(pattern) {
+		c := pattern[j]
+		if c >= 'a' && c <= 'z' || c == '-' {
+			j++
 			continue
 		}
-		for j := i + 2; j < len(pattern); j++ {
-			c := pattern[j]
-			if c == 's' {
-				return true
-			}
-			// The modifier run is letters and one optional '-'; anything else
-			// ends it, and this was some other (?...) construct.
-			if !(c >= 'a' && c <= 'z') && c != '-' {
-				break
-			}
+		if c == ':' || c == ')' {
+			return pattern[i+2 : j], c == ':', j - i + 1, true
 		}
+		return "", false, 0, false
 	}
-	return false
+	return "", false, 0, false
+}
+
+// applyModifiers folds one `add-remove` run into the current dotAll state.
+// Only `s` is read: `i` and `m` reach RE2 unchanged and mean the same thing
+// there, while `s` is the one whose meaning this file has to correct.
+func applyModifiers(run string, dotAll bool) bool {
+	add, remove, _ := strings.Cut(run, "-")
+	if strings.ContainsRune(add, 's') {
+		dotAll = true
+	}
+	if strings.ContainsRune(remove, 's') {
+		dotAll = false
+	}
+	return dotAll
 }
 
 // rewriteECMAClasses gives \s, \S and . their ECMAScript meanings under RE2.
@@ -663,10 +678,25 @@ func hasInlineDotAll(pattern string) bool {
 //
 // Operates on bytes: every construct it inspects is ASCII, and UTF-8
 // continuation bytes are >= 0x80, so multi-byte runes copy through untouched.
+// dotAll is the state the `s` FLAG establishes; inline `(?s:...)` and
+// `(?-s:...)` groups move it per scope from there.
+//
+// Scope tracking is what makes `.` correct in the presence of a modifier, and it
+// used to be skipped: any inline `s` anywhere disabled the rewrite for the whole
+// pattern, so a `.` outside the group fell back to Go's meaning and matched \r,
+// U+2028 and U+2029 — the exact characters this function exists to exclude.
+//
+// The rewrite is what makes the tracking safe. A `.` in a dotAll-OFF scope
+// becomes an explicit class, and a class cannot be widened by a surrounding
+// `(?s)`; only a bare `.` can. So the two states end up independent, which is
+// why the caller can set `(?s)` globally without reaching the dots that must
+// stay narrow.
 func rewriteECMAClasses(pattern string, dotAll bool) string {
 	var b strings.Builder
 	b.Grow(len(pattern))
 	inClass := false
+	// One entry per open group, holding the state to restore when it closes.
+	var scopes []bool
 	for i := 0; i < len(pattern); i++ {
 		c := pattern[i]
 		if c == '\\' && i+1 < len(pattern) {
@@ -699,6 +729,31 @@ func rewriteECMAClasses(pattern string, dotAll bool) string {
 		case c == ']' && inClass:
 			inClass = false
 			b.WriteByte(c)
+		case c == '(' && !inClass:
+			// Parens inside a class are literal, which is why this is gated on
+			// !inClass: `[(]` must not open a scope that never closes.
+			if run, opensGroup, n, ok := modifierRun(pattern, i); ok {
+				if opensGroup {
+					scopes = append(scopes, dotAll)
+					dotAll = applyModifiers(run, dotAll)
+				} else {
+					// The `(?flags)` form sets modifiers for the REST of the
+					// enclosing group rather than opening one, so it changes the
+					// state without pushing. The enclosing `)` restores it.
+					dotAll = applyModifiers(run, dotAll)
+				}
+				b.WriteString(pattern[i : i+n])
+				i += n - 1
+				continue
+			}
+			scopes = append(scopes, dotAll)
+			b.WriteByte(c)
+		case c == ')' && !inClass:
+			if len(scopes) > 0 {
+				dotAll = scopes[len(scopes)-1]
+				scopes = scopes[:len(scopes)-1]
+			}
+			b.WriteByte(c)
 		case c == '.' && !inClass && !dotAll:
 			b.WriteString("[^" + ecmaLineTerminators + "]")
 		default:
@@ -721,10 +776,10 @@ func translateJSFlagsToGo(pattern, flags string) (string, error) {
 		}
 	}
 
-	// Give \s, \S and . ECMAScript semantics before RE2 sees them. Under the s
-	// flag `.` already matches every character, so it needs no rewrite.
-	dotAll := strings.Contains(flags, "s") || hasInlineDotAll(pattern)
-	goPattern := rewriteECMAClasses(pattern, dotAll)
+	// Give \s, \S and . ECMAScript semantics before RE2 sees them. The rewrite
+	// tracks inline `(?s:)` / `(?-s:)` scopes itself, so it takes the s FLAG as
+	// the starting state rather than a pattern-wide verdict.
+	goPattern := rewriteECMAClasses(pattern, strings.Contains(flags, "s"))
 
 	// Apply flags as Go inline flags (prepended to pattern)
 	var flagPrefixes []string
@@ -735,9 +790,11 @@ func translateJSFlagsToGo(pattern, flags string) (string, error) {
 	if strings.Contains(flags, "m") {
 		flagPrefixes = append(flagPrefixes, "(?m)")
 	}
-	if strings.Contains(flags, "s") {
-		flagPrefixes = append(flagPrefixes, "(?s)")
-	}
+	// Unconditional, where this used to follow the s flag. Every `.` that must
+	// stay narrow is now an explicit class, which `(?s)` cannot widen, so the
+	// only dots left for it to reach are the ones a modifier group turned on —
+	// including inside `(?s:...)` in a pattern carrying no s flag at all.
+	flagPrefixes = append(flagPrefixes, "(?s)")
 
 	// Note: 'g' (global) and 'y' (sticky) are handled at the JavaScript level,
 	// not in Go's regex engine. 'u' (unicode) is default in Go.

--- a/tests/scripts/regex_ecma_whitespace_and_dot.ts
+++ b/tests/scripts/regex_ecma_whitespace_and_dot.ts
@@ -1,0 +1,25 @@
+// ECMAScript's \s is WhiteSpace ∪ LineTerminator, which includes U+00A0,
+// U+FEFF and every Zs; its `.` excludes the four LineTerminators. Go's RE2
+// agrees on neither, and it ACCEPTS such a pattern rather than rejecting it,
+// so the wrong semantics used to reach the matcher silently.
+const checks: boolean[] = [
+    // \s must reach past ASCII whitespace.
+    "a b".replace(/\s+/g, "") === "ab",
+    "a b".replace(/\s+/g, "") === "ab",
+    "a﻿b".replace(/\s+/g, "") === "ab",
+    // ...without losing the ASCII members.
+    "a \t\nb".replace(/\s+/g, "") === "ab",
+    // \S is its exact complement, inside a character class too — RE2 has no
+    // set complement there, so that case is spelled out as ranges.
+    "a b".replace(/\S+/g, "X") === "X X",
+    "a b".replace(/[\S]+/g, "X") === "X X",
+    // `.` must not match a LineTerminator, but must match everything under s.
+    "a b".replace(/./g, "X") === "X X",
+    "a b".replace(/./gs, "X") === "XXX",
+    // An inline (?s:) modifier widens `.` for its own scope; the rewrite has
+    // to leave those patterns alone rather than clamp them.
+    /(?s:.)/.test("\n") === true,
+];
+
+checks.every((c: boolean): boolean => c);
+// expect: true

--- a/tests/scripts/regex_modifier_scope.ts
+++ b/tests/scripts/regex_modifier_scope.ts
@@ -1,0 +1,34 @@
+// Inline `(?s:)` / `(?-s:)` modifiers scope dotAll to their own group.
+//
+// The rewrite that gives `.` its ECMAScript meaning used to be skipped entirely
+// whenever any inline `s` modifier appeared, so a `.` OUTSIDE the group fell
+// back to Go's `.` and matched \r, U+2028 and U+2029 — the characters the
+// rewrite exists to exclude. Newlines were never the symptom, which is why this
+// covers all three.
+
+const LS = "\u2028";
+const PS = "\u2029";
+
+// A `.` outside the modified group stays narrow.
+const outerCR = /(?s:x)a.b/.test("xa\rb") === false;
+const outerLS = /(?s:x)a.b/.test("xa" + LS + "b") === false;
+const outerPS = /(?s:x)a.b/.test("xa" + PS + "b") === false;
+
+// ...while the one inside it matches a line terminator, which is the point.
+const innerNL = /(?s:a.)/.test("a\n") === true;
+
+// No modifier anywhere: unchanged behaviour, and the control for the above.
+const plainCR = /a.b/.test("a\rb") === false;
+const plainNL = /a.b/.test("a\nb") === false;
+
+// `(?-s:)` removes dotAll under an s flag, and the spec's own nesting example
+// (built-ins/RegExp/regexp-modifiers/remove-dotAll.js) reads both directions:
+// outside the group `.` spans newlines, inside it must not.
+const removed = /(?-s:a.)/s.test("a\nb") === false;
+const nestOutside = /a.(?-s:b.b).c/s.test("a\nb,b\nc") === true;
+const nestInside = /a.(?-s:b.b).c/s.test("a,b\nb,c") === false;
+
+outerCR && outerLS && outerPS && innerNL && plainCR && plainNL &&
+  removed && nestOutside && nestInside;
+
+// expect: true


### PR DESCRIPTION
Fixes #73.

`\s`, `\S` and `.` reached RE2 carrying Go's definitions. RE2 accepts such a pattern and compiles it to the wrong language rather than refusing it, so the divergence never surfaced as an error — `"a b".replace(/\s+/g, "")` returned `"a b"`, and `/^a.b$/` matched `"a\rb"`. The two definitions agree on ASCII and part company on `<NBSP>`, `<ZWNBSP>`, the Unicode `Zs` category, and three of the four line terminators.

## What changed

The three constructs are rewritten before RE2 sees them. `\S` inside a character class becomes explicit ranges, because RE2 has no set complement there and the rewrite has to be total: this path treats an RE2 refusal as the `SyntaxError` that ECMAScript requires for the modifier and named-group early errors, so a rewrite that gave up would turn a valid pattern into a thrown error.

The second commit removes a bail-out the first one introduced. An inline `s` modifier anywhere in a pattern had skipped the `.` rewrite wholesale, which left `.` with Go's meaning everywhere outside the modified group — `/(?s:x)a.b/` matched `"xa\rb"` where `/a.b/` alone correctly did not. Modifier scope is now tracked: a stack pushed on every group, `(?s:` and `(?-s:` folded in, and `(?flags)` applied to the rest of the enclosing group without pushing.

What makes that tracking safe is the rewrite it feeds. A `.` in a dotAll-off scope becomes an explicit class, and a class cannot be widened by a surrounding `(?s)` — only a bare `.` can. The two states are independent, which is what lets the `(?s)` prefix become unconditional and cover a `(?s:...)` group in a pattern carrying no `s` flag.

The halves are one commit each and can be reviewed separately.

## Verification

`tests/scripts/regex_ecma_whitespace_and_dot.ts` and `tests/scripts/regex_modifier_scope.ts` are new. Both were run against the unfixed code and fail there, so they are guarding the behavior they claim to.

On Test262 at `-timeout 2s`, `built-ins/RegExp` goes 989 → 990 of 1879. The newly passing test is `character-class-escape-non-whitespace.js`; the rest of the failing set is unchanged, so there are no regressions. `built-ins/String`, which shares this path through `match`, `replace` and `split`, is unchanged at 1111 of 1223 with an identical failing set. Timeout does not account for the difference — the unpatched binary scores the same 989 at `-timeout 0.2s`, and two runs of it agree on the failing set exactly.

Test262 moves by one because the `regexp-modifiers` tests that would exercise the scope fix also assert that a single `.` matches a lone surrogate. RE2 cannot express that: it works in runes where ECMAScript works in UTF-16 code units. Those tests fail on that assertion before reaching any of this. The smoke tests carry the coverage instead.
