### PR TITLE
Host API: embed seams for noderati

### DIFF
--- a/docs/noderati-host-plan.md
+++ b/docs/noderati-host-plan.md
@@ -181,10 +181,10 @@ Node order: nextTick → microtasks → timers → I/O → setImmediate. Putting
 
 Once Phase 0 is on paserati `main` (or a `replace` directive):
 
-1. `github.com/nooga/noderati` with `go.work` pointing at local paserati.
-2. `cmd/noderati` — Node-shaped CLI: file, `-e`, `-p`, REPL, `process.argv = [execPath, script, …]`, exit 0/1 not sysexits 70.
-3. `DeclareModule("path"|"os"|"util")` + aliases; own `process` initializer.
-4. Then `fs` sync + `fs.promises` (fetch pattern), `Buffer`, timers (needs Phase 1), `events`/`stream`, then `require` (needs Phase 2).
+- [x] Sister module [`github.com/nooga/noderati`](https://github.com/nooga/noderati) (local: `../noderati`) with `go.work` replacing Paserati to this worktree.
+- [x] `cmd/noderati` — file, `-e`, `-p`, REPL; `process.argv = [execPath, script, …]`; exit 0/1.
+- [x] `DeclareModule("path"|"os"|"util")` + `node:` aliases; noderati-owned `process`; Paserati `NewHostTimerInitializer`.
+- [ ] `fs` sync + `fs.promises` (fetch pattern), `Buffer`, `events`/`stream`, `require` / `node_modules`.
 
 N-API / `.node` files stay optional and CGO-tagged in noderati. Keep CGO out of paserati.
 

--- a/docs/noderati-host-plan.md
+++ b/docs/noderati-host-plan.md
@@ -148,12 +148,12 @@ Node order: nextTick → microtasks → timers → I/O → setImmediate. Putting
 
 **Paserati work:**
 
-- [ ] Emit `file://` URLs for filesystem modules (absolute path, proper slashes, encode).
-- [ ] Native modules can stay `native://fs` (or omit `.url` consumers).
+- [x] Emit `file://` URLs for filesystem modules (absolute path, proper slashes, encode).
+- [x] Native modules can stay `native://fs` (or omit `.url` consumers).
 
 **Advice:** this is a VM/driver change, not noderati. Do it before advertising ESM Node compat. Relative `import` from `import.meta.url` still goes through resolvers.
 
-**Tests:** `new URL('./foo.ts', import.meta.url).pathname` on a real file path.
+**Tests:** [`pkg/driver/host_import_meta_test.go`](../pkg/driver/host_import_meta_test.go) — `new URL('./foo.ts', import.meta.url).pathname` on a real file path (via `net/url`); native `native://fs` unchanged; eval `__code_module__` not abs-pathed into cwd; percent-encoding for spaces.
 
 ---
 

--- a/docs/noderati-host-plan.md
+++ b/docs/noderati-host-plan.md
@@ -133,12 +133,12 @@ Node order: nextTick → microtasks → timers → I/O → setImmediate. Putting
 
 **Paserati work:**
 
-- [ ] Public `RunScript(source, filename)` (or `RunOptions{Script: true, Filename}`) that compiles as script, sets a current path, does not invent ESM exports.
-- [ ] Enough context for noderati to inject `__filename` / `__dirname` (filename argument is enough if noderati wraps the source).
+- [x] Public `RunScript(source, filename)` and `RunOptions{Script: true, Filename}` compile as a Script (`ForceScriptMode`, no `EnableModuleMode`), set `SetCurrentModulePath(filename)`, and do not create a `ModuleRecord` or ESM exports.
+- [x] Filename is the current path the host should pass through as `__filename` (and from which it derives `__dirname`) after wrapping the body.
 
 **Advice:** implement `require()` in noderati as a native function that `LoadModule`s / wraps / caches `module.exports`. Do not teach the parser that `module.exports =` is ESM. Detection (`package.json` `"type"`, `.cjs`/`.mjs`, `--input-type`) is noderati’s.
 
-**Tests to add then:** wrap a CJS snippet, call it with an exports object, read `module.exports`; `__filename` matches the path passed in.
+**Tests:** [`pkg/driver/host_script_test.go`](../pkg/driver/host_script_test.go) — wrap a CJS snippet, `Call` it with an exports object, read `module.exports`; `__filename` matches the path passed in; no module record; `import.meta` rejected after a prior ESM `RunCode`.
 
 ---
 

--- a/docs/noderati-host-plan.md
+++ b/docs/noderati-host-plan.md
@@ -159,11 +159,11 @@ Node order: nextTick → microtasks → timers → I/O → setImmediate. Putting
 
 ## Phase 4 — `AsyncFunction` actually returns a Promise
 
-[`ModuleBuilder.AsyncFunction`](../pkg/driver/native_module.go) delegates to `Function` (sync). Fine for `path.join`; a lie for `fs.promises.readFile`.
+[`ModuleBuilder.AsyncFunction`](../pkg/driver/native_module.go) wraps the Go function so the JS value is a fulfilled/rejected Promise (`NewResolvedPromise` / `NewRejectedPromise`). The Go body still runs on the caller thread.
 
-**Advice:** noderati should **not wait** on this for I/O. Use the fetch pattern. Still fix the declarative API so hosts are not surprised.
+**Advice:** noderati should **not wait** on this for I/O. Use the fetch pattern. The declarative API no longer lies for `path.join`-style helpers that happen to be async in Node.
 
-**Tests:** `AsyncFunction` returning a Go `string` is thenable; `await` gets the string.
+**Tests:** [`pkg/driver/host_async_function_test.go`](../pkg/driver/host_async_function_test.go) — `AsyncFunction` returning a Go `string` is thenable; `await` gets the string; Go `error` rejects and is catchable.
 
 ---
 

--- a/docs/noderati-host-plan.md
+++ b/docs/noderati-host-plan.md
@@ -171,7 +171,9 @@ Node order: nextTick → microtasks → timers → I/O → setImmediate. Putting
 
 [`NativeModuleSource.generateSyntheticSource`](../pkg/driver/native_module.go) still emits placeholder `PI_SQUARED` / `square()`. Runtime skips parse via `IsNativeModule()`, and [`handleNativeModuleSource`](../pkg/modules/loader.go) already copies `GetTypeExports()` onto `record.Exports`. The placeholder is a footgun if anything ever *parses* native source.
 
-**Paserati work:** generate declarations from `exports` (or stop implementing `Read()` as fake TS). Needed when noderati typechecks user TS that imports `fs`.
+- [x] Generate `export declare const` / `export default` from `GetExports()` after init; `export {}` before init. No hardcoded placeholders.
+
+**Tests:** [`pkg/driver/host_native_source_test.go`](../pkg/driver/host_native_source_test.go) — real exports after `LoadModule`; empty `export {}` before init; no `PI_SQUARED` leak.
 
 ---
 

--- a/docs/noderati-host-plan.md
+++ b/docs/noderati-host-plan.md
@@ -1,0 +1,208 @@
+# Noderati host API plan
+
+Tracker: [issue #77](https://github.com/nooga/paserati/issues/77).
+
+Paserati stays the language runtime (parse → check → bytecode → VM). **noderati** is a sister Go module that hosts that runtime and supplies Node APIs. This document is the Paserati-side work so that sister repo does not have to fork `pkg/driver`.
+
+Node built-ins (`fs`, `http`, `Buffer`, `require` implementation, `node_modules` algorithm, N-API) are **not** implemented here. They consume the seams below.
+
+## What already works (do not rebuild)
+
+| Seam | Where | How noderati uses it |
+| --- | --- | --- |
+| Extra globals | [`pkg/builtins/initializer.go`](../pkg/builtins/initializer.go) `BuiltinInitializer`; [`NewPaseratiWithInitializers`](../pkg/driver/driver.go) | `process`, `Buffer`, `setTimeout`, `global` |
+| Go-backed ESM modules | [`DeclareModule`](../pkg/driver/native_module.go) / `ModuleBuilder` | `fs`, `path`, `os`, … |
+| Native resolver priority | `NewNativeModuleResolver` priority `-100` vs filesystem `100` | Builtins win over `node_modules/fs` |
+| Async I/O pattern | [`pkg/builtins/fetch_init.go`](../pkg/builtins/fetch_init.go) (`NewPendingPromise`, goroutine, `BeginExternalOp` / `EndExternalOp`) | `fs.promises`, `http` — copy this, do not use reflection `AsyncFunction` for I/O |
+| Custom async runtime | [`pkg/runtime/async.go`](../pkg/runtime/async.go), [`VM.SetAsyncRuntime`](../pkg/vm/async_runtime.go), [`GetVM()`](../pkg/driver/driver.go) | Node event loop as a replacement `AsyncRuntime` |
+| Script compile (Function) | [`CompileProgramAsScript`](../pkg/driver/driver.go) | Starting point for CJS wrapping, not a host “run this file” API yet |
+| Skip types for `.js` | `SetSkipTypeCheck(true)` | Default for Node JS; keep types on for `.ts` |
+
+A hello-world binary that only `DeclareModule("path", …)` could already compile. It cannot grow into a Node host: `moduleLoader` is unexported, so a sister module cannot install a `node_modules` resolver.
+
+## Architecture
+
+```
+noderati cmd
+    │
+    ├─ NewPaseratiWithInitializers(standard + process/Buffer/timers)
+    ├─ DeclareModule("fs" | "path" | …)
+    ├─ DeclareModuleAlias("node:fs", "fs")     // same NativeModule, same ModuleRecord
+    ├─ AddResolver(NodeResolver)               // bare specifiers, package.json
+    └─ host event loop (custom AsyncRuntime)
+            │
+            ▼
+     paserati driver (this repo)
+            │
+     lexer → parser → checker → compiler → VM
+```
+
+Two layers of Node API, on purpose:
+
+1. **Globals** → `BuiltinInitializer` (same shape as [`ConsoleInitializer`](../pkg/builtins/console_init.go) / the existing [`ProcessInitializer`](../pkg/driver/process_init.go)).
+2. **Importable builtins** → `DeclareModule`, then alias `node:*`.
+
+Do **not** grow [`ProcessInitializer`](../pkg/driver/process_init.go) further in this repo. noderati owns a full `process`. The CLI stub can stay as argv wiring for `paserati` itself.
+
+---
+
+## Phase 0 — embed API (this branch)
+
+**Goal:** a program outside `cmd/paserati` can register resolvers, alias `node:fs` → `fs`, and `import fs from "fs"`.
+
+Unblocks starting the noderati repo.
+
+### 0.1 `AddResolver` / `GetModuleLoader`
+
+[`moduleLoader`](../pkg/driver/driver.go) is an unexported field. [`FileSystemResolver.CanResolve`](../pkg/modules/resolver_fs.go) is only `./`, `../`, and absolute paths. Bare `"lodash"` dies with `no resolver could handle specifier`.
+
+Surface:
+
+```go
+func (p *Paserati) AddResolver(r modules.ModuleResolver)
+func (p *Paserati) GetModuleLoader() modules.ModuleLoader
+```
+
+`AddResolver` is a thin wrap of [`moduleLoader.AddResolver`](../pkg/modules/loader.go) (re-sorts by `Priority()`, lower wins).
+
+**Advice:** noderati’s Node resolver should sit between native (`-100`) and filesystem (`100`), e.g. priority `0`. Let native keep `fs`. Let the Node resolver handle bare specifiers *and* eventually relative paths that need `package.json` `"exports"` (it can beat the FS resolver by using a lower priority number). Do not teach the Paserati FS resolver Node rules.
+
+### 0.2 Specifier aliases + one `ModuleRecord`
+
+[`NativeModuleResolver.CanResolve`](../pkg/driver/native_module.go) is exact-name. Registering `"fs"` twice (once as `"node:fs"`) would init twice and break identity (`require('fs') === require('node:fs')` in Node).
+
+Surface:
+
+```go
+func (p *Paserati) DeclareModuleAlias(alias, canonical string) error
+```
+
+Resolver maps both specifiers to the **same** `*NativeModule`. `Resolve` always returns `ResolvedPath = "native://" + canonicalName`.
+
+The loader caches by **specifier**, so that alone is not enough. Phase 0 also keys the registry by `ResolvedPath`: the second specifier aliases the existing record. That is the same mechanism Node uses for `foo` vs `foo/index.js`, and noderati’s `node_modules` resolver will need it.
+
+### 0.3 `ModuleBuilder.Default`
+
+Today a TODO; Node does `import fs from "fs"`. Checker/compiler look up the `"default"` export ([`ModuleEnvironment.ResolveImportedType`](../pkg/checker/module_environment.go), [`compileImportDeclaration`](../pkg/compiler/compiler.go)).
+
+- `Default(fn)` / `Default(primitive)` — named `"default"` export.
+- `Default(nil)` — **namespace object of all named exports** (Node CJS interop for builtins). Call this **after** the named `Function`/`Const` registrations; it is applied when the builder returns.
+
+**Advice:** for `fs`/`path`/`os`, use `Default(nil)`. For real I/O functions, still implement bodies with `vm.NewNativeFunction` + the fetch Promise pattern, not `ModuleBuilder.AsyncFunction`.
+
+### Tests (Phase 0)
+
+[`pkg/driver/host_embed_test.go`](../pkg/driver/host_embed_test.go) is the embed contract noderati should be able to copy:
+
+- `AddResolver` + in-memory bare specifier
+- `DeclareModule` + `DeclareModuleAlias` → **same record pointer**
+- named import from `"fs"` and default import from `"node:fs"`
+- `Default(nil)` namespace: `fs.readFileSync(...)` via default import
+
+---
+
+## Phase 1 — macrotasks and idle policy
+
+**Why noderati stalls without this:** [`AsyncRuntime`](../pkg/runtime/async.go) is microtasks + “external op” wait. [`process.nextTick`](../pkg/driver/process_init.go) **calls the callback immediately**. Timers are on the bucketlist ([`docs/bucketlist.md`](bucketlist.md)). [`runAsModule`](../pkg/driver/driver.go) always `DrainMicrotasks()` then returns.
+
+Node order: nextTick → microtasks → timers → I/O → setImmediate. Putting `setTimeout` on `ScheduleMicrotask` (via `BeginExternalOp` + sleep) will pass demos and fail real programs (`Promise.resolve().then` vs `setTimeout(0)`).
+
+**Paserati work:**
+
+- [x] Extend `AsyncRuntime` with nextTick / macrotask / timer hooks. `RunUntilIdle` stays microtask-only. Timer expiry goroutines only mark a timer due; callbacks run on the drain thread. `CancelTimer` drops both scheduled and already-due timers.
+- [x] `VM.DrainUntilIdle()` and `runAsModule` drain until host idle (nextTick → microtasks → due timers → macrotasks → wait external / next timer). Top-level await uses the same queues. Hosts that replace `AsyncRuntime` still get this drain via the interface.
+- [x] Do **not** put `setTimeout` in [`GetStandardInitializers`](../pkg/builtins/standard.go). Opt-in [`NewHostTimerInitializer`](../pkg/driver/host_timers.go) (`nextTick` / `setTimeout` / `clearTimeout`) is the reference host wiring noderati can copy or replace.
+
+**Advice:** prefer replacing `AsyncRuntime` in noderati over adding a libuv clone here. Keep paserati’s default runtime for Test262 / smoke tests. Fetch already uses `BeginExternalOp`; timers hold the process alive via `HasPendingTimers`, not by pretending to be microtasks.
+
+**Tests:** [`pkg/runtime/async_test.go`](../pkg/runtime/async_test.go), [`pkg/driver/host_idle_test.go`](../pkg/driver/host_idle_test.go) — Promise vs `setTimeout(0)`; `nextTick` before microtasks; drain waits for a timer; TLA + timer; `clearTimeout` after drain; standard builtins have no `setTimeout`.
+
+---
+
+## Phase 2 — script-mode execution (CJS seam)
+
+**Why:** [`RunCode`](../pkg/driver/driver.go) always goes through `runAsModule`. Most of npm is still CommonJS. noderati should wrap:
+
+```js
+(function (exports, require, module, __filename, __dirname) {
+  /* file body */
+})
+```
+
+[`CompileProgramAsScript`](../pkg/driver/driver.go) exists for `Function()` (`import.meta` forbidden) but is not “run this path as a script with a filename”.
+
+**Paserati work:**
+
+- [ ] Public `RunScript(source, filename)` (or `RunOptions{Script: true, Filename}`) that compiles as script, sets a current path, does not invent ESM exports.
+- [ ] Enough context for noderati to inject `__filename` / `__dirname` (filename argument is enough if noderati wraps the source).
+
+**Advice:** implement `require()` in noderati as a native function that `LoadModule`s / wraps / caches `module.exports`. Do not teach the parser that `module.exports =` is ESM. Detection (`package.json` `"type"`, `.cjs`/`.mjs`, `--input-type`) is noderati’s.
+
+**Tests to add then:** wrap a CJS snippet, call it with an exports object, read `module.exports`; `__filename` matches the path passed in.
+
+---
+
+## Phase 3 — `import.meta.url` as `file://`
+
+[`OpLoadImportMeta`](../pkg/vm/vm.go) stores the raw module path. The comment already says a real environment would use `file://`. Node ESM (`new URL('./x', import.meta.url)`, `fileURLToPath`) depends on it.
+
+**Paserati work:**
+
+- [ ] Emit `file://` URLs for filesystem modules (absolute path, proper slashes, encode).
+- [ ] Native modules can stay `native://fs` (or omit `.url` consumers).
+
+**Advice:** this is a VM/driver change, not noderati. Do it before advertising ESM Node compat. Relative `import` from `import.meta.url` still goes through resolvers.
+
+**Tests:** `new URL('./foo.ts', import.meta.url).pathname` on a real file path.
+
+---
+
+## Phase 4 — `AsyncFunction` actually returns a Promise
+
+[`ModuleBuilder.AsyncFunction`](../pkg/driver/native_module.go) delegates to `Function` (sync). Fine for `path.join`; a lie for `fs.promises.readFile`.
+
+**Advice:** noderati should **not wait** on this for I/O. Use the fetch pattern. Still fix the declarative API so hosts are not surprised.
+
+**Tests:** `AsyncFunction` returning a Go `string` is thenable; `await` gets the string.
+
+---
+
+## Phase 5 — native module types are real
+
+[`NativeModuleSource.generateSyntheticSource`](../pkg/driver/native_module.go) still emits placeholder `PI_SQUARED` / `square()`. Runtime skips parse via `IsNativeModule()`, and [`handleNativeModuleSource`](../pkg/modules/loader.go) already copies `GetTypeExports()` onto `record.Exports`. The placeholder is a footgun if anything ever *parses* native source.
+
+**Paserati work:** generate declarations from `exports` (or stop implementing `Read()` as fake TS). Needed when noderati typechecks user TS that imports `fs`.
+
+---
+
+## Phase 6 — start noderati (other repo)
+
+Once Phase 0 is on paserati `main` (or a `replace` directive):
+
+1. `github.com/nooga/noderati` with `go.work` pointing at local paserati.
+2. `cmd/noderati` — Node-shaped CLI: file, `-e`, `-p`, REPL, `process.argv = [execPath, script, …]`, exit 0/1 not sysexits 70.
+3. `DeclareModule("path"|"os"|"util")` + aliases; own `process` initializer.
+4. Then `fs` sync + `fs.promises` (fetch pattern), `Buffer`, timers (needs Phase 1), `events`/`stream`, then `require` (needs Phase 2).
+
+N-API / `.node` files stay optional and CGO-tagged in noderati. Keep CGO out of paserati.
+
+---
+
+## Suggested PR slices
+
+| Slice | Contents | Unblocks |
+| --- | --- | --- |
+| **0 (this branch)** | `AddResolver`, `GetModuleLoader`, `DeclareModuleAlias`, `Default`, resolved-path cache, embed tests | Sister repo can exist |
+| 1 | `AsyncRuntime` macrotasks + idle policy | Honest `setTimeout` / `nextTick` |
+| 2 | `RunScript` / CJS wrapper seam | `require()` |
+| 3 | `file://` `import.meta.url` | Node ESM packages |
+| 4–5 | `AsyncFunction`, synthetic d.ts | nicer host API, TS checking of builtins |
+
+Do not mix Node `fs` into these PRs.
+
+## Out of scope forever (in paserati)
+
+- Implementing Node stdlib
+- `node_modules` / `"exports"` maps (host resolver)
+- Loading `.node` / N-API / V8 `Nan::`
+- `--inspect`, `worker_threads`, `cluster`

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -4013,6 +4013,11 @@ func (c *Checker) IsModuleMode() bool {
 	return c.moduleEnv != nil
 }
 
+// DisableModuleMode type-checks subsequent programs as scripts (no ESM module environment).
+func (c *Checker) DisableModuleMode() {
+	c.moduleEnv = nil
+}
+
 // GetImportBindings returns all import bindings from the module environment
 // This is used by the compiler to synchronize import information
 func (c *Checker) GetImportBindings() map[string]*ImportBinding {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -599,6 +599,11 @@ func (c *Compiler) IsModuleMode() bool {
 	return c.moduleBindings != nil
 }
 
+// DisableModuleMode compiles subsequent programs as scripts (no ESM import/export bindings).
+func (c *Compiler) DisableModuleMode() {
+	c.moduleBindings = nil
+}
+
 // SetStrictMode sets the initial strict mode for the compiler
 // This is used by eval() to compile code in strict mode when called from strict context
 func (c *Compiler) SetStrictMode(strict bool) {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1125,8 +1125,8 @@ func (p *Paserati) runAsModule(sourceCode string, program *parser.Program, modul
 	// Execute the chunk
 	finalValue, runtimeErrs := p.vmInstance.Interpret(chunk)
 
-	// Drain microtasks for async operations (Promises, etc.)
-	p.vmInstance.DrainMicrotasks()
+	// Drain async work (microtasks, timers, etc.) until idle
+	p.vmInstance.DrainUntilIdle()
 
 	return finalValue, runtimeErrs
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -606,6 +606,22 @@ func (p *Paserati) GetVM() *vm.VM {
 	return p.vmInstance
 }
 
+// GetModuleLoader returns the session's module loader so a host (e.g. noderati)
+// can inspect cache state or load modules without reaching into unexported fields.
+func (p *Paserati) GetModuleLoader() modules.ModuleLoader {
+	return p.moduleLoader
+}
+
+// AddResolver appends a module resolver to the loader chain and re-sorts by
+// Priority() (lower = earlier). Native modules are -100; the filesystem resolver
+// is 100. A Node node_modules resolver should sit in between (e.g. 0).
+func (p *Paserati) AddResolver(resolver modules.ModuleResolver) {
+	if p.moduleLoader == nil || resolver == nil {
+		return
+	}
+	p.moduleLoader.AddResolver(resolver)
+}
+
 // CompileModule compiles a module file with proper dependency resolution
 // This is used by the test framework to compile modules with full module loading
 func (p *Paserati) CompileModule(filename string) (*vm.Chunk, []errors.PaseratiError) {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -207,6 +207,7 @@ func NewPaseratiWithInitializersAndBaseDir(customInitializers []builtins.Builtin
 
 	// Wire the module loader into the VM
 	vmInstance.SetModuleLoader(moduleLoader)
+	vmInstance.SetImportMetaBaseDir(baseDir)
 
 	// Set the eval driver for OpDirectEval
 	vmInstance.SetEvalDriver(paserati)
@@ -291,6 +292,7 @@ func NewPaseratiWithBaseDir(baseDir string) *Paserati {
 
 	// Wire the module loader into the VM
 	vmInstance.SetModuleLoader(moduleLoader)
+	vmInstance.SetImportMetaBaseDir(baseDir)
 
 	// Set the eval driver for OpDirectEval
 	vmInstance.SetEvalDriver(paserati)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/nooga/paserati/pkg/builtins"
@@ -1153,6 +1154,52 @@ func (p *Paserati) runAsTemporaryModule(sourceCode string, program *parser.Progr
 	return p.runAsModule(sourceCode, program, "__temp_module__")
 }
 
+// runAsScript compiles and runs a program as a Script (not an ESM module).
+// Used for CommonJS wrapping: the host wraps the file body in a function and
+// calls it with (exports, require, module, __filename, __dirname).
+func (p *Paserati) runAsScript(program *parser.Program, filename string) (vm.Value, []errors.PaseratiError) {
+	p.checker.DisableModuleMode()
+	p.compiler.DisableModuleMode()
+
+	parser.DumpAST(program, "runAsScript")
+
+	p.compiler.SetIgnoreTypeErrors(p.ignoreTypeErrors)
+	p.compiler.SetSkipTypeCheck(p.skipTypeCheck)
+	p.compiler.SetForceScriptMode(true)
+	chunk, compileAndTypeErrs := p.compiler.Compile(program)
+	p.compiler.SetForceScriptMode(false)
+	if len(compileAndTypeErrs) > 0 {
+		return vm.Undefined, compileAndTypeErrs
+	}
+	if chunk == nil {
+		internalErr := &errors.RuntimeError{
+			Position: errors.Position{Line: 0, Column: 0},
+			Msg:      "Internal Error: Compilation returned nil chunk without errors.",
+		}
+		return vm.Undefined, []errors.PaseratiError{internalErr}
+	}
+
+	p.vmInstance.SyncGlobalNames(p.compiler.GetHeapAlloc().GetNameToIndexMap())
+	p.vmInstance.ResizeHeapForGlobals(p.compiler.GetHeapAlloc().GetAllocatedSize())
+	p.vmInstance.SetCurrentModulePath(filename)
+
+	finalValue, runtimeErrs := p.vmInstance.Interpret(chunk)
+	p.vmInstance.DrainUntilIdle()
+	return finalValue, runtimeErrs
+}
+
+// RunScript compiles source as a Script (not ESM) and runs it with filename as
+// the current path. It does not create a ModuleRecord or ESM exports.
+// A Node host typically wraps CommonJS as:
+//
+//	(function (exports, require, module, __filename, __dirname) { /* body */ })
+//
+// then Call()s the returned function with those arguments. filename is the
+// value noderati should pass as __filename (and from which it derives __dirname).
+func (p *Paserati) RunScript(sourceCode, filename string) (vm.Value, []errors.PaseratiError) {
+	return p.RunCode(sourceCode, RunOptions{Script: true, Filename: filename})
+}
+
 // EmitJavaScript parses TypeScript source and emits equivalent JavaScript code
 // without type annotations and TypeScript-specific syntax.
 func EmitJavaScript(sourceCode string) (string, []errors.PaseratiError) {
@@ -1238,12 +1285,28 @@ type RunOptions struct {
 	ShowCacheStats bool   // Show inline cache statistics
 	ModuleName     string // Module name to use (defaults to "__code_module__" if empty)
 	DisasmFilter   string // Filter string for disassembly (empty = all)
+	Script         bool   // Compile and run as a Script, not an ESM module
+	Filename       string // Current path for Script mode (and error reporting)
+}
+
+func scriptFilename(options RunOptions) string {
+	if options.Filename != "" {
+		return options.Filename
+	}
+	if options.ModuleName != "" {
+		return options.ModuleName
+	}
+	return "<script>"
 }
 
 // RunCode runs source code with the given Paserati session and options.
-// Now runs in module mode by default.
+// Module mode is the default; set Script to run as a Script (see RunScript).
 func (p *Paserati) RunCode(sourceCode string, options RunOptions) (vm.Value, []errors.PaseratiError) {
 	sourceFile := source.NewEvalSource(sourceCode)
+	if options.Script {
+		filename := scriptFilename(options)
+		sourceFile = source.NewSourceFile(filepath.Base(filename), filename, sourceCode)
+	}
 	l := lexer.NewLexerWithSource(sourceFile)
 	parseInstance := parser.NewParser(l)
 	program, parseErrs := parseInstance.ParseProgram()
@@ -1251,14 +1314,17 @@ func (p *Paserati) RunCode(sourceCode string, options RunOptions) (vm.Value, []e
 		return vm.Undefined, parseErrs
 	}
 
-	// Determine module name - use provided name or default to "__code_module__"
-	moduleName := options.ModuleName
-	if moduleName == "" {
-		moduleName = "__code_module__"
+	var value vm.Value
+	var errs []errors.PaseratiError
+	if options.Script {
+		value, errs = p.runAsScript(program, scriptFilename(options))
+	} else {
+		moduleName := options.ModuleName
+		if moduleName == "" {
+			moduleName = "__code_module__"
+		}
+		value, errs = p.runAsModule(sourceCode, program, moduleName)
 	}
-
-	// Run in module mode
-	value, errs := p.runAsModule(sourceCode, program, moduleName)
 
 	// Get the compiled chunk for debugging output if needed
 	if options.ShowBytecode || options.ShowCacheStats {

--- a/pkg/driver/host_async_function_test.go
+++ b/pkg/driver/host_async_function_test.go
@@ -1,0 +1,60 @@
+package driver
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHostAsyncFunctionReturnsPromise(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	p.DeclareModule("io", func(m *ModuleBuilder) {
+		m.AsyncFunction("read", func() string {
+			return "hello"
+		})
+	})
+
+	js := `
+		import { read } from "io";
+		const p = read();
+		const thenable = typeof p.then === "function";
+		const val = await read();
+		thenable && val === "hello"
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected thenable Promise resolving to \"hello\", got %v", result.ToString())
+	}
+}
+
+func TestHostAsyncFunctionRejectsOnError(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	p.DeclareModule("io", func(m *ModuleBuilder) {
+		m.AsyncFunction("fail", func() (string, error) {
+			return "", errors.New("boom")
+		})
+	})
+
+	js := `
+		import { fail } from "io";
+		await (async () => {
+			try {
+				await fail();
+				return "did-not-throw";
+			} catch (e) {
+				return String(e).includes("boom") ? "caught" : String(e);
+			}
+		})()
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if result.ToString() != "caught" {
+		t.Errorf("expected catch of rejected promise, got %v", result.ToString())
+	}
+}

--- a/pkg/driver/host_embed_test.go
+++ b/pkg/driver/host_embed_test.go
@@ -1,0 +1,141 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/modules"
+)
+
+// Embed-API contract for noderati (issue #77 / docs/noderati-host-plan.md).
+// A host outside cmd/paserati must be able to add resolvers, alias node:*
+// specifiers, and default-import native modules without touching unexported fields.
+
+func TestHostAddResolverBareSpecifier(t *testing.T) {
+	p := NewPaserati()
+	if p.GetModuleLoader() == nil {
+		t.Fatal("GetModuleLoader returned nil")
+	}
+
+	mem := modules.NewMemoryResolver("bare-modules")
+	mem.AddModule("left-pad", `
+		export function pad(s: string): string {
+			return "xx" + s;
+		}
+	`)
+	p.AddResolver(mem)
+
+	ts := `
+		import { pad } from "left-pad";
+		pad("hi");
+	`
+	result, errs := p.RunCode(ts, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("bare specifier via AddResolver failed: %v", errs[0])
+	}
+	if result.ToString() != "xxhi" {
+		t.Errorf("expected xxhi, got %v", result.ToString())
+	}
+}
+
+func TestHostDeclareModuleAliasSameRecord(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("fs", func(m *ModuleBuilder) {
+		m.Function("readFileSync", func(path string) string {
+			return "contents:" + path
+		})
+		m.Default(nil)
+	})
+	if err := p.DeclareModuleAlias("node:fs", "fs"); err != nil {
+		t.Fatalf("DeclareModuleAlias: %v", err)
+	}
+
+	a, err := p.LoadModule("fs", ".")
+	if err != nil {
+		t.Fatalf("LoadModule(fs): %v", err)
+	}
+	b, err := p.LoadModule("node:fs", ".")
+	if err != nil {
+		t.Fatalf("LoadModule(node:fs): %v", err)
+	}
+	if a != b {
+		t.Fatal("fs and node:fs must be the same module record")
+	}
+
+	fsRecord := p.GetModuleLoader().GetModule("fs")
+	nodeRecord := p.GetModuleLoader().GetModule("node:fs")
+	if fsRecord == nil || nodeRecord == nil {
+		t.Fatal("expected both specifiers to be cached")
+	}
+	if fsRecord != nodeRecord {
+		t.Fatal("cached fs and node:fs records differ")
+	}
+	if fsRecord.ResolvedPath != "native://fs" {
+		t.Errorf("resolved path = %q, want native://fs", fsRecord.ResolvedPath)
+	}
+}
+
+func TestHostNativeDefaultNamespaceImport(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("fs", func(m *ModuleBuilder) {
+		m.Function("readFileSync", func(path string) string {
+			return "contents:" + path
+		})
+		m.Default(nil)
+	})
+	if err := p.DeclareModuleAlias("node:fs", "fs"); err != nil {
+		t.Fatalf("DeclareModuleAlias: %v", err)
+	}
+
+	ts := `
+		import { readFileSync } from "fs";
+		import fs from "node:fs";
+		readFileSync("a.txt") + "|" + fs.readFileSync("b.txt");
+	`
+	result, errs := p.RunCode(ts, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("default/named import of aliased native module failed: %v", errs[0])
+	}
+	if result.ToString() != "contents:a.txt|contents:b.txt" {
+		t.Errorf("got %q", result.ToString())
+	}
+}
+
+func TestHostNativeDefaultFunctionExport(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("greet", func(m *ModuleBuilder) {
+		m.Default(func(name string) string {
+			return "hello " + name
+		})
+	})
+
+	ts := `
+		import greet from "greet";
+		greet("noderati");
+	`
+	result, errs := p.RunCode(ts, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("default function export failed: %v", errs[0])
+	}
+	if result.ToString() != "hello noderati" {
+		t.Errorf("got %q", result.ToString())
+	}
+}
+
+func TestHostDeclareModuleAliasErrors(t *testing.T) {
+	p := NewPaserati()
+	if err := p.DeclareModuleAlias("node:fs", "fs"); err == nil {
+		t.Fatal("expected error when aliasing a module that was never declared")
+	}
+
+	p.DeclareModule("fs", func(m *ModuleBuilder) {})
+	p.DeclareModule("path", func(m *ModuleBuilder) {})
+	if err := p.DeclareModuleAlias("node:fs", "fs"); err != nil {
+		t.Fatalf("first alias should succeed: %v", err)
+	}
+	if err := p.DeclareModuleAlias("node:fs", "path"); err == nil {
+		t.Fatal("expected error when alias already points at a different module")
+	}
+	if err := p.DeclareModuleAlias("node:fs", "fs"); err != nil {
+		t.Fatalf("re-aliasing to the same module should be idempotent: %v", err)
+	}
+}

--- a/pkg/driver/host_idle_test.go
+++ b/pkg/driver/host_idle_test.go
@@ -1,0 +1,146 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/builtins"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+func newHostTimerPaserati() *Paserati {
+	inits := append(builtins.GetStandardInitializers(), NewHostTimerInitializer())
+	p := NewPaseratiWithInitializers(inits)
+	p.SetSkipTypeCheck(true)
+	return p
+}
+
+func hostArrayJoin(t *testing.T, p *Paserati, name string) string {
+	t.Helper()
+	val, ok := p.GetVM().GetGlobal(name)
+	if !ok {
+		t.Fatalf("global %q not found", name)
+	}
+	if !val.IsArray() {
+		t.Fatalf("global %q is not an array", name)
+	}
+	arr := val.AsArray()
+	parts := make([]string, arr.Length())
+	for i := 0; i < arr.Length(); i++ {
+		parts[i] = arr.Get(i).ToString()
+	}
+	return strings.Join(parts, ",")
+}
+
+func hostGlobalTruthy(t *testing.T, p *Paserati, name string) vm.Value {
+	t.Helper()
+	val, ok := p.GetVM().GetGlobal(name)
+	if !ok {
+		t.Fatalf("global %q not found", name)
+	}
+	return val
+}
+
+func TestHostTimersNotInStandardBuiltins(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	_, errs := p.RunCode(`typeof setTimeout`, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	val, ok := p.GetVM().GetGlobal("setTimeout")
+	if ok && val.IsCallable() {
+		t.Fatal("setTimeout must not be a standard builtin; use NewHostTimerInitializer")
+	}
+}
+
+func TestHostNextTickBeforeMicrotask(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		let order = []
+		nextTick(() => order.push("tick"))
+		Promise.resolve().then(() => order.push("micro"))
+		order.join(",")
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if got := hostArrayJoin(t, p, "order"); got != "tick,micro" {
+		t.Errorf("expected tick,micro, got %q", got)
+	}
+}
+
+func TestHostMicrotaskBeforeTimeoutZero(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		let order = []
+		Promise.resolve().then(() => order.push("micro"))
+		setTimeout(() => order.push("timer"), 0)
+		order.join(",")
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if got := hostArrayJoin(t, p, "order"); got != "micro,timer" {
+		t.Errorf("expected micro,timer, got %q", got)
+	}
+}
+
+func TestHostDrainWaitsForTimer(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		let done = false
+		setTimeout(() => { done = true }, 40)
+		done
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	done := hostGlobalTruthy(t, p, "done")
+	if !done.IsTruthy() {
+		t.Errorf("expected done=true after drain, got %v", done.ToString())
+	}
+}
+
+func TestHostClearTimeout(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		let fired = false
+		let id = setTimeout(() => { fired = true }, 30)
+		clearTimeout(id)
+		fired
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	// Last-statement `fired` is captured before drain; the invariant is that
+	// DrainUntilIdle must not run the cancelled timer.
+	fired := hostGlobalTruthy(t, p, "fired")
+	if fired.IsTruthy() {
+		t.Errorf("expected fired=false after drain, got %v", fired.ToString())
+	}
+}
+
+func TestHostTLAWaitsForTimer(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		await new Promise((resolve) => setTimeout(resolve, 40));
+		true;
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("TLA+timer failed: %v", errs[0])
+	}
+	if result.ToString() != "true" {
+		t.Errorf("expected true after awaited timer, got %v", result.ToString())
+	}
+}

--- a/pkg/driver/host_import_meta_test.go
+++ b/pkg/driver/host_import_meta_test.go
@@ -1,0 +1,137 @@
+package driver
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolveImportMetaPathname simulates new URL(relative, import.meta.url).pathname
+// using net/url, since Paserati has no WHATWG URL builtin.
+func resolveImportMetaPathname(baseURL, relative string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	ref, err := url.Parse(relative)
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(ref).Path, nil
+}
+
+func TestHostImportMetaURLFileModule(t *testing.T) {
+	dir := t.TempDir()
+	entryPath := filepath.Join(dir, "entry.ts")
+	if err := os.WriteFile(entryPath, []byte("import.meta.url"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPaseratiWithBaseDir(dir)
+	p.SetSkipTypeCheck(true)
+
+	val, compileErrs, runtimeErrs := p.RunModuleWithValue("./entry.ts")
+	if len(compileErrs) > 0 {
+		t.Fatalf("compile errors: %v", compileErrs[0])
+	}
+	if len(runtimeErrs) > 0 {
+		t.Fatalf("runtime errors: %v", runtimeErrs[0])
+	}
+
+	got := val.ToString()
+	if !strings.HasPrefix(got, "file://") {
+		t.Fatalf("import.meta.url = %q, want file:// prefix", got)
+	}
+
+	absEntry, err := filepath.Abs(filepath.Join(dir, "entry.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	absEntry = filepath.ToSlash(absEntry)
+	if !strings.Contains(got, absEntry) {
+		t.Errorf("import.meta.url = %q, want to contain absolute path %q", got, absEntry)
+	}
+
+	wantFoo := filepath.ToSlash(filepath.Join(filepath.Dir(absEntry), "foo.ts"))
+	pathname, err := resolveImportMetaPathname(got, "./foo.ts")
+	if err != nil {
+		t.Fatalf("resolveImportMetaPathname: %v", err)
+	}
+	if pathname != wantFoo {
+		t.Errorf("new URL('./foo.ts', import.meta.url).pathname = %q, want %q", pathname, wantFoo)
+	}
+}
+
+func TestHostImportMetaURLNativeModule(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	p.DeclareModule("fs", func(m *ModuleBuilder) {
+		m.Default(nil)
+	})
+
+	val, errs := p.RunCode("import.meta.url", RunOptions{ModuleName: "native://fs"})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if got := val.ToString(); got != "native://fs" {
+		t.Errorf("import.meta.url = %q, want exactly native://fs", got)
+	}
+}
+
+func TestHostImportMetaURLDefaultModuleNotAbsPath(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, errs := p.RunCode("import.meta.url", RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	got := val.ToString()
+	fakeFileURL := "file://" + filepath.ToSlash(filepath.Join(cwd, "__code_module__"))
+	if got == fakeFileURL || strings.HasPrefix(got, fakeFileURL) {
+		t.Errorf("import.meta.url = %q, must not abs-path eval module name into cwd", got)
+	}
+	if strings.Contains(got, filepath.ToSlash(cwd)) && strings.Contains(got, "__code_module__") && strings.HasPrefix(got, "file://") {
+		t.Errorf("import.meta.url = %q, must not turn __code_module__ into a file URL under cwd", got)
+	}
+}
+
+func TestHostImportMetaURLPercentEncoding(t *testing.T) {
+	dir := t.TempDir()
+	modDir := filepath.Join(dir, "my mod")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entryRel := filepath.Join("my mod", "entry.ts")
+	entryPath := filepath.Join(dir, entryRel)
+	if err := os.WriteFile(entryPath, []byte("import.meta.url"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPaseratiWithBaseDir(dir)
+	p.SetSkipTypeCheck(true)
+
+	val, compileErrs, runtimeErrs := p.RunModuleWithValue("./" + filepath.ToSlash(entryRel))
+	if len(compileErrs) > 0 {
+		t.Fatalf("compile errors: %v", compileErrs[0])
+	}
+	if len(runtimeErrs) > 0 {
+		t.Fatalf("runtime errors: %v", runtimeErrs[0])
+	}
+
+	got := val.ToString()
+	if strings.Contains(got, "my mod") {
+		t.Errorf("import.meta.url = %q, space in path must be percent-encoded", got)
+	}
+	if !strings.Contains(got, "%20") {
+		t.Errorf("import.meta.url = %q, want %%20 for space in directory name", got)
+	}
+}

--- a/pkg/driver/host_import_meta_test.go
+++ b/pkg/driver/host_import_meta_test.go
@@ -8,6 +8,17 @@ import (
 	"testing"
 )
 
+// urlPathToSlashPath strips the leading slash a file:// URL's path component
+// carries before a Windows drive letter (/C:/x), which is part of the WHATWG
+// pathname but not of the filesystem path. A no-op on POSIX paths.
+func urlPathToSlashPath(p string) string {
+	if len(p) >= 3 && p[0] == '/' && p[2] == ':' &&
+		((p[1] >= 'A' && p[1] <= 'Z') || (p[1] >= 'a' && p[1] <= 'z')) {
+		return p[1:]
+	}
+	return p
+}
+
 // resolveImportMetaPathname simulates new URL(relative, import.meta.url).pathname
 // using net/url, since Paserati has no WHATWG URL builtin.
 func resolveImportMetaPathname(baseURL, relative string) (string, error) {
@@ -59,7 +70,7 @@ func TestHostImportMetaURLFileModule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveImportMetaPathname: %v", err)
 	}
-	if pathname != wantFoo {
+	if urlPathToSlashPath(pathname) != wantFoo {
 		t.Errorf("new URL('./foo.ts', import.meta.url).pathname = %q, want %q", pathname, wantFoo)
 	}
 }

--- a/pkg/driver/host_native_source_test.go
+++ b/pkg/driver/host_native_source_test.go
@@ -1,0 +1,64 @@
+package driver
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestNativeModuleSyntheticSourceAfterLoad(t *testing.T) {
+	p := NewPaserati()
+	mod := p.DeclareModule("fs", func(m *ModuleBuilder) {
+		m.Function("readFileSync", func(path string) string { return path })
+		m.Const("sep", "/")
+		m.Default(nil)
+	})
+
+	_, err := p.LoadModule("fs", ".")
+	if err != nil {
+		t.Fatalf("LoadModule(fs): %v", err)
+	}
+
+	data, err := io.ReadAll(&NativeModuleSource{module: mod, isNativeModule: true})
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	src := string(data)
+
+	if strings.Contains(src, "PI_SQUARED") {
+		t.Errorf("synthetic source must not contain PI_SQUARED placeholder:\n%s", src)
+	}
+	if !strings.Contains(src, "readFileSync") {
+		t.Errorf("expected readFileSync in synthetic source:\n%s", src)
+	}
+	if !strings.Contains(src, "sep") {
+		t.Errorf("expected sep in synthetic source:\n%s", src)
+	}
+	if !strings.Contains(src, "// Auto-generated native module: fs") {
+		t.Errorf("expected header comment:\n%s", src)
+	}
+}
+
+func TestNativeModuleSyntheticSourceBeforeLoad(t *testing.T) {
+	p := NewPaserati()
+	mod := p.DeclareModule("fs", func(m *ModuleBuilder) {
+		m.Function("readFileSync", func(path string) string { return path })
+		m.Const("sep", "/")
+	})
+
+	data, err := io.ReadAll(&NativeModuleSource{module: mod, isNativeModule: true})
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	src := string(data)
+
+	if strings.Contains(src, "PI_SQUARED") {
+		t.Errorf("synthetic source must not contain PI_SQUARED placeholder:\n%s", src)
+	}
+	if !strings.Contains(src, "export {}") {
+		t.Errorf("expected export {} before load:\n%s", src)
+	}
+	if strings.Contains(src, "readFileSync") {
+		t.Errorf("must not contain exports before load:\n%s", src)
+	}
+}

--- a/pkg/driver/host_script_test.go
+++ b/pkg/driver/host_script_test.go
@@ -1,0 +1,108 @@
+package driver
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+func wrapCJS(body string) string {
+	return "(function (exports, require, module, __filename, __dirname) {\n" + body + "\n})"
+}
+
+func TestHostRunScriptCJSWrap(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	filename := "/app/lib/foo.js"
+	dirname := filepath.Dir(filename)
+	body := `module.exports = { file: __filename, dir: __dirname, n: 1 + exports.seed };`
+	fn, errs := p.RunScript(wrapCJS(body), filename)
+	if len(errs) > 0 {
+		t.Fatalf("RunScript failed: %v", errs[0])
+	}
+	if !fn.IsCallable() {
+		t.Fatalf("expected wrapper function, got %s", fn.ToString())
+	}
+
+	vmInst := p.GetVM()
+	exportsVal := vm.NewObject(vmInst.ObjectPrototype)
+	exportsVal.AsPlainObject().SetOwn("seed", vm.NumberValue(41))
+	moduleVal := vm.NewObject(vmInst.ObjectPrototype)
+	moduleVal.AsPlainObject().SetOwn("exports", exportsVal)
+
+	_, err := vmInst.Call(fn, vm.Undefined, []vm.Value{
+		exportsVal,
+		vm.Undefined,
+		moduleVal,
+		vm.String(filename),
+		vm.String(dirname),
+	})
+	if err != nil {
+		t.Fatalf("CJS wrapper call failed: %v", err)
+	}
+
+	gotExports, ok := moduleVal.AsPlainObject().GetOwn("exports")
+	if !ok || !gotExports.IsObject() {
+		t.Fatal("module.exports missing after wrapper call")
+	}
+	file, ok := gotExports.AsPlainObject().GetOwn("file")
+	if !ok || file.ToString() != filename {
+		t.Errorf("__filename = %q, want %q", file.ToString(), filename)
+	}
+	dir, ok := gotExports.AsPlainObject().GetOwn("dir")
+	if !ok || dir.ToString() != dirname {
+		t.Errorf("__dirname = %q, want %q", dir.ToString(), dirname)
+	}
+	n, ok := gotExports.AsPlainObject().GetOwn("n")
+	if !ok || n.ToFloat() != 42 {
+		t.Errorf("n = %v, want 42", n.ToString())
+	}
+}
+
+func TestHostRunScriptNoModuleRecord(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	filename := "/tmp/cjs-not-esm.js"
+	_, errs := p.RunScript("var x = 1; x", filename)
+	if len(errs) > 0 {
+		t.Fatalf("RunScript failed: %v", errs[0])
+	}
+	if rec := p.GetModuleLoader().GetModule(filename); rec != nil {
+		t.Fatal("RunScript must not invent a ModuleRecord")
+	}
+}
+
+func TestHostRunScriptRejectsImportMeta(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	_, errs := p.RunCode("export const a = 1; a", RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("module RunCode failed: %v", errs[0])
+	}
+
+	_, errs = p.RunScript("import.meta.url", "/app/lib/foo.js")
+	if len(errs) == 0 {
+		t.Fatal("expected import.meta to fail in script mode")
+	}
+	if !strings.Contains(errs[0].Error(), "import.meta") {
+		t.Errorf("error = %q, want import.meta", errs[0].Error())
+	}
+}
+
+func TestHostRunOptionsScript(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	result, errs := p.RunCode("1 + 2", RunOptions{Script: true, Filename: "/tmp/add.js"})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode Script failed: %v", errs[0])
+	}
+	if result.ToFloat() != 3 {
+		t.Errorf("got %v, want 3", result.ToString())
+	}
+}

--- a/pkg/driver/host_timers.go
+++ b/pkg/driver/host_timers.go
@@ -1,0 +1,96 @@
+package driver
+
+import (
+	"time"
+
+	"github.com/nooga/paserati/pkg/builtins"
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// HostTimerInitializer provides opt-in Node-style nextTick/setTimeout globals
+// for embed hosts (e.g. noderati). Not part of standard builtins.
+type HostTimerInitializer struct{}
+
+// NewHostTimerInitializer returns a BuiltinInitializer for host timer globals.
+func NewHostTimerInitializer() builtins.BuiltinInitializer {
+	return &HostTimerInitializer{}
+}
+
+func (h *HostTimerInitializer) Name() string {
+	return "host-timers"
+}
+
+func (h *HostTimerInitializer) Priority() int {
+	return 400 // after standard builtins and process (300)
+}
+
+func (h *HostTimerInitializer) InitTypes(ctx *builtins.TypeContext) error {
+	looseFn := types.NewSimpleFunction([]types.Type{types.Any}, types.Any)
+	if err := ctx.DefineGlobal("nextTick", looseFn); err != nil {
+		return err
+	}
+	if err := ctx.DefineGlobal("setTimeout", types.NewSimpleFunction([]types.Type{types.Any, types.Number}, types.Number)); err != nil {
+		return err
+	}
+	return ctx.DefineGlobal("clearTimeout", types.NewSimpleFunction([]types.Type{types.Number}, types.Undefined))
+}
+
+func (h *HostTimerInitializer) InitRuntime(ctx *builtins.RuntimeContext) error {
+	vmInstance := ctx.VM
+	rt := vmInstance.GetAsyncRuntime()
+
+	nextTickFn := vm.NewNativeFunction(1, true, "nextTick", func(args []vm.Value) (vm.Value, error) {
+		if len(args) == 0 || !args[0].IsCallable() {
+			return vm.Undefined, nil
+		}
+		fn := args[0]
+		fnArgs := args[1:]
+		rt.ScheduleNextTick(func() {
+			_, _ = vmInstance.Call(fn, vm.Undefined, fnArgs)
+		})
+		return vm.Undefined, nil
+	})
+
+	setTimeoutFn := vm.NewNativeFunction(1, true, "setTimeout", func(args []vm.Value) (vm.Value, error) {
+		if len(args) < 1 || !args[0].IsCallable() {
+			return vm.NumberValue(0), nil
+		}
+		fn := args[0]
+		delayMs := 0.0
+		if len(args) > 1 {
+			delayMs = args[1].ToFloat()
+			if delayMs < 0 {
+				delayMs = 0
+			}
+		}
+		fnArgs := args[2:]
+		id := rt.ScheduleTimer(time.Duration(delayMs)*time.Millisecond, func() {
+			_, _ = vmInstance.Call(fn, vm.Undefined, fnArgs)
+		})
+		return vm.NumberValue(float64(id)), nil
+	})
+
+	clearTimeoutFn := vm.NewNativeFunction(1, false, "clearTimeout", func(args []vm.Value) (vm.Value, error) {
+		if len(args) > 0 && args[0].IsNumber() {
+			rt.CancelTimer(uint64(args[0].ToFloat()))
+		}
+		return vm.Undefined, nil
+	})
+
+	if err := ctx.DefineGlobal("nextTick", nextTickFn); err != nil {
+		return err
+	}
+	if err := ctx.DefineGlobal("setTimeout", setTimeoutFn); err != nil {
+		return err
+	}
+	if err := ctx.DefineGlobal("clearTimeout", clearTimeoutFn); err != nil {
+		return err
+	}
+
+	if processVal, ok := vmInstance.GetGlobal("process"); ok && processVal.IsObject() {
+		processVal.AsPlainObject().SetOwn("nextTick", nextTickFn)
+	}
+
+	return nil
+}

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -26,6 +26,10 @@ type ModuleBuilder struct {
 
 	// VM instance for creating runtime objects
 	vm *vm.VM
+
+	// Default export (applied after the builder callback returns)
+	hasDefault   bool
+	defaultValue interface{} // nil means "namespace of named exports"
 }
 
 // NamespaceBuilder provides API for building namespaces within modules
@@ -169,10 +173,51 @@ func (m *ModuleBuilder) Type(name string, typedef interface{}) *ModuleBuilder {
 	return m
 }
 
-// Default sets the default export (TODO: implement)
+// Default sets the ESM default export.
+//
+// Passing nil makes the default a namespace object containing every named
+// export (Node CJS interop: `import fs from "fs"`). Named exports must be
+// registered before Default(nil); it is applied when the builder returns.
 func (m *ModuleBuilder) Default(value interface{}) *ModuleBuilder {
-	// TODO: implement default export
+	m.hasDefault = true
+	m.defaultValue = value
 	return m
+}
+
+func (m *ModuleBuilder) applyDefaultExport() {
+	if !m.hasDefault {
+		return
+	}
+
+	if m.defaultValue == nil {
+		proto := vm.Undefined
+		if m.vm != nil {
+			proto = m.vm.ObjectPrototype
+		}
+		nsType := types.NewObjectType()
+		nsObj := vm.NewObject(proto).AsPlainObject()
+		for name, typ := range m.exports {
+			if name == "default" {
+				continue
+			}
+			nsType = nsType.WithProperty(name, typ)
+			if val, ok := m.values[name]; ok {
+				nsObj.SetOwn(name, val)
+			}
+		}
+		m.exports["default"] = nsType
+		m.values["default"] = vm.NewValueFromPlainObject(nsObj)
+		return
+	}
+
+	if reflect.TypeOf(m.defaultValue) != nil && reflect.TypeOf(m.defaultValue).Kind() == reflect.Func {
+		m.exports["default"] = m.goFunctionToTSType(m.defaultValue)
+		m.values["default"] = m.goFunctionToVM(m.defaultValue)
+		return
+	}
+
+	m.exports["default"] = m.goValueToTSType(m.defaultValue)
+	m.values["default"] = m.goValueToVM(m.defaultValue)
 }
 
 // NamespaceBuilder methods (similar to ModuleBuilder)
@@ -1143,7 +1188,7 @@ func (r *NativeModuleResolver) Resolve(specifier string, fromPath string) (*modu
 
 	return &modules.ResolvedModule{
 		Specifier:    specifier,
-		ResolvedPath: "native://" + specifier,
+		ResolvedPath: "native://" + module.name,
 		Source:       &NativeModuleSource{module: module, isNativeModule: true},
 		Resolver:     "native",
 	}, nil
@@ -1164,6 +1209,31 @@ func (p *Paserati) DeclareModule(name string, builder func(m *ModuleBuilder)) *N
 
 	p.nativeResolver.RegisterModule(name, module)
 	return module
+}
+
+// DeclareModuleAlias registers alias as another specifier for an existing
+// native module (e.g. "node:fs" → "fs"). Both specifiers resolve to the same
+// NativeModule and, once loaded, the same ModuleRecord.
+func (p *Paserati) DeclareModuleAlias(alias, canonical string) error {
+	if alias == "" || canonical == "" {
+		return fmt.Errorf("DeclareModuleAlias: alias and name must be non-empty")
+	}
+	if p.nativeResolver == nil {
+		return fmt.Errorf("DeclareModuleAlias: no native module %q (call DeclareModule first)", canonical)
+	}
+	return p.nativeResolver.RegisterAlias(alias, canonical)
+}
+
+func (r *NativeModuleResolver) RegisterAlias(alias, canonical string) error {
+	module, ok := r.modules[canonical]
+	if !ok {
+		return fmt.Errorf("native module %q is not declared", canonical)
+	}
+	if existing, exists := r.modules[alias]; exists && existing != module {
+		return fmt.Errorf("alias %q is already registered to a different module", alias)
+	}
+	r.modules[alias] = module
+	return nil
 }
 
 // GetName implements the NativeModuleInterface
@@ -1188,6 +1258,7 @@ func (nm *NativeModule) initializeNativeModule(vmInstance *vm.VM) map[string]vm.
 
 		// Call the user's builder function
 		nm.builder(builder)
+		builder.applyDefaultExport()
 
 		// Store the results
 		nm.exports = builder.exports // Type information

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -106,10 +106,53 @@ func (m *ModuleBuilder) Function(name string, fn interface{}) *ModuleBuilder {
 	return m
 }
 
-// AsyncFunction adds an async function to the module (TODO: implement Promise wrapping)
+// AsyncFunction adds a function whose JS return value is a Promise.
+// The Go implementation still runs synchronously on the caller's thread
+// (do not use this for real I/O — copy the fetch BeginExternalOp pattern).
 func (m *ModuleBuilder) AsyncFunction(name string, fn interface{}) *ModuleBuilder {
-	// For now, just treat as regular function
-	return m.Function(name, fn)
+	m.exports[name] = goAsyncFunctionToTSType(fn)
+	m.values[name] = wrapNativeAsAsync(m.vm, name, goFunctionToVM(fn))
+	return m
+}
+
+func goAsyncFunctionToTSType(fn interface{}) types.Type {
+	fnType := reflect.TypeOf(fn)
+	if fnType.Kind() != reflect.Func {
+		return types.Any
+	}
+	params := make([]types.Type, fnType.NumIn())
+	for i := 0; i < fnType.NumIn(); i++ {
+		params[i] = goTypeToTSType(fnType.In(i))
+	}
+	var returnType types.Type = types.Void
+	if fnType.NumOut() > 0 {
+		returnType = goTypeToTSType(fnType.Out(0))
+	}
+	if returnType == nil {
+		returnType = types.Any
+	}
+	promiseRet := types.NewInstantiatedType(types.PromiseGeneric, []types.Type{returnType})
+	return types.NewSimpleFunction(params, promiseRet)
+}
+
+func wrapNativeAsAsync(vmInst *vm.VM, name string, inner vm.Value) vm.Value {
+	if vmInst == nil || !inner.IsCallable() {
+		return inner
+	}
+	arity := 0
+	variadic := true
+	if inner.Type() == vm.TypeNativeFunction {
+		nf := inner.AsNativeFunction()
+		arity = nf.Arity
+		variadic = nf.Variadic
+	}
+	return vm.NewNativeFunction(arity, variadic, name, func(args []vm.Value) (vm.Value, error) {
+		result, err := vmInst.Call(inner, vm.Undefined, args)
+		if err != nil {
+			return vmInst.NewRejectedPromise(vm.NewString(err.Error())), nil
+		}
+		return vmInst.NewResolvedPromise(result), nil
+	})
 }
 
 // Constructor adds a constructor function to the module

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
+	"unicode"
 
+	"github.com/nooga/paserati/pkg/lexer"
 	"github.com/nooga/paserati/pkg/modules"
 	"github.com/nooga/paserati/pkg/parser"
 	"github.com/nooga/paserati/pkg/types"
@@ -1211,16 +1214,63 @@ func (nms *NativeModuleSource) GetNativeModule() interface{} {
 }
 
 func (nms *NativeModuleSource) generateSyntheticSource() []byte {
-	// For now, generate a simple export statement
-	// TODO: Generate proper TypeScript declarations based on module exports
-	return []byte(`
-// Auto-generated native module exports
-export const PI_SQUARED: number = 9.8696; // placeholder
-export const EULER: number = 2.718281828; // placeholder
-export function square(x: number): number { return x * x; }
-export function add(a: number, b: number): number { return a + b; }
-export function divmod(a: number, b: number): any { return {}; }
-`)
+	mod := nms.module
+	exports := mod.GetExports()
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "// Auto-generated native module: %s\n", mod.name)
+
+	if len(exports) == 0 {
+		sb.WriteString("export {}\n")
+		return []byte(sb.String())
+	}
+
+	names := make([]string, 0, len(exports))
+	for name := range exports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		typeStr := exportTypeString(exports[name])
+		switch name {
+		case "default":
+			fmt.Fprintf(&sb, "declare const __default: %s;\n", typeStr)
+			sb.WriteString("export default __default;\n")
+		default:
+			if isValidExportIdentifier(name) {
+				fmt.Fprintf(&sb, "export declare const %s: %s;\n", name, typeStr)
+			}
+		}
+	}
+
+	return []byte(sb.String())
+}
+
+func exportTypeString(typ types.Type) string {
+	if typ == nil {
+		return "any"
+	}
+	if s := typ.String(); s != "" {
+		return s
+	}
+	return "any"
+}
+
+func isValidExportIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 {
+			if r != '_' && r != '$' && !unicode.IsLetter(r) {
+				return false
+			}
+		} else if r != '_' && r != '$' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return lexer.LookupIdent(name) == lexer.IDENT
 }
 
 func (r *NativeModuleResolver) Resolve(specifier string, fromPath string) (*modules.ResolvedModule, error) {

--- a/pkg/modules/interfaces.go
+++ b/pkg/modules/interfaces.go
@@ -83,6 +83,10 @@ type ModuleRegistry interface {
 	// Get retrieves a module record by specifier
 	Get(specifier string) *ModuleRecord
 
+	// GetByResolvedPath retrieves a module record by canonical resolved path.
+	// Specifier aliases (fs vs node:fs, ./foo vs ./foo.ts) share one record.
+	GetByResolvedPath(resolvedPath string) *ModuleRecord
+
 	// Set stores a module record
 	Set(specifier string, record *ModuleRecord)
 

--- a/pkg/modules/loader.go
+++ b/pkg/modules/loader.go
@@ -116,6 +116,18 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 		return nil, err
 	}
 
+	// Specifier aliases (fs vs node:fs) share one record keyed by resolved path.
+	if resolved.ResolvedPath != "" {
+		if existing := ml.registry.GetByResolvedPath(resolved.ResolvedPath); existing != nil {
+			if resolved.Source != nil {
+				_ = resolved.Source.Close()
+			}
+			ml.registry.Set(specifier, existing)
+			debugPrintf("// [ModuleLoader] Aliased specifier %s -> existing %s\n", specifier, resolved.ResolvedPath)
+			return existing, nil
+		}
+	}
+
 	// Create module record
 	record := &ModuleRecord{
 		Specifier:    specifier,

--- a/pkg/modules/registry.go
+++ b/pkg/modules/registry.go
@@ -7,10 +7,11 @@ import (
 
 // registry implements the ModuleRegistry interface
 type registry struct {
-	modules   map[string]*ModuleRecord // Map of specifier -> module record
-	mutex     sync.RWMutex             // Protects concurrent access
-	stats     RegistryStats            // Performance statistics
-	config    *LoaderConfig            // Configuration
+	modules map[string]*ModuleRecord // Map of specifier -> module record
+	byPath  map[string]*ModuleRecord // Map of resolved path -> canonical record
+	mutex   sync.RWMutex             // Protects concurrent access
+	stats   RegistryStats            // Performance statistics
+	config  *LoaderConfig            // Configuration
 }
 
 // NewRegistry creates a new module registry
@@ -18,9 +19,10 @@ func NewRegistry(config *LoaderConfig) ModuleRegistry {
 	if config == nil {
 		config = DefaultLoaderConfig()
 	}
-	
+
 	return &registry{
 		modules: make(map[string]*ModuleRecord),
+		byPath:  make(map[string]*ModuleRecord),
 		config:  config,
 		stats:   RegistryStats{},
 	}
@@ -30,11 +32,11 @@ func NewRegistry(config *LoaderConfig) ModuleRegistry {
 func (r *registry) Get(specifier string) *ModuleRecord {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	record := r.modules[specifier]
 	if record != nil {
 		r.stats.CacheHits++
-		
+
 		// Check TTL if configured
 		if r.config.CacheTTL > 0 {
 			if time.Since(record.LoadTime) > r.config.CacheTTL {
@@ -46,40 +48,52 @@ func (r *registry) Get(specifier string) *ModuleRecord {
 	} else {
 		r.stats.CacheMisses++
 	}
-	
+
 	return record
+}
+
+// GetByResolvedPath retrieves a module record by canonical resolved path.
+func (r *registry) GetByResolvedPath(resolvedPath string) *ModuleRecord {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if resolvedPath == "" {
+		return nil
+	}
+	return r.byPath[resolvedPath]
 }
 
 // Set stores a module record
 func (r *registry) Set(specifier string, record *ModuleRecord) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	
+
 	// Check cache size limits
 	if r.config.CacheSize > 0 && len(r.modules) >= r.config.CacheSize {
 		// Remove oldest module if at capacity
 		r.evictOldest()
 	}
-	
+
 	// Update statistics
 	if r.modules[specifier] == nil {
 		r.stats.TotalModules++
 	}
-	
+
 	if record.State == ModuleCompiled {
 		r.stats.LoadedModules++
 	} else if record.State == ModuleError {
 		r.stats.FailedModules++
 	}
-	
+
 	r.modules[specifier] = record
+	r.indexResolvedPathLocked(record)
 }
 
 // SetParsed updates a module record with parse results
 func (r *registry) SetParsed(specifier string, result *ParseResult) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	
+
 	record := r.modules[specifier]
 	if record == nil {
 		// Create new record if it doesn't exist
@@ -90,18 +104,19 @@ func (r *registry) SetParsed(specifier string, result *ParseResult) {
 			LoadTime:     time.Now(),
 		}
 		r.modules[specifier] = record
+		r.indexResolvedPathLocked(record)
 		r.stats.TotalModules++
 	}
-	
+
 	// Update with parse results
 	record.AST = result.AST
 	record.ParseDuration = result.ParseDuration
 	record.WorkerID = result.WorkerID
 	record.Error = result.Error
-	
+
 	if result.Error == nil {
 		record.State = ModuleParsed
-		
+
 		// Extract dependencies from import specs
 		record.Dependencies = make([]string, len(result.ImportSpecs))
 		for i, importSpec := range result.ImportSpecs {
@@ -117,11 +132,12 @@ func (r *registry) SetParsed(specifier string, result *ParseResult) {
 func (r *registry) Remove(specifier string) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	
+
 	if record := r.modules[specifier]; record != nil {
 		delete(r.modules, specifier)
 		r.stats.TotalModules--
-		
+		r.unindexResolvedPathLocked(record)
+
 		if record.State == ModuleCompiled {
 			r.stats.LoadedModules--
 		} else if record.State == ModuleError {
@@ -134,8 +150,9 @@ func (r *registry) Remove(specifier string) {
 func (r *registry) Clear() {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	
+
 	r.modules = make(map[string]*ModuleRecord)
+	r.byPath = make(map[string]*ModuleRecord)
 	r.stats = RegistryStats{}
 }
 
@@ -143,12 +160,12 @@ func (r *registry) Clear() {
 func (r *registry) List() []string {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	specifiers := make([]string, 0, len(r.modules))
 	for specifier := range r.modules {
 		specifiers = append(specifiers, specifier)
 	}
-	
+
 	return specifiers
 }
 
@@ -156,7 +173,7 @@ func (r *registry) List() []string {
 func (r *registry) Size() int {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	return len(r.modules)
 }
 
@@ -164,7 +181,7 @@ func (r *registry) Size() int {
 func (r *registry) GetStats() RegistryStats {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	// Calculate approximate memory usage
 	memoryUsage := int64(len(r.modules) * 1000) // Rough estimate per module
 	for _, record := range r.modules {
@@ -172,7 +189,7 @@ func (r *registry) GetStats() RegistryStats {
 			memoryUsage += int64(len(record.Source.Content))
 		}
 	}
-	
+
 	stats := r.stats
 	stats.MemoryUsage = memoryUsage
 	return stats
@@ -182,10 +199,10 @@ func (r *registry) GetStats() RegistryStats {
 func (r *registry) UpdateState(specifier string, state ModuleState) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	
+
 	if record := r.modules[specifier]; record != nil {
 		record.State = state
-		
+
 		// Update completion time if module is fully processed
 		if state == ModuleCompiled || state == ModuleError {
 			record.CompleteTime = time.Now()
@@ -197,7 +214,7 @@ func (r *registry) UpdateState(specifier string, state ModuleState) {
 func (r *registry) GetDependents(specifier string) []string {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	var dependents []string
 	for _, record := range r.modules {
 		for _, dep := range record.Dependencies {
@@ -207,7 +224,7 @@ func (r *registry) GetDependents(specifier string) []string {
 			}
 		}
 	}
-	
+
 	return dependents
 }
 
@@ -215,7 +232,7 @@ func (r *registry) GetDependents(specifier string) []string {
 func (r *registry) evictOldest() {
 	var oldestSpecifier string
 	var oldestTime time.Time
-	
+
 	first := true
 	for specifier, record := range r.modules {
 		if first || record.LoadTime.Before(oldestTime) {
@@ -224,27 +241,50 @@ func (r *registry) evictOldest() {
 			first = false
 		}
 	}
-	
+
 	if oldestSpecifier != "" {
+		record := r.modules[oldestSpecifier]
 		delete(r.modules, oldestSpecifier)
 		r.stats.TotalModules--
+		r.unindexResolvedPathLocked(record)
 	}
+}
+
+func (r *registry) indexResolvedPathLocked(record *ModuleRecord) {
+	if record != nil && record.ResolvedPath != "" {
+		r.byPath[record.ResolvedPath] = record
+	}
+}
+
+func (r *registry) unindexResolvedPathLocked(record *ModuleRecord) {
+	if record == nil || record.ResolvedPath == "" {
+		return
+	}
+	if r.byPath[record.ResolvedPath] != record {
+		return
+	}
+	for _, rec := range r.modules {
+		if rec == record {
+			return // still referenced by another specifier alias
+		}
+	}
+	delete(r.byPath, record.ResolvedPath)
 }
 
 // IsStale returns true if a module should be reloaded due to TTL expiry
 func (r *registry) IsStale(specifier string) bool {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	record := r.modules[specifier]
 	if record == nil {
 		return true // Not cached, needs loading
 	}
-	
+
 	if r.config.CacheTTL > 0 {
 		return time.Since(record.LoadTime) > r.config.CacheTTL
 	}
-	
+
 	return false // No TTL configured, never stale
 }
 
@@ -252,13 +292,13 @@ func (r *registry) IsStale(specifier string) bool {
 func (r *registry) GetByState(state ModuleState) []*ModuleRecord {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	
+
 	var modules []*ModuleRecord
 	for _, record := range r.modules {
 		if record.State == state {
 			modules = append(modules, record)
 		}
 	}
-	
+
 	return modules
 }

--- a/pkg/modules/registry_test.go
+++ b/pkg/modules/registry_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestRegistryBasicOperations(t *testing.T) {
 	registry := NewRegistry(DefaultLoaderConfig())
-	
+
 	// Test initial state
 	if registry.Size() != 0 {
 		t.Errorf("Expected empty registry, got size %d", registry.Size())
 	}
-	
+
 	// Test Set and Get
 	record := &ModuleRecord{
 		Specifier:    "./test.ts",
@@ -21,20 +21,20 @@ func TestRegistryBasicOperations(t *testing.T) {
 		State:        ModuleLoaded,
 		LoadTime:     time.Now(),
 	}
-	
+
 	registry.Set("./test.ts", record)
-	
+
 	if registry.Size() != 1 {
 		t.Errorf("Expected registry size 1, got %d", registry.Size())
 	}
-	
+
 	retrieved := registry.Get("./test.ts")
 	if retrieved == nil {
 		t.Error("Expected to retrieve record, got nil")
 	} else if retrieved.Specifier != "./test.ts" {
 		t.Errorf("Expected specifier './test.ts', got '%s'", retrieved.Specifier)
 	}
-	
+
 	// Test Get non-existent
 	nonExistent := registry.Get("./nonexistent.ts")
 	if nonExistent != nil {
@@ -44,7 +44,7 @@ func TestRegistryBasicOperations(t *testing.T) {
 
 func TestRegistryList(t *testing.T) {
 	registry := NewRegistry(DefaultLoaderConfig())
-	
+
 	// Add multiple modules
 	modules := []string{"./a.ts", "./b.ts", "./c.ts"}
 	for _, spec := range modules {
@@ -55,12 +55,12 @@ func TestRegistryList(t *testing.T) {
 		}
 		registry.Set(spec, record)
 	}
-	
+
 	list := registry.List()
 	if len(list) != 3 {
 		t.Errorf("Expected 3 modules in list, got %d", len(list))
 	}
-	
+
 	// Check all modules are present
 	for _, spec := range modules {
 		found := false
@@ -78,25 +78,25 @@ func TestRegistryList(t *testing.T) {
 
 func TestRegistryRemove(t *testing.T) {
 	registry := NewRegistry(DefaultLoaderConfig())
-	
+
 	record := &ModuleRecord{
 		Specifier: "./test.ts",
 		State:     ModuleLoaded,
 		LoadTime:  time.Now(),
 	}
-	
+
 	registry.Set("./test.ts", record)
-	
+
 	if registry.Size() != 1 {
 		t.Errorf("Expected size 1 after set, got %d", registry.Size())
 	}
-	
+
 	registry.Remove("./test.ts")
-	
+
 	if registry.Size() != 0 {
 		t.Errorf("Expected size 0 after remove, got %d", registry.Size())
 	}
-	
+
 	retrieved := registry.Get("./test.ts")
 	if retrieved != nil {
 		t.Error("Expected nil after remove, got record")
@@ -105,7 +105,7 @@ func TestRegistryRemove(t *testing.T) {
 
 func TestRegistryClear(t *testing.T) {
 	registry := NewRegistry(DefaultLoaderConfig())
-	
+
 	// Add multiple modules
 	for i := 0; i < 5; i++ {
 		record := &ModuleRecord{
@@ -115,13 +115,13 @@ func TestRegistryClear(t *testing.T) {
 		}
 		registry.Set(record.Specifier, record)
 	}
-	
+
 	if registry.Size() != 5 {
 		t.Errorf("Expected size 5 before clear, got %d", registry.Size())
 	}
-	
+
 	registry.Clear()
-	
+
 	if registry.Size() != 0 {
 		t.Errorf("Expected size 0 after clear, got %d", registry.Size())
 	}
@@ -129,7 +129,7 @@ func TestRegistryClear(t *testing.T) {
 
 func TestRegistrySetParsed(t *testing.T) {
 	registry := NewRegistry(DefaultLoaderConfig())
-	
+
 	parseResult := &ParseResult{
 		ModulePath:    "./test.ts",
 		ParseDuration: 50 * time.Millisecond,
@@ -137,23 +137,23 @@ func TestRegistrySetParsed(t *testing.T) {
 		Error:         nil,
 		Timestamp:     time.Now(),
 	}
-	
+
 	registry.SetParsed("./test.ts", parseResult)
-	
+
 	record := registry.Get("./test.ts")
 	if record == nil {
 		t.Error("Expected record to be created by SetParsed")
 		return
 	}
-	
+
 	if record.State != ModuleParsed {
 		t.Errorf("Expected state ModuleParsed, got %s", record.State)
 	}
-	
+
 	if record.ParseDuration != parseResult.ParseDuration {
 		t.Errorf("Expected parse duration %v, got %v", parseResult.ParseDuration, record.ParseDuration)
 	}
-	
+
 	if record.WorkerID != parseResult.WorkerID {
 		t.Errorf("Expected worker ID %d, got %d", parseResult.WorkerID, record.WorkerID)
 	}
@@ -162,26 +162,26 @@ func TestRegistrySetParsed(t *testing.T) {
 func TestRegistryTTL(t *testing.T) {
 	config := DefaultLoaderConfig()
 	config.CacheTTL = 10 * time.Millisecond // Very short TTL for testing
-	
+
 	registry := NewRegistry(config)
-	
+
 	record := &ModuleRecord{
 		Specifier: "./test.ts",
 		State:     ModuleLoaded,
 		LoadTime:  time.Now(),
 	}
-	
+
 	registry.Set("./test.ts", record)
-	
+
 	// Should be available immediately
 	retrieved := registry.Get("./test.ts")
 	if retrieved == nil {
 		t.Error("Expected record to be available immediately")
 	}
-	
+
 	// Wait for TTL to expire
 	time.Sleep(15 * time.Millisecond)
-	
+
 	// Should now return nil due to TTL expiry
 	expired := registry.Get("./test.ts")
 	if expired != nil {
@@ -192,9 +192,9 @@ func TestRegistryTTL(t *testing.T) {
 func TestRegistryCacheSize(t *testing.T) {
 	config := DefaultLoaderConfig()
 	config.CacheSize = 2 // Limit cache to 2 modules
-	
+
 	registry := NewRegistry(config)
-	
+
 	// Add 3 modules (should evict the oldest)
 	modules := []string{"./a.ts", "./b.ts", "./c.ts"}
 	for i, spec := range modules {
@@ -206,24 +206,24 @@ func TestRegistryCacheSize(t *testing.T) {
 		registry.Set(spec, record)
 		time.Sleep(1 * time.Millisecond) // Ensure different timestamps
 	}
-	
+
 	// Should only have 2 modules (oldest evicted)
 	if registry.Size() != 2 {
 		t.Errorf("Expected size 2 due to cache limit, got %d", registry.Size())
 	}
-	
+
 	// First module should be evicted
 	first := registry.Get("./a.ts")
 	if first != nil {
 		t.Error("Expected first module to be evicted")
 	}
-	
+
 	// Other modules should still be present
 	second := registry.Get("./b.ts")
 	if second == nil {
 		t.Error("Expected second module to be present")
 	}
-	
+
 	third := registry.Get("./c.ts")
 	if third == nil {
 		t.Error("Expected third module to be present")
@@ -232,7 +232,7 @@ func TestRegistryCacheSize(t *testing.T) {
 
 func TestRegistryStats(t *testing.T) {
 	registry := NewRegistry(DefaultLoaderConfig())
-	
+
 	// Add successful module
 	successRecord := &ModuleRecord{
 		Specifier: "./success.ts",
@@ -240,7 +240,7 @@ func TestRegistryStats(t *testing.T) {
 		LoadTime:  time.Now(),
 	}
 	registry.Set("./success.ts", successRecord)
-	
+
 	// Add failed module
 	failRecord := &ModuleRecord{
 		Specifier: "./fail.ts",
@@ -248,32 +248,32 @@ func TestRegistryStats(t *testing.T) {
 		LoadTime:  time.Now(),
 	}
 	registry.Set("./fail.ts", failRecord)
-	
+
 	// Test cache hit
 	registry.Get("./success.ts")
-	
+
 	// Test cache miss
 	registry.Get("./nonexistent.ts")
-	
+
 	// Get the stats using the interface method
 	stats := registry.GetStats()
-	
+
 	if stats.TotalModules != 2 {
 		t.Errorf("Expected 2 total modules, got %d", stats.TotalModules)
 	}
-	
+
 	if stats.LoadedModules != 1 {
 		t.Errorf("Expected 1 loaded module, got %d", stats.LoadedModules)
 	}
-	
+
 	if stats.FailedModules != 1 {
 		t.Errorf("Expected 1 failed module, got %d", stats.FailedModules)
 	}
-	
+
 	if stats.CacheHits != 1 {
 		t.Errorf("Expected 1 cache hit, got %d", stats.CacheHits)
 	}
-	
+
 	if stats.CacheMisses != 1 {
 		t.Errorf("Expected 1 cache miss, got %d", stats.CacheMisses)
 	}
@@ -298,7 +298,7 @@ func TestModuleStateString(t *testing.T) {
 		{ModuleError, "error"},
 		{ModuleState(999), "invalid"},
 	}
-	
+
 	for _, test := range states {
 		result := test.state.String()
 		if result != test.expected {
@@ -318,7 +318,7 @@ func TestImportTypeString(t *testing.T) {
 		{ImportSideEffect, "side-effect"},
 		{ImportType(999), "unknown"},
 	}
-	
+
 	for _, test := range types {
 		result := test.importType.String()
 		if result != test.expected {
@@ -329,28 +329,58 @@ func TestImportTypeString(t *testing.T) {
 
 func TestDefaultLoaderConfig(t *testing.T) {
 	config := DefaultLoaderConfig()
-	
+
 	if !config.EnableParallel {
 		t.Error("Expected parallel processing to be enabled by default")
 	}
-	
+
 	if config.NumWorkers != runtime.NumCPU() {
 		t.Errorf("Expected NumWorkers to be %d (runtime.NumCPU()) by default, got %d", runtime.NumCPU(), config.NumWorkers)
 	}
-	
+
 	if !config.CacheEnabled {
 		t.Error("Expected caching to be enabled by default")
 	}
-	
+
 	if config.CacheSize != 0 {
 		t.Error("Expected unlimited cache size by default")
 	}
-	
+
 	if config.CacheTTL != 0 {
 		t.Error("Expected no cache TTL by default")
 	}
-	
+
 	if !config.PrewarmLexers {
 		t.Error("Expected lexer prewarming to be enabled by default")
+	}
+}
+
+func TestRegistryResolvedPathAliases(t *testing.T) {
+	reg := NewRegistry(DefaultLoaderConfig())
+
+	canonical := &ModuleRecord{
+		Specifier:    "fs",
+		ResolvedPath: "native://fs",
+		State:        ModuleCompiled,
+		LoadTime:     time.Now(),
+	}
+	reg.Set("fs", canonical)
+	reg.Set("node:fs", canonical)
+
+	if got := reg.GetByResolvedPath("native://fs"); got != canonical {
+		t.Fatalf("GetByResolvedPath did not return the canonical record")
+	}
+	if reg.Get("fs") != reg.Get("node:fs") {
+		t.Fatalf("aliased specifiers must return the same record")
+	}
+
+	reg.Remove("node:fs")
+	if got := reg.GetByResolvedPath("native://fs"); got != canonical {
+		t.Fatalf("removing one alias must keep the resolved-path index")
+	}
+
+	reg.Remove("fs")
+	if got := reg.GetByResolvedPath("native://fs"); got != nil {
+		t.Fatalf("resolved-path index should drop when the last specifier is removed")
 	}
 }

--- a/pkg/runtime/async.go
+++ b/pkg/runtime/async.go
@@ -1,6 +1,11 @@
 package runtime
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
+
+const maxNextTicksPerRun = 10000
 
 // AsyncRuntime provides the async execution environment for Paserati
 // This interface allows plugging in different async execution strategies
@@ -31,22 +36,75 @@ type AsyncRuntime interface {
 	// WaitForExternalOp blocks until at least one external operation completes
 	// Returns immediately if there are no pending external operations
 	WaitForExternalOp()
+
+	// ScheduleNextTick queues a process.nextTick-style callback.
+	ScheduleNextTick(callback func())
+
+	// RunNextTicks snapshots and runs the current nextTick queue.
+	// Returns true if any callbacks ran.
+	RunNextTicks() bool
+
+	// ScheduleMacrotask queues a setImmediate-style callback.
+	ScheduleMacrotask(callback func())
+
+	// RunMacrotasks snapshots and runs the current macrotask queue.
+	// Returns true if any callbacks ran.
+	RunMacrotasks() bool
+
+	// ScheduleTimer schedules a timer callback after delay. delay < 0 is treated as 0.
+	// Timer expiry goroutines only mark the timer due; callbacks run on the drain thread.
+	ScheduleTimer(delay time.Duration, callback func()) (id uint64)
+
+	// CancelTimer cancels a scheduled timer before it fires.
+	CancelTimer(id uint64)
+
+	// RunDueTimers runs callbacks for timers that have expired.
+	// Returns true if any callbacks ran.
+	RunDueTimers() bool
+
+	// HasPendingTimers returns true if timers are scheduled or due but not yet run.
+	HasPendingTimers() bool
+
+	// HasPendingWork returns true if any async work remains (nextTicks, microtasks,
+	// macrotasks, timers, or external ops).
+	HasPendingWork() bool
+
+	// WaitForIdleProgress blocks until a timer is due, an external op completes, or
+	// new work is queued. Returns immediately if runnable work is already pending.
+	WaitForIdleProgress()
+}
+
+type timerEntry struct {
+	id       uint64
+	deadline time.Time
+	callback func()
 }
 
 // DefaultAsyncRuntime is a simple Go-based runtime with a microtask queue
 type DefaultAsyncRuntime struct {
 	microtasks      []func()
+	nextTicks       []func()
+	macrotasks      []func()
+	dueTimers       []*timerEntry
+	timers          map[uint64]*timerEntry
+	nextTimerID     uint64
 	mu              sync.Mutex
 	pendingExternal int
-	externalCond    *sync.Cond
+	idleCond        *sync.Cond
+	wakeWaiters     []chan struct{}
 }
 
 // NewDefaultAsyncRuntime creates a new default async runtime
 func NewDefaultAsyncRuntime() *DefaultAsyncRuntime {
 	rt := &DefaultAsyncRuntime{
-		microtasks: make([]func(), 0, 16),
+		microtasks:  make([]func(), 0, 16),
+		nextTicks:   make([]func(), 0, 16),
+		macrotasks:  make([]func(), 0, 16),
+		dueTimers:   make([]*timerEntry, 0, 8),
+		timers:      make(map[uint64]*timerEntry),
+		wakeWaiters: make([]chan struct{}, 0, 4),
 	}
-	rt.externalCond = sync.NewCond(&rt.mu)
+	rt.idleCond = sync.NewCond(&rt.mu)
 	return rt
 }
 
@@ -55,6 +113,7 @@ func (rt *DefaultAsyncRuntime) ScheduleMicrotask(callback func()) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	rt.microtasks = append(rt.microtasks, callback)
+	rt.signalWaitersLocked()
 }
 
 // RunUntilIdle executes all pending microtasks
@@ -79,12 +138,18 @@ func (rt *DefaultAsyncRuntime) RunUntilIdle() bool {
 	return true
 }
 
-// Reset clears all pending microtasks
+// Reset clears all pending async work
 func (rt *DefaultAsyncRuntime) Reset() {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	rt.microtasks = make([]func(), 0, 16)
+	rt.nextTicks = make([]func(), 0, 16)
+	rt.macrotasks = make([]func(), 0, 16)
+	rt.dueTimers = make([]*timerEntry, 0, 8)
+	rt.timers = make(map[uint64]*timerEntry)
+	rt.nextTimerID = 0
 	rt.pendingExternal = 0
+	rt.signalWaitersLocked()
 }
 
 // BeginExternalOp marks the start of an external async operation
@@ -99,8 +164,7 @@ func (rt *DefaultAsyncRuntime) EndExternalOp() {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	rt.pendingExternal--
-	// Signal any waiters that an operation completed
-	rt.externalCond.Broadcast()
+	rt.signalWaitersLocked()
 }
 
 // HasPendingExternalOps returns true if there are pending external operations
@@ -115,6 +179,254 @@ func (rt *DefaultAsyncRuntime) WaitForExternalOp() {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if rt.pendingExternal > 0 {
-		rt.externalCond.Wait()
+		rt.idleCond.Wait()
 	}
+}
+
+// ScheduleNextTick queues a nextTick callback.
+func (rt *DefaultAsyncRuntime) ScheduleNextTick(callback func()) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.nextTicks = append(rt.nextTicks, callback)
+	rt.signalWaitersLocked()
+}
+
+// RunNextTicks snapshots and runs the current nextTick queue.
+func (rt *DefaultAsyncRuntime) RunNextTicks() bool {
+	rt.mu.Lock()
+	callbacks := rt.nextTicks
+	rt.nextTicks = make([]func(), 0, 16)
+	rt.mu.Unlock()
+
+	if len(callbacks) == 0 {
+		return false
+	}
+
+	limit := len(callbacks)
+	if limit > maxNextTicksPerRun {
+		limit = maxNextTicksPerRun
+	}
+	for i := 0; i < limit; i++ {
+		callbacks[i]()
+	}
+	if len(callbacks) > maxNextTicksPerRun {
+		rt.mu.Lock()
+		rt.nextTicks = append(rt.nextTicks, callbacks[maxNextTicksPerRun:]...)
+		rt.mu.Unlock()
+	}
+	return true
+}
+
+// ScheduleMacrotask queues a setImmediate-style callback.
+func (rt *DefaultAsyncRuntime) ScheduleMacrotask(callback func()) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.macrotasks = append(rt.macrotasks, callback)
+	rt.signalWaitersLocked()
+}
+
+// RunMacrotasks snapshots and runs the current macrotask queue.
+func (rt *DefaultAsyncRuntime) RunMacrotasks() bool {
+	rt.mu.Lock()
+	callbacks := rt.macrotasks
+	rt.macrotasks = make([]func(), 0, 16)
+	rt.mu.Unlock()
+
+	if len(callbacks) == 0 {
+		return false
+	}
+	for _, cb := range callbacks {
+		cb()
+	}
+	return true
+}
+
+// ScheduleTimer schedules a timer callback after delay.
+func (rt *DefaultAsyncRuntime) ScheduleTimer(delay time.Duration, callback func()) uint64 {
+	if delay < 0 {
+		delay = 0
+	}
+
+	rt.mu.Lock()
+	rt.nextTimerID++
+	id := rt.nextTimerID
+	deadline := time.Now().Add(delay)
+	rt.timers[id] = &timerEntry{
+		id:       id,
+		deadline: deadline,
+		callback: callback,
+	}
+	rt.signalWaitersLocked()
+	rt.mu.Unlock()
+
+	go rt.timerExpiryGoroutine(id, delay)
+	return id
+}
+
+func (rt *DefaultAsyncRuntime) timerExpiryGoroutine(id uint64, delay time.Duration) {
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	entry, ok := rt.timers[id]
+	if !ok {
+		return
+	}
+	delete(rt.timers, id)
+	rt.dueTimers = append(rt.dueTimers, entry)
+	rt.signalWaitersLocked()
+}
+
+// CancelTimer cancels a scheduled timer before it fires, including timers
+// that have already expired but not yet been drained.
+func (rt *DefaultAsyncRuntime) CancelTimer(id uint64) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	delete(rt.timers, id)
+	if len(rt.dueTimers) > 0 {
+		kept := rt.dueTimers[:0]
+		for _, e := range rt.dueTimers {
+			if e.id != id {
+				kept = append(kept, e)
+			}
+		}
+		rt.dueTimers = kept
+	}
+	rt.signalWaitersLocked()
+}
+
+// RunDueTimers runs callbacks for timers that have expired.
+func (rt *DefaultAsyncRuntime) RunDueTimers() bool {
+	rt.mu.Lock()
+	entries := rt.dueTimers
+	rt.dueTimers = make([]*timerEntry, 0, 8)
+	rt.mu.Unlock()
+
+	if len(entries) == 0 {
+		return false
+	}
+	for _, e := range entries {
+		if e != nil && e.callback != nil {
+			e.callback()
+		}
+	}
+	return true
+}
+
+// HasPendingTimers returns true if timers are scheduled or due but not yet run.
+func (rt *DefaultAsyncRuntime) HasPendingTimers() bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return len(rt.timers) > 0 || len(rt.dueTimers) > 0
+}
+
+// HasPendingWork returns true if any async work remains.
+func (rt *DefaultAsyncRuntime) HasPendingWork() bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.hasPendingWorkLocked()
+}
+
+func (rt *DefaultAsyncRuntime) hasPendingWorkLocked() bool {
+	return len(rt.nextTicks) > 0 ||
+		len(rt.microtasks) > 0 ||
+		len(rt.macrotasks) > 0 ||
+		len(rt.timers) > 0 ||
+		len(rt.dueTimers) > 0 ||
+		rt.pendingExternal > 0
+}
+
+func (rt *DefaultAsyncRuntime) hasRunnableWorkLocked() bool {
+	return len(rt.nextTicks) > 0 ||
+		len(rt.microtasks) > 0 ||
+		len(rt.macrotasks) > 0 ||
+		len(rt.dueTimers) > 0
+}
+
+// nextDueLocked returns the earliest active timer deadline and whether one exists.
+// delay <= 0 means due immediately.
+func (rt *DefaultAsyncRuntime) nextDueLocked() (time.Time, bool) {
+	var earliest time.Time
+	found := false
+	for _, entry := range rt.timers {
+		if !found || entry.deadline.Before(earliest) {
+			earliest = entry.deadline
+			found = true
+		}
+	}
+	return earliest, found
+}
+
+func (rt *DefaultAsyncRuntime) promoteDueTimersLocked() bool {
+	if len(rt.dueTimers) > 0 {
+		return true
+	}
+
+	now := time.Now()
+	promoted := false
+	for id, entry := range rt.timers {
+		if !entry.deadline.After(now) {
+			delete(rt.timers, id)
+			rt.dueTimers = append(rt.dueTimers, entry)
+			promoted = true
+		}
+	}
+	return promoted
+}
+
+// WaitForIdleProgress blocks until progress can be made.
+func (rt *DefaultAsyncRuntime) WaitForIdleProgress() {
+	rt.mu.Lock()
+	if rt.hasRunnableWorkLocked() || !rt.hasPendingWorkLocked() {
+		rt.mu.Unlock()
+		return
+	}
+
+	if rt.promoteDueTimersLocked() {
+		rt.mu.Unlock()
+		return
+	}
+
+	deadline, hasTimer := rt.nextDueLocked()
+	if !hasTimer {
+		rt.idleCond.Wait()
+		rt.mu.Unlock()
+		return
+	}
+
+	wait := time.Until(deadline)
+	if wait <= 0 {
+		rt.promoteDueTimersLocked()
+		rt.mu.Unlock()
+		return
+	}
+
+	wake := make(chan struct{}, 1)
+	rt.wakeWaiters = append(rt.wakeWaiters, wake)
+	rt.mu.Unlock()
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		rt.mu.Lock()
+		rt.promoteDueTimersLocked()
+		rt.mu.Unlock()
+	case <-wake:
+	}
+}
+
+func (rt *DefaultAsyncRuntime) signalWaitersLocked() {
+	rt.idleCond.Broadcast()
+	for _, ch := range rt.wakeWaiters {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	rt.wakeWaiters = rt.wakeWaiters[:0]
 }

--- a/pkg/runtime/async_test.go
+++ b/pkg/runtime/async_test.go
@@ -1,0 +1,147 @@
+package runtime
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func drainUntilIdle(rt AsyncRuntime) {
+	iterations := 0
+	for {
+		if rt.RunNextTicks() {
+			iterations++
+			continue
+		}
+		if rt.RunUntilIdle() {
+			iterations++
+			continue
+		}
+		if rt.RunDueTimers() {
+			iterations++
+			continue
+		}
+		if rt.RunMacrotasks() {
+			iterations++
+			continue
+		}
+		if rt.HasPendingExternalOps() {
+			rt.WaitForExternalOp()
+			iterations++
+			continue
+		}
+		if rt.HasPendingTimers() {
+			rt.WaitForIdleProgress()
+			iterations++
+			continue
+		}
+		if !rt.HasPendingWork() {
+			return
+		}
+		iterations++
+		if iterations > 1_000_000 {
+			return
+		}
+	}
+}
+
+func TestNextTickBeforeMicrotasks(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var order []string
+
+	rt.ScheduleMicrotask(func() {
+		order = append(order, "micro")
+	})
+	rt.ScheduleNextTick(func() {
+		order = append(order, "nextTick")
+	})
+
+	drainUntilIdle(rt)
+
+	if len(order) != 2 || order[0] != "nextTick" || order[1] != "micro" {
+		t.Fatalf("expected [nextTick micro], got %v", order)
+	}
+}
+
+func TestMicrotasksBeforeTimerZero(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var order []string
+
+	rt.ScheduleTimer(0, func() {
+		order = append(order, "timer")
+	})
+	rt.ScheduleMicrotask(func() {
+		order = append(order, "micro")
+	})
+
+	drainUntilIdle(rt)
+
+	if len(order) != 2 || order[0] != "micro" || order[1] != "timer" {
+		t.Fatalf("expected [micro timer], got %v", order)
+	}
+}
+
+func TestScheduleTimerWaitsForDelay(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var ran atomic.Bool
+
+	rt.ScheduleTimer(30*time.Millisecond, func() {
+		ran.Store(true)
+	})
+
+	start := time.Now()
+	drainUntilIdle(rt)
+	elapsed := time.Since(start)
+
+	if !ran.Load() {
+		t.Fatal("timer callback did not run")
+	}
+	if elapsed < 25*time.Millisecond {
+		t.Fatalf("expected to wait ~30ms, only waited %v", elapsed)
+	}
+}
+
+func TestCancelTimerPreventsCallback(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var ran atomic.Bool
+
+	id := rt.ScheduleTimer(10*time.Millisecond, func() {
+		ran.Store(true)
+	})
+	rt.CancelTimer(id)
+
+	drainUntilIdle(rt)
+
+	if ran.Load() {
+		t.Fatal("cancelled timer callback should not run")
+	}
+}
+
+func TestResetClearsPendingTimer(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var ran atomic.Bool
+
+	rt.ScheduleTimer(50*time.Millisecond, func() {
+		ran.Store(true)
+	})
+	rt.Reset()
+
+	done := make(chan struct{})
+	go func() {
+		rt.WaitForIdleProgress()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("WaitForIdleProgress blocked after Reset with no pending work")
+	}
+
+	if ran.Load() {
+		t.Fatal("reset timer callback should not run")
+	}
+	if rt.HasPendingTimers() {
+		t.Fatal("expected no pending timers after Reset")
+	}
+}

--- a/pkg/vm/async_runtime.go
+++ b/pkg/vm/async_runtime.go
@@ -26,3 +26,45 @@ func (vm *VM) DrainMicrotasks() {
 		}
 	}
 }
+
+// DrainUntilIdle runs the full host event-loop drain: nextTicks, microtasks,
+// due timers, macrotasks, then waits for external ops or future timers.
+func (vm *VM) DrainUntilIdle() {
+	rt := vm.GetAsyncRuntime()
+	iterations := 0
+	for {
+		if rt.RunNextTicks() {
+			iterations++
+			continue
+		}
+		if rt.RunUntilIdle() {
+			iterations++
+			continue
+		}
+		if rt.RunDueTimers() {
+			iterations++
+			continue
+		}
+		if rt.RunMacrotasks() {
+			iterations++
+			continue
+		}
+		if rt.HasPendingExternalOps() {
+			rt.WaitForExternalOp()
+			iterations++
+			continue
+		}
+		if rt.HasPendingTimers() {
+			rt.WaitForIdleProgress()
+			iterations++
+			continue
+		}
+		if !rt.HasPendingWork() {
+			return
+		}
+		iterations++
+		if iterations > 1_000_000 {
+			return
+		}
+	}
+}

--- a/pkg/vm/import_meta.go
+++ b/pkg/vm/import_meta.go
@@ -1,0 +1,65 @@
+package vm
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+var opaqueModuleNames = map[string]struct{}{
+	"__code_module__": {},
+	"__temp_module__": {},
+	"<script>":        {},
+	"<eval>":          {},
+}
+
+// ImportMetaURL is the string stored on import.meta.url for modulePath.
+func ImportMetaURL(modulePath string) string {
+	return ImportMetaURLWithBase(modulePath, "")
+}
+
+// ImportMetaURLWithBase is ImportMetaURL, resolving relative filesystem paths
+// against baseDir (the module resolver's root) instead of the process cwd.
+func ImportMetaURLWithBase(modulePath, baseDir string) string {
+	if modulePath == "" {
+		return ""
+	}
+	if strings.Contains(modulePath, "://") {
+		return modulePath
+	}
+	if _, opaque := opaqueModuleNames[modulePath]; opaque {
+		return modulePath
+	}
+	if !isFilesystemPath(modulePath) {
+		return modulePath
+	}
+
+	fsPath := modulePath
+	if !filepath.IsAbs(fsPath) && baseDir != "" {
+		fsPath = filepath.Join(baseDir, fsPath)
+	}
+	absPath, err := filepath.Abs(fsPath)
+	if err != nil {
+		absPath = fsPath
+	}
+	return pathToFileURL(absPath)
+}
+
+func isFilesystemPath(modulePath string) bool {
+	if filepath.IsAbs(modulePath) {
+		return true
+	}
+	if strings.ContainsAny(modulePath, `/\`) {
+		return true
+	}
+	return filepath.Ext(modulePath) != ""
+}
+
+func pathToFileURL(absPath string) string {
+	slashPath := filepath.ToSlash(absPath)
+	if !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
+	u := url.URL{Scheme: "file", Path: slashPath}
+	return u.String()
+}

--- a/pkg/vm/import_meta_test.go
+++ b/pkg/vm/import_meta_test.go
@@ -1,0 +1,112 @@
+package vm
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestImportMetaURL(t *testing.T) {
+	t.Parallel()
+
+	absFoo, err := filepath.Abs("foo.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	absRelFoo, err := filepath.Abs("./foo.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		skip  string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "unix absolute",
+			input: "/tmp/mod.ts",
+			want:  "file:///tmp/mod.ts",
+			skip:  "windows",
+		},
+		{
+			name:  "space encoding",
+			input: "/tmp/my mod.ts",
+			want:  "file:///tmp/my%20mod.ts",
+			skip:  "windows",
+		},
+		{
+			name:  "native scheme unchanged",
+			input: "native://fs",
+			want:  "native://fs",
+		},
+		{
+			name:  "file scheme unchanged",
+			input: "file:///already",
+			want:  "file:///already",
+		},
+		{
+			name:  "opaque code module",
+			input: "__code_module__",
+			want:  "__code_module__",
+		},
+		{
+			name:  "relative foo.ts",
+			input: "foo.ts",
+			want:  pathToFileURL(absFoo),
+		},
+		{
+			name:  "relative ./foo.ts",
+			input: "./foo.ts",
+			want:  pathToFileURL(absRelFoo),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.skip == "windows" && runtime.GOOS == "windows" {
+				t.Skip("unix-specific path")
+			}
+			if got := ImportMetaURL(tt.input); got != tt.want {
+				t.Errorf("ImportMetaURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImportMetaURLWithBase(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	got := ImportMetaURLWithBase("entry.ts", base)
+	abs, err := filepath.Abs(filepath.Join(base, "entry.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := pathToFileURL(abs)
+	if got != want {
+		t.Errorf("ImportMetaURLWithBase(entry.ts, base) = %q, want %q", got, want)
+	}
+
+	absX := "/abs/x.ts"
+	if runtime.GOOS == "windows" {
+		absX = `C:\abs\x.ts`
+	}
+	got = ImportMetaURLWithBase(absX, base)
+	wantAbs := pathToFileURL(absX)
+	if runtime.GOOS != "windows" {
+		if a, err := filepath.Abs(absX); err == nil {
+			wantAbs = pathToFileURL(a)
+		}
+	}
+	if got != wantAbs {
+		t.Errorf("absolute path must ignore baseDir, got %q want %q", got, wantAbs)
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -367,6 +367,7 @@ type VM struct {
 	moduleContexts    map[string]*ModuleContext // Cached module contexts by path
 	moduleLoader      ModuleLoader              // Reference to module loader for loading modules
 	currentModulePath string                    // Currently executing module path (for module-scoped globals)
+	importMetaBaseDir string                    // FS resolver base dir; relative module paths Abs against this
 
 	// Async runtime (Phase 6 - Async/Await)
 	asyncRuntime runtime.AsyncRuntime
@@ -948,6 +949,12 @@ func (vm *VM) IsOriginalEval(v Value) bool {
 // SetCurrentModulePath sets the current module path for module-specific features like import.meta
 func (vm *VM) SetCurrentModulePath(modulePath string) {
 	vm.currentModulePath = modulePath
+}
+
+// SetImportMetaBaseDir sets the directory used to absolutize relative filesystem
+// module paths when building import.meta.url (DirFS resolved paths are not OS-absolute).
+func (vm *VM) SetImportMetaBaseDir(baseDir string) {
+	vm.importMetaBaseDir = baseDir
 }
 
 // GetGlobal retrieves a global variable by name
@@ -12415,10 +12422,9 @@ startExecution:
 			importMetaValue := NewDictObject(vm.ObjectPrototype)
 			importMetaObj := importMetaValue.AsDictObject()
 
-			// Set import.meta.url property to the current module path
-			// In a real environment this would be a file:// URL, but we use the module path
-			if vm.currentModulePath != "" {
-				importMetaObj.SetOwn("url", NewString(vm.currentModulePath))
+			// Set import.meta.url to a file:// URL for filesystem modules (native:// unchanged).
+			if url := ImportMetaURLWithBase(vm.currentModulePath, vm.importMetaBaseDir); url != "" {
+				importMetaObj.SetOwn("url", NewString(url))
 			} else {
 				// If not in a module context, use undefined (though this shouldn't happen)
 				importMetaObj.SetOwn("url", Undefined)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14319,15 +14319,23 @@ startExecution:
 				if awaitedPromise.State == PromisePending {
 					rt := vm.GetAsyncRuntime()
 					for awaitedPromise.State == PromisePending {
-						if !rt.RunUntilIdle() {
-							// No microtasks to run - check for pending external operations
-							hasPending := rt.HasPendingExternalOps()
-							if hasPending {
-								// Wait for an external operation to complete
-								// This will block until EndExternalOp is called
-								rt.WaitForExternalOp()
-								continue
-							}
+						progress := false
+						if rt.RunNextTicks() {
+							progress = true
+						} else if rt.RunUntilIdle() {
+							progress = true
+						} else if rt.RunDueTimers() {
+							progress = true
+						} else if rt.RunMacrotasks() {
+							progress = true
+						} else if rt.HasPendingExternalOps() {
+							rt.WaitForExternalOp()
+							progress = true
+						} else if rt.HasPendingTimers() {
+							rt.WaitForIdleProgress()
+							progress = true
+						}
+						if !progress {
 							frame.ip = ip
 							status := vm.runtimeError("Top-level await: promise remains pending with no microtasks to process")
 							return status, Undefined


### PR DESCRIPTION
## Summary
- Public embed API so a sister host can live outside this repo: `AddResolver`, `GetModuleLoader`, `DeclareModuleAlias`, and `ModuleBuilder.Default` (including `Default(nil)` as the named-export namespace).
- Event-loop seams for a Node-shaped host: nextTick / timer / macrotask hooks on `AsyncRuntime`, `DrainUntilIdle` after `RunCode`, opt-in `NewHostTimerInitializer` (not in standard builtins), plus `RunScript` for CJS wrapping.
- Host-facing runtime details: `file://` `import.meta.url`, `AsyncFunction` returning a Promise, and synthetic native-module source generated from real `GetExports()` instead of `PI_SQUARED` placeholders.

This is the Paserati-side work from #77. Node stdlib (`fs`, `http`, `Buffer`, `require`, `node_modules`, N-API) stays out of this repo; a skeleton host is in [noderati](https://github.com/nooga/noderati).

Closes #77

## Test plan
- [x] `go test ./pkg/driver ./pkg/runtime ./pkg/vm ./pkg/modules -count=1`
- [x] `go test ./tests -run TestScripts`
- [ ] CI green on this PR
- [x] Embed contract: alias `"node:fs"` → `"fs"` shares one `ModuleRecord`; default import + named import both work (`pkg/driver/host_embed_test.go`)
- [x] Idle drain: `nextTick` before microtasks; `setTimeout(0)` after Promise; `clearTimeout` after drain (`pkg/driver/host_idle_test.go`, `pkg/runtime/async_test.go`)


Made with [Cursor](https://cursor.com)