### PR TITLE
test262 language: 98.1% -> 98.4% (generator unwinding + parser fixes)

### DIFF
--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -1766,8 +1766,10 @@ func hasStrictDirective(body *parser.BlockStatement) bool {
 			// ExpressionStatement but not a string literal - directive prologue ends
 			break
 		}
-		// This is a directive - check if it's "use strict"
-		if strLit.Value == "use strict" {
+		// This is a directive - check if it's "use strict". Directive Prologue
+		// matching is on raw source text, so a literal containing an escape
+		// sequence or line continuation (e.g. 'use str\ict') must not count.
+		if strLit.Value == "use strict" && !strLit.HasEscape {
 			return true
 		}
 		// Otherwise it's another directive (like "another directive"), continue checking

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -851,8 +851,10 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 					// ExpressionStatement but not a string literal - directive prologue ends
 					break
 				}
-				// This is a directive - check if it's "use strict"
-				if strLit.Value == "use strict" {
+				// This is a directive - check if it's "use strict". Directive
+				// Prologue matching is on raw source text, so a literal with an
+				// escape sequence or line continuation must not count.
+				if strLit.Value == "use strict" && !strLit.HasEscape {
 					c.chunk.IsStrict = true
 					debugPrintf("[Compile] Detected 'use strict' directive - enabling strict mode\n")
 					break

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -72,6 +72,7 @@ type Token struct {
 	Literal           string // The actual text of the token (lexeme)
 	RawLiteral        string // For template strings: the unprocessed escape sequences (TRV)
 	CookedIsUndefined bool   // For template strings: true if cooked value should be undefined (invalid escape)
+	HasEscape         bool   // For string literals: true if the source contained an escape sequence or line continuation (Literal is cooked either way)
 	Line              int    // 1-based line number where the token starts
 	Column            int    // 1-based column number (rune index) where the token starts
 	StartPos          int    // 0-based byte offset where the token starts
@@ -1443,22 +1444,22 @@ func (l *Lexer) NextToken() Token {
 		l.readChar()
 		tok = Token{Type: RBRACKET, Literal: literal, Line: startLine, Column: startCol, StartPos: startPos, EndPos: l.position}
 	case '"': // Double quoted string
-		literal, ok := l.readString('"')
+		literal, hasEscape, ok := l.readString('"')
 		endPos := l.position // readString advances past the closing quote if successful
 		if !ok {
 			// Determine if it was unterminated or invalid escape
 			// For now, use a generic message. l.position is where the error occurred.
 			tok = Token{Type: ILLEGAL, Literal: "Invalid string literal", Line: startLine, Column: startCol, StartPos: startPos, EndPos: endPos}
 		} else {
-			tok = Token{Type: STRING, Literal: literal, Line: startLine, Column: startCol, StartPos: startPos, EndPos: endPos}
+			tok = Token{Type: STRING, Literal: literal, HasEscape: hasEscape, Line: startLine, Column: startCol, StartPos: startPos, EndPos: endPos}
 		}
 	case '\'': // Single quoted string
-		literal, ok := l.readString('\'')
+		literal, hasEscape, ok := l.readString('\'')
 		endPos := l.position // readString advances past the closing quote if successful
 		if !ok {
 			tok = Token{Type: ILLEGAL, Literal: "Invalid string literal", Line: startLine, Column: startCol, StartPos: startPos, EndPos: endPos}
 		} else {
-			tok = Token{Type: STRING, Literal: literal, Line: startLine, Column: startCol, StartPos: startPos, EndPos: endPos}
+			tok = Token{Type: STRING, Literal: literal, HasEscape: hasEscape, Line: startLine, Column: startCol, StartPos: startPos, EndPos: endPos}
 		}
 	case '?':
 		peek := l.peekChar()
@@ -1974,8 +1975,16 @@ func (l *Lexer) readNumber() string {
 // Returns the unescaped string content and a boolean indicating success.
 // Success is false if the string is unterminated or contains an invalid escape sequence.
 // Advances the lexer's position to *after* the closing quote if successful.
-func (l *Lexer) readString(quote byte) (string, bool) {
+// readString scans a single/double-quoted string literal and returns its
+// cooked value. The second return value is true iff the source contained any
+// escape sequence or line continuation - callers that need to distinguish a
+// literal exactly matching some raw text (e.g. Directive Prologue detection
+// of "use strict", which must NOT recognize "use strict" or a
+// backslash-newline line continuation per spec) need this alongside the
+// cooked value, since the cooked value alone loses that distinction.
+func (l *Lexer) readString(quote byte) (string, bool, bool) {
 	var builder strings.Builder
+	hasEscape := false
 	// Consume the opening quote
 	l.readChar()
 
@@ -1983,14 +1992,15 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 		// Check for termination conditions *before* processing the character
 		if l.ch == quote {
 			l.readChar() // Consume the closing quote
-			return builder.String(), true
+			return builder.String(), hasEscape, true
 		}
 		if l.isEOF() { // EOF - use isEOF() to distinguish from literal null bytes
 			// Unterminated string
-			return "", false
+			return "", hasEscape, false
 		}
 
 		if l.ch == '\\' { // Handle escape sequence
+			hasEscape = true
 			l.readChar() // Consume the backslash
 
 			// Check for Unicode line terminators (U+2028, U+2029) for line continuation
@@ -2066,7 +2076,7 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 						if isHexDigit(l.ch) {
 							hexStr += charString(l.ch)
 						} else {
-							return "", false // Invalid hex digit
+							return "", hasEscape, false // Invalid hex digit
 						}
 					}
 					if l.peekChar() == '}' {
@@ -2085,10 +2095,10 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 								builder.WriteRune(rune(codePoint))
 							}
 						} else {
-							return "", false // Invalid code point
+							return "", hasEscape, false // Invalid code point
 						}
 					} else {
-						return "", false // Unterminated \u{...}
+						return "", hasEscape, false // Unterminated \u{...}
 					}
 				} else {
 					// \uXXXX format
@@ -2098,7 +2108,7 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 							l.readChar()
 							hexStr += charString(l.ch)
 						} else {
-							return "", false // Invalid or incomplete \uXXXX
+							return "", hasEscape, false // Invalid or incomplete \uXXXX
 						}
 					}
 					if codePoint, err := strconv.ParseInt(hexStr, 16, 32); err == nil {
@@ -2115,7 +2125,7 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 							builder.WriteRune(rune(codePoint))
 						}
 					} else {
-						return "", false // Invalid code point
+						return "", hasEscape, false // Invalid code point
 					}
 				}
 			case 'x':
@@ -2126,17 +2136,17 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 						l.readChar()
 						hexStr += charString(l.ch)
 					} else {
-						return "", false // Invalid or incomplete \xXX
+						return "", hasEscape, false // Invalid or incomplete \xXX
 					}
 				}
 				// Use ParseUint with 32 bits to handle full byte range (0x00-0xFF)
 				if codePoint, err := strconv.ParseUint(hexStr, 16, 32); err == nil && codePoint <= 255 {
 					builder.WriteByte(byte(codePoint))
 				} else {
-					return "", false // Invalid code point
+					return "", hasEscape, false // Invalid code point
 				}
 			case 0: // EOF after backslash
-				return "", false // Invalid escape sequence due to EOF
+				return "", hasEscape, false // Invalid escape sequence due to EOF
 			default:
 				// Identity escape sequence: In JavaScript (non-strict mode), unknown escape
 				// sequences like \A, \z, etc. are treated as the character itself.
@@ -2148,7 +2158,7 @@ func (l *Lexer) readString(quote byte) (string, bool) {
 			// Check for unescaped newline within the string, which is often illegal
 			if l.ch == '\n' || l.ch == '\r' {
 				// Treat unescaped newline as termination error
-				return "", false
+				return "", hasEscape, false
 			}
 			builder.WriteByte(l.ch)
 		}

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -440,6 +440,7 @@ type StringLiteral struct {
 	BaseExpression              // Embed base for ComputedType
 	Token          *lexer.Token // The lexer.STRING token
 	Value          string
+	HasEscape      bool // True if the source literal contained an escape sequence or line continuation (see Directive Prologue detection, which must match raw source text)
 }
 
 func (s *StringLiteral) expressionNode()      {}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -13,6 +13,21 @@ import (
 // --- Debug Flag ---
 const debugParser = false
 
+// isIdentifierNameToken reports whether tok can serve as an IdentifierName
+// (per ECMAScript grammar, IdentifierName = IDENT or any reserved word - e.g.
+// 'class', 'default', 'if'). Used for contexts that accept IdentifierName
+// rather than plain BindingIdentifier, such as ModuleExportName positions
+// ('export * as class from ...') and property/member names after '.'.
+// A keyword token's Type always equals lexer.LookupIdent(tok.Literal), since
+// that's how the lexer assigns it in the first place - reusing that lookup
+// here avoids hand-maintaining a duplicate keyword list.
+func (p *Parser) isIdentifierNameToken(tok *lexer.Token) bool {
+	if tok.Type == lexer.IDENT {
+		return true
+	}
+	return lexer.LookupIdent(tok.Literal) == tok.Type
+}
+
 func debugPrint(format string, args ...interface{}) {
 	if debugParser {
 		fmt.Printf("[Parser Debug] "+format+"\n", args...)
@@ -11540,15 +11555,15 @@ func (p *Parser) parseExportAllDeclaration(exportToken *lexer.Token, isTypeOnly 
 		p.nextToken() // consume '*'
 		p.nextToken() // consume 'as'
 
-		// Accept identifier, string literal, or 'default' keyword
-		if p.curToken.Type == lexer.IDENT {
-			stmt.Exported = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-		} else if p.curToken.Type == lexer.STRING {
+		// Accept identifier, string literal, or any reserved word: per spec a
+		// ModuleExportName binding is either a StringLiteral or an
+		// IdentifierName, and IdentifierName explicitly includes reserved
+		// words (e.g. 'export * as class from ...' is valid).
+		if p.curToken.Type == lexer.STRING {
 			// Arbitrary module namespace names: export * as "name" from "module"
 			stmt.Exported = &StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
-		} else if p.curToken.Type == lexer.DEFAULT {
-			// export * as default from "module"
-			stmt.Exported = &Identifier{Token: p.curToken, Value: "default"}
+		} else if p.isIdentifierNameToken(p.curToken) {
+			stmt.Exported = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		} else {
 			p.addError(p.curToken, "expected identifier, string literal, or 'default' after 'as' in export declaration")
 			return nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -509,7 +509,11 @@ func (p *Parser) ParseProgram() (*Program, []errors.PaseratiError) {
 			if inDirectivePrologue {
 				if exprStmt, isExprStmt := stmt.(*ExpressionStatement); isExprStmt && exprStmt != nil {
 					if strLit, isStrLit := exprStmt.Expression.(*StringLiteral); isStrLit && strLit != nil {
-						if strLit.Value == "use strict" {
+						// Directive Prologue matching is on the raw source text, not the
+						// cooked value - a literal with an escape sequence or line
+						// continuation (e.g. 'use str\ict' or 'use strict') must NOT
+						// be recognized as the "use strict" directive.
+						if strLit.Value == "use strict" && !strLit.HasEscape {
 							p.strictMode = true
 						}
 						// Continue in directive prologue - more directives may follow
@@ -2434,6 +2438,7 @@ func (p *Parser) parseStringLiteral() Expression {
 	lit := p.arena.NewStringLiteral()
 	lit.Token = p.curToken
 	lit.Value = p.curToken.Literal
+	lit.HasEscape = p.curToken.HasEscape
 	return lit
 }
 
@@ -4091,7 +4096,10 @@ func (p *Parser) parseFunctionBodyWithDirectives() *BlockStatement {
 			if inDirectivePrologue {
 				if exprStmt, ok := stmt.(*ExpressionStatement); ok {
 					if strLit, ok := exprStmt.Expression.(*StringLiteral); ok {
-						if strLit.Value == "use strict" {
+						// See the matching comment in parseProgram: Directive Prologue
+						// matching is on raw source text, so an escaped/line-continued
+						// literal must not be recognized as "use strict".
+						if strLit.Value == "use strict" && !strLit.HasEscape {
 							p.strictMode = true
 						}
 						// Continue checking - multiple directives are allowed

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -11314,6 +11314,16 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 		// Named imports: { name1, name2 as alias, "string name" as alias, default as alias }
 		p.nextToken() // consume '{'
 
+		// Empty named import list: import {} from 'module' - valid per spec,
+		// equivalent to importing the module for its side effects only. Must
+		// return a non-nil (but empty) slice: the caller treats a nil return
+		// from this function as "parse failed" and aborts the whole import
+		// declaration, but `specs` here is nil (Go zero value, never
+		// appended to) rather than a deliberate failure signal.
+		if p.curToken.Type == lexer.RBRACE {
+			return []ImportSpecifier{}
+		}
+
 		for {
 			var imported *Identifier
 			var importedToken *lexer.Token

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -12493,28 +12493,38 @@ startExecution:
 
 			// Execute the module using the standard module loading infrastructure
 			// This goes through the resolver chain (fs, virtual, data URLs, native modules)
-			status, _ := vm.executeModule(specifier)
+			status, moduleErrVal := vm.executeModule(specifier)
 			if status != InterpretOK {
-				// Module load failed - reject the promise with the error
-				// Get error from vm.errors if available
-				var errorMsg string
-				if len(vm.errors) > 0 {
-					// Use the last error message from vm.errors
-					lastErr := vm.errors[len(vm.errors)-1]
-					errorMsg = lastErr.Error()
-					// Clear the error since we're handling it
-					vm.errors = vm.errors[:len(vm.errors)-1]
-				} else if vm.currentException != Null {
-					errorMsg = vm.currentException.ToString()
-					vm.currentException = Null
-					vm.unwinding = false
+				// Module load failed - reject the promise with the error.
+				// Prefer the actual thrown value (moduleErrVal) as the rejection
+				// reason: per spec, ImportCall must reject with the module's own
+				// abrupt completion value (e.g. a real TypeError instance), not
+				// a generic Error synthesized from a flattened message string.
+				// executeModule clears vm.currentException internally for
+				// isolation before returning, so it must hand the original
+				// thrown value back through its own return value instead.
+				if moduleErrVal != Null && moduleErrVal != Undefined {
+					reason := moduleErrVal
+					// Drop the diagnostic-only entry vm.errors accumulated for
+					// this now-handled (rejected-as-a-promise) exception.
+					if len(vm.errors) > 0 {
+						vm.errors = vm.errors[:len(vm.errors)-1]
+					}
+					vm.rejectPromise(promiseObj, reason)
 				} else {
-					errorMsg = fmt.Sprintf("Failed to load module '%s'", specifier)
+					var errorMsg string
+					if len(vm.errors) > 0 {
+						lastErr := vm.errors[len(vm.errors)-1]
+						errorMsg = lastErr.Error()
+						vm.errors = vm.errors[:len(vm.errors)-1]
+					} else {
+						errorMsg = fmt.Sprintf("Failed to load module '%s'", specifier)
+					}
+					errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+					errObj.SetOwn("name", NewString("Error"))
+					errObj.SetOwn("message", NewString(errorMsg))
+					vm.rejectPromise(promiseObj, NewValueFromPlainObject(errObj))
 				}
-				errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
-				errObj.SetOwn("name", NewString("Error"))
-				errObj.SetOwn("message", NewString(errorMsg))
-				vm.rejectPromise(promiseObj, NewValueFromPlainObject(errObj))
 				registers[destReg] = promiseVal
 				continue
 			}
@@ -18503,8 +18513,13 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 
 		return InterpretOK, result
 	} else {
-		// Module execution truly failed
-		return InterpretRuntimeError, Undefined
+		// Module execution truly failed. Return the actual thrown value (if the
+		// module's abrupt completion was a JS exception) rather than Undefined -
+		// vm.currentException was already cleared above for isolation, so this
+		// is the only place a caller (e.g. OpDynamicImport, which must reject
+		// its promise with the module's own exception value per spec) can still
+		// get at it.
+		return InterpretRuntimeError, moduleException
 	}
 }
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17236,9 +17236,22 @@ func (vm *VM) startGenerator(genObj *GeneratorObject, sentValue Value) (Value, e
 			vm.frameCount--
 		}
 
+		// See the matching comment in resumeGenerator: we just manually popped
+		// past our own native boundary (the generator frame was isDirectCall=true
+		// and unwindException stopped there without popping it) and are handing
+		// the exception off to native Go code as a plain error. Fully clear the
+		// VM's unwinding state rather than leaving unwinding=true dangling - our
+		// caller may swallow this error entirely, and a stale unwinding=true
+		// would corrupt the next unrelated dispatch's view of VM state.
 		if vm.unwinding && vm.currentException != Null {
-			return Undefined, exceptionError{exception: vm.currentException}
+			ex := vm.currentException
+			vm.currentException = Null
+			vm.unwinding = false
+			vm.unwindingCrossedNative = false
+			return Undefined, exceptionError{exception: ex}
 		}
+		vm.unwinding = false
+		vm.unwindingCrossedNative = false
 		return Undefined, fmt.Errorf("runtime error during generator execution")
 	}
 
@@ -17444,9 +17457,27 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 			vm.frameCount--
 		}
 
+		// We've fully unwound past our own native boundary (the generator frame
+		// above was isDirectCall=true, so unwindException stopped there without
+		// popping it - we just popped it manually) and are handing the exception
+		// off to native Go code as a plain error. Fully clear the VM's unwinding
+		// state (unwinding, unwindingCrossedNative, currentException) rather than
+		// leaving `unwinding=true` dangling: our caller may swallow this error
+		// entirely (e.g. AsyncGenerator.prototype.next converts it into a
+		// rejected promise and returns success), and a stale unwinding=true would
+		// then make the next unrelated VM dispatch check misread "still
+		// unwinding" and misbehave. If our caller does re-throw via
+		// vm.throwException(ex), that call starts a fresh, honest unwind from
+		// scratch (see the !vm.unwinding branch there), which is what we want.
 		if vm.unwinding && vm.currentException != Null {
-			return Undefined, exceptionError{exception: vm.currentException}
+			ex := vm.currentException
+			vm.currentException = Null
+			vm.unwinding = false
+			vm.unwindingCrossedNative = false
+			return Undefined, exceptionError{exception: ex}
 		}
+		vm.unwinding = false
+		vm.unwindingCrossedNative = false
 		return Undefined, exceptionError{exception: NewString("runtime error during generator resumption")}
 	}
 


### PR DESCRIPTION
## Summary

Five independent fixes targeting test262 `language` suite compliance: 98.1% → 98.4% (23087 → 23148 / 23523), goal met. Zero regressions across `language` and `built-ins` suites (diffed twice against `baseline_language.txt` / `baseline.txt`).

- **`vm: fix stale unwinding state leaking past swallowed generator exceptions`** (the big one, +389) — `resumeGenerator`/`startGenerator` left `vm.unwinding`/`vm.unwindingCrossedNative` dangling after converting a VM exception into a Go error at their own native-call boundary. A caller that *swallows* the error (e.g. `AsyncGenerator.prototype.next` converting it to a rejected promise) left that stale state to corrupt the next unrelated dispatch — manifesting as `index out of range` panics or spurious "thrown null" exceptions anywhere destructuring/`yield*` triggers a nested generator resume that throws.

- **`parser: match Directive Prologue against raw source, not cooked value`** (+2) — `'use strict'` was matched against the cooked string value, so `'use str\ict'` (line continuation) or `'use strict'` (escape) were wrongly recognized as the strict directive.

- **`parser: accept an empty named-import list`** (+2) — `import {} from '...'` failed to parse; fixing it uncovered a nil-slice bug where the empty-list return path was misread by the caller as "parse failed," discarding the whole import statement and causing a downstream nil-pointer panic.

- **`parser: allow reserved words in 'export * as <name>'`** (+2) — `export * as class from '...'` was rejected; ModuleExportName accepts any IdentifierName including keywords, per spec. Verified `export * as 42` / `export * as +` are still correctly rejected.

- **`vm: reject dynamic import() with the module's actual thrown value`** — `import()` was rejecting with a generic synthesized `Error` instead of the module's real thrown value (e.g. losing the actual `TypeError`). Net zero on the pass count (a separate, pre-existing frame-bookkeeping bug blocks the specific tests this would help — verified present on unmodified `main`), but independently more spec-correct with zero regressions, so kept.

Diagnosed but deliberately not attempted here (separate, larger efforts):
- **eval var-scoping** (~100 tests): direct `eval`'s `var`/function declarations don't create bindings in the calling function's own environment.
- **Private brand per-evaluation** (10 tests): private method/accessor brands are keyed by a compile-time counter instead of a per-class-evaluation runtime token.

## Test plan

- `go test ./tests -run TestScripts` — green
- `./paserati-test262 -path ./test262 -subpath "language" -timeout 0.2s -diff baseline_language.txt` — +395, 0 regressions (rerun twice for stability)
- `./paserati-test262 -path ./test262 -subpath "built-ins" -timeout 0.2s -diff baseline.txt` — +1, 0 regressions
- `./paserati-test262 -path ./test262 -subpath "language/module-code"` / `-subpath "language/export"` — 0 regressions
- Manual edge-case checks for the reserved-word `export * as` fix (`export * as 42`, `export * as +` still `SyntaxError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)