### PR TITLE
perf(vm): ASCII fast path + classification cache for UTF-16 string access

### DIFF
--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -489,13 +489,11 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				return vm.Undefined, err
 			}
 		}
-		// Convert to UTF-16 code units for proper JavaScript string semantics
-		utf16Units := vm.StringToUTF16(thisStr)
-		if index < 0 || index >= len(utf16Units) {
-			return vm.NewString(""), nil
+		// Return the character at the UTF-16 code unit index
+		if ch, ok := vm.UTF16CharAt(thisStr, index); ok {
+			return vm.NewString(ch), nil
 		}
-		// Return the character at the UTF-16 index
-		return vm.NewString(string(rune(utf16Units[index]))), nil
+		return vm.NewString(""), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("charCodeAt", vm.NewNativeFunction(1, false, "charCodeAt", func(args []vm.Value) (vm.Value, error) {
@@ -519,12 +517,10 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				return vm.Undefined, err
 			}
 		}
-		// Convert to UTF-16 code units for proper JavaScript string semantics
-		utf16Units := vm.StringToUTF16(thisStr)
-		if index < 0 || index >= len(utf16Units) {
-			return vm.NaN, nil // Return NaN for out of bounds
+		if u, ok := vm.UTF16CodeUnitAt(thisStr, index); ok {
+			return vm.NumberValue(float64(u)), nil
 		}
-		return vm.NumberValue(float64(utf16Units[index])), nil
+		return vm.NaN, nil // Return NaN for out of bounds
 	}))
 
 	// String.prototype.at - returns character at relative index (supports negative indices)
@@ -540,9 +536,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		// Convert to UTF-16 code units for proper JavaScript string semantics
-		utf16Units := vm.StringToUTF16(thisStr)
-		length := len(utf16Units)
+		length := vm.UTF16Length(thisStr)
 
 		// Default to 0 if no argument provided, using proper ToInteger conversion
 		// that throws TypeError for Symbols
@@ -560,13 +554,11 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			index = length + index
 		}
 
-		// Return undefined if out of bounds
-		if index < 0 || index >= length {
-			return vm.Undefined, nil
+		// Return the character at the UTF-16 code unit index
+		if ch, ok := vm.UTF16CharAt(thisStr, index); ok {
+			return vm.NewString(ch), nil
 		}
-
-		// Return the character at the UTF-16 index
-		return vm.NewString(string(rune(utf16Units[index]))), nil
+		return vm.Undefined, nil
 	}))
 
 	// String.prototype.codePointAt - returns code point at position (handles surrogate pairs)
@@ -582,10 +574,6 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		// Convert to UTF-16 code units for proper JavaScript string semantics
-		utf16Units := vm.StringToUTF16(thisStr)
-		size := len(utf16Units)
-
 		// Default to 0 if no argument provided, using proper ToInteger conversion
 		// that throws TypeError for Symbols
 		position := 0
@@ -597,31 +585,12 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
-		// Return undefined if out of bounds
-		if position < 0 || position >= size {
-			return vm.Undefined, nil
+		// UTF16CodePointAt combines a surrogate pair when position points at a
+		// lead surrogate followed by a trail surrogate, and reports out-of-range.
+		if cp, ok := vm.UTF16CodePointAt(thisStr, position); ok {
+			return vm.NumberValue(float64(cp)), nil
 		}
-
-		// Get the first code unit
-		first := utf16Units[position]
-
-		// If not a lead surrogate, or at end of string, return the code unit
-		if first < 0xD800 || first > 0xDBFF || position+1 >= size {
-			return vm.NumberValue(float64(first)), nil
-		}
-
-		// Get the second code unit
-		second := utf16Units[position+1]
-
-		// If not a trail surrogate, return the lead surrogate
-		if second < 0xDC00 || second > 0xDFFF {
-			return vm.NumberValue(float64(first)), nil
-		}
-
-		// Compute the full code point from surrogate pair
-		// Formula: (first - 0xD800) * 0x400 + (second - 0xDC00) + 0x10000
-		codePoint := (int(first)-0xD800)*0x400 + (int(second) - 0xDC00) + 0x10000
-		return vm.NumberValue(float64(codePoint)), nil
+		return vm.Undefined, nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("slice", vm.NewNativeFunction(2, false, "slice", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/vm/string_utf16.go
+++ b/pkg/vm/string_utf16.go
@@ -1,0 +1,245 @@
+package vm
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// JavaScript indexes strings by UTF-16 code unit; Paserati stores them as
+// Go (WTF-8) strings. Every code-unit index is therefore a decode, and the
+// naive implementation re-decoded the whole string on every charAt /
+// charCodeAt / codePointAt / .length. TypeScript's scanner is
+// `text.charCodeAt(pos)` in a tight loop, so a few-thousand-line .d.ts was
+// re-encoded thousands of times: O(n^2) CPU plus the GC churn of a fresh
+// []uint16 per call.
+//
+// Two things fix that:
+//
+//  1. ASCII fast path. An all-ASCII string (the overwhelming common case -
+//     every lib.*.d.ts and @types/node .d.ts is pure ASCII) has .length ==
+//     len(s) and code unit i == s[i], with no allocation and no decode.
+//
+//  2. A classification cache. IsASCII is still an O(n) scan, so a scanner
+//     looping charCodeAt over one string would stay O(n^2) without it. The
+//     cache memoises, per string, whether it is ASCII and (if not) its
+//     materialised []uint16 view, so a forward scan pays O(n) once.
+//
+// The cache is a small direct-mapped table of immutable entries behind
+// atomic.Pointer slots. It is keyed by string identity - the (data pointer,
+// length) header, not the bytes - so lookup is unconditionally O(1) and can
+// never return a wrong answer: Go strings are immutable and a reachable entry
+// pins the backing array, so a (ptr,len) match implies identical bytes. Races
+// on a slot are benign (worst case: a redundant re-classification). This keeps
+// the exported helpers usable from every call site - builtins, property
+// helpers, the interpreter loop - without threading *VM through all of them.
+
+const utf16CacheSlots = 8 // must be a power of two
+
+type utf16Entry struct {
+	ptr     *byte    // identity: data pointer of the classified string
+	byteLen int      // identity: len(s) in bytes
+	n       int      // length in UTF-16 code units
+	ascii   bool     // all code points < 0x80
+	units   []uint16 // materialised view; nil when ascii
+}
+
+var utf16Cache [utf16CacheSlots]atomic.Pointer[utf16Entry]
+
+var emptyUTF16Entry = &utf16Entry{ptr: nil, n: 0, ascii: true}
+
+// stringInfo returns the (cached) UTF-16 classification of s. It never returns
+// nil. On a miss it classifies s - and, for non-ASCII strings, materialises the
+// full []uint16 view so that n is exactly len(StringToUTF16(s)) by construction
+// - then stores the entry for next time.
+func stringInfo(s string) *utf16Entry {
+	if len(s) == 0 {
+		return emptyUTF16Entry
+	}
+	ptr := unsafe.StringData(s)
+	slot := (uintptr(unsafe.Pointer(ptr)) ^ uintptr(len(s))) >> 3 & (utf16CacheSlots - 1)
+	if e := utf16Cache[slot].Load(); e != nil && e.ptr == ptr && e.byteLen == len(s) {
+		return e
+	}
+
+	var e *utf16Entry
+	if IsASCII(s) {
+		e = &utf16Entry{ptr: ptr, byteLen: len(s), n: len(s), ascii: true}
+	} else {
+		units := stringToUTF16Uncached(s)
+		e = &utf16Entry{ptr: ptr, byteLen: len(s), n: len(units), ascii: false, units: units}
+	}
+	utf16Cache[slot].Store(e)
+	return e
+}
+
+// IsASCII reports whether every byte of s is < 0x80, i.e. the string is a
+// sequence of one-byte UTF-16 code units. Scans 8 bytes at a time.
+func IsASCII(s string) bool {
+	n := len(s)
+	if n == 0 {
+		return true
+	}
+	const highBits = uint64(0x8080808080808080)
+	ptr := unsafe.Pointer(unsafe.StringData(s))
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		chunk := *(*uint64)(unsafe.Pointer(uintptr(ptr) + uintptr(i)))
+		if chunk&highBits != 0 {
+			return false
+		}
+	}
+	for ; i < n; i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// UTF16Length returns the number of UTF-16 code units in s - the value
+// JavaScript's String.prototype.length reports.
+func UTF16Length(s string) int {
+	return stringInfo(s).n
+}
+
+// UTF16CodeUnitAt returns the UTF-16 code unit at index idx and whether idx was
+// in range. This is the primitive behind charCodeAt and indexed string access.
+func UTF16CodeUnitAt(s string, idx int) (uint16, bool) {
+	if idx < 0 {
+		return 0, false
+	}
+	e := stringInfo(s)
+	if idx >= e.n {
+		return 0, false
+	}
+	if e.ascii {
+		return uint16(s[idx]), true
+	}
+	return e.units[idx], true
+}
+
+// UTF16CodePointAt returns the code point at UTF-16 index idx, combining a
+// surrogate pair when idx points at a lead surrogate followed by a trail
+// surrogate (String.prototype.codePointAt semantics), and whether idx was in
+// range.
+func UTF16CodePointAt(s string, idx int) (uint32, bool) {
+	if idx < 0 {
+		return 0, false
+	}
+	e := stringInfo(s)
+	if idx >= e.n {
+		return 0, false
+	}
+	if e.ascii {
+		return uint32(s[idx]), true
+	}
+	first := e.units[idx]
+	if first < 0xD800 || first > 0xDBFF || idx+1 >= e.n {
+		return uint32(first), true
+	}
+	second := e.units[idx+1]
+	if second < 0xDC00 || second > 0xDFFF {
+		return uint32(first), true
+	}
+	return (uint32(first)-0xD800)*0x400 + (uint32(second) - 0xDC00) + 0x10000, true
+}
+
+// UTF16CharAt returns the one-code-unit substring at UTF-16 index idx (what
+// charAt and String.prototype.at hand back) and whether idx was in range. A
+// lone surrogate is re-encoded as WTF-8 via UTF16ToString rather than through
+// string(rune(u)), which would replace it with U+FFFD.
+func UTF16CharAt(s string, idx int) (string, bool) {
+	u, ok := UTF16CodeUnitAt(s, idx)
+	if !ok {
+		return "", false
+	}
+	if u < 0x80 {
+		return string(rune(u)), true
+	}
+	return UTF16ToString([]uint16{u}), true
+}
+
+// StringToUTF16 converts a Go (WTF-8) string to a freshly allocated slice of
+// UTF-16 code units. Lone surrogates produced by the lexer's WTF-8 encoding are
+// preserved. The returned slice is owned by the caller. Prefer UTF16Length /
+// UTF16CodeUnitAt / UTF16CodePointAt when a full materialisation is not needed.
+func StringToUTF16(s string) []uint16 {
+	e := stringInfo(s)
+	if e.ascii {
+		out := make([]uint16, len(s))
+		for i := 0; i < len(s); i++ {
+			out[i] = uint16(s[i])
+		}
+		return out
+	}
+	out := make([]uint16, len(e.units))
+	copy(out, e.units)
+	return out
+}
+
+// stringToUTF16Uncached is the raw WTF-8 -> UTF-16 decoder. It handles WTF-8
+// encoded lone surrogates that our lexer produces. Callers should go through
+// StringToUTF16 / stringInfo so the result is cached.
+func stringToUTF16Uncached(s string) []uint16 {
+	result := make([]uint16, 0, len(s))
+	bytes := []byte(s)
+	i := 0
+
+	for i < len(bytes) {
+		b := bytes[i]
+		if b < 0x80 {
+			// ASCII
+			result = append(result, uint16(b))
+			i++
+		} else if b < 0xC0 {
+			// Invalid leading byte, treat as single byte
+			result = append(result, uint16(b))
+			i++
+		} else if b < 0xE0 {
+			// 2-byte sequence
+			if i+1 < len(bytes) {
+				r := rune(b&0x1F)<<6 | rune(bytes[i+1]&0x3F)
+				result = append(result, uint16(r))
+				i += 2
+			} else {
+				result = append(result, uint16(b))
+				i++
+			}
+		} else if b < 0xF0 {
+			// 3-byte sequence - check for WTF-8 surrogate encoding
+			if i+2 < len(bytes) {
+				b2 := bytes[i+1]
+				b3 := bytes[i+2]
+				// Decode the code point
+				r := rune(b&0x0F)<<12 | rune(b2&0x3F)<<6 | rune(b3&0x3F)
+				// This handles both regular BMP chars and WTF-8 surrogates
+				result = append(result, uint16(r))
+				i += 3
+			} else {
+				result = append(result, uint16(b))
+				i++
+			}
+		} else if b < 0xF8 {
+			// 4-byte sequence - supplementary character
+			if i+3 < len(bytes) {
+				r := rune(b&0x07)<<18 | rune(bytes[i+1]&0x3F)<<12 |
+					rune(bytes[i+2]&0x3F)<<6 | rune(bytes[i+3]&0x3F)
+				// Convert to surrogate pair
+				r -= 0x10000
+				high := uint16(0xD800 + (r >> 10))
+				low := uint16(0xDC00 + (r & 0x3FF))
+				result = append(result, high, low)
+				i += 4
+			} else {
+				result = append(result, uint16(b))
+				i++
+			}
+		} else {
+			// Invalid UTF-8 leading byte
+			result = append(result, uint16(b))
+			i++
+		}
+	}
+
+	return result
+}

--- a/pkg/vm/string_utf16_bench_test.go
+++ b/pkg/vm/string_utf16_bench_test.go
@@ -1,0 +1,41 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+// BenchmarkCharCodeAtScan models TypeScript's scanner: a forward loop calling
+// charCodeAt over one long string. Before the classification cache this was
+// O(n) per call (a fresh []uint16 materialisation), i.e. O(n^2) for the scan.
+func BenchmarkCharCodeAtScan(b *testing.B) {
+	s := strings.Repeat("x", 100_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var acc uint64
+		n := UTF16Length(s)
+		for j := 0; j < n; j++ {
+			u, _ := UTF16CodeUnitAt(s, j)
+			acc += uint64(u)
+		}
+		if acc == 0 {
+			b.Fatal("unexpected zero")
+		}
+	}
+}
+
+func BenchmarkCharCodeAtScanNonASCII(b *testing.B) {
+	s := strings.Repeat("é", 50_000) // 2 bytes each, 50k code units
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var acc uint64
+		n := UTF16Length(s)
+		for j := 0; j < n; j++ {
+			u, _ := UTF16CodeUnitAt(s, j)
+			acc += uint64(u)
+		}
+		if acc == 0 {
+			b.Fatal("unexpected zero")
+		}
+	}
+}

--- a/pkg/vm/string_utf16_test.go
+++ b/pkg/vm/string_utf16_test.go
@@ -1,0 +1,159 @@
+package vm
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// naiveIsASCII is the obvious byte-at-a-time reference for IsASCII.
+func naiveIsASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// edgeStrings exercises the truncation and surrogate branches of the WTF-8
+// decoder that the counting/indexing helpers must agree with.
+var edgeStrings = []string{
+	"",
+	"a",
+	"ascii only, all bytes < 0x80",
+	strings.Repeat("x", 4096),
+	"\xED\xA0\x80",                          // lone high surrogate (WTF-8) -> 1 code unit
+	"\xED\xA0\x80abc",                       // lone surrogate followed by ASCII
+	"\xED\xB0\x80",                          // lone low surrogate
+	"\xF0\x9D\x90\x80",                      // U+1D400, astral -> surrogate pair (2 units)
+	"a\xF0\x9D\x90\x80b",                    // astral between ASCII
+	"café éè",                               // 2-byte sequences
+	"\xC3",                                  // truncated 2-byte lead at end
+	"\xE2\x82",                              // truncated 3-byte lead at end
+	"\xF0\x9D\x90",                          // truncated 4-byte lead at end
+	"\xF8\x80\x80\x80\x80",                  // 0xF8+ invalid lead
+	"\x80\x80",                              // stray continuation bytes
+	"世界",                                    // CJK, 3-byte BMP
+	"mix \xE2\x82\xAC \xF0\x9F\x98\x80 end", // euro sign + emoji
+}
+
+func TestIsASCII(t *testing.T) {
+	cases := append([]string{}, edgeStrings...)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 2000; i++ {
+		n := r.Intn(40)
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = byte(r.Intn(256))
+		}
+		cases = append(cases, string(b))
+	}
+	for _, s := range cases {
+		if got, want := IsASCII(s), naiveIsASCII(s); got != want {
+			t.Fatalf("IsASCII(%q) = %v, want %v", s, got, want)
+		}
+	}
+}
+
+// TestUTF16HelpersMatchMaterialised checks that the cached length / index
+// helpers agree, at every position, with a fresh full materialisation of the
+// same string. The counting scan for non-ASCII strings is derived from the
+// materialised slice by construction, so this mainly guards the ASCII fast path
+// and the surrogate-pair combination in UTF16CodePointAt.
+func TestUTF16HelpersMatchMaterialised(t *testing.T) {
+	cases := append([]string{}, edgeStrings...)
+	r := rand.New(rand.NewSource(2))
+	for i := 0; i < 5000; i++ {
+		n := r.Intn(64)
+		b := make([]byte, n)
+		for j := range b {
+			// Bias towards ASCII so the fast path gets real coverage, but
+			// leave plenty of high bytes for the decoder branches.
+			if r.Intn(3) == 0 {
+				b[j] = byte(0x80 + r.Intn(128))
+			} else {
+				b[j] = byte(r.Intn(0x80))
+			}
+		}
+		cases = append(cases, string(b))
+	}
+
+	for _, s := range cases {
+		want := stringToUTF16Uncached(s)
+
+		if got := UTF16Length(s); got != len(want) {
+			t.Fatalf("UTF16Length(%q) = %d, want %d", s, got, len(want))
+		}
+
+		// Out-of-range probes.
+		if _, ok := UTF16CodeUnitAt(s, -1); ok {
+			t.Fatalf("UTF16CodeUnitAt(%q, -1) reported in range", s)
+		}
+		if _, ok := UTF16CodeUnitAt(s, len(want)); ok {
+			t.Fatalf("UTF16CodeUnitAt(%q, len) reported in range", s)
+		}
+
+		for i := 0; i < len(want); i++ {
+			u, ok := UTF16CodeUnitAt(s, i)
+			if !ok || u != want[i] {
+				t.Fatalf("UTF16CodeUnitAt(%q, %d) = %#x,%v want %#x,true", s, i, u, ok, want[i])
+			}
+
+			// UTF16CodePointAt: combine a trailing surrogate when present.
+			cp, ok := UTF16CodePointAt(s, i)
+			if !ok {
+				t.Fatalf("UTF16CodePointAt(%q, %d) out of range", s, i)
+			}
+			wantCP := uint32(want[i])
+			if want[i] >= 0xD800 && want[i] <= 0xDBFF && i+1 < len(want) &&
+				want[i+1] >= 0xDC00 && want[i+1] <= 0xDFFF {
+				wantCP = (uint32(want[i])-0xD800)*0x400 + (uint32(want[i+1]) - 0xDC00) + 0x10000
+			}
+			if cp != wantCP {
+				t.Fatalf("UTF16CodePointAt(%q, %d) = %#x, want %#x", s, i, cp, wantCP)
+			}
+		}
+	}
+}
+
+// TestUTF16CharAtPreservesLoneSurrogate makes sure charAt on a lone surrogate
+// round-trips through WTF-8 rather than collapsing to U+FFFD.
+func TestUTF16CharAtPreservesLoneSurrogate(t *testing.T) {
+	s := "\xED\xA0\x80abc" // D800, a, b, c
+	ch, ok := UTF16CharAt(s, 0)
+	if !ok {
+		t.Fatal("UTF16CharAt index 0 out of range")
+	}
+	if ch != "\xED\xA0\x80" {
+		t.Fatalf("UTF16CharAt(loneSurrogate, 0) = %q, want WTF-8 D800", ch)
+	}
+	if got := StringToUTF16(ch); len(got) != 1 || got[0] != 0xD800 {
+		t.Fatalf("round-trip of charAt result = %#v, want [D800]", got)
+	}
+	if ch, _ := UTF16CharAt(s, 1); ch != "a" {
+		t.Fatalf("UTF16CharAt(_, 1) = %q, want \"a\"", ch)
+	}
+}
+
+// TestUTF16CacheDistinctStringsSameSlot guards against a stale cache entry
+// being served for a different string that hashes to the same slot.
+func TestUTF16CacheDistinctStringsSameSlot(t *testing.T) {
+	strs := make([]string, 512)
+	for i := range strs {
+		if i%2 == 0 {
+			strs[i] = strings.Repeat("a", i%37+1)
+		} else {
+			strs[i] = strings.Repeat("é", i%37+1) // non-ASCII, 2 bytes each
+		}
+	}
+	// Interleave so slots get overwritten between reads.
+	for round := 0; round < 4; round++ {
+		for _, s := range strs {
+			want := len(stringToUTF16Uncached(s))
+			if got := UTF16Length(s); got != want {
+				t.Fatalf("UTF16Length(%q) = %d, want %d (round %d)", s, got, want, round)
+			}
+		}
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -7204,11 +7204,10 @@ startExecution:
 						registers[destReg] = Undefined
 					} else {
 						idx := int(numIdx)
-						runes := []rune(str)
-						if idx < 0 || idx >= len(runes) {
-							registers[destReg] = Undefined // Out of bounds -> undefined
+						if ch, ok := UTF16CharAt(str, idx); ok {
+							registers[destReg] = String(ch) // Return code unit as string
 						} else {
-							registers[destReg] = String(string(runes[idx])) // Return char as string
+							registers[destReg] = Undefined // Out of bounds -> undefined
 						}
 					}
 				} else {
@@ -16649,77 +16648,8 @@ func compareStrings(a, b string) int {
 	return compareStringsUTF16(a, b)
 }
 
-// UTF16Length returns the number of UTF-16 code units in a string
-// This is the correct length for JavaScript string.length property
-func UTF16Length(s string) int {
-	return len(StringToUTF16(s))
-}
-
-// StringToUTF16 converts a Go string (UTF-8/WTF-8) to UTF-16 code units
-// This handles WTF-8 encoded lone surrogates that our lexer produces
-func StringToUTF16(s string) []uint16 {
-	result := make([]uint16, 0, len(s))
-	bytes := []byte(s)
-	i := 0
-
-	for i < len(bytes) {
-		b := bytes[i]
-		if b < 0x80 {
-			// ASCII
-			result = append(result, uint16(b))
-			i++
-		} else if b < 0xC0 {
-			// Invalid leading byte, treat as single byte
-			result = append(result, uint16(b))
-			i++
-		} else if b < 0xE0 {
-			// 2-byte sequence
-			if i+1 < len(bytes) {
-				r := rune(b&0x1F)<<6 | rune(bytes[i+1]&0x3F)
-				result = append(result, uint16(r))
-				i += 2
-			} else {
-				result = append(result, uint16(b))
-				i++
-			}
-		} else if b < 0xF0 {
-			// 3-byte sequence - check for WTF-8 surrogate encoding
-			if i+2 < len(bytes) {
-				b2 := bytes[i+1]
-				b3 := bytes[i+2]
-				// Decode the code point
-				r := rune(b&0x0F)<<12 | rune(b2&0x3F)<<6 | rune(b3&0x3F)
-				// This handles both regular BMP chars and WTF-8 surrogates
-				result = append(result, uint16(r))
-				i += 3
-			} else {
-				result = append(result, uint16(b))
-				i++
-			}
-		} else if b < 0xF8 {
-			// 4-byte sequence - supplementary character
-			if i+3 < len(bytes) {
-				r := rune(b&0x07)<<18 | rune(bytes[i+1]&0x3F)<<12 |
-					rune(bytes[i+2]&0x3F)<<6 | rune(bytes[i+3]&0x3F)
-				// Convert to surrogate pair
-				r -= 0x10000
-				high := uint16(0xD800 + (r >> 10))
-				low := uint16(0xDC00 + (r & 0x3FF))
-				result = append(result, high, low)
-				i += 4
-			} else {
-				result = append(result, uint16(b))
-				i++
-			}
-		} else {
-			// Invalid UTF-8 leading byte
-			result = append(result, uint16(b))
-			i++
-		}
-	}
-
-	return result
-}
+// UTF16Length, StringToUTF16, UTF16CodeUnitAt, UTF16CodePointAt and the string
+// classification cache that backs them live in string_utf16.go.
 
 // UTF16ToString converts a slice of UTF-16 code units back to a Go string
 // This preserves lone surrogates using WTF-8 encoding (same as lexer)

--- a/tests/scripts/string_utf16_code_units.ts
+++ b/tests/scripts/string_utf16_code_units.ts
@@ -1,0 +1,58 @@
+// charCodeAt / codePointAt / bracket indexing / at() address UTF-16 code units.
+//
+// Companion to string_utf16_indexing.ts. These four went through
+// vm.StringToUTF16, which re-decoded the whole string on every call — O(n^2)
+// for a scanner loop. They now share one code-unit path (see
+// pkg/vm/string_utf16.go) with an ASCII fast path and a classification cache.
+// Bracket indexing in particular changed semantics: it used to index by Unicode
+// code *point* (`[]rune`), so `s[i]` past an astral character was off by one and
+// an astral character came back whole instead of as its lead surrogate.
+
+const astral = "a😀b"; // code units: 'a', D83D, DE00, 'b'  — 4 units, not 3
+
+const len = astral.length === 4;
+
+// charCodeAt exposes the raw code units, including each half of the pair.
+const cc0 = astral.charCodeAt(0) === 0x61;
+const cc1 = astral.charCodeAt(1) === 0xd83d;
+const cc2 = astral.charCodeAt(2) === 0xde00;
+const cc3 = astral.charCodeAt(3) === 0x62;
+const ccOOB = Number.isNaN(astral.charCodeAt(4));
+
+// codePointAt combines the pair at the lead surrogate, returns the bare unit
+// at the trail.
+const cp0 = astral.codePointAt(0) === 0x61;
+const cp1 = astral.codePointAt(1) === 0x1f600;
+const cp2 = astral.codePointAt(2) === 0xde00;
+const cpOOB = astral.codePointAt(4) === undefined;
+
+// Bracket indexing is by code unit: s[1] is the lead surrogate alone, and the
+// trailing 'b' sits at index 3, not 2.
+const u1 = astral[1] as string;
+const br1 = u1.length === 1 && u1.charCodeAt(0) === 0xd83d;
+const br3 = astral[3] === "b";
+const brOOB = astral[4] === undefined;
+
+// at() takes the same units and supports negative indices.
+const at1 = (astral.at(1) as string).charCodeAt(0) === 0xd83d;
+const atNeg = astral.at(-1) === "b";
+const atOOB = astral.at(9) === undefined;
+
+// Plain ASCII stays on the fast path and behaves normally.
+const ascii = "hello";
+const asciiOk =
+  ascii.length === 5 &&
+  ascii.charCodeAt(1) === 0x65 &&
+  ascii[4] === "o" &&
+  ascii.at(-2) === "l" &&
+  ascii.codePointAt(0) === 0x68;
+
+// A scanner-style loop (the tsc hot path) sums every code unit.
+let sum = 0;
+for (let i = 0; i < astral.length; i++) sum += astral.charCodeAt(i);
+const loop = sum === 0x61 + 0xd83d + 0xde00 + 0x62;
+
+len && cc0 && cc1 && cc2 && cc3 && ccOOB && cp0 && cp1 && cp2 && cpOOB &&
+  br1 && br3 && brOOB && at1 && atNeg && atOOB && asciiOk && loop;
+
+// expect: true


### PR DESCRIPTION
Fixes #82.

## Problem

`String.prototype.charAt` / `charCodeAt` / `codePointAt` / `at` and string `.length` all went through `vm.StringToUTF16`, which allocated a `[]uint16` and **re-decoded the whole string on every call**. TypeScript's scanner is `text.charCodeAt(pos)` in a tight loop, so a few-thousand-line `.d.ts` was re-encoded thousands of times — O(n²) CPU plus GC churn. That's why `tsc` under noderati looked hung.

```
"x".repeat(100000) charCodeAt loop:  17375 ms  ->  16 ms
```

## Approach

All UTF-16 code-unit access is centralized in `pkg/vm/string_utf16.go` behind one entry point, `stringInfo(s)`:

1. **ASCII fast path** — an all-ASCII string (every `lib.*.d.ts` and `@types/node` `.d.ts` is pure ASCII, verified) has `.length == len(s)` and code unit `i == s[i]`, with no allocation and no decode.
2. **Classification cache** — a lock-free direct-mapped table (8 slots, `atomic.Pointer` to immutable entries) keyed by string **identity** `(data pointer, byte length)`. It memoizes the ASCII flag and, for non-ASCII strings, the materialized `[]uint16`, so a scanner looping over one string pays O(n) once instead of O(n²). Same `(ptr,len)` implies same bytes — Go strings are immutable and a reachable entry pins the backing array — so a hit is always correct; slot races only cost a redundant reclassification.

`charAt` / `charCodeAt` / `at` / `codePointAt`, `s[i]` indexing, and `.length` / `OpGetLength` are rewired through the new helpers. `StringToUTF16` / `UTF16Length` keep their signatures as cache-backed wrappers, so cold callers (string comparison, `normalize`) benefit too — without threading `*VM` through the builtins.

Net **−123 / +22** lines in existing files; the rest is the new file + tests.

## Behavior changes (both toward spec)

- **`s[i]` bracket indexing now indexes by UTF-16 code unit, not Unicode code point.** It used `[]rune`, so an index past an astral character was off by one and an astral character came back whole. Now `"a😀b"[1]` is the lead surrogate and `[3]` is `"b"`. This is the same coordinate fix already applied to `substring`/`slice`/`indexOf` (see `tests/scripts/string_utf16_indexing.ts`); this PR finishes it for bracket access and adds `tests/scripts/string_utf16_code_units.ts`.
- **`charAt` / `at` on a lone surrogate** round-trip via WTF-8 (`UTF16ToString`) instead of collapsing to `U+FFFD`.

## Verification

Sequential, memory-guarded clean-vs-patched sweeps (hard cap 4 GB, never hit):

| suite | tests | clean | patched | outcome |
|---|---|---|---|---|
| `language/` | 23523 | 42 s, 131 MB, 23153/370 | 43 s, 135 MB, 23153/370 | **byte-identical** |
| `built-ins/` | 23294 | 52 s, 814 MB, 16152/7142 | 52 s, 815 MB, 16154/7140 | **+2 pass, 0 regress** |

New passes: `built-ins/String/prototype/at/returns-code-unit.js`, `built-ins/RegExp/prototype/exec/u-captured-value.js`.

- `go test ./tests -run TestScripts` — green (incl. new `string_utf16_code_units.ts`)
- `go test ./pkg/vm` incl. `-race` — green. New `string_utf16_test.go` differential-tests the helpers against a fresh full materialization over ~7k random + edge strings (truncated multibyte leads, lone/paired surrogates, `0xF8+`), plus a same-slot cache-collision guard.
- Memory-neutral: +1–4 MB peak RSS.

## Follow-ups (not this PR)

- `utf16Len` / `utf16ToByteOffset` in `pkg/builtins/string_init.go` still use range-based (non-WTF-8-aware) counting and **disagree with `StringToUTF16` on lone surrogates** (6 vs 4 units for `"\xED\xA0\x80abc"`). Unifying them moves `substring` / `slice` / `indexOf` on such strings — worth its own PR with a visible test262 diff.
- Two-representation (Latin-1 / UTF-16) string storage like V8/JSC/SpiderMonkey would make code-unit access unconditionally O(1). `stringInfo` is the seam to build that behind.
- **Full** test262 sweeps balloon to 6–8 GB in `staging/sm/*` (giant-string tests) on **both** this branch and `main` — a pre-existing harness goroutine-leak-on-timeout (`cmd/paserati-test262/main.go:561`) compounding the O(n²) string pattern. Separate issue; `language/` and `built-ins/` are unaffected (131 MB / 814 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)