### PR TITLE
vm: eliminate accessor/control-flow panics found chasing built-ins Test262 coverage

### DIFF
--- a/pkg/builtins/abort_controller_init.go
+++ b/pkg/builtins/abort_controller_init.go
@@ -100,10 +100,12 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		// Check if any input signal is already aborted
 		if len(args) > 0 {
-			if arr := args[0].AsArray(); arr != nil {
+			if args[0].Type() == vm.TypeArray {
+				arr := args[0].AsArray()
 				for i := 0; i < arr.Length(); i++ {
 					elem := arr.Get(i)
-					if obj := elem.AsPlainObject(); obj != nil {
+					if elem.Type() == vm.TypeObject {
+						obj := elem.AsPlainObject()
 						if aborted, exists := obj.GetOwn("aborted"); exists && aborted.IsBoolean() && aborted.AsBoolean() {
 							signal.aborted = true
 							if reason, exists := obj.GetOwn("reason"); exists {
@@ -141,7 +143,8 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	controllerConstructor := vm.NewConstructorWithProps(0, false, "AbortController", controllerConstructorFn)
-	if ctorProps := controllerConstructor.AsNativeFunctionWithProps(); ctorProps != nil {
+	if controllerConstructor.Type() == vm.TypeNativeFunctionWithProps {
+		ctorProps := controllerConstructor.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(controllerProto))
 	}
 

--- a/pkg/builtins/arraybuffer_init.go
+++ b/pkg/builtins/arraybuffer_init.go
@@ -223,7 +223,8 @@ func (a *ArrayBufferInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Step 6: Get [Symbol.species] from constructor
 		var species vm.Value
 		if ctor.IsObject() {
-			if po := ctor.AsPlainObject(); po != nil {
+			if ctor.Type() == vm.TypeObject {
+				po := ctor.AsPlainObject()
 				species, _ = po.GetOwnByKey(vm.NewSymbolKey(vmInstance.SymbolSpecies))
 			}
 		}

--- a/pkg/builtins/bigint_init.go
+++ b/pkg/builtins/bigint_init.go
@@ -62,7 +62,8 @@ func thisBigIntValue(v vm.Value) (vm.Value, bool) {
 	case vm.TypeBigInt:
 		return v, true
 	case vm.TypeObject:
-		if po := v.AsPlainObject(); po != nil {
+		if v.Type() == vm.TypeObject {
+			po := v.AsPlainObject()
 			if data, exists := po.GetOwn("[[PrimitiveValue]]"); exists && data.Type() == vm.TypeBigInt {
 				return data, true
 			}

--- a/pkg/builtins/blob_init.go
+++ b/pkg/builtins/blob_init.go
@@ -36,9 +36,9 @@ func (b *BlobInitializer) InitTypes(ctx *TypeContext) error {
 
 	// Blob constructor type
 	blobConstructorType := types.NewObjectType().
-		WithSimpleCallSignature([]types.Type{}, blobType).                            // Blob()
-		WithSimpleCallSignature([]types.Type{types.Any}, blobType).                   // Blob(blobParts)
-		WithSimpleCallSignature([]types.Type{types.Any, blobOptionsType}, blobType).  // Blob(blobParts, options)
+		WithSimpleCallSignature([]types.Type{}, blobType).                           // Blob()
+		WithSimpleCallSignature([]types.Type{types.Any}, blobType).                  // Blob(blobParts)
+		WithSimpleCallSignature([]types.Type{types.Any, blobOptionsType}, blobType). // Blob(blobParts, options)
 		WithProperty("prototype", blobType)
 
 	return ctx.DefineGlobal("Blob", blobConstructorType)
@@ -60,7 +60,8 @@ func (b *BlobInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Parse blobParts if provided
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined && args[0].Type() != vm.TypeNull {
 			parts := args[0]
-			if arr := parts.AsArray(); arr != nil {
+			if parts.Type() == vm.TypeArray {
+				arr := parts.AsArray()
 				for i := 0; i < arr.Length(); i++ {
 					part := arr.Get(i)
 					blob.data = append(blob.data, blobPartToBytes(part)...)
@@ -73,11 +74,13 @@ func (b *BlobInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Parse options if provided
 		if len(args) > 1 && args[1].Type() != vm.TypeUndefined && args[1].Type() != vm.TypeNull {
-			if opts := args[1].AsPlainObject(); opts != nil {
+			if args[1].Type() == vm.TypeObject {
+				opts := args[1].AsPlainObject()
 				if t, exists := opts.GetOwn("type"); exists && t.Type() == vm.TypeString {
 					blob.mimeType = t.ToString()
 				}
-			} else if opts := args[1].AsDictObject(); opts != nil {
+			} else if args[1].Type() == vm.TypeDictObject {
+				opts := args[1].AsDictObject()
 				if t, exists := opts.GetOwn("type"); exists && t.Type() == vm.TypeString {
 					blob.mimeType = t.ToString()
 				}
@@ -88,7 +91,8 @@ func (b *BlobInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	blobConstructor := vm.NewConstructorWithProps(2, false, "Blob", blobConstructorFn)
-	if ctorProps := blobConstructor.AsNativeFunctionWithProps(); ctorProps != nil {
+	if blobConstructor.Type() == vm.TypeNativeFunctionWithProps {
+		ctorProps := blobConstructor.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(blobProto))
 	}
 
@@ -124,11 +128,9 @@ func blobPartToBytes(part vm.Value) []byte {
 		}
 	case vm.TypeObject:
 		// Check if it's a Blob-like object with data
-		if obj := part.AsPlainObject(); obj != nil {
-			// Try to get internal blob data (would need special handling)
-			// For now, convert to string
-			return []byte(part.ToString())
-		}
+		// Try to get internal blob data (would need special handling)
+		// For now, convert to string
+		return []byte(part.ToString())
 	default:
 		return []byte(part.ToString())
 	}

--- a/pkg/builtins/boolean_init.go
+++ b/pkg/builtins/boolean_init.go
@@ -125,7 +125,7 @@ func (b *BooleanInitializer) InitRuntime(ctx *RuntimeContext) error {
 				primitiveValue = false
 			default:
 				// For objects, try valueOf/toString
-				if arg.IsObject() {
+				if arg.Type() == vm.TypeObject {
 					// Try valueOf first
 					if valueOf, exists := arg.AsPlainObject().GetOwn("valueOf"); exists && valueOf.IsFunction() {
 						result, err := vmInstance.Call(valueOf, arg, nil)

--- a/pkg/builtins/date_init.go
+++ b/pkg/builtins/date_init.go
@@ -845,10 +845,10 @@ func (d *DateInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	dateProto.SetOwnNonEnumerable("setYear", vm.NewNativeFunction(1, false, "setYear", func(args []vm.Value) (vm.Value, error) {
 		thisDate := vmInstance.GetThis()
-		dateObj := thisDate.AsPlainObject()
-		if dateObj == nil {
+		if thisDate.Type() != vm.TypeObject {
 			return vm.Undefined, vmInstance.NewTypeError("setYear called on non-Date object")
 		}
+		dateObj := thisDate.AsPlainObject()
 
 		// Check if it's a Date object by verifying it has __timestamp__ property
 		if _, exists := dateObj.GetOwn("__timestamp__"); !exists {

--- a/pkg/builtins/date_init.go
+++ b/pkg/builtins/date_init.go
@@ -1535,10 +1535,10 @@ func (d *DateInitializer) InitRuntime(ctx *RuntimeContext) error {
 // It returns the [[DateValue]] internal slot if value is a Date object, otherwise returns an error.
 // This is used by Date.prototype methods to validate the "this" value.
 func thisTimeValue(vmInstance *vm.VM, dateValue vm.Value) (float64, error) {
-	obj := dateValue.AsPlainObject()
-	if obj == nil {
+	if dateValue.Type() != vm.TypeObject {
 		return 0, vmInstance.NewTypeError("this is not a Date object")
 	}
+	obj := dateValue.AsPlainObject()
 	timestampValue, exists := obj.GetOwn("__timestamp__")
 	if !exists {
 		return 0, vmInstance.NewTypeError("this is not a Date object")
@@ -1549,7 +1549,8 @@ func thisTimeValue(vmInstance *vm.VM, dateValue vm.Value) (float64, error) {
 // getDateTimestamp is a legacy helper that returns (timestamp, ok).
 // For new code, prefer thisTimeValue which properly throws TypeError.
 func getDateTimestamp(dateValue vm.Value) (float64, bool) {
-	if obj := dateValue.AsPlainObject(); obj != nil {
+	if dateValue.Type() == vm.TypeObject {
+		obj := dateValue.AsPlainObject()
 		if timestampValue, exists := obj.GetOwn("__timestamp__"); exists {
 			return timestampValue.ToFloat(), true
 		}
@@ -1568,7 +1569,8 @@ func timeClip(t float64) float64 {
 
 func setDateTimestamp(dateValue vm.Value, timestamp float64) float64 {
 	clipped := timeClip(timestamp)
-	if obj := dateValue.AsPlainObject(); obj != nil {
+	if dateValue.Type() == vm.TypeObject {
+		obj := dateValue.AsPlainObject()
 		obj.SetOwnNonEnumerable("__timestamp__", vm.NumberValue(clipped))
 	}
 	return clipped

--- a/pkg/builtins/disposable_stack_init.go
+++ b/pkg/builtins/disposable_stack_init.go
@@ -96,10 +96,10 @@ func getDisposeMethod(vmInstance *vm.VM, value vm.Value, async bool) (vm.Value, 
 // though they share a Go struct here).
 func disposableBrandCheck(vmInstance *vm.VM, methodLabel string, wantAsync bool) (*vm.PlainObject, *vm.DisposableStackState, error) {
 	thisVal := vmInstance.GetThis()
-	po := thisVal.AsPlainObject()
-	if po == nil {
+	if thisVal.Type() != vm.TypeObject {
 		return nil, nil, vmInstance.NewTypeError(methodLabel + " requires that 'this' be an Object")
 	}
+	po := thisVal.AsPlainObject()
 	st := po.DisposableState()
 	if st == nil || st.Async != wantAsync {
 		return nil, nil, vmInstance.NewTypeError(methodLabel + " called on incompatible receiver")

--- a/pkg/builtins/error_init.go
+++ b/pkg/builtins/error_init.go
@@ -74,7 +74,8 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		message := ""
 
 		// Get name and message properties
-		if plainObj := thisValue.AsPlainObject(); plainObj != nil {
+		if thisValue.Type() == vm.TypeObject {
+			plainObj := thisValue.AsPlainObject()
 			// Step 3-4: Get name property, default to "Error"
 			if nameValue, exists := plainObj.GetOwn("name"); exists {
 				if nameValue.Type() == vm.TypeUndefined {
@@ -91,7 +92,8 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 					message = messageValue.ToString()
 				}
 			}
-		} else if dictObj := thisValue.AsDictObject(); dictObj != nil {
+		} else if thisValue.Type() == vm.TypeDictObject {
+			dictObj := thisValue.AsDictObject()
 			if nameValue, exists := dictObj.GetOwn("name"); exists {
 				if nameValue.Type() == vm.TypeUndefined {
 					name = "Error"
@@ -170,7 +172,8 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Make it a proper constructor with prototype property
-	if ctorObj := errorConstructor.AsNativeFunction(); ctorObj != nil {
+	if errorConstructor.Type() == vm.TypeNativeFunction {
+		ctorObj := errorConstructor.AsNativeFunction()
 		// Convert to object with properties
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
@@ -317,7 +320,8 @@ func (e *AggregateErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Handle options.cause if provided
 		if len(args) > 2 && args[2].IsObject() {
-			if optObj := args[2].AsPlainObject(); optObj != nil {
+			if args[2].Type() == vm.TypeObject {
+				optObj := args[2].AsPlainObject()
 				if cause, hasCause := optObj.Get("cause"); hasCause {
 					inst.SetOwnNonEnumerable("cause", cause)
 				}
@@ -327,7 +331,8 @@ func (e *AggregateErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vm.NewValueFromPlainObject(inst), nil
 	})
 
-	if nf := ctor.AsNativeFunction(); nf != nil {
+	if ctor.Type() == vm.TypeNativeFunction {
+		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
@@ -420,7 +425,8 @@ func (e *SuppressedErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vm.NewValueFromPlainObject(inst), nil
 	})
 
-	if nf := ctor.AsNativeFunction(); nf != nil {
+	if ctor.Type() == vm.TypeNativeFunction {
+		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
@@ -478,7 +484,8 @@ func initErrorSubclass(ctx *RuntimeContext, name string) error {
 		// If options is an Object and HasProperty(options, "cause") is true,
 		// install the cause property
 		if len(args) > 1 && args[1].IsObject() {
-			if optObj := args[1].AsPlainObject(); optObj != nil {
+			if args[1].Type() == vm.TypeObject {
+				optObj := args[1].AsPlainObject()
 				if cause, hasCause := optObj.Get("cause"); hasCause {
 					inst.SetOwnNonEnumerable("cause", cause)
 				}
@@ -487,7 +494,8 @@ func initErrorSubclass(ctx *RuntimeContext, name string) error {
 
 		return vm.NewValueFromPlainObject(inst), nil
 	})
-	if nf := ctor.AsNativeFunction(); nf != nil {
+	if ctor.Type() == vm.TypeNativeFunction {
+		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
@@ -529,11 +537,13 @@ func isErrorValue(vmInstance *vm.VM, val vm.Value) bool {
 	}
 
 	// Check for [[ErrorData]] internal slot on the object itself
-	if po := val.AsPlainObject(); po != nil {
+	if val.Type() == vm.TypeObject {
+		po := val.AsPlainObject()
 		_, hasErrorData := po.GetOwn("[[ErrorData]]")
 		return hasErrorData
 	}
-	if d := val.AsDictObject(); d != nil {
+	if val.Type() == vm.TypeDictObject {
+		d := val.AsDictObject()
 		_, hasErrorData := d.GetOwn("[[ErrorData]]")
 		return hasErrorData
 	}

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -75,11 +75,11 @@ func (f *FetchInitializer) InitTypes(ctx *TypeContext) error {
 
 	// Response constructor type
 	responseConstructorType := types.NewObjectType().
-		WithSimpleCallSignature([]types.Type{}, responseType).                                    // Response()
-		WithSimpleCallSignature([]types.Type{types.Any}, responseType).                           // Response(body)
-		WithSimpleCallSignature([]types.Type{types.Any, responseInitType}, responseType).         // Response(body, init)
+		WithSimpleCallSignature([]types.Type{}, responseType).                            // Response()
+		WithSimpleCallSignature([]types.Type{types.Any}, responseType).                   // Response(body)
+		WithSimpleCallSignature([]types.Type{types.Any, responseInitType}, responseType). // Response(body, init)
 		WithProperty("prototype", responseType).
-		WithProperty("error", types.NewSimpleFunction([]types.Type{}, responseType)).             // Response.error()
+		WithProperty("error", types.NewSimpleFunction([]types.Type{}, responseType)).                              // Response.error()
 		WithProperty("redirect", types.NewSimpleFunction([]types.Type{types.String, types.Number}, responseType)). // Response.redirect(url, status)
 		WithProperty("json", types.NewSimpleFunction([]types.Type{types.Any, responseInitType}, responseType))     // Response.json(data, init)
 
@@ -92,8 +92,8 @@ func (f *FetchInitializer) InitTypes(ctx *TypeContext) error {
 		WithOptionalProperty("method", types.String).
 		WithOptionalProperty("headers", types.NewUnionType(headersType, types.NewObjectType())).
 		WithOptionalProperty("body", types.NewUnionType(types.String, types.NewObjectType())).
-		WithOptionalProperty("signal", types.Any).      // AbortSignal
-		WithOptionalProperty("redirect", types.String). // "follow" | "error" | "manual"
+		WithOptionalProperty("signal", types.Any).         // AbortSignal
+		WithOptionalProperty("redirect", types.String).    // "follow" | "error" | "manual"
 		WithOptionalProperty("credentials", types.String). // "omit" | "same-origin" | "include"
 		WithOptionalProperty("cache", types.String).       // cache mode
 		WithOptionalProperty("mode", types.String).        // CORS mode
@@ -116,20 +116,20 @@ func (f *FetchInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("redirect", types.String).
 		WithProperty("referrer", types.String).
 		WithProperty("referrerPolicy", types.String).
-		WithProperty("signal", types.Any). // AbortSignal
-		WithProperty("clone", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Request
-		WithProperty("arrayBuffer", types.NewSimpleFunction([]types.Type{}, types.Any)).  // Returns Promise<ArrayBuffer>
-		WithProperty("blob", types.NewSimpleFunction([]types.Type{}, types.Any)).         // Returns Promise<Blob>
-		WithProperty("formData", types.NewSimpleFunction([]types.Type{}, types.Any)).     // Returns Promise<FormData>
-		WithProperty("json", types.NewSimpleFunction([]types.Type{}, types.Any)).         // Returns Promise<any>
-		WithProperty("text", types.NewSimpleFunction([]types.Type{}, types.Any))          // Returns Promise<string>
+		WithProperty("signal", types.Any).                                               // AbortSignal
+		WithProperty("clone", types.NewSimpleFunction([]types.Type{}, types.Any)).       // Returns Request
+		WithProperty("arrayBuffer", types.NewSimpleFunction([]types.Type{}, types.Any)). // Returns Promise<ArrayBuffer>
+		WithProperty("blob", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<Blob>
+		WithProperty("formData", types.NewSimpleFunction([]types.Type{}, types.Any)).    // Returns Promise<FormData>
+		WithProperty("json", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<any>
+		WithProperty("text", types.NewSimpleFunction([]types.Type{}, types.Any))         // Returns Promise<string>
 
 	// Request constructor type
 	requestConstructorType := types.NewObjectType().
-		WithSimpleCallSignature([]types.Type{types.String}, requestType).                 // Request(url)
+		WithSimpleCallSignature([]types.Type{types.String}, requestType).                  // Request(url)
 		WithSimpleCallSignature([]types.Type{types.String, requestInitType}, requestType). // Request(url, init)
-		WithSimpleCallSignature([]types.Type{requestType}, requestType).                  // Request(request)
-		WithSimpleCallSignature([]types.Type{requestType, requestInitType}, requestType). // Request(request, init)
+		WithSimpleCallSignature([]types.Type{requestType}, requestType).                   // Request(request)
+		WithSimpleCallSignature([]types.Type{requestType, requestInitType}, requestType).  // Request(request, init)
 		WithProperty("prototype", requestType)
 
 	if err := ctx.DefineGlobal("Request", requestConstructorType); err != nil {
@@ -183,7 +183,8 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Use NewConstructorWithProps to make it callable with 'new'
 	headersConstructor := vm.NewConstructorWithProps(1, false, "Headers", headersConstructorFn)
-	if ctorProps := headersConstructor.AsNativeFunctionWithProps(); ctorProps != nil {
+	if headersConstructor.Type() == vm.TypeNativeFunctionWithProps {
+		ctorProps := headersConstructor.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(headersProto))
 	}
 
@@ -253,7 +254,8 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	responseConstructor := vm.NewConstructorWithProps(2, false, "Response", responseConstructorFn)
-	if ctorProps := responseConstructor.AsNativeFunctionWithProps(); ctorProps != nil {
+	if responseConstructor.Type() == vm.TypeNativeFunctionWithProps {
+		ctorProps := responseConstructor.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(responseProto))
 
 		// Response.error() - returns an error response
@@ -443,7 +445,8 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	requestConstructor := vm.NewConstructorWithProps(2, false, "Request", requestConstructorFn)
-	if ctorProps := requestConstructor.AsNativeFunctionWithProps(); ctorProps != nil {
+	if requestConstructor.Type() == vm.TypeNativeFunctionWithProps {
+		ctorProps := requestConstructor.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(requestProto))
 	}
 
@@ -594,16 +597,16 @@ type FetchHeaders struct {
 
 // FetchResponse represents the Response object with VM reference for async methods
 type FetchResponse struct {
-	vm          *vm.VM
-	OK          bool
-	Status      int
-	StatusText  string
-	URL         string
-	Headers     *FetchHeaders
-	body        []byte
-	bodyUsed    bool
-	Redirected  bool   // Whether this response is the result of a redirect
-	Type        string // Response type: "basic", "cors", "default", "error", "opaque", "opaqueredirect"
+	vm         *vm.VM
+	OK         bool
+	Status     int
+	StatusText string
+	URL        string
+	Headers    *FetchHeaders
+	body       []byte
+	bodyUsed   bool
+	Redirected bool   // Whether this response is the result of a redirect
+	Type       string // Response type: "basic", "cors", "default", "error", "opaque", "opaqueredirect"
 }
 
 // boolToValue converts a bool to vm.Value

--- a/pkg/builtins/formdata_init.go
+++ b/pkg/builtins/formdata_init.go
@@ -55,7 +55,8 @@ func (f *FormDataInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	formDataConstructor := vm.NewConstructorWithProps(0, false, "FormData", formDataConstructorFn)
-	if ctorProps := formDataConstructor.AsNativeFunctionWithProps(); ctorProps != nil {
+	if formDataConstructor.Type() == vm.TypeNativeFunctionWithProps {
+		ctorProps := formDataConstructor.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(formDataProto))
 	}
 

--- a/pkg/builtins/function_init.go
+++ b/pkg/builtins/function_init.go
@@ -136,7 +136,8 @@ func (f *FunctionInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Make it a proper constructor with static methods
-	if ctorObj := functionCtor.AsNativeFunction(); ctorObj != nil {
+	if functionCtor.Type() == vm.TypeNativeFunction {
+		ctorObj := functionCtor.AsNativeFunction()
 		// Convert to object with properties
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
@@ -165,7 +166,8 @@ func (f *FunctionInitializer) InitRuntime(ctx *RuntimeContext) error {
 	asyncFunctionProto := vm.NewObject(functionProtoFn)
 	asyncFunctionProtoObj := asyncFunctionProto.AsPlainObject()
 
-	if ctorObj := asyncFunctionCtor.AsNativeFunction(); ctorObj != nil {
+	if asyncFunctionCtor.Type() == vm.TypeNativeFunction {
+		ctorObj := asyncFunctionCtor.AsNativeFunction()
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
 		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", asyncFunctionProto)
@@ -304,15 +306,18 @@ func functionPrototypeBindImpl(vmInstance *vm.VM, args []vm.Value) (vm.Value, er
 	functionName := "bound"
 	switch originalFunc.Type() {
 	case vm.TypeNativeFunction:
-		if nativeFunc := originalFunc.AsNativeFunction(); nativeFunc != nil {
+		if originalFunc.Type() == vm.TypeNativeFunction {
+			nativeFunc := originalFunc.AsNativeFunction()
 			functionName = "bound " + nativeFunc.Name
 		}
 	case vm.TypeNativeFunctionWithProps:
-		if nativeFuncWithProps := originalFunc.AsNativeFunctionWithProps(); nativeFuncWithProps != nil {
+		if originalFunc.Type() == vm.TypeNativeFunctionWithProps {
+			nativeFuncWithProps := originalFunc.AsNativeFunctionWithProps()
 			functionName = "bound " + nativeFuncWithProps.Name
 		}
 	case vm.TypeFunction:
-		if fn := originalFunc.AsFunction(); fn != nil {
+		if originalFunc.Type() == vm.TypeFunction {
+			fn := originalFunc.AsFunction()
 			functionName = "bound " + fn.Name
 		}
 	case vm.TypeClosure:
@@ -320,7 +325,8 @@ func functionPrototypeBindImpl(vmInstance *vm.VM, args []vm.Value) (vm.Value, er
 			functionName = "bound " + closure.Fn.Name
 		}
 	case vm.TypeBoundFunction:
-		if boundFn := originalFunc.AsBoundFunction(); boundFn != nil {
+		if originalFunc.Type() == vm.TypeBoundFunction {
+			boundFn := originalFunc.AsBoundFunction()
 			functionName = "bound " + boundFn.Name
 		}
 	}
@@ -546,7 +552,8 @@ func functionConstructorImpl(vmInstance *vm.VM, driver interface{}, args []vm.Va
 	// Set the function's HomeRealm to the realm where the Function constructor was defined
 	// This is critical for cross-realm behavior (GetFunctionRealm spec)
 	// If homeRealm was captured at constructor init time, use it; otherwise fall back to current realm
-	if fnObj := functionValue.AsFunction(); fnObj != nil {
+	if functionValue.Type() == vm.TypeFunction {
+		fnObj := functionValue.AsFunction()
 		if homeRealm != nil {
 			fnObj.HomeRealm = homeRealm
 		} else {
@@ -647,7 +654,8 @@ func asyncFunctionConstructorImpl(vmInstance *vm.VM, driver interface{}, args []
 
 	// Set the function's HomeRealm to the realm where the AsyncFunction constructor was defined
 	// This is critical for cross-realm behavior (GetFunctionRealm spec)
-	if fnObj := functionValue.AsFunction(); fnObj != nil {
+	if functionValue.Type() == vm.TypeFunction {
+		fnObj := functionValue.AsFunction()
 		if homeRealm != nil {
 			fnObj.HomeRealm = homeRealm
 		} else {

--- a/pkg/builtins/iterator_init.go
+++ b/pkg/builtins/iterator_init.go
@@ -2006,7 +2006,8 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if !paddingVal.IsUndefined() && paddingVal.IsObject() {
 				padding = make(map[string]vm.Value)
 				// Extract padding values keyed by property name
-				if plainObj := paddingVal.AsPlainObject(); plainObj != nil {
+				if paddingVal.Type() == vm.TypeObject {
+					plainObj := paddingVal.AsPlainObject()
 					for _, key := range plainObj.OwnKeys() {
 						if val, exists := plainObj.GetOwn(key); exists {
 							padding[key] = val
@@ -2052,7 +2053,8 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		var keys []string
 		iterators := make(map[string]vm.Value)
 
-		if plainObj := iterablesObj.AsPlainObject(); plainObj != nil {
+		if iterablesObj.Type() == vm.TypeObject {
+			plainObj := iterablesObj.AsPlainObject()
 			for _, key := range plainObj.OwnKeys() {
 				keys = append(keys, key)
 				item, _ := plainObj.GetOwn(key)
@@ -2068,7 +2070,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("Iterator.zipKeyed: first argument must be a plain object")
 		}
 
-			// Create the zipKeyed iterator
+		// Create the zipKeyed iterator
 		zipKeyedIter := vm.NewObject(vmInstance.IteratorHelperPrototype).AsPlainObject()
 		exhausted := make(map[string]bool)
 		for _, k := range keys {
@@ -2095,105 +2097,105 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 				return createIteratorResult(vm.Undefined, true), nil
 			}
 
-				results := make(map[string]vm.Value)
-				anyDone := false
-				allExhausted := true
+			results := make(map[string]vm.Value)
+			anyDone := false
+			allExhausted := true
 
-				for _, key := range keys {
-					if exhausted[key] {
-						// Already exhausted, use padding
-						if padding != nil {
-							if padVal, ok := padding[key]; ok {
-								results[key] = padVal
-							} else {
-								results[key] = vm.Undefined
-							}
-						} else {
-							results[key] = vm.Undefined
-						}
-						continue
-					}
-
-					allExhausted = false
-					iter := iterators[key]
-
-					nextMethod, _ := vmInstance.GetProperty(iter, "next")
-					result, err := vmInstance.Call(nextMethod, iter, []vm.Value{})
-					if err != nil {
-						return vm.Undefined, err
-					}
-
-					doneVal, _ := vmInstance.GetProperty(result, "done")
-					if doneVal.IsTruthy() {
-						exhausted[key] = true
-						anyDone = true
-						// Use padding for this key
-						if padding != nil {
-							if padVal, ok := padding[key]; ok {
-								results[key] = padVal
-							} else {
-								results[key] = vm.Undefined
-							}
+			for _, key := range keys {
+				if exhausted[key] {
+					// Already exhausted, use padding
+					if padding != nil {
+						if padVal, ok := padding[key]; ok {
+							results[key] = padVal
 						} else {
 							results[key] = vm.Undefined
 						}
 					} else {
-						valueVal, _ := vmInstance.GetProperty(result, "value")
-						results[key] = valueVal
+						results[key] = vm.Undefined
 					}
+					continue
 				}
 
-				// Handle modes
-				switch mode {
-				case "shortest":
-					if anyDone {
-						allDone = true
-						return createIteratorResult(vm.Undefined, true), nil
-					}
-				case "strict":
-					if anyDone {
-						// Check if ALL are done
-						allAreDone := true
-						for _, ex := range exhausted {
-							if !ex {
-								allAreDone = false
-								break
-							}
+				allExhausted = false
+				iter := iterators[key]
+
+				nextMethod, _ := vmInstance.GetProperty(iter, "next")
+				result, err := vmInstance.Call(nextMethod, iter, []vm.Value{})
+				if err != nil {
+					return vm.Undefined, err
+				}
+
+				doneVal, _ := vmInstance.GetProperty(result, "done")
+				if doneVal.IsTruthy() {
+					exhausted[key] = true
+					anyDone = true
+					// Use padding for this key
+					if padding != nil {
+						if padVal, ok := padding[key]; ok {
+							results[key] = padVal
+						} else {
+							results[key] = vm.Undefined
 						}
-						if !allAreDone {
-							allDone = true
-							return vm.Undefined, vmInstance.NewTypeError("Iterator.zipKeyed: iterators have different lengths in strict mode")
-						}
-						allDone = true
-						return createIteratorResult(vm.Undefined, true), nil
+					} else {
+						results[key] = vm.Undefined
 					}
-				case "longest":
-					// Check if all iterators were already exhausted at the start
-					if allExhausted {
-						allDone = true
-						return createIteratorResult(vm.Undefined, true), nil
-					}
-					// Also check if all iterators became exhausted during this iteration
-					nowAllExhausted := true
+				} else {
+					valueVal, _ := vmInstance.GetProperty(result, "value")
+					results[key] = valueVal
+				}
+			}
+
+			// Handle modes
+			switch mode {
+			case "shortest":
+				if anyDone {
+					allDone = true
+					return createIteratorResult(vm.Undefined, true), nil
+				}
+			case "strict":
+				if anyDone {
+					// Check if ALL are done
+					allAreDone := true
 					for _, ex := range exhausted {
 						if !ex {
-							nowAllExhausted = false
+							allAreDone = false
 							break
 						}
 					}
-					if nowAllExhausted {
+					if !allAreDone {
 						allDone = true
-						return createIteratorResult(vm.Undefined, true), nil
+						return vm.Undefined, vmInstance.NewTypeError("Iterator.zipKeyed: iterators have different lengths in strict mode")
+					}
+					allDone = true
+					return createIteratorResult(vm.Undefined, true), nil
+				}
+			case "longest":
+				// Check if all iterators were already exhausted at the start
+				if allExhausted {
+					allDone = true
+					return createIteratorResult(vm.Undefined, true), nil
+				}
+				// Also check if all iterators became exhausted during this iteration
+				nowAllExhausted := true
+				for _, ex := range exhausted {
+					if !ex {
+						nowAllExhausted = false
+						break
 					}
 				}
-
-				// Create result object
-				resultObj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-				for _, key := range keys {
-					resultObj.SetOwn(key, results[key])
+				if nowAllExhausted {
+					allDone = true
+					return createIteratorResult(vm.Undefined, true), nil
 				}
-				return createIteratorResult(vm.NewValueFromPlainObject(resultObj), false), nil
-			}))
+			}
+
+			// Create result object
+			resultObj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+			for _, key := range keys {
+				resultObj.SetOwn(key, results[key])
+			}
+			return createIteratorResult(vm.NewValueFromPlainObject(resultObj), false), nil
+		}))
 
 		// Add return method to close all iterators
 		zipKeyedIter.SetOwnNonEnumerable("return", vm.NewNativeFunction(0, false, "return", func(innerArgs []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/iterator_init.go
+++ b/pkg/builtins/iterator_init.go
@@ -409,7 +409,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// SetterThatIgnoresPrototypeProperties(%Iterator.prototype%, %Symbol.toStringTag%, v)
 		thisVal := vmInstance.GetThis()
 		// 1. If this is not an Object, throw TypeError
-		if !thisVal.IsObject() {
+		if thisVal.Type() != vm.TypeObject {
 			return vm.Undefined, vmInstance.NewTypeError("setter called on non-object")
 		}
 		// 2. If this is home, throw TypeError
@@ -1421,13 +1421,10 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	mapIterNextFn := vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
 		thisVal := vmInstance.GetThis()
 		// Check for internal slots (branding)
-		if !thisVal.IsObject() {
+		if thisVal.Type() != vm.TypeObject {
 			return vm.Undefined, vmInstance.NewTypeError("%MapIteratorPrototype%.next requires that 'this' be an Object")
 		}
 		thisObj := thisVal.AsPlainObject()
-		if thisObj == nil {
-			return vm.Undefined, vmInstance.NewTypeError("%MapIteratorPrototype%.next requires that 'this' be an Object")
-		}
 		// Brand check: the internal iterator state doubles as the spec's
 		// [[IteratedMap]] internal slot (a Set iterator has Set-kind state
 		// and must be rejected here).
@@ -1465,13 +1462,10 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	setIterNextFn := vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
 		thisVal := vmInstance.GetThis()
 		// Check for internal slots (branding)
-		if !thisVal.IsObject() {
+		if thisVal.Type() != vm.TypeObject {
 			return vm.Undefined, vmInstance.NewTypeError("%SetIteratorPrototype%.next requires that 'this' be an Object")
 		}
 		thisObj := thisVal.AsPlainObject()
-		if thisObj == nil {
-			return vm.Undefined, vmInstance.NewTypeError("%SetIteratorPrototype%.next requires that 'this' be an Object")
-		}
 		// Brand check: the internal iterator state doubles as the spec's
 		// [[IteratedSet]] internal slot (a Map iterator has Map-kind state
 		// and must be rejected here).
@@ -2224,7 +2218,7 @@ func (i *IteratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// SetterThatIgnoresPrototypeProperties(%Iterator.prototype%, "constructor", v)
 		thisVal := vmInstance.GetThis()
 		// 1. If this is not an Object, throw TypeError
-		if !thisVal.IsObject() {
+		if thisVal.Type() != vm.TypeObject {
 			return vm.Undefined, vmInstance.NewTypeError("setter called on non-object")
 		}
 		// 2. If this is home, throw TypeError

--- a/pkg/builtins/json_init.go
+++ b/pkg/builtins/json_init.go
@@ -165,7 +165,8 @@ func (j *JSONInitializer) InitRuntime(ctx *RuntimeContext) error {
 						}
 					} else if elem.Type() == vm.TypeObject {
 						// Check if it's a String or Number wrapper object
-						if obj := elem.AsPlainObject(); obj != nil {
+						if elem.Type() == vm.TypeObject {
+							obj := elem.AsPlainObject()
 							if _, ok := obj.GetOwn("[[PrimitiveValue]]"); ok {
 								// Has [[PrimitiveValue]] - it's a wrapper, call ToString via ToPrimitive
 								primVal := vmInstance.ToPrimitive(elem, "string")

--- a/pkg/builtins/number_init.go
+++ b/pkg/builtins/number_init.go
@@ -230,7 +230,7 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisNum := vmInstance.GetThis()
 
 		// Extract primitive value from Number wrapper object
-		if thisNum.IsObject() {
+		if thisNum.Type() == vm.TypeObject {
 			obj := thisNum.AsPlainObject()
 			if primVal, found := obj.GetOwn("[[PrimitiveValue]]"); found && primVal != vm.Undefined {
 				thisNum = primVal
@@ -326,7 +326,7 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// If this is a Number wrapper object, extract [[PrimitiveValue]]
 		// IMPORTANT: Must verify the [[PrimitiveValue]] is actually a Number type
 		// (String objects also have [[PrimitiveValue]] but with string type)
-		if thisNum.IsObject() {
+		if thisNum.Type() == vm.TypeObject {
 			if primitiveVal, exists := thisNum.AsPlainObject().GetOwn("[[PrimitiveValue]]"); exists {
 				// Verify it's a Number primitive
 				if primitiveVal.Type() == vm.TypeFloatNumber || primitiveVal.Type() == vm.TypeIntegerNumber {
@@ -343,7 +343,7 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisNum := vmInstance.GetThis()
 
 		// Extract primitive value from wrapper if needed
-		if thisNum.IsObject() {
+		if thisNum.Type() == vm.TypeObject {
 			if primitiveVal, exists := thisNum.AsPlainObject().GetOwn("[[PrimitiveValue]]"); exists {
 				thisNum = primitiveVal
 			}
@@ -409,7 +409,7 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisNum := vmInstance.GetThis()
 
 		// Extract primitive value from wrapper if needed
-		if thisNum.IsObject() {
+		if thisNum.Type() == vm.TypeObject {
 			if primitiveVal, exists := thisNum.AsPlainObject().GetOwn("[[PrimitiveValue]]"); exists {
 				thisNum = primitiveVal
 			}
@@ -498,7 +498,7 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisNum := vmInstance.GetThis()
 
 		// Extract primitive value from wrapper if needed
-		if thisNum.IsObject() {
+		if thisNum.Type() == vm.TypeObject {
 			if primitiveVal, exists := thisNum.AsPlainObject().GetOwn("[[PrimitiveValue]]"); exists {
 				thisNum = primitiveVal
 			}
@@ -588,7 +588,7 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 			arg := args[0]
 
 			// Handle boxed primitives by extracting primitive value
-			if arg.IsObject() {
+			if arg.Type() == vm.TypeObject {
 				obj := arg.AsPlainObject()
 				if primVal, found := obj.GetOwn("[[PrimitiveValue]]"); found && primVal != vm.Undefined {
 					arg = primVal

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -804,47 +804,37 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, nil
 		}
 		propName := keyVal.ToString()
-		// Walk up the prototype chain looking for accessor
+		// Walk up the prototype chain looking for an accessor. Only
+		// PlainObject/Array carry accessors in this VM's model; other kinds
+		// (Function, DictObject, ...) can still hold a matching data property
+		// (returning undefined per spec) or sit in the middle of the chain,
+		// so they're still visited via vmInstance.PrototypeOf, just without
+		// an accessor check.
 		current := thisValue
-		for {
-			var po *vm.PlainObject
+		for depth := 0; depth < 200 && current.Type() != vm.TypeNull && current.Type() != vm.TypeUndefined; depth++ {
 			switch current.Type() {
 			case vm.TypeObject:
-				po = current.AsPlainObject()
-			case vm.TypeArray:
-				arr := current.AsArray()
-				// Check if array has accessor property
-				if getter, _, _, _, isAccessor := arr.GetOwnAccessor(propName); isAccessor {
-					return getter, nil
-				}
-				// Check if array has data property (if so, return undefined)
-				if _, hasData := arr.GetOwn(propName); hasData {
-					return vm.Undefined, nil
-				}
-				// Move to array prototype
-				current = vmInstance.ArrayPrototype
-				continue
-			default:
-				po = current.AsPlainObject()
-			}
-			if po != nil {
-				// Check if it's an accessor property
+				po := current.AsPlainObject()
 				if getter, _, _, _, isAccessor := po.GetOwnAccessor(propName); isAccessor {
 					return getter, nil
 				}
-				// Check if it's a data property (if so, return undefined per spec)
 				if _, hasData := po.GetOwn(propName); hasData {
 					return vm.Undefined, nil
 				}
-				// Move up prototype chain
-				proto := po.GetPrototype()
-				if proto.Type() == vm.TypeNull || proto.Type() == vm.TypeUndefined || proto.Type() == 0 {
-					break
+			case vm.TypeArray:
+				arr := current.AsArray()
+				if getter, _, _, _, isAccessor := arr.GetOwnAccessor(propName); isAccessor {
+					return getter, nil
 				}
-				current = proto
-			} else {
-				break
+				if _, hasData := arr.GetOwn(propName); hasData {
+					return vm.Undefined, nil
+				}
+			default:
+				if _, hasData := vmInstance.GetOwnGeneric(current, propName); hasData {
+					return vm.Undefined, nil
+				}
 			}
+			current = vmInstance.PrototypeOf(current)
 		}
 		return vm.Undefined, nil
 	})
@@ -868,47 +858,37 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, nil
 		}
 		propName := keyVal.ToString()
-		// Walk up the prototype chain looking for accessor
+		// Walk up the prototype chain looking for an accessor. Only
+		// PlainObject/Array carry accessors in this VM's model; other kinds
+		// (Function, DictObject, ...) can still hold a matching data property
+		// (returning undefined per spec) or sit in the middle of the chain,
+		// so they're still visited via vmInstance.PrototypeOf, just without
+		// an accessor check.
 		current := thisValue
-		for {
-			var po *vm.PlainObject
+		for depth := 0; depth < 200 && current.Type() != vm.TypeNull && current.Type() != vm.TypeUndefined; depth++ {
 			switch current.Type() {
 			case vm.TypeObject:
-				po = current.AsPlainObject()
-			case vm.TypeArray:
-				arr := current.AsArray()
-				// Check if array has accessor property
-				if _, setter, _, _, isAccessor := arr.GetOwnAccessor(propName); isAccessor {
-					return setter, nil
-				}
-				// Check if array has data property (if so, return undefined)
-				if _, hasData := arr.GetOwn(propName); hasData {
-					return vm.Undefined, nil
-				}
-				// Move to array prototype
-				current = vmInstance.ArrayPrototype
-				continue
-			default:
-				po = current.AsPlainObject()
-			}
-			if po != nil {
-				// Check if it's an accessor property
+				po := current.AsPlainObject()
 				if _, setter, _, _, isAccessor := po.GetOwnAccessor(propName); isAccessor {
 					return setter, nil
 				}
-				// Check if it's a data property (if so, return undefined per spec)
 				if _, hasData := po.GetOwn(propName); hasData {
 					return vm.Undefined, nil
 				}
-				// Move up prototype chain
-				proto := po.GetPrototype()
-				if proto.Type() == vm.TypeNull || proto.Type() == vm.TypeUndefined || proto.Type() == 0 {
-					break
+			case vm.TypeArray:
+				arr := current.AsArray()
+				if _, setter, _, _, isAccessor := arr.GetOwnAccessor(propName); isAccessor {
+					return setter, nil
 				}
-				current = proto
-			} else {
-				break
+				if _, hasData := arr.GetOwn(propName); hasData {
+					return vm.Undefined, nil
+				}
+			default:
+				if _, hasData := vmInstance.GetOwnGeneric(current, propName); hasData {
+					return vm.Undefined, nil
+				}
 			}
+			current = vmInstance.PrototypeOf(current)
 		}
 		return vm.Undefined, nil
 	})

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -466,7 +466,8 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if desc.IsUndefined() {
 				return vm.BooleanValue(false), nil
 			}
-			if descObj := desc.AsPlainObject(); descObj != nil {
+			if desc.Type() == vm.TypeObject {
+				descObj := desc.AsPlainObject()
 				if enumVal, hasEnum := descObj.GetOwn("enumerable"); hasEnum {
 					return vm.BooleanValue(!enumVal.IsFalsey()), nil
 				}
@@ -517,7 +518,8 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			case vm.TypeRegExp:
 				builtinTag = "RegExp"
 			case vm.TypeObject:
-				if plainObj := thisValue.AsPlainObject(); plainObj != nil {
+				if thisValue.Type() == vm.TypeObject {
+					plainObj := thisValue.AsPlainObject()
 					if _, hasErrorData := plainObj.GetOwn("[[ErrorData]]"); hasErrorData {
 						builtinTag = "Error"
 					} else if primitiveVal, exists := plainObj.GetOwn("[[PrimitiveValue]]"); exists {
@@ -680,7 +682,8 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			handler := proxy.Handler()
 			var setProtoTrap vm.Value
 			var hasTrap bool
-			if po := handler.AsPlainObject(); po != nil {
+			if handler.Type() == vm.TypeObject {
+				po := handler.AsPlainObject()
 				setProtoTrap, hasTrap = po.GetOwn("setPrototypeOf")
 			}
 			if hasTrap && setProtoTrap.IsCallable() {
@@ -700,11 +703,13 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		success := true
 		switch thisValue.Type() {
 		case vm.TypeObject:
-			if po := thisValue.AsPlainObject(); po != nil {
+			if thisValue.Type() == vm.TypeObject {
+				po := thisValue.AsPlainObject()
 				success = po.SetPrototype(protoArg)
 			}
 		case vm.TypeDictObject:
-			if d := thisValue.AsDictObject(); d != nil {
+			if thisValue.Type() == vm.TypeDictObject {
+				d := thisValue.AsDictObject()
 				success = d.SetPrototype(protoArg)
 			}
 		default:
@@ -997,7 +1002,8 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Make it a proper constructor with static methods
-	if ctorObj := objectCtor.AsNativeFunction(); ctorObj != nil {
+	if objectCtor.Type() == vm.TypeNativeFunction {
+		ctorObj := objectCtor.AsNativeFunction()
 		// Convert to object with properties
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
@@ -1543,7 +1549,8 @@ func objectCreateWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if proto.Type() == vm.TypeNull {
 		// For null prototype, create object and set prototype to null
 		obj = vm.NewObject(vm.Null)
-		if plainObj := obj.AsPlainObject(); plainObj != nil {
+		if obj.Type() == vm.TypeObject {
+			plainObj := obj.AsPlainObject()
 			plainObj.SetPrototype(vm.Null)
 		}
 	} else {
@@ -1586,7 +1593,8 @@ func objectDefinePropertiesImpl(vmInstance *vm.VM, obj vm.Value, propertiesDesc 
 	var keys []string
 	switch propertiesDesc.Type() {
 	case vm.TypeObject:
-		if po := propertiesDesc.AsPlainObject(); po != nil {
+		if propertiesDesc.Type() == vm.TypeObject {
+			po := propertiesDesc.AsPlainObject()
 			for _, key := range po.OwnKeys() {
 				if _, _, enumerable, _, ok := po.GetOwnDescriptor(key); ok && enumerable {
 					keys = append(keys, key)
@@ -1594,7 +1602,8 @@ func objectDefinePropertiesImpl(vmInstance *vm.VM, obj vm.Value, propertiesDesc 
 			}
 		}
 	case vm.TypeArray:
-		if arr := propertiesDesc.AsArray(); arr != nil {
+		if propertiesDesc.Type() == vm.TypeArray {
+			arr := propertiesDesc.AsArray()
 			// Include numeric indices
 			for i := 0; i < arr.Length(); i++ {
 				keys = append(keys, strconv.Itoa(i))
@@ -1609,7 +1618,8 @@ func objectDefinePropertiesImpl(vmInstance *vm.VM, obj vm.Value, propertiesDesc 
 		}
 	default:
 		// For function types and others, try to get as PlainObject if possible
-		if po := propertiesDesc.AsPlainObject(); po != nil {
+		if propertiesDesc.Type() == vm.TypeObject {
+			po := propertiesDesc.AsPlainObject()
 			for _, key := range po.OwnKeys() {
 				if _, _, enumerable, _, ok := po.GetOwnDescriptor(key); ok && enumerable {
 					keys = append(keys, key)
@@ -1722,7 +1732,8 @@ func isTargetKeyEnumerable(vmInstance *vm.VM, target vm.Value, key string) bool 
 		return false
 	case vm.TypeDictObject:
 		// DictObject keys are always enumerable
-		if do := target.AsDictObject(); do != nil {
+		if target.Type() == vm.TypeDictObject {
+			do := target.AsDictObject()
 			if _, ok := do.Get(key); ok {
 				return true
 			}
@@ -2252,9 +2263,11 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 	success := true
 	switch obj.Type() {
 	case vm.TypeObject:
-		if plainObj := obj.AsPlainObject(); plainObj != nil {
+		if obj.Type() == vm.TypeObject {
+			plainObj := obj.AsPlainObject()
 			success = plainObj.SetPrototype(proto)
-		} else if dictObj := obj.AsDictObject(); dictObj != nil {
+		} else if obj.Type() == vm.TypeDictObject {
+			dictObj := obj.AsDictObject()
 			success = dictObj.SetPrototype(proto)
 		}
 	case vm.TypeFunction:
@@ -2276,7 +2289,8 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		success = true
 	default:
 		// For other object types (Map, Set, Generator, etc.), try setting via AsPlainObject
-		if plainObj := obj.AsPlainObject(); plainObj != nil {
+		if obj.Type() == vm.TypeObject {
+			plainObj := obj.AsPlainObject()
 			success = plainObj.SetPrototype(proto)
 		}
 	}
@@ -2515,12 +2529,14 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 		arrObj.Append(vm.NewString("length"))
 		return arr, nil
 	case vm.TypeObject:
-		if po := obj.AsPlainObject(); po != nil {
+		if obj.Type() == vm.TypeObject {
+			po := obj.AsPlainObject()
 			// OwnPropertyNames returns ALL own string property names including non-enumerable
 			for _, k := range po.OwnPropertyNames() {
 				arrObj.Append(vm.NewString(k))
 			}
-		} else if d := obj.AsDictObject(); d != nil {
+		} else if obj.Type() == vm.TypeDictObject {
+			d := obj.AsDictObject()
 			// DictObject.OwnPropertyNames returns all property names
 			for _, k := range d.OwnPropertyNames() {
 				arrObj.Append(vm.NewString(k))
@@ -2664,7 +2680,8 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 	}
 	arr := vm.NewArray()
 	arrObj := arr.AsArray()
-	if po := obj.AsPlainObject(); po != nil {
+	if obj.Type() == vm.TypeObject {
+		po := obj.AsPlainObject()
 		for _, s := range po.OwnSymbolKeys() {
 			arrObj.Append(s)
 		}
@@ -2704,7 +2721,8 @@ func reflectOwnKeysImpl(args []vm.Value) (vm.Value, error) {
 	}
 	out := vm.NewArray()
 	outArr := out.AsArray()
-	if po := obj.AsPlainObject(); po != nil {
+	if obj.Type() == vm.TypeObject {
+		po := obj.AsPlainObject()
 		// Strings first
 		for _, k := range po.OwnKeys() {
 			outArr.Append(vm.NewString(k))
@@ -2713,12 +2731,14 @@ func reflectOwnKeysImpl(args []vm.Value) (vm.Value, error) {
 		for _, s := range po.OwnSymbolKeys() {
 			outArr.Append(s)
 		}
-	} else if d := obj.AsDictObject(); d != nil {
+	} else if obj.Type() == vm.TypeDictObject {
+		d := obj.AsDictObject()
 		for _, k := range d.OwnKeys() {
 			outArr.Append(vm.NewString(k))
 		}
 		// DictObject: no symbols yet
-	} else if a := obj.AsArray(); a != nil {
+	} else if obj.Type() == vm.TypeArray {
+		a := obj.AsArray()
 		for i := 0; i < a.Length(); i++ {
 			outArr.Append(vm.NewString(strconv.Itoa(i)))
 		}
@@ -2773,42 +2793,53 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		}
 
 		// Get own enumerable properties from source
-		if plainObj := source.AsPlainObject(); plainObj != nil {
+		if source.Type() == vm.TypeObject {
+			plainObj := source.AsPlainObject()
 			for _, key := range plainObj.OwnKeys() {
 				value, _ := plainObj.GetOwn(key)
 				// Set on target
-				if targetPlain := target.AsPlainObject(); targetPlain != nil {
+				if target.Type() == vm.TypeObject {
+					targetPlain := target.AsPlainObject()
 					targetPlain.SetOwnNonEnumerable(key, value)
-				} else if targetDict := target.AsDictObject(); targetDict != nil {
+				} else if target.Type() == vm.TypeDictObject {
+					targetDict := target.AsDictObject()
 					targetDict.SetOwn(key, value)
 				}
 			}
-		} else if dictObj := source.AsDictObject(); dictObj != nil {
+		} else if source.Type() == vm.TypeDictObject {
+			dictObj := source.AsDictObject()
 			for _, key := range dictObj.OwnKeys() {
 				value, _ := dictObj.GetOwn(key)
 				// Set on target
-				if targetPlain := target.AsPlainObject(); targetPlain != nil {
+				if target.Type() == vm.TypeObject {
+					targetPlain := target.AsPlainObject()
 					targetPlain.SetOwnNonEnumerable(key, value)
-				} else if targetDict := target.AsDictObject(); targetDict != nil {
+				} else if target.Type() == vm.TypeDictObject {
+					targetDict := target.AsDictObject()
 					targetDict.SetOwn(key, value)
 				}
 			}
-		} else if arrObj := source.AsArray(); arrObj != nil {
+		} else if source.Type() == vm.TypeArray {
+			arrObj := source.AsArray()
 			// For arrays, copy indexed properties
 			for i := 0; i < arrObj.Length(); i++ {
 				key := strconv.Itoa(i)
 				value := arrObj.Get(i)
 				// Set on target
-				if targetPlain := target.AsPlainObject(); targetPlain != nil {
+				if target.Type() == vm.TypeObject {
+					targetPlain := target.AsPlainObject()
 					targetPlain.SetOwnNonEnumerable(key, value)
-				} else if targetDict := target.AsDictObject(); targetDict != nil {
+				} else if target.Type() == vm.TypeDictObject {
+					targetDict := target.AsDictObject()
 					targetDict.SetOwn(key, value)
 				}
 			}
 			// Also copy length property
-			if targetPlain := target.AsPlainObject(); targetPlain != nil {
+			if target.Type() == vm.TypeObject {
+				targetPlain := target.AsPlainObject()
 				targetPlain.SetOwnNonEnumerable("length", vm.NumberValue(float64(arrObj.Length())))
-			} else if targetDict := target.AsDictObject(); targetDict != nil {
+			} else if target.Type() == vm.TypeDictObject {
+				targetDict := target.AsDictObject()
 				targetDict.SetOwn("length", vm.NumberValue(float64(arrObj.Length())))
 			}
 		}
@@ -2848,21 +2879,24 @@ func objectHasOwnWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	isSymbol := keyVal.Type() == vm.TypeSymbol
 
 	// Check if object has the property as own property
-	if plainObj := obj.AsPlainObject(); plainObj != nil {
+	if obj.Type() == vm.TypeObject {
+		plainObj := obj.AsPlainObject()
 		if isSymbol {
 			return vm.BooleanValue(plainObj.HasOwnByKey(vm.NewSymbolKey(keyVal))), nil
 		}
 		_, hasOwn := plainObj.GetOwn(keyVal.ToString())
 		return vm.BooleanValue(hasOwn), nil
 	}
-	if dictObj := obj.AsDictObject(); dictObj != nil {
+	if obj.Type() == vm.TypeDictObject {
+		dictObj := obj.AsDictObject()
 		if isSymbol {
 			return vm.BooleanValue(false), nil
 		}
 		_, hasOwn := dictObj.GetOwn(keyVal.ToString())
 		return vm.BooleanValue(hasOwn), nil
 	}
-	if arrObj := obj.AsArray(); arrObj != nil {
+	if obj.Type() == vm.TypeArray {
+		arrObj := obj.AsArray()
 		if isSymbol {
 			return vm.BooleanValue(false), nil
 		}
@@ -2894,15 +2928,19 @@ func objectFromEntriesImpl(args []vm.Value) (vm.Value, error) {
 	resultObj := result.AsPlainObject()
 
 	// If it's an array, iterate through it
-	if arr := iterable.AsArray(); arr != nil {
+	if iterable.Type() == vm.TypeArray {
+		arr := iterable.AsArray()
 		for i := 0; i < arr.Length(); i++ {
 			entry := arr.Get(i)
 
 			// Each entry should be an array-like with at least 2 elements
-			if entryArr := entry.AsArray(); entryArr != nil && entryArr.Length() >= 2 {
-				key := entryArr.Get(0).ToString()
-				value := entryArr.Get(1)
-				resultObj.SetOwnNonEnumerable(key, value)
+			if entry.Type() == vm.TypeArray {
+				entryArr := entry.AsArray()
+				if entryArr.Length() >= 2 {
+					key := entryArr.Get(0).ToString()
+					value := entryArr.Get(1)
+					resultObj.SetOwnNonEnumerable(key, value)
+				}
 			}
 		}
 	}
@@ -2992,7 +3030,8 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			var targetDescFound bool
 			var targetValue vm.Value
 			var targetConfigurable, targetWritable, targetEnumerable bool
-			if targetObj := target.AsPlainObject(); targetObj != nil {
+			if target.Type() == vm.TypeObject {
+				targetObj := target.AsPlainObject()
 				var found bool
 				targetValue, targetWritable, targetEnumerable, targetConfigurable, found = targetObj.GetOwnDescriptor(propName)
 				targetDescFound = found
@@ -3000,7 +3039,8 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 
 			// Step 16: Let extensibleTarget be target.[[IsExtensible]]()
 			targetExtensible := true
-			if targetObj := target.AsPlainObject(); targetObj != nil {
+			if target.Type() == vm.TypeObject {
+				targetObj := target.AsPlainObject()
 				targetExtensible = targetObj.IsExtensible()
 			}
 
@@ -3079,56 +3119,56 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 	// Returns true if no change is requested, false otherwise
 	if obj.Type() == vm.TypeObject {
 		if plainObj := obj.AsPlainObject(); plainObj != nil && plainObj.IsModuleNamespace() {
-		// Get current property descriptor
-		var currentDesc vm.Value
-		if keyIsSymbol {
-			if _, _, wr, en, conf := plainObj.GetOwnDescriptorByKey(vm.NewSymbolKey(propSym)); wr || en || conf {
-				// Property exists
-				currentDesc = vm.NewObject(vmInstance.ObjectPrototype)
+			// Get current property descriptor
+			var currentDesc vm.Value
+			if keyIsSymbol {
+				if _, _, wr, en, conf := plainObj.GetOwnDescriptorByKey(vm.NewSymbolKey(propSym)); wr || en || conf {
+					// Property exists
+					currentDesc = vm.NewObject(vmInstance.ObjectPrototype)
+				}
+			} else {
+				if _, exists := plainObj.GetOwn(propName); exists {
+					// Property exists
+					currentDesc = vm.NewObject(vmInstance.ObjectPrototype)
+				}
 			}
-		} else {
-			if _, exists := plainObj.GetOwn(propName); exists {
-				// Property exists
-				currentDesc = vm.NewObject(vmInstance.ObjectPrototype)
+
+			// If property doesn't exist, fail
+			if currentDesc.Type() == vm.TypeUndefined {
+				return vm.Undefined, vmInstance.NewTypeError("Cannot define property " + propName + " on a module namespace object")
 			}
-		}
 
-		// If property doesn't exist, fail
-		if currentDesc.Type() == vm.TypeUndefined {
-			return vm.Undefined, vmInstance.NewTypeError("Cannot define property " + propName + " on a module namespace object")
-		}
-
-		// Property exists - check if descriptor requests any changes
-		// For namespace properties, we only allow descriptors that don't change anything
-		descObj := descriptor.AsPlainObject()
-		if descObj != nil {
-			// Check for value change
-			if val, hasValue := descObj.GetOwn("value"); hasValue {
-				if keyIsSymbol {
-					if currentVal, ok := plainObj.GetOwnByKey(vm.NewSymbolKey(propSym)); ok {
-						if !val.StrictlyEquals(currentVal) {
-							return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property " + propName + " on a module namespace object")
+			// Property exists - check if descriptor requests any changes
+			// For namespace properties, we only allow descriptors that don't change anything
+			descObj := descriptor.AsPlainObject()
+			if descObj != nil {
+				// Check for value change
+				if val, hasValue := descObj.GetOwn("value"); hasValue {
+					if keyIsSymbol {
+						if currentVal, ok := plainObj.GetOwnByKey(vm.NewSymbolKey(propSym)); ok {
+							if !val.StrictlyEquals(currentVal) {
+								return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property " + propName + " on a module namespace object")
+							}
 						}
-					}
-				} else {
-					if currentVal, ok := plainObj.GetOwn(propName); ok {
-						if !val.StrictlyEquals(currentVal) {
-							return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property " + propName + " on a module namespace object")
+					} else {
+						if currentVal, ok := plainObj.GetOwn(propName); ok {
+							if !val.StrictlyEquals(currentVal) {
+								return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property " + propName + " on a module namespace object")
+							}
 						}
 					}
 				}
-			}
-			// Check for configurable change (namespace props are always non-configurable)
-			if conf, hasConf := descObj.GetOwn("configurable"); hasConf {
-				if conf.IsTruthy() {
-					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property " + propName + " on a module namespace object")
+				// Check for configurable change (namespace props are always non-configurable)
+				if conf, hasConf := descObj.GetOwn("configurable"); hasConf {
+					if conf.IsTruthy() {
+						return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property " + propName + " on a module namespace object")
+					}
 				}
 			}
-		}
 
-		// No changes requested or descriptor matches - return the object
-		return obj, nil
-	}
+			// No changes requested or descriptor matches - return the object
+			return obj, nil
+		}
 	}
 
 	// Per ECMAScript 8.10.5 ToPropertyDescriptor step 1: If Type(Obj) is not Object, throw TypeError
@@ -3175,11 +3215,13 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 
 		switch obj.Type() {
 		case vm.TypeObject:
-			if po := obj.AsPlainObject(); po != nil {
+			if obj.Type() == vm.TypeObject {
+				po := obj.AsPlainObject()
 				exists = po.Has(propName)
 			}
 		case vm.TypeDictObject:
-			if do := obj.AsDictObject(); do != nil {
+			if obj.Type() == vm.TypeDictObject {
+				do := obj.AsDictObject()
 				_, exists = do.Get(propName)
 			}
 		case vm.TypeFunction:
@@ -3373,118 +3415,119 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 
 	// Define the property with attributes (on plain objects only for now)
 	if obj.Type() == vm.TypeObject {
-	if plainObj := obj.AsPlainObject(); plainObj != nil {
-		// Check if property already exists and get existing attributes
-		var exists bool
-		var w0, e0, c0 bool
-		var isAccessor0 bool
-		if keyIsSymbol {
-			if g, s, e, c, ok := plainObj.GetOwnAccessorByKey(vm.NewSymbolKey(propSym)); ok {
-				isAccessor0, e0, c0, exists = true, e, c, true
-				_ = g
-				_ = s
-			} else {
-				_, w0, e0, c0, exists = plainObj.GetOwnDescriptorByKey(vm.NewSymbolKey(propSym))
-			}
-		} else {
-			if g, s, e, c, ok := plainObj.GetOwnAccessor(propName); ok {
-				isAccessor0, e0, c0, exists = true, e, c, true
-				_ = g
-				_ = s
-			} else {
-				_, w0, e0, c0, exists = plainObj.GetOwnDescriptor(propName)
-			}
-		}
-
-		// Per ECMAScript spec:
-		// - When creating a new property, missing attributes default to false
-		// - When updating an existing property, missing attributes are preserved
-		if exists {
-			// Preserve existing attributes for missing descriptor fields
-			if !(hasGetter || hasSetter) && writablePtr == nil {
-				writablePtr = &w0
-			}
-			if enumerablePtr == nil {
-				enumerablePtr = &e0
-			}
-			if configurablePtr == nil {
-				configurablePtr = &c0
-			}
-			// Preserve existing value when descriptor doesn't specify a value
-			// and we're not converting to an accessor property
-			if !hasValue && !isAccessor0 && !(hasGetter || hasSetter) {
-				if keyIsSymbol {
-					if existingVal, ok := plainObj.GetOwnByKey(vm.NewSymbolKey(propSym)); ok {
-						value = existingVal
-					}
+		if obj.Type() == vm.TypeObject {
+			plainObj := obj.AsPlainObject()
+			// Check if property already exists and get existing attributes
+			var exists bool
+			var w0, e0, c0 bool
+			var isAccessor0 bool
+			if keyIsSymbol {
+				if g, s, e, c, ok := plainObj.GetOwnAccessorByKey(vm.NewSymbolKey(propSym)); ok {
+					isAccessor0, e0, c0, exists = true, e, c, true
+					_ = g
+					_ = s
 				} else {
-					if existingVal, ok := plainObj.GetOwn(propName); ok {
-						value = existingVal
+					_, w0, e0, c0, exists = plainObj.GetOwnDescriptorByKey(vm.NewSymbolKey(propSym))
+				}
+			} else {
+				if g, s, e, c, ok := plainObj.GetOwnAccessor(propName); ok {
+					isAccessor0, e0, c0, exists = true, e, c, true
+					_ = g
+					_ = s
+				} else {
+					_, w0, e0, c0, exists = plainObj.GetOwnDescriptor(propName)
+				}
+			}
+
+			// Per ECMAScript spec:
+			// - When creating a new property, missing attributes default to false
+			// - When updating an existing property, missing attributes are preserved
+			if exists {
+				// Preserve existing attributes for missing descriptor fields
+				if !(hasGetter || hasSetter) && writablePtr == nil {
+					writablePtr = &w0
+				}
+				if enumerablePtr == nil {
+					enumerablePtr = &e0
+				}
+				if configurablePtr == nil {
+					configurablePtr = &c0
+				}
+				// Preserve existing value when descriptor doesn't specify a value
+				// and we're not converting to an accessor property
+				if !hasValue && !isAccessor0 && !(hasGetter || hasSetter) {
+					if keyIsSymbol {
+						if existingVal, ok := plainObj.GetOwnByKey(vm.NewSymbolKey(propSym)); ok {
+							value = existingVal
+						}
+					} else {
+						if existingVal, ok := plainObj.GetOwn(propName); ok {
+							value = existingVal
+						}
 					}
 				}
-			}
-		} else {
-			// New property: check extensibility first
-			if !plainObj.IsExtensible() {
-				keyStr := propName
-				if keyIsSymbol {
-					keyStr = propSym.ToString()
+			} else {
+				// New property: check extensibility first
+				if !plainObj.IsExtensible() {
+					keyStr := propName
+					if keyIsSymbol {
+						keyStr = propSym.ToString()
+					}
+					return vm.Undefined, vmInstance.NewTypeError("Cannot define property " + keyStr + ", object is not extensible")
 				}
-				return vm.Undefined, vmInstance.NewTypeError("Cannot define property " + keyStr + ", object is not extensible")
-			}
-			// New property: default missing attributes to false
-			if !(hasGetter || hasSetter) {
-				if writablePtr == nil {
+				// New property: default missing attributes to false
+				if !(hasGetter || hasSetter) {
+					if writablePtr == nil {
+						b := false
+						writablePtr = &b
+					}
+				}
+				if enumerablePtr == nil {
 					b := false
-					writablePtr = &b
+					enumerablePtr = &b
+				}
+				if configurablePtr == nil {
+					b := false
+					configurablePtr = &b
 				}
 			}
-			if enumerablePtr == nil {
-				b := false
-				enumerablePtr = &b
-			}
-			if configurablePtr == nil {
-				b := false
-				configurablePtr = &b
-			}
-		}
 
-		if exists && !c0 {
-			// Non-configurable property validation - throw TypeError per DefinePropertyOrThrow
-			if configurablePtr != nil && *configurablePtr != c0 {
-				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+			if exists && !c0 {
+				// Non-configurable property validation - throw TypeError per DefinePropertyOrThrow
+				if configurablePtr != nil && *configurablePtr != c0 {
+					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+				}
+				if enumerablePtr != nil && *enumerablePtr != e0 {
+					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+				}
+				// If data non-writable cannot make writable true
+				if !isAccessor0 && !w0 && writablePtr != nil && *writablePtr {
+					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+				}
+				// Disallow converting kind when not configurable (step 7c)
+				// A generic descriptor (no value/writable/get/set) does NOT trigger kind conversion
+				if isAccessor0 && (hasValue || hasWritable) {
+					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+				}
+				if !isAccessor0 && (hasGetter || hasSetter) {
+					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+				}
 			}
-			if enumerablePtr != nil && *enumerablePtr != e0 {
-				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
-			}
-			// If data non-writable cannot make writable true
-			if !isAccessor0 && !w0 && writablePtr != nil && *writablePtr {
-				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
-			}
-			// Disallow converting kind when not configurable (step 7c)
-			// A generic descriptor (no value/writable/get/set) does NOT trigger kind conversion
-			if isAccessor0 && (hasValue || hasWritable) {
-				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
-			}
-			if !isAccessor0 && (hasGetter || hasSetter) {
-				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
+			if hasGetter || hasSetter {
+				// Accessor path
+				if keyIsSymbol {
+					plainObj.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				} else {
+					plainObj.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				}
+			} else {
+				if keyIsSymbol {
+					plainObj.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+				} else {
+					plainObj.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+				}
 			}
 		}
-		if hasGetter || hasSetter {
-			// Accessor path
-			if keyIsSymbol {
-				plainObj.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
-			} else {
-				plainObj.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
-			}
-		} else {
-			if keyIsSymbol {
-				plainObj.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
-			} else {
-				plainObj.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
-			}
-		}
-	}
 	} else if obj.Type() == vm.TypeDictObject {
 		// DictObject has no attributes; set value only for string keys; symbols unsupported
 		if !keyIsSymbol {
@@ -3665,7 +3708,8 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			// Step 11: Get the target's own property descriptor
 			var targetDescFound bool
 			var targetConfigurable bool
-			if targetObj := target.AsPlainObject(); targetObj != nil {
+			if target.Type() == vm.TypeObject {
+				targetObj := target.AsPlainObject()
 				_, _, _, targetConfigurable, targetDescFound = targetObj.GetOwnDescriptor(propName)
 			} else if target.Type() == vm.TypeArray {
 				arrObj := target.AsArray()
@@ -3684,7 +3728,8 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 
 			// Step 12: Check target extensibility
 			targetExtensible := true
-			if targetObj := target.AsPlainObject(); targetObj != nil {
+			if target.Type() == vm.TypeObject {
+				targetObj := target.AsPlainObject()
 				targetExtensible = targetObj.IsExtensible()
 			} else if target.Type() == vm.TypeArray {
 				targetExtensible = target.AsArray().IsExtensible()
@@ -3735,7 +3780,8 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 				}
 				// Step 22 additional: If result is non-configurable+non-writable, target must also be non-writable
 				if writableVal, hasWritable := resultObj.GetOwn("writable"); hasWritable && writableVal.IsFalsey() {
-					if targetObj := target.AsPlainObject(); targetObj != nil {
+					if target.Type() == vm.TypeObject {
+						targetObj := target.AsPlainObject()
 						_, targetWritable, _, _, found := targetObj.GetOwnDescriptor(propName)
 						if found && targetWritable {
 							return vm.Undefined, vmInstance.NewTypeError("'getOwnPropertyDescriptor' on proxy: trap reported non-configurable and non-writable for property '" + propName + "' which is writable in the proxy target")
@@ -4279,10 +4325,12 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 
 	switch obj.Type() {
 	case vm.TypeObject:
-		if po := obj.AsPlainObject(); po != nil {
+		if obj.Type() == vm.TypeObject {
+			po := obj.AsPlainObject()
 			stringKeys = po.OwnPropertyNames()
 			symbolKeys = po.OwnSymbolKeys()
-		} else if d := obj.AsDictObject(); d != nil {
+		} else if obj.Type() == vm.TypeDictObject {
+			d := obj.AsDictObject()
 			stringKeys = d.OwnPropertyNames()
 		}
 	case vm.TypeArray:
@@ -4340,10 +4388,13 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 	case vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps:
 		// Native functions have length and name
 		stringKeys = append(stringKeys, "length", "name")
-		if nfp := obj.AsNativeFunctionWithProps(); nfp != nil && nfp.Properties != nil {
-			for _, k := range nfp.Properties.OwnPropertyNames() {
-				if k != "length" && k != "name" {
-					stringKeys = append(stringKeys, k)
+		if obj.Type() == vm.TypeNativeFunctionWithProps {
+			nfp := obj.AsNativeFunctionWithProps()
+			if nfp.Properties != nil {
+				for _, k := range nfp.Properties.OwnPropertyNames() {
+					if k != "length" && k != "name" {
+						stringKeys = append(stringKeys, k)
+					}
 				}
 			}
 		}
@@ -4408,7 +4459,8 @@ func objectIsExtensibleWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, err
 			trapResult := result.IsTruthy()
 			targetExtensible := true
 			if proxy.Target().Type() == vm.TypeObject {
-				if targetObj := proxy.Target().AsPlainObject(); targetObj != nil {
+				if proxy.Target().Type() == vm.TypeObject {
+					targetObj := proxy.Target().AsPlainObject()
 					targetExtensible = targetObj.IsExtensible()
 				}
 			} else if proxy.Target().Type() == vm.TypeArray {
@@ -4432,7 +4484,8 @@ func objectIsExtensibleWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, err
 
 	// Check if object is extensible
 	if obj.IsObject() {
-		if plainObj := obj.AsPlainObject(); plainObj != nil {
+		if obj.Type() == vm.TypeObject {
+			plainObj := obj.AsPlainObject()
 			return vm.BooleanValue(plainObj.IsExtensible()), nil
 		}
 		// Other object types (DictObject, etc.) are extensible by default for now
@@ -4493,7 +4546,8 @@ func objectPreventExtensionsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value
 			// ECMAScript 10.5.4: if trap returns true, target must be non-extensible
 			targetExtensible := true
 			if proxy.Target().Type() == vm.TypeObject {
-				if targetObj := proxy.Target().AsPlainObject(); targetObj != nil {
+				if proxy.Target().Type() == vm.TypeObject {
+					targetObj := proxy.Target().AsPlainObject()
 					targetExtensible = targetObj.IsExtensible()
 				}
 			} else if proxy.Target().Type() == vm.TypeArray {
@@ -4524,7 +4578,8 @@ func objectPreventExtensionsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value
 
 	// Mark the object as non-extensible
 	if obj.Type() == vm.TypeObject {
-		if plainObj := obj.AsPlainObject(); plainObj != nil {
+		if obj.Type() == vm.TypeObject {
+			plainObj := obj.AsPlainObject()
 			plainObj.SetExtensible(false)
 		}
 	} else if obj.Type() == vm.TypeDictObject {
@@ -4555,7 +4610,8 @@ func objectFreezeWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	}
 
 	// Freeze: make object non-extensible and all properties non-configurable and non-writable
-	if plainObj := obj.AsPlainObject(); plainObj != nil {
+	if obj.Type() == vm.TypeObject {
+		plainObj := obj.AsPlainObject()
 		plainObj.SetExtensible(false)
 		// Use FreezeAllProperties to freeze ALL own properties (including non-enumerable and symbol)
 		plainObj.FreezeAllProperties()
@@ -4585,7 +4641,8 @@ func objectSealWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	}
 
 	// Seal: make object non-extensible and all properties non-configurable (but leave writable as-is)
-	if plainObj := obj.AsPlainObject(); plainObj != nil {
+	if obj.Type() == vm.TypeObject {
+		plainObj := obj.AsPlainObject()
 		plainObj.SetExtensible(false)
 		plainObj.SealAllProperties()
 	}
@@ -4612,7 +4669,8 @@ func objectIsFrozenWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) 
 	}
 
 	// Check if extensible - frozen objects must not be extensible
-	if plainObj := obj.AsPlainObject(); plainObj != nil {
+	if obj.Type() == vm.TypeObject {
+		plainObj := obj.AsPlainObject()
 		if plainObj.IsExtensible() {
 			return vm.BooleanValue(false), nil
 		}
@@ -4620,7 +4678,8 @@ func objectIsFrozenWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) 
 	}
 
 	// Functions are objects - check their properties object
-	if fn := obj.AsFunction(); fn != nil {
+	if obj.Type() == vm.TypeFunction {
+		fn := obj.AsFunction()
 		if fn.Properties != nil {
 			if fn.Properties.IsExtensible() {
 				return vm.BooleanValue(false), nil
@@ -4629,7 +4688,8 @@ func objectIsFrozenWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) 
 		}
 		return vm.BooleanValue(false), nil // extensible by default
 	}
-	if cl := obj.AsClosure(); cl != nil {
+	if obj.Type() == vm.TypeClosure {
+		cl := obj.AsClosure()
 		if cl.Properties != nil {
 			if cl.Properties.IsExtensible() {
 				return vm.BooleanValue(false), nil
@@ -4666,7 +4726,8 @@ func objectIsSealedWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) 
 	}
 
 	// Check if extensible - sealed objects must not be extensible
-	if plainObj := obj.AsPlainObject(); plainObj != nil {
+	if obj.Type() == vm.TypeObject {
+		plainObj := obj.AsPlainObject()
 		if plainObj.IsExtensible() {
 			return vm.BooleanValue(false), nil
 		}
@@ -4674,7 +4735,8 @@ func objectIsSealedWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) 
 	}
 
 	// Functions are objects
-	if fn := obj.AsFunction(); fn != nil {
+	if obj.Type() == vm.TypeFunction {
+		fn := obj.AsFunction()
 		if fn.Properties != nil {
 			if fn.Properties.IsExtensible() {
 				return vm.BooleanValue(false), nil
@@ -4683,7 +4745,8 @@ func objectIsSealedWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) 
 		}
 		return vm.BooleanValue(false), nil
 	}
-	if cl := obj.AsClosure(); cl != nil {
+	if obj.Type() == vm.TypeClosure {
+		cl := obj.AsClosure()
 		if cl.Properties != nil {
 			if cl.Properties.IsExtensible() {
 				return vm.BooleanValue(false), nil

--- a/pkg/builtins/paserati_init.go
+++ b/pkg/builtins/paserati_init.go
@@ -250,7 +250,8 @@ func (ctx *schemaContext) convert(typeDesc vm.Value) (vm.Value, error) {
 			if arr.Length() > 0 {
 				// Use the first index signature's value type for additionalProperties
 				firstSig := arr.Get(0)
-				if sigObj := firstSig.AsPlainObject(); sigObj != nil {
+				if firstSig.Type() == vm.TypeObject {
+					sigObj := firstSig.AsPlainObject()
 					valueTypeVal, _ := sigObj.GetOwn("valueType")
 					additionalSchema, err := ctx.convert(valueTypeVal)
 					if err != nil {

--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -59,8 +59,8 @@ func (p *PromiseInitializer) InitTypes(ctx *TypeContext) error {
 			types.Any,               // Promise<any>
 		)).
 		WithProperty("try", types.NewVariadicFunction(
-			[]types.Type{types.Any}, // callbackfn
-			types.Any,               // Promise<any>
+			[]types.Type{types.Any},                  // callbackfn
+			types.Any,                                // Promise<any>
 			&types.ArrayType{ElementType: types.Any}, // ...args
 		))
 
@@ -72,6 +72,36 @@ func (p *PromiseInitializer) InitTypes(ctx *TypeContext) error {
 	promiseCtorType = promiseCtorType.WithSimpleCallSignature([]types.Type{executorType}, promiseProtoType)
 
 	return ctx.DefineGlobal("Promise", promiseCtorType)
+}
+
+// promiseCapabilityGuard returns a per-executor closure implementing the
+// bounds-safe argument extraction and "already called" TypeError guard from
+// the spec's GetCapabilitiesExecutor Functions (called by NewPromiseCapability):
+// resolve/reject default to undefined when the caller invokes the executor
+// with fewer than 2 arguments (a hand-rolled "constructor" passed to
+// Promise.all/race/etc. via .call() is free to do this), and a second call
+// throws once either slot already holds a non-undefined value. Call once per
+// executor closure - the guard must be called at the top of the native body.
+func promiseCapabilityGuard(vmInstance *vm.VM) func(execArgs []vm.Value) (vm.Value, vm.Value, error) {
+	capResolve, capReject := vm.Undefined, vm.Undefined
+	return func(execArgs []vm.Value) (vm.Value, vm.Value, error) {
+		resolve := vm.Undefined
+		if len(execArgs) > 0 {
+			resolve = execArgs[0]
+		}
+		reject := vm.Undefined
+		if len(execArgs) > 1 {
+			reject = execArgs[1]
+		}
+		if capResolve.Type() != vm.TypeUndefined {
+			return vm.Undefined, vm.Undefined, vmInstance.NewTypeError("Promise capability's resolve function was already set")
+		}
+		if capReject.Type() != vm.TypeUndefined {
+			return vm.Undefined, vm.Undefined, vmInstance.NewTypeError("Promise capability's reject function was already set")
+		}
+		capResolve, capReject = resolve, reject
+		return capResolve, capReject, nil
+	}
 }
 
 func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
@@ -300,9 +330,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Create the result promise via executor
 		// Per spec: NewPromiseCapability(C) first, then GetPromiseResolve(C),
 		// then IfAbruptRejectPromise if it fails
+		capabilityGuard := promiseCapabilityGuard(vmInstance)
 		executor := vm.NewNativeFunction(2, false, "executor", func(execArgs []vm.Value) (vm.Value, error) {
-			resolve := execArgs[0]
-			reject := execArgs[1]
+			resolve, reject, guardErr := capabilityGuard(execArgs)
+			if guardErr != nil {
+				return vm.Undefined, guardErr
+			}
 
 			if length == 0 {
 				_, _ = vmInstance.Call(resolve, vm.Undefined, []vm.Value{arr})
@@ -445,9 +478,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		length := arrayObj.Length()
 
 		// Create a new promise that settles when the first promise settles
+		capabilityGuard := promiseCapabilityGuard(vmInstance)
 		executor := vm.NewNativeFunction(2, false, "executor", func(execArgs []vm.Value) (vm.Value, error) {
-			resolve := execArgs[0]
-			reject := execArgs[1]
+			resolve, reject, guardErr := capabilityGuard(execArgs)
+			if guardErr != nil {
+				return vm.Undefined, guardErr
+			}
 
 			if length == 0 {
 				// Empty array - promise never settles (per ECMAScript spec)
@@ -569,9 +605,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Create a new promise that resolves with the first fulfilled promise
+		capabilityGuard := promiseCapabilityGuard(vmInstance)
 		executor := vm.NewNativeFunction(2, false, "executor", func(execArgs []vm.Value) (vm.Value, error) {
-			resolve := execArgs[0]
-			reject := execArgs[1]
+			resolve, reject, guardErr := capabilityGuard(execArgs)
+			if guardErr != nil {
+				return vm.Undefined, guardErr
+			}
 
 			// GetPromiseResolve(C) - per spec, if this fails, reject the promise
 			promiseResolve, resolveErr := getPromiseResolve(constructor)
@@ -711,9 +750,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Create a new promise that resolves when all promises settle
+		capabilityGuard := promiseCapabilityGuard(vmInstance)
 		executor := vm.NewNativeFunction(2, false, "executor", func(execArgs []vm.Value) (vm.Value, error) {
-			resolve := execArgs[0]
-			reject := execArgs[1]
+			resolve, reject, guardErr := capabilityGuard(execArgs)
+			if guardErr != nil {
+				return vm.Undefined, guardErr
+			}
 
 			// GetPromiseResolve(C) - per spec, if this fails, reject the promise
 			promiseResolve, resolveErr := getPromiseResolve(constructor)
@@ -857,9 +899,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Create a new promise via executor
+		capabilityGuard := promiseCapabilityGuard(vmInstance)
 		executor := vm.NewNativeFunction(2, false, "executor", func(execArgs []vm.Value) (vm.Value, error) {
-			resolve := execArgs[0]
-			reject := execArgs[1]
+			resolve, reject, guardErr := capabilityGuard(execArgs)
+			if guardErr != nil {
+				return vm.Undefined, guardErr
+			}
 
 			// Call the callback synchronously
 			result, err := vmInstance.Call(callbackfn, vm.Undefined, callArgs)

--- a/pkg/builtins/reference_error_init.go
+++ b/pkg/builtins/reference_error_init.go
@@ -92,7 +92,8 @@ func (r *ReferenceErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// If options is an Object and HasProperty(options, "cause") is true,
 		// install the cause property
 		if len(args) > 1 && args[1].IsObject() {
-			if optObj := args[1].AsPlainObject(); optObj != nil {
+			if args[1].Type() == vm.TypeObject {
+				optObj := args[1].AsPlainObject()
 				if cause, hasCause := optObj.Get("cause"); hasCause {
 					referenceErrorInstancePtr.SetOwnNonEnumerable("cause", cause)
 				}
@@ -103,7 +104,8 @@ func (r *ReferenceErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Make it a proper constructor with prototype property
-	if ctorObj := referenceErrorConstructor.AsNativeFunction(); ctorObj != nil {
+	if referenceErrorConstructor.Type() == vm.TypeNativeFunction {
+		ctorObj := referenceErrorConstructor.AsNativeFunction()
 		// Convert to object with properties
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -156,8 +156,10 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Module Namespace Exotic Object [[Set]] behavior (ECMAScript 10.4.6.9)
 		// [[Set]] on a namespace always returns false
-		if po := target.AsPlainObject(); po != nil && po.IsModuleNamespace() {
-			return vm.BooleanValue(false), nil
+		if target.Type() == vm.TypeObject {
+			if po := target.AsPlainObject(); po.IsModuleNamespace() {
+				return vm.BooleanValue(false), nil
+			}
 		}
 
 		// For Proxy targets, we need to use the set trap differently
@@ -315,7 +317,8 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Handle PlainObject
-		if po := target.AsPlainObject(); po != nil {
+		if target.Type() == vm.TypeObject {
+			po := target.AsPlainObject()
 			// Module Namespace Exotic Object [[Delete]] behavior (ECMAScript 10.4.6.8)
 			if po.IsModuleNamespace() {
 				if propKeyArg.Type() == vm.TypeSymbol {
@@ -355,7 +358,8 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Handle DictObject
-		if d := target.AsDictObject(); d != nil {
+		if target.Type() == vm.TypeDictObject {
+			d := target.AsDictObject()
 			propKey := propKeyArg.ToString()
 			success := d.DeleteOwn(propKey)
 			return vm.BooleanValue(success), nil
@@ -501,10 +505,12 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			// For now, delegate to Object.getOwnPropertyNames + getOwnPropertySymbols
 			// This is a simplification
 			if objCtor, ok := vmInstance.GetGlobal("Object"); ok {
-				if nfp := objCtor.AsNativeFunctionWithProps(); nfp != nil {
+				if objCtor.Type() == vm.TypeNativeFunctionWithProps {
+					nfp := objCtor.AsNativeFunctionWithProps()
 					if f, ok := nfp.Properties.GetOwn("getOwnPropertyNames"); ok {
 						if names, err := vmInstance.Call(f, vm.Undefined, []vm.Value{target}); err == nil {
-							if namesArr := names.AsArray(); namesArr != nil {
+							if names.Type() == vm.TypeArray {
+								namesArr := names.AsArray()
 								for i := 0; i < namesArr.Length(); i++ {
 									arr.Append(namesArr.Get(i))
 								}

--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -1385,11 +1385,13 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 				}
 				// Per spec: RegExp.prototype itself returns undefined for flag getters
 				if thisVal.IsObject() && !thisVal.IsRegExp() {
-					protoObj := thisVal.AsPlainObject()
-					if protoObj != nil {
-						rpObj := vmInstance.RegExpPrototype.AsPlainObject()
-						if rpObj != nil && protoObj == rpObj {
-							return vm.Undefined, nil
+					if thisVal.Type() == vm.TypeObject {
+						protoObj := thisVal.AsPlainObject()
+						if vmInstance.RegExpPrototype.Type() == vm.TypeObject {
+							rpObj := vmInstance.RegExpPrototype.AsPlainObject()
+							if protoObj == rpObj {
+								return vm.Undefined, nil
+							}
 						}
 					}
 					return vm.Undefined, vmInstance.NewTypeError("RegExp.prototype." + name + " getter called on incompatible receiver")
@@ -1414,10 +1416,10 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		sourceGetter := vm.NewNativeFunction(0, false, "get source", func(args []vm.Value) (vm.Value, error) {
 			thisVal := vmInstance.GetThis()
 			if !thisVal.IsRegExp() {
-				if thisVal.IsObject() {
+				if thisVal.Type() == vm.TypeObject && vmInstance.RegExpPrototype.Type() == vm.TypeObject {
 					protoObj := thisVal.AsPlainObject()
 					rpObj := vmInstance.RegExpPrototype.AsPlainObject()
-					if protoObj != nil && rpObj != nil && protoObj == rpObj {
+					if protoObj == rpObj {
 						return vm.NewString("(?:)"), nil
 					}
 				}

--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -191,7 +191,8 @@ func processReplacementPatternEx(str string, matched string, position int, captu
 					}
 					if endIdx < len(replacement) {
 						name := replacement[i+2 : endIdx]
-						if po := namedCaptures.AsPlainObject(); po != nil {
+						if namedCaptures.Type() == vm.TypeObject {
+							po := namedCaptures.AsPlainObject()
 							if val, ok := po.GetOwn(name); ok && val.Type() != vm.TypeUndefined {
 								result.WriteString(val.ToString())
 							}
@@ -498,7 +499,8 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			arg := args[0]
 			// Handle boxed String objects and other objects via ToPrimitive
 			if arg.IsObject() {
-				if plainObj := arg.AsPlainObject(); plainObj != nil {
+				if arg.Type() == vm.TypeObject {
+					plainObj := arg.AsPlainObject()
 					if primitiveVal, exists := plainObj.GetOwn("[[PrimitiveValue]]"); exists && primitiveVal.Type() == vm.TypeString {
 						str = primitiveVal.ToString()
 					} else {
@@ -539,7 +541,8 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		if val.IsObject() {
 			// Check for [[PrimitiveValue]] (String wrapper)
-			if plainObj := val.AsPlainObject(); plainObj != nil {
+			if val.Type() == vm.TypeObject {
+				plainObj := val.AsPlainObject()
 				if primitiveVal, exists := plainObj.GetOwn("[[PrimitiveValue]]"); exists && primitiveVal.Type() == vm.TypeString {
 					return primitiveVal.ToString()
 				}

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -113,7 +113,8 @@ func getStringValueWithVM(vmInstance *vm.VM, val vm.Value) (string, error) {
 
 	// If it's an object, check for [[PrimitiveValue]] (String wrapper)
 	if val.IsObject() {
-		if plainObj := val.AsPlainObject(); plainObj != nil {
+		if val.Type() == vm.TypeObject {
+			plainObj := val.AsPlainObject()
 			if primitiveVal, exists := plainObj.GetOwn("[[PrimitiveValue]]"); exists {
 				if primitiveVal.Type() == vm.TypeString {
 					return primitiveVal.ToString(), nil
@@ -154,7 +155,8 @@ func getStringValue(val vm.Value) string {
 
 	// If it's an object, check for [[PrimitiveValue]] (String wrapper)
 	if val.IsObject() {
-		if plainObj := val.AsPlainObject(); plainObj != nil {
+		if val.Type() == vm.TypeObject {
+			plainObj := val.AsPlainObject()
 			if primitiveVal, exists := plainObj.GetOwn("[[PrimitiveValue]]"); exists {
 				if primitiveVal.Type() == vm.TypeString {
 					return primitiveVal.ToString()

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -437,7 +437,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// If this is a String wrapper object, extract [[PrimitiveValue]]
-		if thisStr.IsObject() {
+		if thisStr.Type() == vm.TypeObject {
 			if primitiveVal, exists := thisStr.AsPlainObject().GetOwn("[[PrimitiveValue]]"); exists {
 				return primitiveVal, nil
 			}
@@ -456,7 +456,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// If this is a String wrapper object, extract [[PrimitiveValue]]
-		if thisStr.IsObject() {
+		if thisStr.Type() == vm.TypeObject {
 			if primitiveVal, exists := thisStr.AsPlainObject().GetOwn("[[PrimitiveValue]]"); exists {
 				if primitiveVal.Type() == vm.TypeString {
 					return primitiveVal, nil
@@ -746,25 +746,52 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if len(args) < 1 || args[0].Type() == vm.TypeUndefined {
 			return vm.NewString(thisStr), nil
 		}
-		start := int(args[0].ToFloat())
-		if start < 0 {
-			start = length + start
+		// ToIntegerOrInfinity (7.1.5): NaN -> 0, otherwise Math.trunc first,
+		// *then* classify the truncated value - +/-Infinity must stay
+		// representable through the clamps below rather than going through
+		// Go's undefined float->int conversion for out-of-range values
+		// (that previously fed a garbage negative length into a byte-offset
+		// slice expression and panicked). Truncating before the sign check
+		// also matters for correctness: -0.5 truncates to 0, not "negative".
+		toIntegerOrInfinity := func(f float64) float64 {
+			if math.IsNaN(f) {
+				return 0
+			}
+			return math.Trunc(f)
+		}
+		startFloat := toIntegerOrInfinity(args[0].ToFloat())
+		var start int
+		switch {
+		case math.IsInf(startFloat, -1):
+			start = 0
+		case startFloat < 0:
+			start = length + int(startFloat)
 			if start < 0 {
 				start = 0
 			}
-		} else if start >= length {
+		case math.IsInf(startFloat, 1) || int(startFloat) >= length:
 			return vm.NewString(""), nil
+		default:
+			start = int(startFloat)
 		}
 		substrLength := length - start
 		if len(args) >= 2 && args[1].Type() != vm.TypeUndefined {
-			substrLength = int(args[1].ToFloat())
-			if substrLength < 0 {
+			lengthFloat := toIntegerOrInfinity(args[1].ToFloat())
+			switch {
+			case lengthFloat < 0:
 				return vm.NewString(""), nil
+			case math.IsInf(lengthFloat, 1):
+				substrLength = length - start
+			default:
+				substrLength = int(lengthFloat)
 			}
 		}
 		end := start + substrLength
 		if end > length {
 			end = length
+		}
+		if end < start {
+			end = start
 		}
 		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
 	}))

--- a/pkg/builtins/symbol_init.go
+++ b/pkg/builtins/symbol_init.go
@@ -101,12 +101,10 @@ func (s *SymbolInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return thisVal, nil
 		}
 		// Check for Symbol wrapper object
-		if thisVal.IsObject() {
+		if thisVal.Type() == vm.TypeObject {
 			po := thisVal.AsPlainObject()
-			if po != nil {
-				if pv, ok := po.GetOwn("[[PrimitiveValue]]"); ok && pv.IsSymbol() {
-					return pv, nil
-				}
+			if pv, ok := po.GetOwn("[[PrimitiveValue]]"); ok && pv.IsSymbol() {
+				return pv, nil
 			}
 		}
 		return vm.Undefined, vmInstance.NewTypeError("Symbol.prototype.valueOf requires that 'this' be a Symbol")

--- a/pkg/builtins/syntax_error_init.go
+++ b/pkg/builtins/syntax_error_init.go
@@ -92,7 +92,8 @@ func (s *SyntaxErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// If options is an Object and HasProperty(options, "cause") is true,
 		// install the cause property
 		if len(args) > 1 && args[1].IsObject() {
-			if optObj := args[1].AsPlainObject(); optObj != nil {
+			if args[1].Type() == vm.TypeObject {
+				optObj := args[1].AsPlainObject()
 				if cause, hasCause := optObj.Get("cause"); hasCause {
 					syntaxErrorInstancePtr.SetOwnNonEnumerable("cause", cause)
 				}
@@ -103,7 +104,8 @@ func (s *SyntaxErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Make it a proper constructor with prototype property
-	if ctorObj := syntaxErrorConstructor.AsNativeFunction(); ctorObj != nil {
+	if syntaxErrorConstructor.Type() == vm.TypeNativeFunction {
+		ctorObj := syntaxErrorConstructor.AsNativeFunction()
 		// Convert to object with properties
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()

--- a/pkg/builtins/temporal_init.go
+++ b/pkg/builtins/temporal_init.go
@@ -90,13 +90,13 @@ func (t *TemporalInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("valueOf", types.NewSimpleFunction([]types.Type{}, types.Any))
 
 	temporalPlainTimeCtorType := types.NewObjectType().
-		WithSimpleConstructSignature([]types.Type{}, temporalPlainTimeProtoType).                                                                                                                          // PlainTime()
-		WithSimpleConstructSignature([]types.Type{types.Number}, temporalPlainTimeProtoType).                                                                                                              // PlainTime(hour)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalPlainTimeProtoType).                                                                                                // PlainTime(hour, minute)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).                                                                                  // PlainTime(h,m,s)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).                                                                    // PlainTime(h,m,s,ms)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).                                                      // PlainTime(h,m,s,ms,us)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).                                        // PlainTime(h,m,s,ms,us,ns)
+		WithSimpleConstructSignature([]types.Type{}, temporalPlainTimeProtoType).                                                                                   // PlainTime()
+		WithSimpleConstructSignature([]types.Type{types.Number}, temporalPlainTimeProtoType).                                                                       // PlainTime(hour)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalPlainTimeProtoType).                                                         // PlainTime(hour, minute)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).                                           // PlainTime(h,m,s)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).                             // PlainTime(h,m,s,ms)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainTimeProtoType).               // PlainTime(h,m,s,ms,us)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainTimeProtoType). // PlainTime(h,m,s,ms,us,ns)
 		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, temporalPlainTimeProtoType)).
 		WithProperty("compare", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Number)).
 		WithProperty("prototype", temporalPlainTimeProtoType)
@@ -124,13 +124,13 @@ func (t *TemporalInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("subtract", types.NewSimpleFunction([]types.Type{types.Any}, types.Any))
 
 	temporalPlainDateTimeCtorType := types.NewObjectType().
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                                                                              // (y,m,d)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                                                                // (y,m,d,h)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                                                  // (y,m,d,h,min)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                                    // (y,m,d,h,min,s)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                      // (y,m,d,h,min,s,ms)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                        // (y,m,d,h,min,s,ms,us)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                          // (y,m,d,h,min,s,ms,us,ns)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                                                     // (y,m,d)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                                       // (y,m,d,h)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                                         // (y,m,d,h,min)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                                           // (y,m,d,h,min,s)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).                             // (y,m,d,h,min,s,ms)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType).               // (y,m,d,h,min,s,ms,us)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalPlainDateTimeProtoType). // (y,m,d,h,min,s,ms,us,ns)
 		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, temporalPlainDateTimeProtoType)).
 		WithProperty("compare", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Number)).
 		WithProperty("prototype", temporalPlainDateTimeProtoType)
@@ -151,9 +151,9 @@ func (t *TemporalInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("valueOf", types.NewSimpleFunction([]types.Type{}, types.Any))
 
 	temporalPlainYearMonthCtorType := types.NewObjectType().
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalPlainYearMonthProtoType).                                  // PlainYearMonth(year, month)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String}, temporalPlainYearMonthProtoType).                    // PlainYearMonth(year, month, calendar)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String, types.Number}, temporalPlainYearMonthProtoType).      // PlainYearMonth(year, month, calendar, referenceDay)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalPlainYearMonthProtoType).                             // PlainYearMonth(year, month)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String}, temporalPlainYearMonthProtoType).               // PlainYearMonth(year, month, calendar)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String, types.Number}, temporalPlainYearMonthProtoType). // PlainYearMonth(year, month, calendar, referenceDay)
 		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, temporalPlainYearMonthProtoType)).
 		WithProperty("compare", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Number)).
 		WithProperty("prototype", temporalPlainYearMonthProtoType)
@@ -170,9 +170,9 @@ func (t *TemporalInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("valueOf", types.NewSimpleFunction([]types.Type{}, types.Any))
 
 	temporalPlainMonthDayCtorType := types.NewObjectType().
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalPlainMonthDayProtoType).                                  // PlainMonthDay(month, day)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String}, temporalPlainMonthDayProtoType).                    // PlainMonthDay(month, day, calendar)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String, types.Number}, temporalPlainMonthDayProtoType).      // PlainMonthDay(month, day, calendar, referenceYear)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalPlainMonthDayProtoType).                             // PlainMonthDay(month, day)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String}, temporalPlainMonthDayProtoType).               // PlainMonthDay(month, day, calendar)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.String, types.Number}, temporalPlainMonthDayProtoType). // PlainMonthDay(month, day, calendar, referenceYear)
 		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, temporalPlainMonthDayProtoType)).
 		WithProperty("prototype", temporalPlainMonthDayProtoType)
 
@@ -199,17 +199,17 @@ func (t *TemporalInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("abs", types.NewSimpleFunction([]types.Type{}, types.Any))
 
 	temporalDurationCtorType := types.NewObjectType().
-		WithSimpleConstructSignature([]types.Type{}, temporalDurationProtoType).                                                                                                                                                                                                    // Duration()
-		WithSimpleConstructSignature([]types.Type{types.Number}, temporalDurationProtoType).                                                                                                                                                                                        // Duration(years)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalDurationProtoType).                                                                                                                                                                          // Duration(y,mo)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                                                                                            // Duration(y,mo,w)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                                                                              // Duration(y,mo,w,d)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                                                                // Duration(y,mo,w,d,h)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                                                  // Duration(y,mo,w,d,h,min)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                                    // Duration(y,mo,w,d,h,min,s)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                      // Duration(y,mo,w,d,h,min,s,ms)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                        // Duration(y,mo,w,d,h,min,s,ms,us)
-		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                          // Duration(y,mo,w,d,h,min,s,ms,us,ns)
+		WithSimpleConstructSignature([]types.Type{}, temporalDurationProtoType).                                                                                                                                           // Duration()
+		WithSimpleConstructSignature([]types.Type{types.Number}, temporalDurationProtoType).                                                                                                                               // Duration(years)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number}, temporalDurationProtoType).                                                                                                                 // Duration(y,mo)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                                   // Duration(y,mo,w)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                                     // Duration(y,mo,w,d)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                                       // Duration(y,mo,w,d,h)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                                         // Duration(y,mo,w,d,h,min)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                                           // Duration(y,mo,w,d,h,min,s)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).                             // Duration(y,mo,w,d,h,min,s,ms)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType).               // Duration(y,mo,w,d,h,min,s,ms,us)
+		WithSimpleConstructSignature([]types.Type{types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number, types.Number}, temporalDurationProtoType). // Duration(y,mo,w,d,h,min,s,ms,us,ns)
 		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, temporalDurationProtoType)).
 		WithProperty("compare", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Number)).
 		WithProperty("prototype", temporalDurationProtoType)
@@ -237,8 +237,8 @@ func (t *TemporalInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("until", types.NewOptionalFunction([]types.Type{types.Any, types.Any}, types.Any, []bool{false, true}))
 
 	temporalZonedDateTimeCtorType := types.NewObjectType().
-		WithSimpleConstructSignature([]types.Type{types.Any, types.String}, temporalZonedDateTimeProtoType).                  // ZonedDateTime(epochNs, timeZone)
-		WithSimpleConstructSignature([]types.Type{types.Any, types.String, types.String}, temporalZonedDateTimeProtoType).    // ZonedDateTime(epochNs, timeZone, calendar)
+		WithSimpleConstructSignature([]types.Type{types.Any, types.String}, temporalZonedDateTimeProtoType).               // ZonedDateTime(epochNs, timeZone)
+		WithSimpleConstructSignature([]types.Type{types.Any, types.String, types.String}, temporalZonedDateTimeProtoType). // ZonedDateTime(epochNs, timeZone, calendar)
 		WithProperty("from", types.NewSimpleFunction([]types.Type{types.Any}, temporalZonedDateTimeProtoType)).
 		WithProperty("compare", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Number)).
 		WithProperty("prototype", temporalZonedDateTimeProtoType)
@@ -307,13 +307,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Helper to get nanoseconds from a Temporal.Instant object
 	getInstantNanos := func(val vm.Value) (*big.Int, error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return nil, vmInstance.NewTypeError("Value is not a Temporal.Instant")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return nil, vmInstance.NewTypeError("Value is not a Temporal.Instant")
-		}
 		nanosVal, exists := obj.GetOwn("[[EpochNanoseconds]]")
 		if !exists {
 			return nil, vmInstance.NewTypeError("Value is not a Temporal.Instant")
@@ -453,13 +450,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Helper to get duration fields from a value (Duration or duration-like object)
 	getDurationFromArg := func(arg vm.Value) (years, months, weeks, days, hours, minutes, seconds, ms, us, ns int, err error) {
-		if !arg.IsObject() {
+		if arg.Type() != vm.TypeObject {
 			return 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Invalid duration")
 		}
 		obj := arg.AsPlainObject()
-		if obj == nil {
-			return 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Invalid duration")
-		}
 		// Try internal slots first (for Temporal.Duration objects)
 		if yVal, ok := obj.GetOwn("[[Years]]"); ok {
 			yearsVal, _ := obj.GetOwn("[[Years]]")
@@ -785,13 +779,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Helper to get date components from PlainDate
 	getPlainDateFields := func(val vm.Value) (year, month, day int, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainDate")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainDate")
-		}
 		yVal, yOk := obj.GetOwn("[[ISOYear]]")
 		mVal, mOk := obj.GetOwn("[[ISOMonth]]")
 		dVal, dOk := obj.GetOwn("[[ISODay]]")
@@ -1070,13 +1061,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	getPlainTimeFields := func(val vm.Value) (hour, minute, second, ms, us, ns int, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainTime")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainTime")
-		}
 		hVal, hOk := obj.GetOwn("[[ISOHour]]")
 		minVal, minOk := obj.GetOwn("[[ISOMinute]]")
 		sVal, sOk := obj.GetOwn("[[ISOSecond]]")
@@ -1277,13 +1265,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	getPlainDateTimeFields := func(val vm.Value) (year, month, day, hour, minute, second, ms, us, ns int, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return 0, 0, 0, 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainDateTime")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return 0, 0, 0, 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainDateTime")
-		}
 		yVal, yOk := obj.GetOwn("[[ISOYear]]")
 		moVal, moOk := obj.GetOwn("[[ISOMonth]]")
 		dVal, dOk := obj.GetOwn("[[ISODay]]")
@@ -1645,13 +1630,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	getPlainYearMonthFields := func(val vm.Value) (year, month int, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainYearMonth")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainYearMonth")
-		}
 		yVal, yOk := obj.GetOwn("[[ISOYear]]")
 		mVal, mOk := obj.GetOwn("[[ISOMonth]]")
 		if !yOk || !mOk {
@@ -1859,13 +1841,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	getPlainMonthDayFields := func(val vm.Value) (month, day int, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainMonthDay")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return 0, 0, vmInstance.NewTypeError("Value is not a Temporal.PlainMonthDay")
-		}
 		mVal, mOk := obj.GetOwn("[[ISOMonth]]")
 		dVal, dOk := obj.GetOwn("[[ISODay]]")
 		if !mOk || !dOk {
@@ -2011,13 +1990,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	getDurationFields := func(val vm.Value) (years, months, weeks, days, hours, minutes, seconds, ms, us, ns int, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.Duration")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, vmInstance.NewTypeError("Value is not a Temporal.Duration")
-		}
 		// Check for internal slots to verify this is a Temporal.Duration
 		yearsVal, hasYears := obj.GetOwn("[[Years]]")
 		if !hasYears {
@@ -2447,13 +2423,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	getZonedDateTimeFields := func(val vm.Value) (nanos *big.Int, tzId string, err error) {
-		if !val.IsObject() {
+		if val.Type() != vm.TypeObject {
 			return nil, "", vmInstance.NewTypeError("Value is not a Temporal.ZonedDateTime")
 		}
 		obj := val.AsPlainObject()
-		if obj == nil {
-			return nil, "", vmInstance.NewTypeError("Value is not a Temporal.ZonedDateTime")
-		}
 		nanosVal, nanosOk := obj.GetOwn("[[EpochNanoseconds]]")
 		tzVal, tzOk := obj.GetOwn("[[TimeZone]]")
 		if !nanosOk || !tzOk {
@@ -2601,12 +2574,10 @@ func (t *TemporalInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Check for options
 		timeZoneName := "auto" // default
-		if len(args) > 0 && args[0].IsObject() {
+		if len(args) > 0 && args[0].Type() == vm.TypeObject {
 			opts := args[0].AsPlainObject()
-			if opts != nil {
-				if tzNameVal, ok := opts.Get("timeZoneName"); ok && tzNameVal.Type() == vm.TypeString {
-					timeZoneName = tzNameVal.ToString()
-				}
+			if tzNameVal, ok := opts.Get("timeZoneName"); ok && tzNameVal.Type() == vm.TypeString {
+				timeZoneName = tzNameVal.ToString()
 			}
 		}
 
@@ -3138,11 +3109,11 @@ func parseYearMonthString(str string) (year, month int, ok bool) {
 
 // Duration range limits per ECMAScript Temporal spec
 const (
-	maxYearsMonthsWeeks = 4294967295           // 2^32 - 1
-	maxDays             = 104249991374         // ceil(maxSafeInteger / 86400) - 1
-	maxHours            = 2501999792983        // ceil(maxSafeInteger / 3600) - 1
-	maxMinutes          = 150119987579016      // ceil(maxSafeInteger / 60) - 1
-	maxSeconds          = 9007199254740991     // max safe integer
+	maxYearsMonthsWeeks = 4294967295       // 2^32 - 1
+	maxDays             = 104249991374     // ceil(maxSafeInteger / 86400) - 1
+	maxHours            = 2501999792983    // ceil(maxSafeInteger / 3600) - 1
+	maxMinutes          = 150119987579016  // ceil(maxSafeInteger / 60) - 1
+	maxSeconds          = 9007199254740991 // max safe integer
 )
 
 // validateDurationRange checks if duration values are within valid range

--- a/pkg/builtins/text_codec_init.go
+++ b/pkg/builtins/text_codec_init.go
@@ -65,7 +65,8 @@ func (t *TextEncoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return inst, nil
 	})
 
-	if nf := ctor.AsNativeFunction(); nf != nil {
+	if ctor.Type() == vm.TypeNativeFunction {
+		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(encoderProto))
@@ -119,7 +120,8 @@ func (t *TextDecoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		input := args[0]
 		// Handle ArrayObject (Uint8Array-like)
-		if arrObj := input.AsArray(); arrObj != nil {
+		if input.Type() == vm.TypeArray {
+			arrObj := input.AsArray()
 			bytes := make([]byte, arrObj.Length())
 			for i := 0; i < arrObj.Length(); i++ {
 				val := arrObj.Get(i)
@@ -142,7 +144,8 @@ func (t *TextDecoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vm.NewValueFromPlainObject(inst), nil
 	})
 
-	if nf := ctor.AsNativeFunction(); nf != nil {
+	if ctor.Type() == vm.TypeNativeFunction {
+		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
 		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(decoderProto))

--- a/pkg/builtins/type_error_init.go
+++ b/pkg/builtins/type_error_init.go
@@ -94,7 +94,8 @@ func (t *TypeErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if len(args) > 1 && args[1].IsObject() {
 			options := args[1]
 			// Check if options has "cause" property (via prototype chain)
-			if optObj := options.AsPlainObject(); optObj != nil {
+			if options.Type() == vm.TypeObject {
+				optObj := options.AsPlainObject()
 				if cause, hasCause := optObj.Get("cause"); hasCause {
 					typeErrorInstancePtr.SetOwnNonEnumerable("cause", cause)
 				}
@@ -105,7 +106,8 @@ func (t *TypeErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Make it a proper constructor with prototype property
-	if ctorObj := typeErrorConstructor.AsNativeFunction(); ctorObj != nil {
+	if typeErrorConstructor.Type() == vm.TypeNativeFunction {
+		ctorObj := typeErrorConstructor.AsNativeFunction()
 		// Convert to object with properties
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()

--- a/pkg/builtins/typedarray_base_init.go
+++ b/pkg/builtins/typedarray_base_init.go
@@ -996,15 +996,17 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 			}
 		}
 
-		// Now do bounds adjustments
+		// Now do bounds adjustments. Per spec (23.2.3.6), target/start/end are
+		// each independently clamped to [0, length] - negative values count
+		// back from length (floored at 0), non-negative values are capped at
+		// length (a huge or out-of-range argument must not escape the slice).
 		if target < 0 {
 			target = length + target
 			if target < 0 {
 				target = 0
 			}
-		}
-		if target >= length {
-			return thisArray, nil
+		} else if target > length {
+			target = length
 		}
 
 		if start < 0 {
@@ -1012,17 +1014,25 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 			if start < 0 {
 				start = 0
 			}
+		} else if start > length {
+			start = length
 		}
+
 		if end < 0 {
 			end = length + end
-		}
-		if end > length {
+			if end < 0 {
+				end = 0
+			}
+		} else if end > length {
 			end = length
 		}
 
 		count := end - start
 		if target+count > length {
 			count = length - target
+		}
+		if count < 0 {
+			count = 0
 		}
 
 		// Step 11.c: If count > 0 and buffer is detached, throw TypeError

--- a/pkg/builtins/typedarray_base_init.go
+++ b/pkg/builtins/typedarray_base_init.go
@@ -1389,7 +1389,7 @@ func setupTypedArrayPrototypeWithErrors(proto *vm.PlainObject, vmInstance *vm.VM
 		var srcLength int
 		if source.Type() == vm.TypeArray {
 			srcLength = source.AsArray().Length()
-		} else if obj := source.AsPlainObject(); obj != nil {
+		} else if source.Type() == vm.TypeObject {
 			// Step 16: Let srcLength be ? ToLength(? Get(src, "length")) -
 			// through the VM so a "length" accessor property actually runs.
 			lengthVal, gerr := vmInstance.GetProperty(source, "length")

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -458,7 +458,8 @@ func NumericTypedArrayCtorBody(vmInstance *vm.VM, ek TypedArrayElementKind) func
 			}
 			return applyGPFCPrototype(vm.NewTypedArray(kind, sab, off, ln), proto), nil
 		}
-		if arr := arg.AsArray(); arr != nil {
+		if arg.Type() == vm.TypeArray {
+			arr := arg.AsArray()
 			proto, err := TypedArrayGPFC(vmInstance, protoName)
 			if err != nil {
 				return vm.Undefined, err
@@ -496,7 +497,8 @@ func TypedArrayFromArrayLike(ek TypedArrayElementKind, args []vm.Value) vm.Value
 		return vm.NewTypedArray(ek.Kind, 0, 0, 0)
 	}
 	source := args[0]
-	if sourceArray := source.AsArray(); sourceArray != nil {
+	if source.Type() == vm.TypeArray {
+		sourceArray := source.AsArray()
 		values := make([]vm.Value, sourceArray.Length())
 		for i := 0; i < sourceArray.Length(); i++ {
 			values[i] = ek.coerceElement(sourceArray.Get(i))

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/nooga/paserati/pkg/types"
@@ -168,13 +169,31 @@ func ValidateTypedArrayBufferAlignmentShared(vmInstance *vm.VM, buffer *vm.Share
 	return nil
 }
 
-// TypedArrayGPFC implements the shared first steps of every %TypedArray%
-// subclass constructor overload (22.2.5.1 step 1: "If NewTarget is undefined,
-// throw a TypeError exception", then AllocateTypedArray's
-// GetPrototypeFromConstructor(newTarget, defaultProto) step). The caller must
-// apply the returned prototype to the newly created typed array itself
-// (GetPrototypeFromConstructor only computes [[Prototype]]; it doesn't know
-// where to install it).
+// TypedArrayRequireNewTarget implements 22.2.5.1 step 1: "If NewTarget is
+// undefined, throw a TypeError exception." This check has no observable side
+// effects and per spec must run before any argument-specific processing
+// (ToIndex on a Symbol/BigInt argument throws TypeError too, buffer
+// validation can throw RangeError, etc.) - unlike the prototype lookup in
+// TypedArrayGPFC below, which runs a user-observable "prototype" getter on
+// NewTarget and per spec (AllocateTypedArray) must happen *last*, after
+// that argument processing, not before it.
+func TypedArrayRequireNewTarget(vmInstance *vm.VM) error {
+	if vmInstance.GetNewTarget().IsUndefined() {
+		return vmInstance.NewTypeError("Constructor TypedArray requires 'new'")
+	}
+	return nil
+}
+
+// TypedArrayGPFC implements AllocateTypedArray's
+// GetPrototypeFromConstructor(newTarget, defaultProto) step. Callers must
+// have already checked TypedArrayRequireNewTarget and finished any
+// argument-specific processing that can throw (ToIndex, buffer bounds,
+// etc.) before calling this, since GetPrototypeFromConstructor can run
+// user-observable code (a custom "prototype" getter on NewTarget) and per
+// spec that must happen after argument validation, not before it. The
+// caller must apply the returned prototype to the newly created typed array
+// itself (GetPrototypeFromConstructor only computes [[Prototype]]; it
+// doesn't know where to install it).
 func TypedArrayGPFC(vmInstance *vm.VM, defaultProtoIntrinsic string) (vm.Value, error) {
 	newTarget := vmInstance.GetNewTarget()
 	if newTarget.IsUndefined() {
@@ -278,6 +297,21 @@ func TypedArrayToIndex(vmInstance *vm.VM, arg vm.Value) (int, error) {
 		return 0, vmInstance.NewTypeError("Cannot convert a BigInt value to a number")
 	}
 	n := arg.ToFloat()
+	// ToIndex (7.1.22): first ToIntegerOrInfinity - NaN -> 0, otherwise
+	// Math.trunc (this must happen *before* the sign/range check below: a
+	// value like -0.1 truncates to 0, which is in range, not "negative").
+	// +Infinity (and anything beyond the safe-integer range) must also be
+	// rejected here - converting an out-of-range float straight to int is
+	// undefined territory in Go and previously fed a garbage length into
+	// make([]Value, l), panicking instead of throwing the spec'd RangeError.
+	if math.IsNaN(n) {
+		n = 0
+	} else {
+		n = math.Trunc(n)
+	}
+	if math.IsInf(n, 0) || n < 0 || n > maxSafeInteger {
+		return 0, vmInstance.NewRangeError("Invalid typed array length")
+	}
 	l := int(n)
 	if l < 0 {
 		return 0, vmInstance.NewRangeError("Invalid typed array length")
@@ -411,6 +445,10 @@ func NumericTypedArrayCtorBody(vmInstance *vm.VM, ek TypedArrayElementKind) func
 	elementSize := ek.ElementSize
 	protoName := typedArrayIntrinsicProtoName(kind)
 	return func(args []vm.Value) (vm.Value, error) {
+		// Step 1: NewTarget undefined check, before any argument processing.
+		if err := TypedArrayRequireNewTarget(vmInstance); err != nil {
+			return vm.Undefined, err
+		}
 		if len(args) == 0 {
 			proto, err := TypedArrayGPFC(vmInstance, protoName)
 			if err != nil {
@@ -420,6 +458,10 @@ func NumericTypedArrayCtorBody(vmInstance *vm.VM, ek TypedArrayElementKind) func
 		}
 		arg := args[0]
 		if arg.IsNumber() {
+			// ToIndex(length) (step 3) before GPFC's prototype lookup: that
+			// lookup can run a user-observable getter and per spec
+			// (AllocateTypedArray) happens after argument processing, not
+			// before it. NewTarget-undefined was already checked above.
 			l, err := TypedArrayToIndex(vmInstance, arg)
 			if err != nil {
 				return vm.Undefined, err
@@ -477,7 +519,8 @@ func NumericTypedArrayCtorBody(vmInstance *vm.VM, ek TypedArrayElementKind) func
 			}
 			return applyGPFCPrototype(vm.NewTypedArray(kind, 0, 0, 0), proto), nil
 		}
-		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex first, then GPFC
+		// Non-number, non-object (e.g. string, Symbol, BigInt): ToIndex
+		// before GPFC's prototype lookup, matching the number branch above.
 		l, err := TypedArrayToIndex(vmInstance, arg)
 		if err != nil {
 			return vm.Undefined, err

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -1118,20 +1118,18 @@ func (o *PlainObject) Get(name string) (Value, bool) {
 	// Walk prototype chain
 	current := o.prototype
 	for current.typ != TypeNull && current.typ != TypeUndefined {
-		if current.IsObject() {
-			if proto := current.AsPlainObject(); proto != nil {
-				if value, exists := proto.GetOwn(name); exists {
-					return value, true
-				}
-				current = proto.prototype
-			} else if dict := current.AsDictObject(); dict != nil {
-				if value, exists := dict.GetOwn(name); exists {
-					return value, true
-				}
-				current = dict.prototype
-			} else {
-				break
+		if current.Type() == TypeObject {
+			proto := current.AsPlainObject()
+			if value, exists := proto.GetOwn(name); exists {
+				return value, true
 			}
+			current = proto.prototype
+		} else if current.Type() == TypeDictObject {
+			dict := current.AsDictObject()
+			if value, exists := dict.GetOwn(name); exists {
+				return value, true
+			}
+			current = dict.prototype
 		} else if current.Type() == TypeClosure {
 			// Functions can be prototypes in JavaScript
 			closure := current.AsClosure()
@@ -1553,12 +1551,14 @@ func (d *DictObject) Get(name string) (Value, bool) {
 	current := d.prototype
 	for current.typ != TypeNull && current.typ != TypeUndefined {
 		if current.IsObject() {
-			if proto := current.AsPlainObject(); proto != nil {
+			if current.Type() == TypeObject {
+				proto := current.AsPlainObject()
 				if value, exists := proto.GetOwn(name); exists {
 					return value, true
 				}
 				current = proto.prototype
-			} else if dict := current.AsDictObject(); dict != nil {
+			} else if current.Type() == TypeDictObject {
+				dict := current.AsDictObject()
 				if value, exists := dict.GetOwn(name); exists {
 					return value, true
 				}

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -41,7 +41,8 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			}
 			// If not in heap, check Object.prototype for standard methods
 			// GlobalObject has Null prototype to avoid issues, but should inherit Object.prototype methods
-			if objProto := vm.ObjectPrototype.AsPlainObject(); objProto != nil {
+			if vm.ObjectPrototype.Type() == TypeObject {
+				objProto := vm.ObjectPrototype.AsPlainObject()
 				if value, exists := objProto.GetOwn(propName); exists {
 					*dest = value
 					return true, InterpretOK, *dest
@@ -353,7 +354,7 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 				current := po
 				for i := int8(0); i < entry.protoDepth && current != nil; i++ {
 					pv := current.GetPrototype()
-					if !pv.IsObject() {
+					if pv.Type() != TypeObject {
 						current = nil
 						break
 					}
@@ -491,9 +492,10 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			return true, InterpretOK, *dest
 		}
 
-		// resolvePropertyMeta didn't find property - try PlainObject.Get which handles
-		// function prototypes (functions can be used as prototypes in JavaScript)
-		if fv, ok := po.Get(propName); ok {
+		// resolvePropertyMeta didn't find property - fall back to a full generic
+		// chain walk, which handles prototypes of any object kind (functions,
+		// arrays, etc. can all be used as prototypes in JavaScript)
+		if fv, ok := vm.getInheritedGeneric(NewValueFromPlainObject(po), propName); ok {
 			*dest = fv
 			return true, InterpretOK, *dest
 		}
@@ -571,7 +573,8 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			current := po.GetPrototype()
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if p := current.AsPlainObject(); p != nil {
+					if current.Type() == TypeObject {
+						p := current.AsPlainObject()
 						if v, ok := p.GetOwn(propName); ok {
 							*dest = v
 							return true, InterpretOK, *dest
@@ -911,13 +914,15 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwn(propName); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -944,13 +949,15 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwn(propName); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -985,7 +992,8 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			current := proto.GetPrototype()
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if p := current.AsPlainObject(); p != nil {
+					if current.Type() == TypeObject {
+						p := current.AsPlainObject()
 						if v, ok := p.GetOwn(propName); ok {
 							*dest = v
 							return true, InterpretOK, *dest
@@ -1105,7 +1113,8 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 				return false, InterpretRuntimeError, Undefined
 			}
 			// ECMAScript 10.5.8 invariant validation
-			if targetObj := proxy.target.AsPlainObject(); targetObj != nil {
+			if proxy.target.Type() == TypeObject {
+				targetObj := proxy.target.AsPlainObject()
 				if g, _, _, c, isAccessor := targetObj.GetOwnAccessor(propName); isAccessor && !c {
 					if g.Type() == TypeUndefined && !result.IsUndefined() {
 						if frame != nil && !frameWasNil {
@@ -1216,7 +1225,8 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 					current := funcProto.Properties.GetPrototype()
 					for current.typ != TypeNull && current.typ != TypeUndefined {
 						if current.IsObject() {
-							if proto := current.AsPlainObject(); proto != nil {
+							if current.Type() == TypeObject {
+								proto := current.AsPlainObject()
 								if v, ok := proto.GetOwn(propName); ok {
 									*dest = v
 									return true, InterpretOK, *dest
@@ -1239,7 +1249,8 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 					current := funcProto.prototype
 					for current.typ != TypeNull && current.typ != TypeUndefined {
 						if current.IsObject() {
-							if proto := current.AsPlainObject(); proto != nil {
+							if current.Type() == TypeObject {
+								proto := current.AsPlainObject()
 								if v, ok := proto.GetOwn(propName); ok {
 									*dest = v
 									return true, InterpretOK, *dest
@@ -1298,7 +1309,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							if debugVM {
@@ -1307,7 +1319,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1342,7 +1355,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							if debugVM {
@@ -1351,7 +1365,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1422,7 +1437,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						// Check for accessor property first
 						if getter, _, _, _, exists := proto2.GetOwnAccessorByKey(symKeyVal); exists {
 							if getter.Type() != TypeUndefined {
@@ -1445,7 +1461,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1469,13 +1486,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1499,13 +1518,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1529,13 +1550,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1575,7 +1598,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							if debugVM {
@@ -1584,7 +1608,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1611,7 +1636,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							if debugVM {
@@ -1620,7 +1646,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1647,7 +1674,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							if debugVM {
@@ -1656,7 +1684,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1703,13 +1732,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1735,13 +1766,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1771,13 +1804,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1807,13 +1842,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(NewSymbolKey(symKey)); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1849,13 +1886,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwnByKey(key); ok {
 							*dest = v
 							return true, InterpretOK, *dest
 						}
 						current = proto2.prototype
-					} else if dict := current.AsDictObject(); dict != nil {
+					} else if current.Type() == TypeDictObject {
+						dict := current.AsDictObject()
 						current = dict.prototype
 					} else {
 						break
@@ -1931,7 +1970,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 			if !current.IsObject() {
 				break
 			}
-			if proto := current.AsPlainObject(); proto != nil {
+			if current.Type() == TypeObject {
+				proto := current.AsPlainObject()
 				if g, _, _, _, ok := proto.GetOwnAccessorByKey(key); ok {
 					if g.Type() != TypeUndefined {
 						res, err := vm.Call(g, base, nil)
@@ -1984,7 +2024,8 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 				current = proto.prototype
 				continue
 			}
-			if dict := current.AsDictObject(); dict != nil {
+			if current.Type() == TypeDictObject {
+				dict := current.AsDictObject()
 				current = dict.prototype
 				continue
 			}

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -85,7 +85,8 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			// ECMAScript 10.5.9 invariant validation
 			if !result.IsFalsey() {
 				target := proxy.target
-				if targetObj := target.AsPlainObject(); targetObj != nil {
+				if target.Type() == TypeObject {
+					targetObj := target.AsPlainObject()
 					// Check for non-configurable target properties
 					if g, s, _, c, isAccessor := targetObj.GetOwnAccessor(propName); isAccessor {
 						// Accessor property invariant
@@ -603,7 +604,9 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 
 			// Move up the prototype chain
 			protoVal := current.GetPrototype()
-			if !protoVal.IsObject() {
+			// Non-PlainObject prototypes (Array, Function, DictObject, ...) can't hold
+			// accessors via this shape-based lookup; stop walking rather than panic.
+			if protoVal.Type() != TypeObject {
 				break
 			}
 			current = protoVal.AsPlainObject()
@@ -639,7 +642,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		// Per ECMAScript spec, you cannot shadow a non-writable property from prototype
 		if !propertyExists {
 			protoChain := po.GetPrototype()
-			for protoChain.IsObject() {
+			for protoChain.Type() == TypeObject {
 				protoObj := protoChain.AsPlainObject()
 				if protoObj == nil {
 					break

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -34,7 +34,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		}
 
 		// Check if handler has a set trap (per spec: GetMethod returns undefined for null/undefined)
-		setTrap, ok := proxy.handler.AsPlainObject().GetOwn("set")
+		setTrap, ok := vm.getOwnGeneric(proxy.handler, "set")
 		if ok && setTrap.Type() != TypeUndefined && setTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !setTrap.IsCallable() {
@@ -449,7 +449,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 				// Found a proxy in the chain - invoke its set trap
 				proxy := current.AsProxy()
 				if !proxy.Revoked {
-					if setTrap, ok := proxy.handler.AsPlainObject().GetOwn("set"); ok && setTrap.IsCallable() {
+					if setTrap, ok := vm.getOwnGeneric(proxy.handler, "set"); ok && setTrap.IsCallable() {
 						// Call the set trap: trap(target, property, value, receiver)
 						// receiver is the original primitive coerced to object
 						trapArgs := []Value{proxy.Target(), NewString(propName), *valueToSet, *objVal}
@@ -459,7 +459,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 					}
 				}
 			}
-			if current.IsObject() {
+			if current.Type() == TypeObject {
 				po := current.AsPlainObject()
 				// Check for setter in the setters map
 				if po.setters != nil {
@@ -471,6 +471,15 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 					}
 				}
 				current = po.prototype
+			} else if current.Type() == TypeProxy {
+				// Already handled above (set trap checked); continue walking
+				// past it via the generic [[Prototype]] step.
+				current = vm.prototypeOf(current)
+			} else if current.IsObject() {
+				// Non-PlainObject link (Array, DictObject, ...): this VM's
+				// model doesn't attach setters to those directly, so just
+				// keep walking the chain instead of stopping here.
+				current = vm.prototypeOf(current)
 			} else {
 				break
 			}
@@ -969,7 +978,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		}
 
 		// Check if handler has a set trap
-		setTrap, ok := proxy.handler.AsPlainObject().GetOwn("set")
+		setTrap, ok := vm.getOwnGeneric(proxy.handler, "set")
 		if ok && setTrap.IsCallable() {
 			// Call the set trap: handler.set(target, propertyKey, value, receiver)
 			trapArgs := []Value{proxy.target, symKey, *valueToSet, *objVal}

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -21,9 +21,9 @@ const (
 
 // PromiseReaction represents a callback registered via .then()
 type PromiseReaction struct {
-	Handler Value          // Function to call (onFulfilled or onRejected)
-	Resolve func(Value)    // Resolve the chained promise
-	Reject  func(Value)    // Reject the chained promise
+	Handler Value       // Function to call (onFulfilled or onRejected)
+	Resolve func(Value) // Resolve the chained promise
+	Reject  func(Value) // Reject the chained promise
 }
 
 // PromiseObject represents a JavaScript Promise
@@ -35,9 +35,9 @@ type PromiseObject struct {
 	RejectReactions  []PromiseReaction
 
 	// For async functions: suspended execution state
-	Frame            *SuspendedFrame // Execution frame (nil if not an async function promise)
-	Function         Value           // The async function (for resumption)
-	ThisValue        Value           // The 'this' value when async function was called
+	Frame     *SuspendedFrame // Execution frame (nil if not an async function promise)
+	Function  Value           // The async function (for resumption)
+	ThisValue Value           // The 'this' value when async function was called
 
 	prototype Value // Per-instance [[Prototype]] override for subclassing; Undefined = intrinsic
 }
@@ -368,7 +368,8 @@ func (vm *VM) IterableToArray(value Value) (Value, error) {
 			if next, exists := obj.GetOwn("next"); exists {
 				nextMethod = next
 			}
-		} else if dictObj := iteratorObj.AsDictObject(); dictObj != nil {
+		} else if iteratorObj.Type() == TypeDictObject {
+			dictObj := iteratorObj.AsDictObject()
 			if next, exists := dictObj.GetOwn("next"); exists {
 				nextMethod = next
 			}
@@ -397,7 +398,8 @@ func (vm *VM) IterableToArray(value Value) (Value, error) {
 				if d, exists := obj.GetOwn("done"); exists {
 					done = d
 				}
-			} else if dictObj := result.AsDictObject(); dictObj != nil {
+			} else if result.Type() == TypeDictObject {
+				dictObj := result.AsDictObject()
 				if d, exists := dictObj.GetOwn("done"); exists {
 					done = d
 				}
@@ -433,7 +435,8 @@ func (vm *VM) IterableToArray(value Value) (Value, error) {
 				if v, exists := obj.GetOwn("value"); exists {
 					itemValue = v
 				}
-			} else if dictObj := result.AsDictObject(); dictObj != nil {
+			} else if result.Type() == TypeDictObject {
+				dictObj := result.AsDictObject()
 				if v, exists := dictObj.GetOwn("value"); exists {
 					itemValue = v
 				}

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -709,28 +709,32 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 	switch objVal.Type() {
 	case TypeArray:
-		if arr := objVal.AsArray(); arr != nil {
+		if objVal.Type() == TypeArray {
+			arr := objVal.AsArray()
 			if proto := arr.GetPrototype(); proto.IsObject() {
 				return proto
 			}
 		}
 		return vm.ArrayPrototype
 	case TypeMap:
-		if mp := objVal.AsMap(); mp != nil {
+		if objVal.Type() == TypeMap {
+			mp := objVal.AsMap()
 			if proto := mp.GetPrototype(); proto.IsObject() {
 				return proto
 			}
 		}
 		return vm.MapPrototype
 	case TypeSet:
-		if st := objVal.AsSet(); st != nil {
+		if objVal.Type() == TypeSet {
+			st := objVal.AsSet()
 			if proto := st.GetPrototype(); proto.IsObject() {
 				return proto
 			}
 		}
 		return vm.SetPrototype
 	case TypeWeakRef:
-		if wr := objVal.AsWeakRef(); wr != nil {
+		if objVal.Type() == TypeWeakRef {
+			wr := objVal.AsWeakRef()
 			if proto := wr.GetPrototype(); proto.IsObject() {
 				return proto
 			}
@@ -1115,7 +1119,7 @@ func (vm *VM) resolvePropertyMeta(objVal Value, propName string, cache *PropInli
 			}
 		}
 		pv := current.GetPrototype()
-		if pv.IsObject() {
+		if pv.Type() == TypeObject {
 			current = pv.AsPlainObject()
 			depth++
 		} else if pv.Type() == TypeClosure || pv.Type() == TypeFunction || pv.Type() == TypeNativeFunction || pv.Type() == TypeNativeFunctionWithProps {

--- a/pkg/vm/proto.go
+++ b/pkg/vm/proto.go
@@ -10,12 +10,16 @@ package vm
 // helpers here give those slow/uncommon paths a correct, non-panicking way to
 // step through a mixed-kind chain.
 
-// prototypeOf returns v's [[Prototype]], honoring per-instance overrides set
+// PrototypeOf returns v's [[Prototype]], honoring per-instance overrides set
 // by subclassing a native constructor (see subclass.go) and otherwise falling
 // back to the realm's intrinsic prototype for v's kind. Returns Undefined for
 // values with no [[Prototype]] concept (primitive numbers aside from their
 // boxed prototype, null, undefined) — callers should treat that as "chain
 // exhausted".
+func (vm *VM) PrototypeOf(v Value) Value {
+	return vm.prototypeOf(v)
+}
+
 func (vm *VM) prototypeOf(v Value) Value {
 	if p, ok := vm.InstancePrototypeOverride(v); ok {
 		return p
@@ -108,9 +112,13 @@ func (vm *VM) prototypeOf(v Value) Value {
 	}
 }
 
-// getOwnGeneric looks up an own (non-inherited) property by name on any
+// GetOwnGeneric looks up an own (non-inherited) property by name on any
 // object-kind value. It does not consult accessors beyond what the
 // underlying kind's GetOwn already reports as a plain value.
+func (vm *VM) GetOwnGeneric(v Value, propName string) (Value, bool) {
+	return vm.getOwnGeneric(v, propName)
+}
+
 func (vm *VM) getOwnGeneric(v Value, propName string) (Value, bool) {
 	switch v.Type() {
 	case TypeObject:
@@ -163,11 +171,15 @@ func (vm *VM) getOwnGeneric(v Value, propName string) (Value, bool) {
 	}
 }
 
-// getInheritedGeneric walks start's own properties and then its full
+// GetInheritedGeneric walks start's own properties and then its full
 // [[Prototype]] chain (of any object kind) looking for propName. It is an
 // uncached, correctness-first fallback for the uncommon case where a
 // prototype chain contains something other than a PlainObject/DictObject
 // (e.g. `Foo.prototype = new Array(...)` or `Foo.prototype = someFunction`).
+func (vm *VM) GetInheritedGeneric(start Value, propName string) (Value, bool) {
+	return vm.getInheritedGeneric(start, propName)
+}
+
 func (vm *VM) getInheritedGeneric(start Value, propName string) (Value, bool) {
 	current := start
 	for i := 0; i < 200 && current.Type() != TypeNull && current.Type() != TypeUndefined; i++ {

--- a/pkg/vm/proto.go
+++ b/pkg/vm/proto.go
@@ -1,0 +1,180 @@
+package vm
+
+// Generic [[Prototype]] chain traversal for arbitrary object-kind values.
+//
+// Most VM chain walks are written for PlainObject/DictObject only, since that
+// covers the overwhelming majority of real prototype chains. But any object
+// value can legally sit in a prototype chain (`Foo.prototype = new Array(...)`,
+// `Bar.prototype = someFunction`, etc.), and code that assumes PlainObject and
+// calls AsPlainObject() unconditionally will panic when it hits one. The
+// helpers here give those slow/uncommon paths a correct, non-panicking way to
+// step through a mixed-kind chain.
+
+// prototypeOf returns v's [[Prototype]], honoring per-instance overrides set
+// by subclassing a native constructor (see subclass.go) and otherwise falling
+// back to the realm's intrinsic prototype for v's kind. Returns Undefined for
+// values with no [[Prototype]] concept (primitive numbers aside from their
+// boxed prototype, null, undefined) — callers should treat that as "chain
+// exhausted".
+func (vm *VM) prototypeOf(v Value) Value {
+	if p, ok := vm.InstancePrototypeOverride(v); ok {
+		return p
+	}
+	switch v.Type() {
+	case TypeObject:
+		return v.AsPlainObject().GetPrototype()
+	case TypeDictObject:
+		return v.AsDictObject().GetPrototype()
+	case TypeArray:
+		return vm.ArrayPrototype
+	case TypeRegExp:
+		return vm.RegExpPrototype
+	case TypeMap:
+		return vm.MapPrototype
+	case TypeSet:
+		return vm.SetPrototype
+	case TypeWeakMap:
+		return vm.WeakMapPrototype
+	case TypeWeakSet:
+		return vm.WeakSetPrototype
+	case TypeWeakRef:
+		return vm.WeakRefPrototype
+	case TypeFinalizationRegistry:
+		return vm.FinalizationRegistryPrototype
+	case TypeArrayBuffer:
+		return vm.ArrayBufferPrototype
+	case TypeSharedArrayBuffer:
+		return vm.SharedArrayBufferPrototype
+	case TypeDataView:
+		return vm.DataViewPrototype
+	case TypeTypedArray:
+		return vm.TypedArrayPrototype
+	case TypeArguments:
+		return vm.ObjectPrototype
+	case TypePromise:
+		return vm.PromisePrototype
+	case TypeFunction:
+		fn := v.AsFunction()
+		if fn.IsAsync && fn.IsGenerator {
+			return vm.AsyncGeneratorFunctionPrototype
+		} else if fn.IsGenerator {
+			return vm.GeneratorFunctionPrototype
+		} else if fn.IsAsync {
+			return vm.AsyncFunctionPrototype
+		}
+		return vm.FunctionPrototype
+	case TypeClosure:
+		cl := v.AsClosure()
+		if cl.Fn.IsAsync && cl.Fn.IsGenerator {
+			return vm.AsyncGeneratorFunctionPrototype
+		} else if cl.Fn.IsGenerator {
+			return vm.GeneratorFunctionPrototype
+		} else if cl.Fn.IsAsync {
+			return vm.AsyncFunctionPrototype
+		}
+		return vm.FunctionPrototype
+	case TypeNativeFunctionWithProps:
+		nfp := v.AsNativeFunctionWithProps()
+		if nfp.Properties != nil {
+			return nfp.Properties.GetPrototype()
+		}
+		return vm.FunctionPrototype
+	case TypeNativeFunction, TypeBoundFunction, TypeAsyncNativeFunction:
+		return vm.FunctionPrototype
+	case TypeGenerator:
+		genObj := v.AsGenerator()
+		if genObj.Prototype != nil {
+			return NewValueFromPlainObject(genObj.Prototype)
+		}
+		return vm.GeneratorPrototype
+	case TypeAsyncGenerator:
+		asyncGenObj := v.AsAsyncGenerator()
+		if asyncGenObj.Prototype != nil {
+			return NewValueFromPlainObject(asyncGenObj.Prototype)
+		}
+		return vm.AsyncGeneratorPrototype
+	case TypeString:
+		return vm.StringPrototype
+	case TypeFloatNumber, TypeIntegerNumber:
+		return vm.NumberPrototype
+	case TypeBoolean:
+		return vm.BooleanPrototype
+	case TypeSymbol:
+		return vm.SymbolPrototype
+	case TypeBigInt:
+		return vm.BigIntPrototype
+	default:
+		return Undefined
+	}
+}
+
+// getOwnGeneric looks up an own (non-inherited) property by name on any
+// object-kind value. It does not consult accessors beyond what the
+// underlying kind's GetOwn already reports as a plain value.
+func (vm *VM) getOwnGeneric(v Value, propName string) (Value, bool) {
+	switch v.Type() {
+	case TypeObject:
+		return v.AsPlainObject().GetOwn(propName)
+	case TypeDictObject:
+		return v.AsDictObject().GetOwn(propName)
+	case TypeArray:
+		return v.AsArray().GetOwn(propName)
+	case TypeClosure:
+		cl := v.AsClosure()
+		if cl.Properties != nil {
+			if val, ok := cl.Properties.GetOwn(propName); ok {
+				return val, true
+			}
+		}
+		if cl.Fn.Properties != nil {
+			return cl.Fn.Properties.GetOwn(propName)
+		}
+		return Undefined, false
+	case TypeFunction:
+		fn := v.AsFunction()
+		if fn.Properties != nil {
+			return fn.Properties.GetOwn(propName)
+		}
+		return Undefined, false
+	case TypeNativeFunctionWithProps:
+		nfp := v.AsNativeFunctionWithProps()
+		if nfp.Properties != nil {
+			return nfp.Properties.GetOwn(propName)
+		}
+		return Undefined, false
+	case TypeNativeFunction:
+		nf := v.AsNativeFunction()
+		if nf != nil && nf.Properties != nil {
+			return nf.Properties.GetOwn(propName)
+		}
+		return Undefined, false
+	case TypeBoundFunction:
+		bf := v.AsBoundFunction()
+		if bf != nil && bf.Properties != nil {
+			return bf.Properties.GetOwn(propName)
+		}
+		return Undefined, false
+	default:
+		// Other object kinds used as ad-hoc prototypes (RegExp, Map, Set,
+		// Promise, TypedArray, ...) don't carry extra own properties in this
+		// VM's model beyond their intrinsic .prototype object, which is
+		// reached separately via prototypeOf.
+		return Undefined, false
+	}
+}
+
+// getInheritedGeneric walks start's own properties and then its full
+// [[Prototype]] chain (of any object kind) looking for propName. It is an
+// uncached, correctness-first fallback for the uncommon case where a
+// prototype chain contains something other than a PlainObject/DictObject
+// (e.g. `Foo.prototype = new Array(...)` or `Foo.prototype = someFunction`).
+func (vm *VM) getInheritedGeneric(start Value, propName string) (Value, bool) {
+	current := start
+	for i := 0; i < 200 && current.Type() != TypeNull && current.Type() != TypeUndefined; i++ {
+		if v, ok := vm.getOwnGeneric(current, propName); ok {
+			return v, true
+		}
+		current = vm.prototypeOf(current)
+	}
+	return Undefined, false
+}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -188,18 +188,18 @@ type ArrayObject struct {
 	Object
 	length       int
 	elements     []Value
-	properties   map[string]Value           // Named properties (e.g., "index", "input" for match results)
-	propertyDesc map[string]PropertyDesc    // Property descriptors for named properties
-	symbolProps  map[*SymbolObject]Value    // Symbol-keyed properties (e.g., Symbol.iterator override)
-	getters      map[string]Value           // Accessor getters for named properties
-	setters      map[string]Value           // Accessor setters for named properties
-	extensible   bool                       // When false, no new properties can be added (for Object.freeze/seal)
-	frozen       bool                       // When true, elements are also non-writable and non-configurable
-	execMeta     *execResultMeta            // Lazy exec result properties (nil for normal arrays)
+	properties   map[string]Value        // Named properties (e.g., "index", "input" for match results)
+	propertyDesc map[string]PropertyDesc // Property descriptors for named properties
+	symbolProps  map[*SymbolObject]Value // Symbol-keyed properties (e.g., Symbol.iterator override)
+	getters      map[string]Value        // Accessor getters for named properties
+	setters      map[string]Value        // Accessor setters for named properties
+	extensible   bool                    // When false, no new properties can be added (for Object.freeze/seal)
+	frozen       bool                    // When true, elements are also non-writable and non-configurable
+	execMeta     *execResultMeta         // Lazy exec result properties (nil for normal arrays)
 	// Subclass prototype override: for `class S extends Array {} new S()` instances,
 	// this points at S.prototype (whose own [[Prototype]] chains through Array.prototype).
 	// Zero value (TypeUndefined) means use the realm's intrinsic ArrayPrototype.
-	prototype    Value
+	prototype Value
 }
 
 // PropertyDesc stores property descriptor attributes
@@ -307,18 +307,18 @@ type GeneratorFrame = SuspendedFrame
 // Based on the design from docs/archived/generators-implementation-plan.md
 type GeneratorObject struct {
 	Object
-	Function          Value           // The generator function
-	State             GeneratorState  // Current state (suspended/completed/executing)
-	Frame             *SuspendedFrame // Execution frame (nil if completed)
-	YieldedValue      Value           // Last yielded value
-	ReturnValue       Value           // Final return value (when completed)
-	Done              bool            // True when generator is exhausted
-	Args              []Value         // Arguments passed when the generator was created
-	This              Value           // The 'this' value for the generator context
-	Prototype         *PlainObject    // Custom prototype (if set via function.prototype)
-	DelegatedIterator     Value // Iterator being delegated to (for yield* forwarding of .return()/.throw())
-	DelegationResult      Value // Result value when delegation completed via external throw/return with done:true
-	DelegationResultReady bool  // Flag indicating DelegationResult is set (needed because result could be undefined)
+	Function              Value           // The generator function
+	State                 GeneratorState  // Current state (suspended/completed/executing)
+	Frame                 *SuspendedFrame // Execution frame (nil if completed)
+	YieldedValue          Value           // Last yielded value
+	ReturnValue           Value           // Final return value (when completed)
+	Done                  bool            // True when generator is exhausted
+	Args                  []Value         // Arguments passed when the generator was created
+	This                  Value           // The 'this' value for the generator context
+	Prototype             *PlainObject    // Custom prototype (if set via function.prototype)
+	DelegatedIterator     Value           // Iterator being delegated to (for yield* forwarding of .return()/.throw())
+	DelegationResult      Value           // Result value when delegation completed via external throw/return with done:true
+	DelegationResultReady bool            // Flag indicating DelegationResult is set (needed because result could be undefined)
 }
 
 type AsyncGeneratorObject GeneratorObject
@@ -556,7 +556,7 @@ var (
 	Uninitialized = Value{typ: TypeUninitialized} // TDZ marker for let/const before initialization
 	True          = Value{typ: TypeBoolean, payload: 1}
 	False         = Value{typ: TypeBoolean, payload: 0}
-	NaN       = Value{typ: TypeFloatNumber, payload: math.Float64bits(math.NaN())}
+	NaN           = Value{typ: TypeFloatNumber, payload: math.Float64bits(math.NaN())}
 )
 
 func NumberValue(value float64) Value {
@@ -1442,8 +1442,8 @@ func (v Value) ToFloat() float64 {
 		return parseStringToNumber(v.AsString())
 	case TypeObject, TypeDictObject, TypeArray, TypeArguments, TypeRegExp, TypeMap, TypeSet, TypeArrayBuffer, TypeSharedArrayBuffer, TypeTypedArray, TypeDataView, TypeProxy:
 		// Special case for Date objects - directly get timestamp
-		if obj := v.AsPlainObject(); obj != nil {
-			if timestampValue, exists := obj.GetOwn("__timestamp__"); exists {
+		if v.typ == TypeObject {
+			if timestampValue, exists := v.AsPlainObject().GetOwn("__timestamp__"); exists {
 				return timestampValue.ToFloat()
 			}
 		}
@@ -1469,7 +1469,8 @@ func (v Value) ToPrimitive(hint string) Value {
 	// For objects, we need to call valueOf/toString methods
 	// Since we don't have VM instance here, we use a simplified approach
 	// This will be enhanced when we have access to VM in this context
-	if po := v.AsPlainObject(); po != nil {
+	if v.typ == TypeObject {
+		po := v.AsPlainObject()
 		// For built-in wrappers, we can extract the primitive value directly
 		switch v.typ {
 		case TypeBoolean:
@@ -1480,10 +1481,8 @@ func (v Value) ToPrimitive(hint string) Value {
 			return NewString(v.ToString())
 		case TypeBigInt:
 			// For BigInt object wrappers, extract the primitive value from [[BigIntData]]
-			if po := v.AsPlainObject(); po != nil {
-				if dataVal, exists := po.GetOwn("[[BigIntData]]"); exists {
-					return dataVal
-				}
+			if dataVal, exists := po.GetOwn("[[BigIntData]]"); exists {
+				return dataVal
 			}
 			// If no [[BigIntData]], return as-is (shouldn't happen for valid BigInt objects)
 			return v
@@ -2804,8 +2803,8 @@ func (m *MapObject) Delete(key Value) bool {
 func (m *MapObject) Clear() {
 	m.entries = make(map[mapKey]Value)
 	m.keys = make(map[mapKey]Value)
-	m.order = nil        // Reset insertion order
-	m.tombstones = nil   // Clear tombstones
+	m.order = nil      // Reset insertion order
+	m.tombstones = nil // Clear tombstones
 	m.size = 0
 }
 
@@ -3155,7 +3154,7 @@ func findToStringMethod(obj *PlainObject) Value {
 	for current != nil && depth < 10 { // Prevent infinite loops
 		// Move up the prototype chain
 		protoVal := current.GetPrototype()
-		if !protoVal.IsObject() {
+		if protoVal.Type() != TypeObject {
 			break
 		}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6917,8 +6917,8 @@ startExecution:
 						continue
 					}
 
-					if idx >= len(arr.elements) {
-						registers[destReg] = Undefined // Out of bounds -> undefined
+					if idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
+						registers[destReg] = Undefined // Out of bounds or hole -> undefined
 					} else {
 						registers[destReg] = arr.elements[idx]
 					}
@@ -6932,7 +6932,7 @@ startExecution:
 						// In JavaScript, obj["0"] should access obj[0] for arrays
 						if idx, isNumeric := vm.parseArrayIndex(key); isNumeric {
 							// Convert string index to numeric and access array element
-							if idx < 0 || idx >= len(arr.elements) {
+							if idx < 0 || idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
 								registers[destReg] = Undefined
 							} else {
 								registers[destReg] = arr.elements[idx]
@@ -7464,7 +7464,7 @@ startExecution:
 						arr := targetBase.AsArray()
 						if IsNumber(indexVal) {
 							idx := int(AsNumber(indexVal))
-							if idx < 0 || idx >= len(arr.elements) {
+							if idx < 0 || idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
 								registers[destReg] = Undefined
 							} else {
 								registers[destReg] = arr.elements[idx]
@@ -13446,6 +13446,20 @@ startExecution:
 				frame.hasOwnUpvalues = false
 			}
 
+			// Check if this is a generator function returning (same as OpReturn's
+			// pending-action completion path): wrap the value as an iterator
+			// result and mark the generator completed before popping its frame.
+			if frame.generatorObj != nil {
+				frame.generatorObj.State = GeneratorCompleted
+				frame.generatorObj.Done = true
+				frame.generatorObj.ReturnValue = result
+				frame.generatorObj.Frame = nil
+				iterResult := NewObject(vm.ObjectPrototype).AsPlainObject()
+				iterResult.SetOwn("value", result)
+				iterResult.SetOwn("done", BooleanValue(true))
+				result = NewValueFromPlainObject(iterResult)
+			}
+
 			// Pop the current frame (same logic as OpReturn)
 			returningFrameRegSize := function.RegisterSize
 			callerTargetRegister := frame.targetRegister
@@ -13457,6 +13471,23 @@ startExecution:
 
 			if vm.frameCount == 0 {
 				// Returned from the top-level script frame.
+				return InterpretOK, result
+			}
+
+			// Check if we hit a sentinel frame (e.g. resumeGeneratorWithReturn's
+			// caller context) - it has no closure to resume into, so return
+			// immediately with the result instead of falling through to the
+			// caller-frame restoration below, which would nil-deref
+			// sentinelFrame.closure.
+			if vm.frames[vm.frameCount-1].isSentinelFrame {
+				sentinelFrame := &vm.frames[vm.frameCount-1]
+				if sentinelFrame.registers != nil && int(callerTargetRegister) < len(sentinelFrame.registers) {
+					sentinelFrame.registers[callerTargetRegister] = result
+				}
+				vm.frameCount--
+				if vm.finallyDepth > 0 {
+					vm.finallyDepth--
+				}
 				return InterpretOK, result
 			}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3918,7 +3918,7 @@ startExecution:
 					fmt.Printf("[DEBUG vm.go] OpCall: Exception thrown but not handled, unwinding=%v, frameCount=%d, crossedNative=%v\n", vm.unwinding, vm.frameCount, vm.unwindingCrossedNative)
 				}
 				// If we hit an isDirectCall boundary, return to let native code handle it
-				if vm.unwindingCrossedNative {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					if debugCalls {
 						fmt.Printf("[DEBUG vm.go] OpCall: Returning InterpretRuntimeError due to crossedNative\n")
 					}
@@ -9909,7 +9909,7 @@ startExecution:
 					fmt.Printf("[DEBUG vm.go] OpCallMethod: Exception thrown during call, unwinding=%v, crossedNative=%v\n", vm.unwinding, vm.unwindingCrossedNative)
 				}
 				// If we hit an isDirectCall boundary, return to let native code handle it
-				if vm.unwindingCrossedNative {
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
 					return InterpretRuntimeError, vm.currentException
 				}
 				// Reload frame state and continue unwinding

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -573,7 +573,8 @@ func (vm *VM) WithRealmValue(realm *Realm, fn func() Value) Value {
 func (vm *VM) GetFunctionRealm(fn Value) (*Realm, error) {
 	switch fn.Type() {
 	case TypeFunction:
-		if fnObj := fn.AsFunction(); fnObj != nil {
+		if fn.Type() == TypeFunction {
+			fnObj := fn.AsFunction()
 			if fnObj.HomeRealm != nil {
 				return fnObj.HomeRealm, nil
 			}
@@ -585,24 +586,28 @@ func (vm *VM) GetFunctionRealm(fn Value) (*Realm, error) {
 			}
 		}
 	case TypeNativeFunction:
-		if nfn := fn.AsNativeFunction(); nfn != nil {
+		if fn.Type() == TypeNativeFunction {
+			nfn := fn.AsNativeFunction()
 			if nfn.HomeRealm != nil {
 				return nfn.HomeRealm, nil
 			}
 		}
 	case TypeNativeFunctionWithProps:
-		if nfp := fn.AsNativeFunctionWithProps(); nfp != nil {
+		if fn.Type() == TypeNativeFunctionWithProps {
+			nfp := fn.AsNativeFunctionWithProps()
 			if nfp.HomeRealm != nil {
 				return nfp.HomeRealm, nil
 			}
 		}
 	case TypeBoundFunction:
-		if bf := fn.AsBoundFunction(); bf != nil {
+		if fn.Type() == TypeBoundFunction {
+			bf := fn.AsBoundFunction()
 			// Recursively get realm from original function
 			return vm.GetFunctionRealm(bf.OriginalFunction)
 		}
 	case TypeProxy:
-		if proxy := fn.AsProxy(); proxy != nil {
+		if fn.Type() == TypeProxy {
+			proxy := fn.AsProxy()
 			if proxy.Revoked {
 				return nil, fmt.Errorf("cannot get realm of revoked proxy")
 			}
@@ -2946,7 +2951,8 @@ startExecution:
 						// ECMAScript 10.5.7 step 11: Invariant validation when trap returns false
 						if !hasProperty {
 							target := proxy.target
-							if targetObj := target.AsPlainObject(); targetObj != nil {
+							if target.Type() == TypeObject {
+								targetObj := target.AsPlainObject()
 								// Check if target has a non-configurable own property
 								if _, _, _, c, found := targetObj.GetOwnDescriptor(propKey); found && !c {
 									vm.ThrowTypeError("'has' on proxy: trap returned false for property '" + propKey + "' which exists in the proxy target as non-configurable")
@@ -7434,7 +7440,8 @@ startExecution:
 					}
 					// ECMAScript 10.5.8 invariant validation
 					propName := indexVal.ToString()
-					if targetObj := proxy.target.AsPlainObject(); targetObj != nil {
+					if proxy.target.Type() == TypeObject {
+						targetObj := proxy.target.AsPlainObject()
 						if g, _, _, c, isAccessor := targetObj.GetOwnAccessor(propName); isAccessor && !c {
 							if g.Type() == TypeUndefined && !result.IsUndefined() {
 								vm.ThrowTypeError("'get' on proxy: property '" + propName + "' is a non-configurable accessor without a getter, but the trap returned a non-undefined value")
@@ -8160,7 +8167,8 @@ startExecution:
 				// Use UTF-16 code unit count for JavaScript string length
 				length = float64(UTF16Length(str))
 			case TypeObject, TypeDictObject:
-				if po := srcVal.AsPlainObject(); po != nil {
+				if srcVal.Type() == TypeObject {
+					po := srcVal.AsPlainObject()
 					if v, ok := po.GetOwn("length"); ok {
 						length = v.ToFloat()
 						break
@@ -14481,7 +14489,8 @@ startExecution:
 
 					// ECMAScript 10.5.10 invariant: can't delete non-configurable property
 					if success {
-						if targetObj := proxy.target.AsPlainObject(); targetObj != nil {
+						if proxy.target.Type() == TypeObject {
+							targetObj := proxy.target.AsPlainObject()
 							if _, _, _, c, found := targetObj.GetOwnDescriptor(propName); found && !c {
 								vm.ThrowTypeError("'deleteProperty' on proxy: trap returned truish for property '" + propName + "' which is non-configurable in the proxy target")
 								return InterpretRuntimeError, Undefined
@@ -14491,15 +14500,18 @@ startExecution:
 				} else {
 					// No delete trap, fallback to target
 					if proxy.target.IsObject() {
-						if po := proxy.target.AsPlainObject(); po != nil {
+						if proxy.target.Type() == TypeObject {
+							po := proxy.target.AsPlainObject()
 							success = po.DeleteOwn(propName)
-						} else if d := proxy.target.AsDictObject(); d != nil {
+						} else if proxy.target.Type() == TypeDictObject {
+							d := proxy.target.AsDictObject()
 							success = d.DeleteOwn(propName)
 						}
 					}
 				}
 			} else if obj.IsObject() {
-				if po := obj.AsPlainObject(); po != nil {
+				if obj.Type() == TypeObject {
+					po := obj.AsPlainObject()
 					// Module Namespace Exotic Object [[Delete]] behavior (ECMAScript 10.4.6.8)
 					// For string properties: if the property exists in exports, throw TypeError
 					// (Symbols are handled normally below - not applicable here since propName is string)
@@ -14615,7 +14627,8 @@ startExecution:
 							vm.heap.Delete(idx)
 						}
 					}
-				} else if d := obj.AsDictObject(); d != nil {
+				} else if obj.Type() == TypeDictObject {
+					d := obj.AsDictObject()
 					// DictObject properties are always configurable, no strict mode check needed
 					success = d.DeleteOwn(propName)
 				}
@@ -14899,7 +14912,8 @@ startExecution:
 				registers[destReg] = BooleanValue(success)
 				continue
 			} else if obj.Type() == TypeObject {
-				if po := obj.AsPlainObject(); po != nil {
+				if obj.Type() == TypeObject {
+					po := obj.AsPlainObject()
 					if key.Type() == TypeSymbol {
 						// Check if property is non-configurable
 						symKey := NewSymbolKey(key)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -13794,9 +13794,31 @@ startExecution:
 				vm.pendingAction = ActionNone
 				vm.pendingValue = Undefined
 				vm.throwException(savedValue)
-				// If handler was found (unwinding=false), refresh local state from frame
-				// because throwException -> unwindException may have changed frame.ip
-				if !vm.unwinding {
+				// throwException -> unwindException may have popped every
+				// frame (uncaught exception) or crossed a native boundary;
+				// in either case there's no valid frame left to resync into
+				// or continue executing against, so return immediately
+				// instead of falling through to `continue` with a stale
+				// frame/code/ip - same shape as OpThrow's own handling just
+				// above.
+				if vm.unwinding {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
+						return InterpretRuntimeError, vm.currentException
+					}
+					// Still unwinding but hasn't hit a native boundary or
+					// been fully unwound - reload frame state and let the
+					// loop continue searching for a handler.
+					frame = &vm.frames[vm.frameCount-1]
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					registers = frame.registers
+					ip = frame.ip
+				} else {
+					// Handler was found - refresh local state from frame
+					// because throwException -> unwindException may have
+					// changed frame.ip
 					frame = &vm.frames[vm.frameCount-1]
 					closure = frame.closure
 					function = closure.Fn
@@ -15548,6 +15570,31 @@ startExecution:
 				vm.pendingValue = Undefined
 				// fmt.Printf("[DEBUG] Re-throwing saved exception: %s\n", savedValue.ToString())
 				vm.throwException(savedValue)
+				// Same shape as OpThrow/OpHandlePending's ActionThrow: a
+				// fully-unwound (uncaught) exception or a native-boundary
+				// crossing leaves no valid frame to resync into or keep
+				// executing against - return immediately rather than
+				// `continue`ing with a stale frame/code/ip.
+				if vm.unwinding {
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
+						return InterpretRuntimeError, vm.currentException
+					}
+					frame = &vm.frames[vm.frameCount-1]
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					registers = frame.registers
+					ip = frame.ip
+				} else {
+					frame = &vm.frames[vm.frameCount-1]
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					registers = frame.registers
+					ip = frame.ip
+				}
 				continue // Let exception unwinding take over
 			case ActionReturn:
 				// Resume the return with saved value

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -354,7 +354,8 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		current := po.GetPrototype()
 		for current.typ != TypeNull && current.typ != TypeUndefined {
 			if current.IsObject() {
-				if proto := current.AsPlainObject(); proto != nil {
+				if current.Type() == TypeObject {
+					proto := current.AsPlainObject()
 					// Check for accessor in prototype
 					if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 						// Call the getter with this=original obj (not proto)
@@ -390,7 +391,8 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			current := po.prototype
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if proto2 := current.AsPlainObject(); proto2 != nil {
+					if current.Type() == TypeObject {
+						proto2 := current.AsPlainObject()
 						if v, ok := proto2.GetOwn(propName); ok {
 							return v, nil
 						}
@@ -517,7 +519,8 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					current := proto.GetPrototype()
 					for current.typ != TypeNull && current.typ != TypeUndefined {
 						if current.IsObject() {
-							if grandProto := current.AsPlainObject(); grandProto != nil {
+							if current.Type() == TypeObject {
+								grandProto := current.AsPlainObject()
 								if g, _, _, _, ok := grandProto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 									result, err := vm.Call(g, obj, nil)
 									if err != nil {
@@ -988,7 +991,8 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			current := po.GetPrototype()
 			for current.typ != TypeNull && current.typ != TypeUndefined {
 				if current.IsObject() {
-					if cur := current.AsPlainObject(); cur != nil {
+					if current.Type() == TypeObject {
+						cur := current.AsPlainObject()
 						if g, _, _, _, ok := cur.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 							result, err := vm.Call(g, obj, nil)
 							if err != nil {

--- a/tests/scripts/exotic_prototype_chain.ts
+++ b/tests/scripts/exotic_prototype_chain.ts
@@ -1,0 +1,20 @@
+// expect: true
+// Regression test: a prototype chain can legally contain non-PlainObject
+// values (an Array, a plain function, etc.), not just PlainObject/DictObject.
+// The VM must walk past these instead of panicking or truncating the lookup.
+
+function foo() {}
+foo.prototype = new Array(1, 2, 3);
+const f = new foo();
+// `every` isn't own on the Array instance; it must be found by continuing
+// up the chain to Array.prototype.
+const arrayMethodFound = typeof f.every === "function";
+
+function bar() {}
+bar.prototype = function () {};
+(bar.prototype as any).baz = 42;
+const b = new bar();
+// A plain function used as a prototype must still expose its own properties.
+const functionProtoFound = (b as any).baz === 42;
+
+arrayMethodFound && functionProtoFound;


### PR DESCRIPTION
## Summary

Started from "improve built-ins Test262 coverage" and found the dominant cause of built-ins failures wasn't missing features — it was a systemic panic class plus a handful of independent VM bugs. This PR is six commits eliminating all of them.

**Built-ins Test262 panics: 562 → 0.** Pass rate 66.4% → 67.7% overall (77.8% excluding Temporal, a separate largely-unimplemented proposal-stage API). Zero regressions verified against `baseline.txt` across `built-ins` (incl. Temporal), `language`, and `annexB` after every commit.

## Commits

1. **`064b9e9`** — two `frames[vm.frameCount-1]` out-of-bounds panics in `OpCall`/`OpCallMethod`'s exception-unwind path, missing a `frameCount == 0` guard a sibling branch already had.

2. **`fcbf684`** — the root systemic bug: many `pkg/vm` property-access paths assumed every `[[Prototype]]` chain link is a `PlainObject` and called `AsPlainObject()` after only a loose `IsObject()` check (which covers Array, DictObject, Function, etc. too), panicking on anything else (`Foo.prototype = new Array(...)`, a non-`Date` `this`, ...). Adds `pkg/vm/proto.go` — a generic `prototypeOf`/`getInheritedGeneric` that walks a chain of any object kind — and rewires `opGetProp`'s fallback to use it, so inherited properties resolve correctly instead of silently returning `undefined`.

3. **`afeb3fa`** — same fix applied across `pkg/builtins` (184 sites via a verified mechanical sweep + ~10 hand-fixed cases).

4. **`52bf22a`** — three more panics found hunting the remainder: a generator-return sentinel-frame nil-deref in `OpReturnFinally`, three `OpGetElem` fast paths leaking the internal sparse-array `Hole` marker into user code, and `opSetProp`'s primitive-property walk panicking on a `Proxy`/non-`PlainObject` handler.

5. **`5084193`** — the remaining this-value/argument accessor panics (Date/Number/RegExp/String/Symbol/Temporal, `__lookupGetter__`/`__lookupSetter__`), plus three independent correctness bugs found along the way: Promise's capability-executor helpers indexing arguments out of bounds, `TypedArray.prototype.copyWithin`/`TypedArrayToIndex`/`String.prototype.substr` all mishandling `NaN`/`±Infinity` before truncation, and a spec step-ordering bug in the TypedArray constructor (NewTarget check vs. argument coercion vs. prototype lookup).

6. **`1d778db`** — a `frameCount` underflow found by building a temporary instrumented binary (tagged every decrement site, full opcode tracing) after a "this only shows up with long timeouts, must be a runner artifact" dismissal turned out to be wrong. `OpHandlePending`'s and `OpRunInitializers`' `ActionThrow` cases resumed a pending exception and unconditionally `continue`d with stale cached frame state when it turned out to be uncaught, instead of returning immediately like `OpThrow` itself does. Minimal repro is plain vanilla JS, no Temporal/test262 involved:
   ```js
   for (const v of values) {
     assert.throws(RangeError, () => noReallyThrows(), "msg " + v);
   }
   ```

## Verification

- `go test ./...` and the smoke suite (`tests/scripts`) green throughout, checked after every commit.
- `-diff baseline.txt` run after every fix batch: zero regressions in `built-ins` (Temporal included), `language`, `annexB`.
- The frameCount fix (commit 6) verified separately with a dedicated repro plus repeated runs of the two Test262 suites that originally surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)