### PR TITLE
builtins: fix Array.prototype mutator correctness gaps (Test262 built-ins +378)

### DIFF
--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -160,22 +160,81 @@ func getOwnPlainObjectProperty(vmInstance *vm.VM, po *vm.PlainObject, receiver v
 	return vm.Undefined, false, nil
 }
 
+// arrayIndexGetFromProto walks arr's prototype chain looking for key (a
+// canonical array index or any other property name) - the
+// OrdinaryHasProperty (9.1.7) + [[Get]] (9.1.8) fallback used once an
+// index's own slot has come up empty (a hole, or never set). Returns
+// (value, found, error); found mirrors HasProperty so callers can
+// distinguish "inherited value is undefined" from "no such property
+// anywhere". receiver is passed as `this` to an inherited getter, per
+// [[Get]]'s Receiver parameter.
+//
+// This does its own chain walk with vmInstance.Call rather than delegating
+// to vmInstance.GetProperty: GetProperty's own TypeArray fast path (see
+// opGetProp) returns arr.Get(idx) - Undefined for a hole - as soon as
+// idx < arr.Length(), without ever reaching its own prototype-walk code
+// below that check. Duplicating the walk here is what actually reaches the
+// prototype for an in-bounds hole.
+func arrayIndexGetFromProto(vmInstance *vm.VM, arr *vm.ArrayObject, receiver vm.Value, key string) (vm.Value, bool, error) {
+	proto := arr.GetPrototype()
+	if !proto.IsObject() {
+		proto = vmInstance.ArrayPrototype
+	}
+	for proto.IsObject() {
+		po := proto.AsPlainObject()
+		if g, _, _, _, ok := po.GetOwnAccessor(key); ok {
+			if g.Type() == vm.TypeUndefined {
+				return vm.Undefined, true, nil
+			}
+			v, err := vmInstance.Call(g, receiver, nil)
+			if err != nil {
+				return vm.Undefined, false, err
+			}
+			return v, true, nil
+		}
+		if v, ok := po.GetOwn(key); ok {
+			return v, true, nil
+		}
+		proto = po.GetPrototype()
+	}
+	return vm.Undefined, false, nil
+}
+
 // arrayLikeGet returns (value, exists, error) for index i of an array-like
 // `this`. "exists" mirrors HasProperty so callers can skip holes in a sparse
 // Array or a PlainObject missing that key, matching spec semantics for
-// every/filter/forEach/etc. Real Arrays preserve the exact hole-checking the
-// previous fast path did; PlainObjects go through getOwnPlainObjectProperty
-// for correct accessor handling (see its comment); every other type
-// (TypedArray, Arguments, Proxy, boxed primitives, Map/Set/...) has no holes
-// to speak of, so a plain Get is both correct and simpler.
+// every/filter/forEach/etc. Real Arrays check for an own accessor at that
+// index first (set via Object.defineProperty - see ArrayDefineOwnProperty)
+// before falling back to the exact hole-checking the previous fast path
+// did; PlainObjects go through getOwnPlainObjectProperty for correct
+// accessor handling (see its comment); every other type (TypedArray,
+// Arguments, Proxy, boxed primitives, Map/Set/...) has no holes to speak
+// of, so a plain Get is both correct and simpler.
 func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, error) {
 	switch thisVal.Type() {
 	case vm.TypeArray:
 		arr := thisVal.AsArray()
-		if !arr.HasIndex(i) {
-			return vm.Undefined, false, nil
+		if arr.HasAccessors() {
+			if g, _, _, _, ok := arr.GetOwnAccessor(strconv.Itoa(i)); ok {
+				if g.Type() == vm.TypeUndefined {
+					return vm.Undefined, true, nil
+				}
+				v, err := vmInstance.Call(g, thisVal, nil)
+				if err != nil {
+					return vm.Undefined, false, err
+				}
+				return v, true, nil
+			}
 		}
-		return arr.Get(i), true, nil
+		if arr.HasIndex(i) {
+			return arr.Get(i), true, nil
+		}
+		// Own slot is a hole (or absent, or was `delete`d): [[HasProperty]]
+		// (7.3.11 -> OrdinaryHasProperty 9.1.7) doesn't stop at "no own
+		// property" - it walks the prototype chain. Array.prototype[i] is
+		// rarely set, so only pay for the walk once the fast own-value path
+		// above has already missed.
+		return arrayIndexGetFromProto(vmInstance, arr, thisVal, strconv.Itoa(i))
 	case vm.TypeObject:
 		return getOwnPlainObjectProperty(vmInstance, thisVal.AsPlainObject(), thisVal, strconv.Itoa(i))
 	default:
@@ -190,15 +249,26 @@ func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, e
 
 // arrayLikeSet writes index i of an array-like `this` to val - used by the
 // mutating generic methods (push, splice, copyWithin, fill, reverse, sort,
-// ...). Real Arrays write directly; PlainObjects invoke an own accessor
-// setter if present (mirroring arrayLikeGet's getter handling) before
+// ...). Real Arrays invoke an own accessor setter if present (mirroring the
+// PlainObject case just below) before falling back to a plain element
+// write; PlainObjects invoke an own accessor setter if present before
 // falling back to a plain data-property write; anything else goes through
 // the VM's generic property set (correct for TypedArray element coercion,
 // Proxy set traps, setters, etc.).
 func arrayLikeSet(vmInstance *vm.VM, thisVal vm.Value, i int, val vm.Value) error {
 	switch thisVal.Type() {
 	case vm.TypeArray:
-		thisVal.AsArray().Set(i, val)
+		arr := thisVal.AsArray()
+		if arr.HasAccessors() {
+			if _, s, _, _, ok := arr.GetOwnAccessor(strconv.Itoa(i)); ok {
+				if s.Type() == vm.TypeUndefined {
+					return nil // accessor with no setter: silently ignored (sloppy-mode semantics)
+				}
+				_, err := vmInstance.Call(s, thisVal, []vm.Value{val})
+				return err
+			}
+		}
+		arr.Set(i, val)
 		return nil
 	case vm.TypeObject:
 		po := thisVal.AsPlainObject()

--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -73,6 +73,29 @@ func toLengthInt(v vm.Value) int {
 	return int(n)
 }
 
+// toLengthWithVM converts v via the real ECMAScript ToLength algorithm:
+// ToNumber(v) - invoking a user-defined valueOf/toString through the VM when
+// v is an object, per OrdinaryToPrimitive - clamped to [0, 2^53-1] the same
+// way toLengthInt clamps a value already known to be a number. Any exception
+// thrown during that conversion (a throwing valueOf/toString, or a Symbol)
+// is propagated as ErrVMUnwinding/TypeError instead of silently coercing to
+// NaN, mirroring toIntegerOrInfinityWithVM's handling for ToInteger.
+func toLengthWithVM(vmInstance *vm.VM, v vm.Value) (int, error) {
+	if v.Type() == vm.TypeSymbol {
+		return 0, vmInstance.NewTypeError("Cannot convert a Symbol value to a number")
+	}
+	if !v.IsObject() && !v.IsCallable() {
+		return toLengthInt(v), nil
+	}
+	vmInstance.EnterHelperCall()
+	n := vmInstance.ToNumber(v)
+	vmInstance.ExitHelperCall()
+	if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
+		return 0, ErrVMUnwinding
+	}
+	return toLengthInt(vm.NumberValue(n)), nil
+}
+
 // arrayLikeLength returns LengthOfArrayLike(thisVal) (ECMA-262 7.3.20): the
 // real Length() for an Array, otherwise ToLength(Get(thisVal, "length")).
 // The PlainObject case goes through getOwnPlainObjectProperty so a "length"
@@ -80,7 +103,10 @@ func toLengthInt(v vm.Value) int {
 // as absent (see that helper's comment - this matters for real Test262
 // cases, not just theoretical ones). Everything else goes through the VM's
 // generic property get, which correctly handles TypedArray/Arguments/Proxy/
-// getters/etc.
+// getters/etc. Both branches finish through toLengthWithVM so a "length"
+// whose value is itself an object (e.g. `{toString(){return '2'}}`) gets
+// ToNumber's real valueOf/toString dispatch rather than silently reading as
+// NaN/0 - see toLengthWithVM's comment.
 func arrayLikeLength(vmInstance *vm.VM, thisVal vm.Value) (int, error) {
 	switch thisVal.Type() {
 	case vm.TypeArray:
@@ -93,13 +119,13 @@ func arrayLikeLength(vmInstance *vm.VM, thisVal vm.Value) (int, error) {
 		if !exists {
 			return 0, nil
 		}
-		return toLengthInt(lv), nil
+		return toLengthWithVM(vmInstance, lv)
 	default:
 		lv, err := vmInstance.GetProperty(thisVal, "length")
 		if err != nil {
 			return 0, err
 		}
-		return toLengthInt(lv), nil
+		return toLengthWithVM(vmInstance, lv)
 	}
 }
 

--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -47,6 +47,14 @@ const maxSafeInteger = 9007199254740991
 // that off immediately rather than requiring a fast per-iteration no-op.
 const maxArrayLength = 4294967295
 
+// maxDenseArraySetIndex bounds how far arrayLikeSet will grow a real
+// Array's elements slice via ArrayObject.Set for a single index write -
+// same value and same hazard as maxDenseArrayDefineIndex in package vm's
+// array_props.go (kept as a separate constant here rather than exported
+// from there, since the two guard unrelated call sites that happen to
+// share a threshold, not one shared piece of logic).
+const maxDenseArraySetIndex = 16777216 // 2^24
+
 // checkArrayCreateLength returns a RangeError if length exceeds the largest
 // valid Array length, matching ArrayCreate's own bounds check. Call this
 // immediately after computing a result array's target length and before any
@@ -311,7 +319,16 @@ func arrayLikeGetProxy(vmInstance *vm.VM, proxyVal vm.Value, i int) (vm.Value, b
 // arrayLikeSet writes index i of an array-like `this` to val - used by the
 // mutating generic methods (push, splice, copyWithin, fill, reverse, sort,
 // ...). Real Arrays invoke an own accessor setter if present (mirroring the
-// PlainObject case just below) before falling back to a plain element
+// PlainObject case just below); if there's no own property at that index at
+// all (a hole, or beyond the array's current length - i.e. this would
+// create a *new* own property), an inherited Array.prototype setter takes
+// priority over a plain write too, per [[Set]]'s "no own descriptor -> ask
+// the prototype" rule (see ArrayPrototypeSetterFor - this is what a push()
+// past the end of the array, or into a hole, needs to invoke a setter
+// defined on Array.prototype at that index, e.g. Test262's
+// push/set-length-array-is-frozen.js, which freezes the array from inside
+// such a setter and expects the *subsequent* length write to then fail).
+// Only once neither check applies does this fall back to a plain element
 // write; PlainObjects invoke an own accessor setter if present before
 // falling back to a plain data-property write; anything else goes through
 // the VM's generic property set (correct for TypedArray element coercion,
@@ -329,7 +346,32 @@ func arrayLikeSet(vmInstance *vm.VM, thisVal vm.Value, i int, val vm.Value) erro
 				return err
 			}
 		}
-		arr.Set(i, val)
+		if !arr.HasIndex(i) {
+			if handled, err := vmInstance.ArrayPrototypeSetterFor(thisVal, i, val); err != nil {
+				return err
+			} else if handled {
+				return nil
+			}
+		}
+		// ArrayObject.Set(i, ...) is O(i): it fills every slot up to i with
+		// Hole before writing, same hazard maxDenseArrayDefineIndex guards
+		// against in ArrayDefineOwnProperty (package vm). i can reach here
+		// as an array-index-sized value - not just a small loop counter -
+		// whenever the caller's own bound came from arrayLikeLength on a
+		// receiver whose "length" was set arbitrarily high without ever
+		// materializing that many elements (Array(N) for large N, or
+		// {length: N} array-likes); push/pop/shift/unshift all compute
+		// their write indices exactly that way. Past the bound, track it
+		// as a named property instead - same known-gap tradeoff
+		// ArrayDefineOwnProperty documents for the same case.
+		if i <= maxDenseArraySetIndex {
+			arr.Set(i, val)
+		} else {
+			arr.DefineOwnProperty(strconv.Itoa(i), val, true, true, true)
+			if i+1 > arr.Length() {
+				arr.SetLength(i + 1)
+			}
+		}
 		return nil
 	case vm.TypeObject:
 		po := thisVal.AsPlainObject()
@@ -346,22 +388,41 @@ func arrayLikeSet(vmInstance *vm.VM, thisVal vm.Value, i int, val vm.Value) erro
 }
 
 // arrayLikeSetLength writes a new "length" onto an array-like `this` -
-// needed by push/splice/etc. when the receiver isn't a real Array (whose
-// length is derived, not stored).
+// needed by push/pop/shift/unshift/splice/etc.'s final
+// Set(O, "length", newLen, true) step. Throw=true means this must reject a
+// non-writable "length" with a TypeError (ECMA-262 OrdinarySetWithOwnDescriptor:
+// "IsDataDescriptor(ownDesc) is true and ownDesc.[[Writable]] is false ->
+// return false", which Set's Throw=true then turns into a TypeError) - and
+// critically, that check fires even when newLen equals the current length
+// (no actual change), which is why every branch below checks writability
+// unconditionally rather than only on an actual length delta.
 func arrayLikeSetLength(vmInstance *vm.VM, thisVal vm.Value, length int) error {
 	switch thisVal.Type() {
 	case vm.TypeArray:
+		arr := thisVal.AsArray()
+		if !arr.IsLengthWritable() {
+			return vmInstance.NewTypeError("Cannot assign to read only property 'length' of object")
+		}
 		// A real Array's length is spec-capped at 2^32-1 (ArraySetLength);
 		// an arbitrary object's "length" property has no such limit, so
 		// this check only applies to the TypeArray branch.
 		if err := checkArrayCreateLength(vmInstance, length); err != nil {
 			return err
 		}
-		thisVal.AsArray().SetLength(length)
+		arr.SetLength(length)
 		return nil
 	case vm.TypeObject:
-		thisVal.AsPlainObject().SetOwn("length", vm.NumberValue(float64(length)))
+		po := thisVal.AsPlainObject()
+		if _, writable, _, _, exists := po.GetOwnDescriptor("length"); exists && !writable {
+			return vmInstance.NewTypeError("Cannot assign to read only property 'length' of object")
+		}
+		po.SetOwn("length", vm.NumberValue(float64(length)))
 		return nil
+	case vm.TypeString:
+		// A String exotic object's "length" is always non-configurable and
+		// non-writable (ECMA-262 10.4.3.4) - there's no descriptor to
+		// consult, it's simply never settable.
+		return vmInstance.NewTypeError("Cannot assign to read only property 'length' of object")
 	default:
 		return vmInstance.SetProperty(thisVal, "length", vm.NumberValue(float64(length)))
 	}

--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -177,10 +177,17 @@ func getOwnPlainObjectProperty(vmInstance *vm.VM, po *vm.PlainObject, receiver v
 // prototype for an in-bounds hole.
 func arrayIndexGetFromProto(vmInstance *vm.VM, arr *vm.ArrayObject, receiver vm.Value, key string) (vm.Value, bool, error) {
 	proto := arr.GetPrototype()
-	if !proto.IsObject() {
+	if proto.Type() != vm.TypeObject {
 		proto = vmInstance.ArrayPrototype
 	}
-	for proto.IsObject() {
+	// proto.IsObject() is true for TypeArray/TypeProxy/TypeMap/... too (see
+	// Value.IsObject's doc comment) - not just TypeObject/PlainObject, so
+	// this must check the concrete type before calling AsPlainObject
+	// (which panics on anything else), same as opGetProp's own prototype
+	// walk for arrays. A chain member that isn't a PlainObject (a Proxy
+	// spliced in via Object.setPrototypeOf, say) ends the walk rather than
+	// being consulted - a known gap, not a crash.
+	for proto.Type() == vm.TypeObject {
 		po := proto.AsPlainObject()
 		if g, _, _, _, ok := po.GetOwnAccessor(key); ok {
 			if g.Type() == vm.TypeUndefined {

--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -244,6 +244,16 @@ func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, e
 		return arrayIndexGetFromProto(vmInstance, arr, thisVal, strconv.Itoa(i))
 	case vm.TypeObject:
 		return getOwnPlainObjectProperty(vmInstance, thisVal.AsPlainObject(), thisVal, strconv.Itoa(i))
+	case vm.TypeProxy:
+		// Proxy needs a real HasProperty check (invoking the "has" trap
+		// when present) before Get - unlike the default branch below,
+		// which just calls Get and always reports exists=true. That
+		// conflation is harmless for types with no genuinely-absent
+		// indices, but for a Proxy it means a "has" trap that would throw
+		// (or return false) never runs at all, and DeletePropertyOrThrow-
+		// based callers like copyWithin never see "this index doesn't
+		// exist, delete the destination instead" - see arrayLikeGetProxy.
+		return arrayLikeGetProxy(vmInstance, thisVal, i)
 	default:
 		key := strconv.Itoa(i)
 		v, err := vmInstance.GetProperty(thisVal, key)
@@ -252,6 +262,50 @@ func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, e
 		}
 		return v, true, nil
 	}
+}
+
+// arrayLikeGetProxy invokes a Proxy's "has" trap when one is defined,
+// before falling through to Get - fixing the specific failure mode where a
+// "has" trap that throws (or returns false) must be seen by a
+// DeletePropertyOrThrow-based caller like copyWithin's
+// `fromPresent := HasProperty(...)` step, which arrayLikeGet's default
+// branch below can't do at all (it only ever calls Get).
+//
+// This deliberately does NOT attempt full HasProperty semantics when no
+// "has" trap is defined (i.e. it does not fall back to consulting the
+// target's own properties/prototype chain for existence) - callers that
+// discard the returned `exists` bool (the majority - see arrayLikeGet's
+// callers) need Get invoked unconditionally regardless of "existence",
+// exactly like Array.prototype.includes's own spec algorithm (Get only, no
+// HasProperty at all: its Proxy test fixture defines only a "get" trap and
+// expects it invoked for every index). Reporting exists=false without ever
+// calling Get - which a target-consulting fallback would do for an
+// absent-on-target index - broke that. So: no has trap means "assume
+// present, just Get", same as this function's non-Proxy siblings; only an
+// explicit has-trap result changes that answer.
+func arrayLikeGetProxy(vmInstance *vm.VM, proxyVal vm.Value, i int) (vm.Value, bool, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return vm.Undefined, false, vmInstance.NewTypeError("Cannot perform 'has' on a proxy that has been revoked")
+	}
+	key := strconv.Itoa(i)
+	if hasTrap, ok := proxy.Handler().AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != vm.TypeUndefined && hasTrap.Type() != vm.TypeNull {
+		if !hasTrap.IsCallable() {
+			return vm.Undefined, false, vmInstance.NewTypeError("'has' on proxy: trap is not a function")
+		}
+		result, err := vmInstance.Call(hasTrap, proxy.Handler(), []vm.Value{proxy.Target(), vm.NewString(key)})
+		if err != nil {
+			return vm.Undefined, false, err
+		}
+		if !result.IsTruthy() {
+			return vm.Undefined, false, nil
+		}
+	}
+	v, err := vmInstance.GetProperty(proxyVal, key)
+	if err != nil {
+		return vm.Undefined, false, err
+	}
+	return v, true, nil
 }
 
 // arrayLikeSet writes index i of an array-like `this` to val - used by the
@@ -375,22 +429,61 @@ func isConcatSpreadable(vmInstance *vm.VM, v vm.Value) (bool, error) {
 	return isArraySpec(vmInstance, v)
 }
 
-// arrayLikeDelete removes index i from an array-like `this`, leaving a hole
-// - used by splice/pop/shift-style methods on a non-Array receiver where
-// spec semantics call for DeletePropertyOrThrow rather than writing
-// undefined (so a subsequent HasProperty/`in` check on that index is false).
+// arrayLikeDelete implements DeletePropertyOrThrow(O, ToString(i))
+// (ECMA-262 7.3.11) for index i of an array-like `this` - used by
+// copyWithin/splice/pop/shift-style methods where spec semantics call for
+// a real delete (so a subsequent HasProperty/`in` check on that index is
+// false) that throws a TypeError if it fails, rather than the silent
+// always-succeeds write-undefined this replaced.
 func arrayLikeDelete(vmInstance *vm.VM, thisVal vm.Value, i int) error {
+	key := strconv.Itoa(i)
 	switch thisVal.Type() {
 	case vm.TypeArray:
-		// Arrays don't track holes below their length via delete in this
-		// engine's element storage; writing Undefined matches this file's
-		// pre-existing behavior for Array receivers in these code paths.
-		thisVal.AsArray().Set(i, vm.Undefined)
+		if !thisVal.AsArray().DeleteIndex(i) {
+			return vmInstance.NewTypeError("Cannot delete property '" + key + "' of array")
+		}
 		return nil
 	case vm.TypeObject:
-		thisVal.AsPlainObject().DeleteOwn(strconv.Itoa(i))
+		if !thisVal.AsPlainObject().DeleteOwn(key) {
+			return vmInstance.NewTypeError("Cannot delete property '" + key + "' of object")
+		}
 		return nil
+	case vm.TypeProxy:
+		return proxyDeleteProperty(vmInstance, thisVal, i, key)
 	default:
-		return vmInstance.SetProperty(thisVal, strconv.Itoa(i), vm.Undefined)
+		return vmInstance.SetProperty(thisVal, key, vm.Undefined)
 	}
+}
+
+// proxyDeleteProperty implements the Proxy exotic object's [[Delete]]
+// (ECMA-262 10.5.10) for one property key: invoke the deleteProperty trap
+// if present, checking the "can't report deleting a non-configurable
+// target property" invariant on a truthy result; otherwise delegate to the
+// target (recursively, so a Proxy wrapping a Proxy wrapping an Array all
+// resolves through the same DeleteIndex/DeleteOwn paths above).
+func proxyDeleteProperty(vmInstance *vm.VM, proxyVal vm.Value, i int, key string) error {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return vmInstance.NewTypeError("Cannot delete property from a revoked Proxy")
+	}
+	deleteTrap, ok := proxy.Handler().AsPlainObject().GetOwn("deleteProperty")
+	if !ok || deleteTrap.Type() == vm.TypeUndefined || deleteTrap.Type() == vm.TypeNull {
+		return arrayLikeDelete(vmInstance, proxy.Target(), i)
+	}
+	if !deleteTrap.IsCallable() {
+		return vmInstance.NewTypeError("'deleteProperty' on proxy: trap is not a function")
+	}
+	result, err := vmInstance.Call(deleteTrap, proxy.Handler(), []vm.Value{proxy.Target(), vm.NewString(key)})
+	if err != nil {
+		return err
+	}
+	if !result.IsTruthy() {
+		return vmInstance.NewTypeError("'deleteProperty' on proxy: trap returned falsish for property '" + key + "'")
+	}
+	if target := proxy.Target(); target.Type() == vm.TypeObject {
+		if _, _, _, configurable, found := target.AsPlainObject().GetOwnDescriptor(key); found && !configurable {
+			return vmInstance.NewTypeError("'deleteProperty' on proxy: trap returned truish for property '" + key + "' which is non-configurable in the proxy target")
+		}
+	}
+	return nil
 }

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -246,13 +246,18 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		if thisVal.Type() == vm.TypeArray {
-			thisArray := thisVal.AsArray()
-			for i := 0; i < len(args); i++ {
-				thisArray.Append(args[i])
-			}
-			return vm.NumberValue(float64(thisArray.Length())), nil
-		}
+		// No TypeArray fast path (see pop's identical comment above for
+		// why): the old one appended directly, bypassing
+		// Set(..., "length", ..., true)'s required TypeError on a
+		// frozen/non-writable-length array (the no-argument case,
+		// push() with zero elements to write still performs this step).
+		// Known gap this doesn't close: writing each new index still
+		// goes through arrayLikeSet's plain arr.Set(i, val), not a full
+		// [[Set]] that would walk Array.prototype for an inherited setter
+		// - so a setter defined on Array.prototype[<next index>] that
+		// freezes the array mid-push (the same trick pop's
+		// set-length-array-is-frozen.js test uses, via a getter) isn't
+		// observed here; push's own version of that test needs that walk.
 		length, err := arrayLikeLength(vmInstance, thisVal)
 		if err != nil {
 			return vm.Undefined, err
@@ -274,16 +279,20 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		if thisVal.Type() == vm.TypeArray {
-			thisArray := thisVal.AsArray()
-			if thisArray.Length() == 0 {
-				return vm.Undefined, nil
-			}
-			lastIndex := thisArray.Length() - 1
-			lastElement := thisArray.Get(lastIndex)
-			thisArray.SetLength(lastIndex)
-			return lastElement, nil
-		}
+		// No TypeArray fast path here (unlike several sibling methods
+		// below): the generic arrayLike* helpers ARE the fast path for a
+		// real Array (arrayLikeLength/Get/Delete/SetLength each resolve to
+		// a couple of ArrayObject method calls, no extra allocation), and
+		// skipping them like the old fast path here did meant bypassing
+		// DeletePropertyOrThrow and Set(..., "length", ..., true)'s
+		// required TypeError on a frozen/non-writable-length array - a
+		// gap Test262's set-length-*-is-frozen.js /
+		// set-length-*-length-is-non-writable.js cover, including one
+		// (set-length-array-is-frozen.js) that only throws because a
+		// getter on Array.prototype[0] freezes the array *during* the Get
+		// step, before the length write - arrayLikeGet's prototype-chain
+		// fallback (for the hole this creates) is what makes that
+		// ordering observable at all.
 		length, err := arrayLikeLength(vmInstance, thisVal)
 		if err != nil {
 			return vm.Undefined, err
@@ -310,20 +319,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		if thisVal.Type() == vm.TypeArray {
-			thisArray := thisVal.AsArray()
-			if thisArray.Length() == 0 {
-				return vm.Undefined, nil
-			}
-			firstElement := thisArray.Get(0)
-			// Shift all elements left
-			newElements := make([]vm.Value, thisArray.Length()-1)
-			for i := 1; i < thisArray.Length(); i++ {
-				newElements[i-1] = thisArray.Get(i)
-			}
-			thisArray.SetElements(newElements)
-			return firstElement, nil
-		}
+		// No TypeArray fast path (see pop's identical comment just above
+		// for why): the old one rebuilt elements directly, bypassing
+		// DeletePropertyOrThrow/Set(..., "length", ..., true)'s required
+		// TypeError on a frozen/non-writable-length array.
 		length, err := arrayLikeLength(vmInstance, thisVal)
 		if err != nil {
 			return vm.Undefined, err
@@ -363,21 +362,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisVal.Type() == vm.TypeUndefined || thisVal.Type() == vm.TypeNull {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
 		}
-		if thisVal.Type() == vm.TypeArray {
-			thisArray := thisVal.AsArray()
-			// Create new array with unshifted elements
-			newElements := make([]vm.Value, 0, thisArray.Length()+len(args))
-			// Add new elements first
-			for i := 0; i < len(args); i++ {
-				newElements = append(newElements, args[i])
-			}
-			// Add existing elements
-			for i := 0; i < thisArray.Length(); i++ {
-				newElements = append(newElements, thisArray.Get(i))
-			}
-			thisArray.SetElements(newElements)
-			return vm.NumberValue(float64(thisArray.Length())), nil
-		}
+		// No TypeArray fast path (see pop's identical comment above for
+		// why): the old one rebuilt elements directly, bypassing
+		// Set(..., "length", ..., true)'s required TypeError on a
+		// frozen/non-writable-length array (the zero-argument case still
+		// performs this step).
 		length, err := arrayLikeLength(vmInstance, thisVal)
 		if err != nil {
 			return vm.Undefined, err

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3411,6 +3411,45 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		}
 	}
 
+	// Array objects: Object.defineProperty(arr, "length", desc) - ES
+	// 10.4.2.1 step 3 -> ArraySetLength (10.4.2.4). Only the "writable"
+	// attribute is implemented (see ArrayObject.IsLengthWritable/
+	// SetLengthWritable); a descriptor that also tries to change the
+	// length *value* to something other than the array's current length
+	// would need ArraySetLength's truncate-from-the-top semantics, which
+	// aren't implemented - such a call is a no-op (matching this
+	// function's pre-existing behavior for "length" before this block
+	// existed) rather than applying any requested writable attribute
+	// alongside it. get/set on "length" is always rejected: it's
+	// inherently a data property.
+	if obj.Type() == vm.TypeArray && !keyIsSymbol && propName == "length" {
+		arr := obj.AsArray()
+		if arr != nil {
+			if hasGetter || hasSetter {
+				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: length")
+			}
+			if enumerablePtr != nil && *enumerablePtr {
+				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: length")
+			}
+			if configurablePtr != nil && *configurablePtr {
+				return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: length")
+			}
+			if !hasValue || uint32(int64(value.ToFloat())) == uint32(arr.Length()) {
+				if writablePtr != nil {
+					if !arr.IsLengthWritable() && *writablePtr {
+						return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: length")
+					}
+					arr.SetLengthWritable(*writablePtr)
+				}
+			}
+			// else: a genuine value change - left untouched, same as this
+			// function's pre-existing no-op behavior for "length" before
+			// this block existed (ArraySetLength's truncation semantics
+			// aren't implemented - see this block's doc comment).
+			return obj, nil
+		}
+	}
+
 	// Array objects: implement ES 10.4.2.1 Array exotic [[DefineOwnProperty]]
 	// for everything except "length" (ArraySetLength's truncate-from-the-top
 	// semantics aren't implemented - see ArrayDefineOwnProperty's doc
@@ -3978,10 +4017,12 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 		// For arrays, check if it's a valid index or 'length'
 		if propName == "length" {
 			value = vm.NumberValue(float64(arrObj.Length()))
-			// length is non-enumerable, non-configurable; writable unless frozen
+			// length is non-enumerable, non-configurable; writable unless
+			// frozen or explicitly made non-writable (Object.defineProperty
+			// - see ArrayObject.IsLengthWritable).
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 			descriptor.SetOwn("value", value)
-			descriptor.SetOwn("writable", vm.BooleanValue(!isFrozen))
+			descriptor.SetOwn("writable", vm.BooleanValue(arrObj.IsLengthWritable()))
 			descriptor.SetOwn("enumerable", vm.BooleanValue(false))
 			descriptor.SetOwn("configurable", vm.BooleanValue(false))
 			return vm.NewValueFromPlainObject(descriptor), nil

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -190,9 +190,27 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if propName == "length" {
 				return vm.BooleanValue(true), nil
 			}
-			// Check numeric indices
-			if index, err := strconv.Atoi(propName); err == nil {
-				return vm.BooleanValue(index >= 0 && index < arrObj.Length()), nil
+			// Check numeric indices. An own accessor at this index (set via
+			// Object.defineProperty - see ArrayDefineOwnProperty) counts
+			// even for an index >= Length() (huge sparse indices are
+			// tracked in the properties map, not elements - see
+			// maxDenseArrayDefineIndex); otherwise fall back to
+			// HasIndex, which correctly reports a hole (from a literal
+			// array's elision, or a prior `delete arr[i]`) as absent
+			// rather than just checking the index is in bounds.
+			if index, err := strconv.Atoi(propName); err == nil && index >= 0 {
+				if arrObj.HasAccessors() {
+					if _, _, _, _, ok := arrObj.GetOwnAccessor(propName); ok {
+						return vm.BooleanValue(true), nil
+					}
+				}
+				if arrObj.HasIndex(index) {
+					return vm.BooleanValue(true), nil
+				}
+				// Beyond the dense elements slice: a huge sparse index (see
+				// maxDenseArrayDefineIndex) is tracked in the properties map.
+				_, hasOwn := arrObj.GetOwn(propName)
+				return vm.BooleanValue(hasOwn), nil
 			}
 			// Check custom named properties (e.g., pos, end for TypeScript node arrays)
 			_, hasOwn := arrObj.GetOwn(propName)
@@ -3393,6 +3411,21 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		}
 	}
 
+	// Array objects: implement ES 10.4.2.1 Array exotic [[DefineOwnProperty]]
+	// for everything except "length" (ArraySetLength's truncate-from-the-top
+	// semantics aren't implemented - see ArrayDefineOwnProperty's doc
+	// comment - so a "length" redefinition falls through to the no-op
+	// below, same pre-existing behavior as before this branch existed).
+	if obj.Type() == vm.TypeArray && !keyIsSymbol && propName != "length" {
+		arr := obj.AsArray()
+		if arr != nil {
+			if err := vmInstance.ArrayDefineOwnProperty(arr, propName, hasValue, value, writablePtr, enumerablePtr, configurablePtr, hasGetter, getter, hasSetter, setter); err != nil {
+				return vm.Undefined, err
+			}
+			return obj, nil
+		}
+	}
+
 	// Define the property with attributes (on plain objects only for now)
 	if obj.Type() == vm.TypeObject {
 		if obj.Type() == vm.TypeObject {
@@ -3930,6 +3963,18 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	if obj.Type() == vm.TypeArray {
 		arrObj := obj.AsArray()
 		isFrozen := arrObj.IsFrozen()
+		// An index (or named key) explicitly turned into an accessor via
+		// Object.defineProperty takes priority over the plain-element read
+		// below - see ArrayDefineOwnProperty's doc comment for why elements
+		// and accessors are tracked separately.
+		if g, s, e, c, ok := arrObj.GetOwnAccessor(propName); ok {
+			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+			descriptor.SetOwn("get", g)
+			descriptor.SetOwn("set", s)
+			descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+			descriptor.SetOwn("configurable", vm.BooleanValue(c))
+			return vm.NewValueFromPlainObject(descriptor), nil
+		}
 		// For arrays, check if it's a valid index or 'length'
 		if propName == "length" {
 			value = vm.NumberValue(float64(arrObj.Length()))

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -1,0 +1,175 @@
+package vm
+
+// maxDenseArrayDefineIndex bounds how far ArrayDefineOwnProperty will grow
+// the elements slice via ArrayObject.Set for a single index write. A valid
+// array index can be as large as 2^32-2 (ArraySetLength's bound - see
+// tryParseArrayIndex), and Set(idx, ...) is O(idx): it fills every slot up
+// to idx with Hole before writing. Without this guard, defining a property
+// at a huge index (a real Test262 boundary-condition pattern, e.g. testing
+// behavior at 4294967294) would attempt a multi-billion-entry allocation -
+// mirrors OpSetIndex's own identical guard in vm.go for `arr[hugeIdx] = v`.
+const maxDenseArrayDefineIndex = 16777216 // 2^24
+
+// ArrayDefineOwnProperty implements the Array exotic object's
+// [[DefineOwnProperty]] (ECMA-262 10.4.2.1, deferring to
+// OrdinaryDefineOwnProperty 10.1.6.3 for everything but the "length" key,
+// which callers must handle separately - see below) for one property key,
+// covering both a numeric index (an element of the array) and an arbitrary
+// named property.
+//
+// Array elements have no per-index attribute storage: the elements slice
+// holds only values (or Hole for a sparse gap), not a writable/enumerable/
+// configurable triple per slot. So a plain data element's "current"
+// descriptor is always reported as the ES default (value, true, true,
+// true) - this codebase's existing posture of not enforcing per-element
+// non-writable/non-configurable (see e.g. Object.freeze's array handling,
+// which sets a single array-wide `frozen` flag rather than per-index
+// descriptors). An index that has been explicitly turned into an accessor
+// *is* tracked precisely, through the same getters/setters/propertyDesc
+// maps a named property uses (see ArrayObject.DefineAccessorProperty).
+//
+// Mirrors ArgumentsDefineOwnProperty's structure (arguments_props.go) for a
+// different exotic object with the same shape of problem: numeric indices
+// need customized [[DefineOwnProperty]] behavior beyond a bare property
+// bag. This does not implement Array's "length" key at all (ArraySetLength,
+// 10.4.2.4, requires re-deriving/possibly truncating elements top-down,
+// rejecting invalid uint32 lengths, and stopping partway through a
+// non-configurable element) - callers must special-case "length" and skip
+// this function for it, same as ArgumentsDefineOwnProperty's callers
+// special-case "length"/"callee".
+func (vm *VM) ArrayDefineOwnProperty(
+	a *ArrayObject, key string,
+	hasValue bool, value Value,
+	writablePtr, enumerablePtr, configurablePtr *bool,
+	hasGetter bool, getter Value,
+	hasSetter bool, setter Value,
+) error {
+	becomingAccessor := hasGetter || hasSetter
+	idx, isIndex := tryParseArrayIndex(key)
+
+	// Resolve the current descriptor, in priority order: a tracked accessor
+	// (numeric or named), a plain in-bounds element, a tracked named data
+	// property. Whichever matches (or none) sets exists/isAccessor/curX.
+	var exists, isAccessor, curWritable, curEnumerable, curConfigurable bool
+	if _, _, e, c, ok := a.GetOwnAccessor(key); ok {
+		exists, isAccessor, curEnumerable, curConfigurable = true, true, e, c
+	} else if isIndex && idx < len(a.elements) && a.elements[idx].typ != TypeHole {
+		exists, curWritable, curEnumerable, curConfigurable = true, true, true, true
+	} else if _, desc, ok := a.GetOwnPropertyDescriptor(key); ok {
+		exists, curWritable, curEnumerable, curConfigurable = true, desc.Writable, desc.Enumerable, desc.Configurable
+	}
+
+	// OrdinaryDefineOwnProperty 10.1.6.3 steps 3-4: reject on a
+	// non-configurable existing property whose descriptor the caller is
+	// trying to widen or whose kind/writability it's trying to narrow.
+	if exists && !curConfigurable {
+		if configurablePtr != nil && *configurablePtr {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if enumerablePtr != nil && *enumerablePtr != curEnumerable {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if isAccessor && (hasValue || writablePtr != nil) {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if !isAccessor && becomingAccessor {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+		if !isAccessor && !becomingAccessor && !curWritable && writablePtr != nil && *writablePtr {
+			return vm.NewTypeError("Cannot redefine property: " + key)
+		}
+	} else if !exists && !a.IsExtensible() {
+		return vm.NewTypeError("Cannot define property " + key + ", object is not extensible")
+	}
+
+	enumerable := curEnumerable
+	if !exists {
+		enumerable = false
+	}
+	if enumerablePtr != nil {
+		enumerable = *enumerablePtr
+	}
+	configurable := curConfigurable
+	if !exists {
+		configurable = false
+	}
+	if configurablePtr != nil {
+		configurable = *configurablePtr
+	}
+
+	if becomingAccessor {
+		a.DefineAccessorProperty(key, getter, hasGetter, setter, hasSetter, &enumerable, &configurable)
+		if isIndex {
+			// Every read path that knows about per-index accessors
+			// (arrayLikeGet/Set in package builtins, opGetProp,
+			// OpGetIndex/OpSetIndex) checks GetOwnAccessor before ever
+			// consulting the elements slice, so nothing needs to be written
+			// there. Just grow the tracked length the way defining an
+			// array-index property past the end would (ArraySetLength) -
+			// a bare int bump, safe for any idx up to the 2^32-2 bound
+			// (unlike touching `elements`, see maxDenseArrayDefineIndex).
+			if idx+1 > a.length {
+				a.length = idx + 1
+			}
+		}
+		return nil
+	}
+
+	writable := curWritable
+	if !exists {
+		writable = false
+	}
+	if writablePtr != nil {
+		writable = *writablePtr
+	}
+	newValue := value
+	if !hasValue {
+		if isIndex {
+			newValue = a.Get(idx)
+		} else if v, ok := a.GetOwn(key); ok {
+			newValue = v
+		} else {
+			newValue = Undefined
+		}
+	}
+
+	if isIndex {
+		// Converting an accessor index back to a data property: drop the
+		// tracked accessor state so GetOwnAccessor stops shadowing it.
+		if a.getters != nil {
+			delete(a.getters, key)
+		}
+		if a.setters != nil {
+			delete(a.setters, key)
+		}
+		if a.propertyDesc != nil {
+			delete(a.propertyDesc, key)
+		}
+		if idx <= maxDenseArrayDefineIndex {
+			a.Set(idx, newValue)
+		} else {
+			// Beyond the dense-allocation bound: track it as a named
+			// property instead of materializing the elements slice up to
+			// idx (see maxDenseArrayDefineIndex). Known gap, shared with
+			// OpSetIndex's identical fallback: a direct `arr[idx]`/
+			// arrayLikeGet read for an index this large that's still below
+			// the (now-grown) `length` hits the elements-array fast path
+			// first and misses this map, rather than falling through to
+			// the named-property lookup that would find it. Rare enough in
+			// practice (an index this close to the 2^32-2 boundary) that
+			// this codebase accepts it elsewhere rather than adding a
+			// sparse-index data structure.
+			a.DefineOwnProperty(key, newValue, true, true, true)
+			if idx+1 > a.length {
+				a.length = idx + 1
+			}
+		}
+		// writable/enumerable/configurable for a plain element have nowhere
+		// to live (see doc comment) - dropped here, matching this
+		// codebase's existing non-enforcement of per-element attributes.
+		return nil
+	}
+
+	a.DefineOwnProperty(key, newValue, writable, enumerable, configurable)
+	return nil
+}

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -10,6 +10,52 @@ package vm
 // mirrors OpSetIndex's own identical guard in vm.go for `arr[hugeIdx] = v`.
 const maxDenseArrayDefineIndex = 16777216 // 2^24
 
+// ArrayPrototypeSetterFor checks whether idx has an inherited accessor
+// somewhere on Array.prototype's chain - an own-index write on an array
+// with no own property there must still consult the prototype first
+// (ECMA-262 9.1.9.2 OrdinarySetWithOwnDescriptor step 2's "ownDesc is
+// undefined -> walk to the parent" rule) rather than unconditionally
+// creating a new own data property. Returns (handled, err): handled is
+// true if a setter was invoked (delivering val that way) or a getter-only
+// accessor silently swallowed the write (matching sloppy-mode semantics,
+// since neither OpSetIndex nor arrayLikeSet's callers track strict mode);
+// false means the caller should fall through to a plain own-property
+// write.
+//
+// Guarded behind arrayIndexAccessorSeen (object.go) the same way this
+// logic always was, back when it only existed inline in OpSetIndex:
+// integer-indexed accessors on Array.prototype essentially never exist, so
+// the whole walk (a string-key format + chain scan on every element write)
+// is skipped until one is actually defined. Factored out here so
+// OpSetIndex (the `arr[i] = v` bytecode fast path) and arrayLikeSet
+// (package builtins - Array.prototype.push/unshift/... writing new
+// indices) share one implementation instead of two that could drift.
+func (vm *VM) ArrayPrototypeSetterFor(receiver Value, idx int, val Value) (bool, error) {
+	if !arrayIndexAccessorSeen.Load() || !vm.ArrayPrototype.IsObject() {
+		return false, nil
+	}
+	setterKey := "s:" + intToString(idx) // PropertyKey hash format for string keys
+	for cur := vm.ArrayPrototype.AsPlainObject(); cur != nil; {
+		if cur.setters != nil {
+			if s, ok := cur.setters[setterKey]; ok {
+				_, err := vm.Call(s, receiver, []Value{val})
+				return true, err
+			}
+		}
+		if cur.getters != nil {
+			if _, ok := cur.getters[setterKey]; ok {
+				return true, nil
+			}
+		}
+		protoVal := cur.GetPrototype()
+		if protoVal.Type() != TypeObject {
+			break
+		}
+		cur = protoVal.AsPlainObject()
+	}
+	return false, nil
+}
+
 // ArrayDefineOwnProperty implements the Array exotic object's
 // [[DefineOwnProperty]] (ECMA-262 10.4.2.1, deferring to
 // OrdinaryDefineOwnProperty 10.1.6.3 for everything but the "length" key,

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -173,3 +173,46 @@ func (vm *VM) ArrayDefineOwnProperty(
 	a.DefineOwnProperty(key, newValue, writable, enumerable, configurable)
 	return nil
 }
+
+// DeleteIndex implements [[Delete]] (ECMA-262 10.4.2.1 -> OrdinaryDelete
+// 10.1.7) for a numeric array index, clearing the slot (and any tracked
+// accessor/descriptor state for it) and reporting success. A plain element
+// has no per-index configurable bit of its own (see this file's doc
+// comment on why) - its configurability instead comes from the array-wide
+// `frozen` flag (Object.freeze - SetFrozen), treated as making every
+// element non-configurable, same as this codebase's other frozen-array
+// checks (e.g. IsFrozen). An index that was turned into an accessor (or
+// otherwise given an explicit descriptor - see ArrayDefineOwnProperty) has
+// its own tracked configurable bit in propertyDesc and is checked instead.
+//
+// Shared by OpDeleteIndex (`delete arr[i]` in JS) and arrayLikeDelete
+// (array_generic.go, package builtins - copyWithin/splice/etc.'s
+// DeletePropertyOrThrow) so both report identical success/failure.
+func (a *ArrayObject) DeleteIndex(idx int) bool {
+	key := intToString(idx)
+	configurable := !a.frozen
+	if a.propertyDesc != nil {
+		if desc, ok := a.propertyDesc[key]; ok {
+			configurable = desc.Configurable
+		}
+	}
+	if !configurable {
+		return false
+	}
+	if a.getters != nil {
+		delete(a.getters, key)
+	}
+	if a.setters != nil {
+		delete(a.setters, key)
+	}
+	if a.propertyDesc != nil {
+		delete(a.propertyDesc, key)
+	}
+	if a.properties != nil {
+		delete(a.properties, key)
+	}
+	if idx < len(a.elements) {
+		a.elements[idx] = Hole
+	}
+	return true
+}

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -1075,6 +1075,12 @@ func tryParseArrayIndex(key string) (int, bool) {
 	return idx, true
 }
 
+// ParseArrayIndex is the exported wrapper around tryParseArrayIndex, for
+// callers outside package vm (e.g. builtins' Object.defineProperty) that
+// need to tell a canonical array-index key ("0", "17", ...) apart from an
+// arbitrary named property key ("foo", "01", "-1", ...).
+func ParseArrayIndex(key string) (int, bool) { return tryParseArrayIndex(key) }
+
 // intToString converts an int to string without importing strconv
 func intToString(n int) string {
 	if n == 0 {

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -524,6 +524,30 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 	// 8. Array objects (after special properties are handled)
 	if objVal.Type() == TypeArray {
 		arr := objVal.AsArray()
+		// An index (or named key) explicitly turned into an accessor via
+		// Object.defineProperty (see ArrayDefineOwnProperty) takes priority
+		// over a plain element/named-property read below. Guarded behind
+		// HasAccessors() so the overwhelmingly common array - which never
+		// had one defined - pays only a nil check here, not a map probe.
+		if arr.HasAccessors() {
+			if g, _, _, _, ok := arr.GetOwnAccessor(propName); ok {
+				if g.Type() == TypeUndefined {
+					*dest = Undefined
+					return true, InterpretOK, *dest
+				}
+				result, err := vm.Call(g, *objVal, nil)
+				if err != nil {
+					if ee, ok := err.(ExceptionError); ok {
+						vm.throwException(ee.GetExceptionValue())
+						return false, InterpretRuntimeError, Undefined
+					}
+					status := vm.runtimeError("%v", err)
+					return false, status, Undefined
+				}
+				*dest = result
+				return true, InterpretOK, *dest
+			}
+		}
 		// Check if propName is a valid array index (numeric string like "0", "1", etc.)
 		// Per ECMAScript, arr["0"] should work the same as arr[0]
 		if len(propName) > 0 {

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2353,6 +2353,36 @@ func (a *ArrayObject) SetOwn(name string, value Value) {
 	a.properties[name] = value
 }
 
+// DeleteOwn removes a named (non-index) property, along with any tracked
+// accessor/descriptor state for it - unless propertyDesc marks it
+// non-configurable (e.g. Object.freeze/seal - see sealOrFreezeProperties,
+// or an explicit Object.defineProperty(..., {configurable: false})), in
+// which case it's left alone and this reports failure, matching
+// OrdinaryDelete's (10.1.7) [[Configurable]] check. A property with no
+// tracked descriptor at all (added via SetOwn, never through
+// DefineOwnProperty/DefineAccessorProperty) has the ES default
+// configurable: true.
+func (a *ArrayObject) DeleteOwn(name string) bool {
+	if a.propertyDesc != nil {
+		if desc, ok := a.propertyDesc[name]; ok && !desc.Configurable {
+			return false
+		}
+	}
+	if a.properties != nil {
+		delete(a.properties, name)
+	}
+	if a.propertyDesc != nil {
+		delete(a.propertyDesc, name)
+	}
+	if a.getters != nil {
+		delete(a.getters, name)
+	}
+	if a.setters != nil {
+		delete(a.setters, name)
+	}
+	return true
+}
+
 // DefineOwnProperty sets a named property with specified descriptor attributes
 func (a *ArrayObject) DefineOwnProperty(name string, value Value, writable, enumerable, configurable bool) {
 	if a.properties == nil {
@@ -2534,6 +2564,16 @@ func (a *ArrayObject) DefineAccessorProperty(name string, getter Value, hasGette
 
 	// Remove from regular properties if it was a data property
 	delete(a.properties, name)
+}
+
+// HasAccessors reports whether this array has ever had an accessor property
+// defined on it (via Object.defineProperty - see ArrayDefineOwnProperty).
+// Cheap nil-map check callers use to skip the GetOwnAccessor lookup (a
+// strconv.Itoa + map probe) on the overwhelmingly common array that has
+// never had one, on hot per-element paths like arrayLikeGet/Set and
+// OpGetIndex/OpSetIndex.
+func (a *ArrayObject) HasAccessors() bool {
+	return a.getters != nil || a.setters != nil
 }
 
 // GetOwnAccessor returns the getter and setter for an accessor property

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -195,7 +195,13 @@ type ArrayObject struct {
 	setters      map[string]Value        // Accessor setters for named properties
 	extensible   bool                    // When false, no new properties can be added (for Object.freeze/seal)
 	frozen       bool                    // When true, elements are also non-writable and non-configurable
-	execMeta     *execResultMeta         // Lazy exec result properties (nil for normal arrays)
+	// lengthNonWritable tracks Object.defineProperty(arr, "length",
+	// {writable: false}) - stored inverted (zero value = writable, the ES
+	// default) so every existing ArrayObject construction site, which
+	// zero-initializes this field, doesn't need updating. See
+	// IsLengthWritable/SetLengthWritable.
+	lengthNonWritable bool
+	execMeta          *execResultMeta // Lazy exec result properties (nil for normal arrays)
 	// Subclass prototype override: for `class S extends Array {} new S()` instances,
 	// this points at S.prototype (whose own [[Prototype]] chains through Array.prototype).
 	// Zero value (TypeUndefined) means use the realm's intrinsic ArrayPrototype.
@@ -2493,6 +2499,31 @@ func (a *ArrayObject) sealOrFreezeProperties(freeze bool) {
 // IsExtensible returns whether new properties can be added to this array
 func (a *ArrayObject) IsExtensible() bool {
 	return a.extensible
+}
+
+// IsLengthWritable reports whether "length" is currently a writable own
+// property: false once either Object.freeze (SetFrozen) or an explicit
+// Object.defineProperty(arr, "length", {writable: false}) - see
+// SetLengthWritable - has been applied. Array.prototype's length-setting
+// methods (push/pop/shift/unshift/splice/...) must check this before
+// mutating length and throw a TypeError if it's false, per Set(O, "length",
+// v, true) -> OrdinarySetWithOwnDescriptor's "IsDataDescriptor(ownDesc) is
+// true and ownDesc.[[Writable]] is false -> return false" rule - which
+// fires even when v equals the current length (no actual change).
+func (a *ArrayObject) IsLengthWritable() bool {
+	return !a.frozen && !a.lengthNonWritable
+}
+
+// SetLengthWritable implements the "writable" half of
+// Object.defineProperty(arr, "length", {writable: ...}) - see
+// IsLengthWritable's doc comment. Only the writable bit is tracked here;
+// a defineProperty call that also tries to change the length *value* is
+// handled by the caller (ArrayDefineOwnProperty's caller in
+// objectDefinePropertyWithVM), which still doesn't implement
+// ArraySetLength's truncate-from-the-top semantics for an actual value
+// change - see that function's doc comment.
+func (a *ArrayObject) SetLengthWritable(writable bool) {
+	a.lengthNonWritable = !writable
 }
 
 // SetExtensible sets whether new properties can be added to this array

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -15169,45 +15169,13 @@ startExecution:
 			} else if obj.Type() == TypeArray {
 				// [[Delete]] for the Array exotic object (ECMA-262 10.4.2.1
 				// defers to OrdinaryDelete 10.1.7 for non-"length" keys).
-				// A plain element has no per-index configurable bit of its
-				// own (see ArrayDefineOwnProperty's doc comment on why) -
-				// its configurability instead comes from the array-wide
-				// `frozen` flag (Object.freeze - SetFrozen), which is
-				// treated as making every element non-configurable, same
-				// as this codebase's other frozen-array checks (e.g.
-				// IsFrozen). An index that was turned into an accessor (or
-				// otherwise given an explicit descriptor - see
-				// ArrayDefineOwnProperty) has its own tracked configurable
-				// bit in propertyDesc and is checked directly.
+				// See ArrayObject.DeleteIndex's doc comment for why a
+				// numeric index's configurability comes from the array-wide
+				// `frozen` flag rather than a per-element bit.
 				arr := obj.AsArray()
 				keyStr := key.ToString()
 				if idx, isNumeric := tryParseArrayIndex(keyStr); isNumeric {
-					configurable := !arr.frozen
-					if arr.propertyDesc != nil {
-						if desc, ok := arr.propertyDesc[keyStr]; ok {
-							configurable = desc.Configurable
-						}
-					}
-					if !configurable {
-						success = false
-					} else {
-						if arr.getters != nil {
-							delete(arr.getters, keyStr)
-						}
-						if arr.setters != nil {
-							delete(arr.setters, keyStr)
-						}
-						if arr.propertyDesc != nil {
-							delete(arr.propertyDesc, keyStr)
-						}
-						if arr.properties != nil {
-							delete(arr.properties, keyStr)
-						}
-						if idx < len(arr.elements) {
-							arr.elements[idx] = Hole
-						}
-						success = true
-					}
+					success = arr.DeleteIndex(idx)
 				} else if key.Type() != TypeSymbol {
 					success = arr.DeleteOwn(keyStr)
 				} else {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -7903,50 +7903,19 @@ startExecution:
 				// idx is now set from either number or string path
 				// and we've verified it's a valid array index (non-negative integer)
 
-				// Check for setter on Array.prototype chain before direct write.
-				// ECMAScript requires invoking inherited setters for array indices,
-				// but integer-indexed accessors on the prototype chain essentially
-				// never exist, so guard the whole walk (a strconv.Itoa + string
-				// concat + chain scan, on every element write) behind a latch that is
-				// only set once such an accessor is actually defined. See
-				// arrayIndexAccessorSeen in object.go.
-				setterFound := false
-				if arrayIndexAccessorSeen.Load() && vm.ArrayPrototype.IsObject() {
-					idxKey := strconv.Itoa(idx)
-					setterKey := "s:" + idxKey // PropertyKey hash format for string keys
-					for cur := vm.ArrayPrototype.AsPlainObject(); cur != nil; {
-						// Check directly in the setters map (keyed by PropertyKey.hash())
-						if cur.setters != nil {
-							if s, ok := cur.setters[setterKey]; ok {
-								// Call the setter with this=array (original object)
-								frame.ip = ip
-								_, err := vm.Call(s, baseVal, []Value{valueVal})
-								if err != nil {
-									if ee, ok := err.(ExceptionError); ok {
-										vm.throwException(ee.GetExceptionValue())
-										return InterpretRuntimeError, Undefined
-									}
-									status := vm.runtimeError("%v", err)
-									return status, Undefined
-								}
-								setterFound = true
-								break
-							}
-						}
-						// Also check getters-only accessor (has getter but no setter)
-						if cur.getters != nil {
-							if _, ok := cur.getters[setterKey]; ok {
-								// Found accessor with getter but no setter - silently fail in non-strict mode
-								setterFound = true
-								break
-							}
-						}
-						protoVal := cur.GetPrototype()
-						if !protoVal.IsObject() {
-							break
-						}
-						cur = protoVal.AsPlainObject()
+				// Check for an inherited setter on Array.prototype's chain
+				// before direct write - see ArrayPrototypeSetterFor
+				// (array_props.go), which this and arrayLikeSet
+				// (package builtins) share.
+				frame.ip = ip
+				setterFound, setterErr := vm.ArrayPrototypeSetterFor(baseVal, idx, valueVal)
+				if setterErr != nil {
+					if ee, ok := setterErr.(ExceptionError); ok {
+						vm.throwException(ee.GetExceptionValue())
+						return InterpretRuntimeError, Undefined
 					}
+					status := vm.runtimeError("%v", setterErr)
+					return status, Undefined
 				}
 				if setterFound {
 					continue

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6917,6 +6917,16 @@ startExecution:
 						continue
 					}
 
+					if arr.HasAccessors() {
+						if ok, status, value := vm.opGetProp(frame, ip, &baseVal, strconv.Itoa(idx), &registers[destReg]); !ok {
+							if status != InterpretOK {
+								return status, value
+							}
+							goto reloadFrame
+						}
+						continue
+					}
+
 					if idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
 						registers[destReg] = Undefined // Out of bounds or hole -> undefined
 					} else {
@@ -6931,6 +6941,15 @@ startExecution:
 						// Check if the string is a valid array index (numeric)
 						// In JavaScript, obj["0"] should access obj[0] for arrays
 						if idx, isNumeric := vm.parseArrayIndex(key); isNumeric {
+							if arr.HasAccessors() {
+								if ok, status, value := vm.opGetProp(frame, ip, &baseVal, key, &registers[destReg]); !ok {
+									if status != InterpretOK {
+										return status, value
+									}
+									goto reloadFrame
+								}
+								continue
+							}
 							// Convert string index to numeric and access array element
 							if idx < 0 || idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
 								registers[destReg] = Undefined
@@ -7931,6 +7950,32 @@ startExecution:
 				}
 				if setterFound {
 					continue
+				}
+
+				// Check for an accessor defined directly on this index of
+				// this array (via Object.defineProperty - see
+				// ArrayDefineOwnProperty), same guard pattern as the
+				// Array.prototype walk just above: HasAccessors() is a nil
+				// check, so an array that never had one defined pays
+				// nothing extra here.
+				if arr.HasAccessors() {
+					if _, s, _, _, ok := arr.GetOwnAccessor(strconv.Itoa(idx)); ok {
+						if s.Type() != TypeUndefined {
+							frame.ip = ip
+							_, err := vm.Call(s, baseVal, []Value{valueVal})
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+									return InterpretRuntimeError, Undefined
+								}
+								status := vm.runtimeError("%v", err)
+								return status, Undefined
+							}
+						}
+						// Getter-only (no setter): silently ignored, same as
+						// the prototype-chain case above.
+						continue
+					}
 				}
 
 				// Handle Array Expansion
@@ -13025,10 +13070,31 @@ startExecution:
 				keys = dict.OwnKeys()
 			case TypeArray:
 				arr := objValue.AsArray()
-				// Arrays enumerate their indices as strings
-				keys = make([]string, arr.Length())
+				// Arrays enumerate their indices as strings, skipping holes
+				// and any index made non-enumerable via Object.defineProperty
+				// (see ArrayDefineOwnProperty) - mirrors the TypeArguments
+				// case just below for the same reason (propertyHelper.js's
+				// for-in-based isEnumerable() check relies on this).
 				for i := 0; i < arr.Length(); i++ {
-					keys[i] = strconv.Itoa(i)
+					key := strconv.Itoa(i)
+					if arr.HasAccessors() {
+						if _, _, e, _, ok := arr.GetOwnAccessor(key); ok {
+							if e {
+								keys = append(keys, key)
+							}
+							continue
+						}
+					}
+					if arr.HasIndex(i) {
+						keys = append(keys, key)
+					} else if arr.propertyDesc != nil {
+						// Beyond maxDenseArrayDefineIndex, a defined data
+						// property is tracked in propertyDesc/properties
+						// instead of elements - see ArrayDefineOwnProperty.
+						if desc, ok := arr.propertyDesc[key]; ok && desc.Enumerable {
+							keys = append(keys, key)
+						}
+					}
 				}
 			case TypeArguments:
 				// Arguments objects enumerate their indices as strings, skipping
@@ -15101,8 +15167,52 @@ startExecution:
 					success = obj.AsDictObject().DeleteOwn(key.ToString())
 				}
 			} else if obj.Type() == TypeArray {
-				// Not supporting element deletion yet
-				success = false
+				// [[Delete]] for the Array exotic object (ECMA-262 10.4.2.1
+				// defers to OrdinaryDelete 10.1.7 for non-"length" keys).
+				// A plain element has no per-index configurable bit of its
+				// own (see ArrayDefineOwnProperty's doc comment on why) -
+				// its configurability instead comes from the array-wide
+				// `frozen` flag (Object.freeze - SetFrozen), which is
+				// treated as making every element non-configurable, same
+				// as this codebase's other frozen-array checks (e.g.
+				// IsFrozen). An index that was turned into an accessor (or
+				// otherwise given an explicit descriptor - see
+				// ArrayDefineOwnProperty) has its own tracked configurable
+				// bit in propertyDesc and is checked directly.
+				arr := obj.AsArray()
+				keyStr := key.ToString()
+				if idx, isNumeric := tryParseArrayIndex(keyStr); isNumeric {
+					configurable := !arr.frozen
+					if arr.propertyDesc != nil {
+						if desc, ok := arr.propertyDesc[keyStr]; ok {
+							configurable = desc.Configurable
+						}
+					}
+					if !configurable {
+						success = false
+					} else {
+						if arr.getters != nil {
+							delete(arr.getters, keyStr)
+						}
+						if arr.setters != nil {
+							delete(arr.setters, keyStr)
+						}
+						if arr.propertyDesc != nil {
+							delete(arr.propertyDesc, keyStr)
+						}
+						if arr.properties != nil {
+							delete(arr.properties, keyStr)
+						}
+						if idx < len(arr.elements) {
+							arr.elements[idx] = Hole
+						}
+						success = true
+					}
+				} else if key.Type() != TypeSymbol {
+					success = arr.DeleteOwn(keyStr)
+				} else {
+					success = true
+				}
 			} else if obj.Type() == TypeString {
 				// String primitives: indices within length are non-configurable
 				// indices beyond length don't exist, so delete returns true


### PR DESCRIPTION
## Summary

Fixes a cluster of Test262 `built-ins/Array` compliance gaps around array-like length coercion, `Object.defineProperty`/`delete` on real Array elements, Proxy trap wiring, and frozen/non-writable-length enforcement on mutator methods.

- `99907ff` — array-like length coercion now uses real ToNumber/ToPrimitive (`toLengthWithVM`) instead of a VM-less `ToFloat()`
- `1e90021` — implements `Object.defineProperty`/`delete` for real Array elements (`ArrayDefineOwnProperty`, `DeleteIndex`), previously a silent no-op / hardcoded failure
- `cf84554` — guards `arrayIndexGetFromProto` against a non-PlainObject value spliced into the prototype chain (e.g. via `Object.setPrototypeOf`)
- `6dcd198` — makes `DeletePropertyOrThrow` actually throw (was a guaranteed-success no-op) across `copyWithin`/`splice`/`pop`/`shift`/etc., and wires the Proxy `"has"` trap into `arrayLikeGet` for `copyWithin`'s HasProperty-then-Get-or-delete algorithm, without regressing `includes`'s Get-only algorithm sharing the same helper
- `ebec1eb` — enforces `Object.freeze`/non-writable-`length` on `push`/`pop`/`shift`/`unshift` (previously these silently succeeded regardless of freeze state), plus `Object.defineProperty(arr, "length", {writable: false})` support

Along the way, caught and fixed a memory-blowup hazard before it landed: removing the `push`/`pop`/`shift`/`unshift` `TypeArray` fast paths exposed that `arrayLikeSet`'s underlying `ArrayObject.Set` is O(index) (fills every slot up to the index with a hole), so a `push()` on a sparse array with an artificially huge `length` (e.g. `new Array(4294967290)`) could attempt to allocate/fill billions of slots. Fixed with a `maxDenseArraySetIndex` (2^24) bound, mirroring the existing `maxDenseArrayDefineIndex` guard, falling back to a sparse property write beyond that bound.

## Test262 impact

`built-ins` baseline: **15,773 → 16,151 passing** (+378) out of 23,294.

## Known gaps (not attempted here, documented in code/commit messages)

- `ArraySpeciesCreate` abrupt-completion handling (affects `splice`/`concat`/`slice`/`filter`/`map`/`flatMap` — largest remaining Array.prototype cluster)
- `shift`'s `throws-when-this-value-length-is-writable-false.js` (Function-receiver default length writability)
- `ArraySetLength`'s actual value-truncation semantics (`Object.defineProperty(arr, "length", {value: N})` for `N != current length` remains unimplemented)
- Reading back a sparse array index beyond 2^24 (written via the `maxDenseArraySetIndex`/`maxDenseArrayDefineIndex` fallback) still misses the elements-array fast read path — pre-existing, already-documented gap, now reachable from a second call site

## Verification

- `go test ./tests -run TestScripts` — smoke suite green
- `go vet ./...`, `go build ./...` — clean
- Full `built-ins` Test262 diff against baseline, RSS-monitored to confirm no regression of the memory-blowup fix
- `language` subpath re-run twice to rule out transient flakiness (matches CLAUDE.md's documented flaky-test list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)