### PR TITLE
perf(vm): frame-owned open-upvalue list; close spill captures (#84)

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -345,6 +345,7 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		newFrame.isConstructorCall = false
 		newFrame.isDirectCall = false
 		newFrame.isSentinelFrame = false // Clear sentinel flag when reusing frame
+		newFrame.openUpvalues = nil      // Clear stale open-upvalue list from prior use of this slot
 		newFrame.generatorObj = nil      // Clear generator object when reusing frame
 		newFrame.argCount = argCount     // Store actual argument count for arguments object
 		// Arguments handling:
@@ -357,7 +358,7 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		// duration of this callee frame. If/when `arguments` is accessed, NewArguments will
 		// allocate as needed.
 		newFrame.args = args
-		newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
+		newFrame.argumentsObject = Undefined  // Initialize to Undefined (will be created on first access)
 		newFrame.calleeValue = originalCallee // Store original callee for arguments.callee
 		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
 		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup

--- a/pkg/vm/function.go
+++ b/pkg/vm/function.go
@@ -7,8 +7,8 @@ import (
 
 type FunctionObject struct {
 	Object
-	Arity                int          // Number of declared parameters (used for VM register allocation)
-	Length               int          // ECMAScript length property (params before first default, per spec)
+	Arity                int // Number of declared parameters (used for VM register allocation)
+	Length               int // ECMAScript length property (params before first default, per spec)
 	Variadic             bool
 	Chunk                *Chunk
 	Name                 string
@@ -31,8 +31,9 @@ type FunctionObject struct {
 	DeletedLength bool // True if the 'length' property has been deleted
 
 	// HasLocalCaptures indicates if any nested closure captures locals from this function.
-	// When false, closeUpvalues can be skipped entirely on return (major performance win).
+	// When false, upvalue closing can be skipped entirely on return (major performance win).
 	// Set at compile time when emitting OpClosure with CaptureFromRegister or CaptureFromSpill.
+	// The runtime-tighter gate is CallFrame.openUpvalues != nil.
 	HasLocalCaptures bool
 
 	// cachedClosure is used to avoid per-call allocations when invoking TypeFunction values.
@@ -44,7 +45,9 @@ type FunctionObject struct {
 type Upvalue struct {
 	Location *Value
 	Closed   Value
-	next     *Upvalue
+	// next links this upvalue into the owning CallFrame's open-upvalue list while
+	// it is still open. Cleared when the upvalue is closed or unlinked.
+	next *Upvalue
 }
 
 func (uv *Upvalue) Close() {
@@ -65,12 +68,12 @@ type ClosureObject struct {
 	Object
 	Fn                       *FunctionObject
 	Upvalues                 []*Upvalue
-	WithObjects              []Value // Captured with-object stack from enclosing with statements
-	CapturedThis             Value   // Captured 'this' for arrow functions (lexical this binding)
-	CapturedSuperConstructor Value   // Captured super constructor for arrow functions with super() calls
-	CapturedArguments        Value   // Captured 'arguments' for arrow functions (lexical arguments binding)
-	CapturedNewTarget        Value   // Captured 'new.target' for arrow functions (lexical new.target binding)
-	CapturedHomeObject       Value   // Captured [[HomeObject]] for arrow functions (for super property access)
+	WithObjects              []Value      // Captured with-object stack from enclosing with statements
+	CapturedThis             Value        // Captured 'this' for arrow functions (lexical this binding)
+	CapturedSuperConstructor Value        // Captured super constructor for arrow functions with super() calls
+	CapturedArguments        Value        // Captured 'arguments' for arrow functions (lexical arguments binding)
+	CapturedNewTarget        Value        // Captured 'new.target' for arrow functions (lexical new.target binding)
+	CapturedHomeObject       Value        // Captured [[HomeObject]] for arrow functions (for super property access)
 	Properties               *PlainObject // Per-closure properties like .prototype (created lazily, shadows Fn.Properties)
 	constructorFixed         bool         // True after we've fixed the constructor property to point to this closure
 }
@@ -133,11 +136,11 @@ type NativeFunctionObjectWithProps struct {
 // This uses Go channels for async communication with the VM
 type AsyncNativeFunctionObject struct {
 	Object
-	Arity      int
-	Variadic   bool
-	Name       string
+	Arity    int
+	Variadic bool
+	Name     string
 	// AsyncFn receives a VMCaller interface that can call bytecode functions
-	AsyncFn    func(caller VMCaller, args []Value) Value
+	AsyncFn func(caller VMCaller, args []Value) Value
 }
 
 // VMCaller provides an interface for native functions to call bytecode functions

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -304,6 +304,12 @@ type SuspendedFrame struct {
 	outputReg  byte    // Register where sent/resolved value should be stored on resumption
 	thisValue  Value   // The 'this' value for this frame (must be preserved across suspensions)
 	homeObject Value   // The [[HomeObject]] for super property access (must be preserved for object literal methods)
+	// openUpvalues is the head of this frame's open-upvalue list (Upvalue.next
+	// chain). Generators/async functions do NOT close their captures on
+	// suspend - a suspended closure over a `let` must stay live - so the list
+	// must survive the suspend and be restored on resume, then closed when the
+	// function finally completes.
+	openUpvalues *Upvalue
 }
 
 // GeneratorFrame is an alias for backwards compatibility

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -112,21 +112,21 @@ type CallFrame struct {
 	// `registers` is a slice pointing into the VM's main register stack,
 	// defining the window for this frame.
 	registers           []Value
-	spillSlots          []Value // Spill slots for register overflow (allocated only if needed)
-	allocatedRegSize    int     // Actual allocated register window size (may differ from function.RegisterSize due to TCO expansion)
-	targetRegister      byte    // Which register in the CALLER the result should go into
-	thisValue           Value   // The 'this' value for method calls (undefined for regular function calls)
-	homeObject          Value   // The [[HomeObject]] for super property access (object where method is defined)
-	hasOwnUpvalues      bool    // True iff captureUpvalue created an upvalue pointing into this frame's registers/spill slots. Runtime-tighter gate for closeUpvalues than the compile-time HasLocalCaptures flag.
-	isConstructorCall   bool    // Whether this frame was created by a constructor call (new expression)
-	newTargetValue      Value   // The constructor that was invoked with 'new' (for new.target)
-	isDirectCall        bool    // Whether this frame should return immediately upon OpReturn (for Function.prototype.call)
-	isSentinelFrame     bool    // Whether this frame is a sentinel that should cause vm.run() to return immediately
-	isGeneratorPrologue bool    // Whether this frame is executing a generator prologue (suppresses uncaught exception printing)
-	argCount            int     // Actual number of arguments passed to this function (for arguments object)
-	args                []Value // Actual argument values passed to this function (for arguments object, copied before registers are mutated)
-	argumentsObject     Value   // Cached arguments object (created on first access to 'arguments')
-	calleeValue         Value   // The original callee Value (for arguments.callee to reference the same object)
+	spillSlots          []Value  // Spill slots for register overflow (allocated only if needed)
+	allocatedRegSize    int      // Actual allocated register window size (may differ from function.RegisterSize due to TCO expansion)
+	targetRegister      byte     // Which register in the CALLER the result should go into
+	thisValue           Value    // The 'this' value for method calls (undefined for regular function calls)
+	homeObject          Value    // The [[HomeObject]] for super property access (object where method is defined)
+	openUpvalues        *Upvalue // Head of this frame's open-upvalue list (captures into this frame's registers/spill slots), linked via Upvalue.next. nil iff the frame has captured nothing.
+	isConstructorCall   bool     // Whether this frame was created by a constructor call (new expression)
+	newTargetValue      Value    // The constructor that was invoked with 'new' (for new.target)
+	isDirectCall        bool     // Whether this frame should return immediately upon OpReturn (for Function.prototype.call)
+	isSentinelFrame     bool     // Whether this frame is a sentinel that should cause vm.run() to return immediately
+	isGeneratorPrologue bool     // Whether this frame is executing a generator prologue (suppresses uncaught exception printing)
+	argCount            int      // Actual number of arguments passed to this function (for arguments object)
+	args                []Value  // Actual argument values passed to this function (for arguments object, copied before registers are mutated)
+	argumentsObject     Value    // Cached arguments object (created on first access to 'arguments')
+	calleeValue         Value    // The original callee Value (for arguments.callee to reference the same object)
 
 	// For async native functions that can call bytecode
 	isNativeFrame    bool
@@ -173,10 +173,12 @@ type VM struct {
 	// allocation. Same nesting invariant as sentinelRegPool.
 	argsBufPool [][]Value
 
-	// List of upvalues pointing to variables still on the registerStack
-	openUpvalues []*Upvalue
-	// Map for O(1) lookup of existing upvalues by location pointer
-	openUpvalueMap map[*Value]*Upvalue
+	// Open upvalues are tracked per-frame (CallFrame.openUpvalues), not VM-wide:
+	// every capture targets the currently-active frame's registers or spill slots,
+	// and dedup of sibling closures over the same local is a walk of that short
+	// per-frame list. Closing a frame walks its list only - O(this frame's
+	// captures), and it closes spill captures too (a global register-window scan
+	// could not).
 
 	// Enhanced inline cache for property access (maps instruction pointer to cache)
 	propCache      map[int]*PropInlineCache
@@ -442,8 +444,6 @@ func dumpFrameStack(vm *VM, context string) {
 func NewVM() *VM {
 	vm := &VM{
 		// frameCount and nextRegSlot initialized to 0
-		openUpvalues:            make([]*Upvalue, 0, 16),         // Pre-allocate slightly
-		openUpvalueMap:          make(map[*Value]*Upvalue, 16),   // Map for O(1) lookup
 		propCache:               make(map[int]*PropInlineCache),  // Initialize inline cache
 		cacheStats:              ICacheStats{},                   // Initialize cache statistics
 		emptyRestArray:          NewArray(),                      // Initialize singleton empty array for rest params
@@ -1068,6 +1068,7 @@ func (vm *VM) Reset() {
 	for i := 0; i < vm.frameCount; i++ {
 		vm.frames[i].closure = nil
 		vm.frames[i].registers = nil
+		vm.frames[i].openUpvalues = nil
 		vm.frames[i].thisValue = Undefined
 		vm.frames[i].newTargetValue = Undefined
 	}
@@ -1080,11 +1081,6 @@ func (vm *VM) Reset() {
 
 	vm.frameCount = 0
 	vm.nextRegSlot = 0
-	vm.openUpvalues = vm.openUpvalues[:0] // Clear slice while keeping capacity
-	// Clear the map while keeping the allocation
-	for k := range vm.openUpvalueMap {
-		delete(vm.openUpvalueMap, k)
-	}
 	vm.errors = vm.errors[:0] // Clear errors slice
 	vm.callDepth = 0          // Reset call depth counter
 	// Clear inline cache (with lock to prevent concurrent access)
@@ -1211,6 +1207,7 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	}
 	frame.isConstructorCall = false
 	frame.newTargetValue = Undefined
+	frame.openUpvalues = nil // frame slot is reused; start with no open upvalues
 	// IMPORTANT: Set isDirectCall=true for NESTED Interpret() calls (eval) so they return immediately
 	// This ensures eval()'s script execution returns its completion value back to the native function
 	// For top-level scripts (frameCount==0 before pushing), keep isDirectCall=false to allow normal completion
@@ -1571,20 +1568,23 @@ startExecution:
 			reg := code[ip]
 			ip++
 			targetPtr := &registers[reg]
-			// Use map for O(1) lookup instead of linear search
-			if upvalue, exists := vm.openUpvalueMap[targetPtr]; exists {
-				// Close this upvalue
-				upvalue.Closed = *upvalue.Location
-				upvalue.Location = nil
-				delete(vm.openUpvalueMap, targetPtr)
-				// Remove from slice by filtering
-				newOpenUpvalues := vm.openUpvalues[:0]
-				for _, uv := range vm.openUpvalues {
-					if uv.Location != nil {
-						newOpenUpvalues = append(newOpenUpvalues, uv)
+			// Walk this frame's open-upvalue list, close the one pointing at the
+			// target register (if any), and unlink it. The list is short (one entry
+			// per still-open per-iteration binding).
+			var prev *Upvalue
+			for uv := frame.openUpvalues; uv != nil; uv = uv.next {
+				if uv.Location == targetPtr {
+					uv.Closed = *uv.Location
+					uv.Location = nil
+					if prev == nil {
+						frame.openUpvalues = uv.next
+					} else {
+						prev.next = uv.next
 					}
+					uv.next = nil
+					break
 				}
-				vm.openUpvalues = newOpenUpvalues
+				prev = uv
 			}
 
 		case OpIteratorCleanupAbrupt:
@@ -3426,9 +3426,8 @@ startExecution:
 					}
 
 					// 4. Close upvalues for current frame BEFORE overwriting (only if needed)
-					if frame.hasOwnUpvalues {
-						vm.closeUpvalues(registers)
-						frame.hasOwnUpvalues = false
+					if frame.openUpvalues != nil {
+						vm.closeFrameUpvalues(frame)
 					}
 
 					// 5. Expand register window if needed (but never shrink)
@@ -3655,9 +3654,8 @@ startExecution:
 					// We can perform TCO!
 
 					// 5. Close upvalues for current frame BEFORE overwriting (only if needed)
-					if frame.hasOwnUpvalues {
-						vm.closeUpvalues(registers)
-						frame.hasOwnUpvalues = false
+					if frame.openUpvalues != nil {
+						vm.closeFrameUpvalues(frame)
 					}
 
 					// 6. Expand register window if needed (but never shrink)
@@ -5443,9 +5441,8 @@ startExecution:
 
 			// No finally handler, proceed with normal return
 			// Close upvalues for the returning frame (only if this function has captured locals)
-			if frame.hasOwnUpvalues {
-				vm.closeUpvalues(frame.registers)
-				frame.hasOwnUpvalues = false
+			if frame.openUpvalues != nil {
+				vm.closeFrameUpvalues(frame)
 			}
 
 			// Check if this is a generator function returning (not yielding)
@@ -5706,15 +5703,8 @@ startExecution:
 
 			// No finally handler, proceed with normal return
 			// Close upvalues for the returning frame (only if this function has captured locals)
-			if frame.hasOwnUpvalues {
-				if debugVM {
-					fmt.Printf("[DBG] About to closeUpvalues for frame with %d registers, openUpvalues=%d\n", len(frame.registers), len(vm.openUpvalues))
-				}
-				vm.closeUpvalues(frame.registers)
-				frame.hasOwnUpvalues = false
-				if debugVM {
-					fmt.Printf("[DBG] closeUpvalues completed\n")
-				}
+			if frame.openUpvalues != nil {
+				vm.closeFrameUpvalues(frame)
 			}
 
 			// Pop the current frame
@@ -10312,11 +10302,12 @@ startExecution:
 				newFrame.closure = constructorClosure
 				newFrame.ip = 0
 				newFrame.targetRegister = destReg
-				newFrame.thisValue = newInstance         // Set the new instance as 'this' (or undefined for derived)
-				newFrame.homeObject = instancePrototype  // Set [[HomeObject]] for super property access in constructors
-				newFrame.isConstructorCall = true        // Mark this as a constructor call
-				newFrame.isDirectCall = false            // Not a direct call (normal OpNew)
-				newFrame.isSentinelFrame = false         // Clear sentinel flag when reusing frame
+				newFrame.thisValue = newInstance        // Set the new instance as 'this' (or undefined for derived)
+				newFrame.homeObject = instancePrototype // Set [[HomeObject]] for super property access in constructors
+				newFrame.isConstructorCall = true       // Mark this as a constructor call
+				newFrame.isDirectCall = false           // Not a direct call (normal OpNew)
+				newFrame.isSentinelFrame = false        // Clear sentinel flag when reusing frame
+				newFrame.openUpvalues = nil
 				newFrame.newTargetValue = newTargetValue // Set new.target (propagated from caller or constructor)
 				newFrame.argCount = argCount             // Store actual argument count for arguments object
 				// Avoid per-call allocation: store a slice view of the caller args for OpGetArguments.
@@ -10498,11 +10489,12 @@ startExecution:
 				newFrame.closure = constructorClosure
 				newFrame.ip = 0
 				newFrame.targetRegister = destReg
-				newFrame.thisValue = newInstance         // Set the new instance as 'this' (or undefined for derived)
-				newFrame.homeObject = instancePrototype  // Set [[HomeObject]] for super property access in constructors
-				newFrame.isConstructorCall = true        // Mark this as a constructor call
-				newFrame.isDirectCall = false            // Not a direct call (normal OpNew)
-				newFrame.isSentinelFrame = false         // Clear sentinel flag when reusing frame
+				newFrame.thisValue = newInstance        // Set the new instance as 'this' (or undefined for derived)
+				newFrame.homeObject = instancePrototype // Set [[HomeObject]] for super property access in constructors
+				newFrame.isConstructorCall = true       // Mark this as a constructor call
+				newFrame.isDirectCall = false           // Not a direct call (normal OpNew)
+				newFrame.isSentinelFrame = false        // Clear sentinel flag when reusing frame
+				newFrame.openUpvalues = nil
 				newFrame.newTargetValue = newTargetValue // Set new.target (propagated from caller or constructor)
 				newFrame.argCount = argCount             // Store actual argument count for arguments object
 				// Avoid per-call allocation: store a slice view of the caller args for OpGetArguments.
@@ -10943,6 +10935,7 @@ startExecution:
 					newFrame.isConstructorCall = true
 					newFrame.isDirectCall = false
 					newFrame.isSentinelFrame = false
+					newFrame.openUpvalues = nil
 					newFrame.newTargetValue = newTargetValue
 					newFrame.argCount = finalArgCount
 					newFrame.args = finalArgs
@@ -13481,9 +13474,8 @@ startExecution:
 			}
 
 			// Close upvalues for the returning frame (only if this function has captured locals)
-			if frame.hasOwnUpvalues {
-				vm.closeUpvalues(frame.registers)
-				frame.hasOwnUpvalues = false
+			if frame.openUpvalues != nil {
+				vm.closeFrameUpvalues(frame)
 			}
 
 			// Check if this is a generator function returning (same as OpReturn's
@@ -13677,9 +13669,8 @@ startExecution:
 				vm.pendingValue = Undefined
 
 				// Close upvalues for the returning frame (only if this function has captured locals)
-				if frame.hasOwnUpvalues {
-					vm.closeUpvalues(frame.registers)
-					frame.hasOwnUpvalues = false
+				if frame.openUpvalues != nil {
+					vm.closeFrameUpvalues(frame)
 				}
 
 				// Check if this is a generator function returning
@@ -14196,6 +14187,8 @@ startExecution:
 
 			// Copy register state to generator frame
 			copy(genObj.Frame.registers, registers)
+			// Carry the frame's open-upvalue list across the suspend (not closed on yield)
+			genObj.Frame.openUpvalues = frame.openUpvalues
 
 			// Create iterator result { value: yieldedValue, done: false }
 			result := NewObject(vm.ObjectPrototype).AsPlainObject()
@@ -14244,6 +14237,7 @@ startExecution:
 					outputReg:  0, // Not used for init yield
 				}
 				copy(genObj.Frame.registers, registers)
+				genObj.Frame.openUpvalues = frame.openUpvalues
 
 				// Transition to SuspendedStart state
 				logGeneratorStateTransition(genObj, GeneratorSuspendedStart, "OpInitYield")
@@ -14309,6 +14303,7 @@ startExecution:
 
 			// Copy register state to generator frame
 			copy(genObj.Frame.registers, registers)
+			genObj.Frame.openUpvalues = frame.openUpvalues
 
 			// Return the iterator result as-is (don't wrap it)
 			return InterpretOK, iterResult
@@ -14412,6 +14407,8 @@ startExecution:
 				frame.promiseObj.Frame.homeObject = frame.homeObject // Update [[HomeObject]]
 			}
 			copy(frame.promiseObj.Frame.registers, registers)
+			// Carry the frame's open-upvalue list across the await (not closed on suspend)
+			frame.promiseObj.Frame.openUpvalues = frame.openUpvalues
 
 			asyncPromise := frame.promiseObj
 			rt := vm.GetAsyncRuntime()
@@ -15696,93 +15693,43 @@ reloadFrame:
 	goto startExecution // Continue the execution loop with updated frame
 }
 
-// captureUpvalue creates a new Upvalue object for a local variable at the given stack location.
-// It checks if an upvalue for this location already exists using a map for O(1) lookup.
+// captureUpvalue returns the Upvalue for a local variable at the given stack location,
+// creating one if this is the first closure to capture it.
+//
 // Callers MUST ensure location points into the currently-active frame's registers or
-// spill slots; this is relied on for the hasOwnUpvalues flag below.
+// spill slots. Given that invariant, dedup (sibling closures over the same local must
+// share one Upvalue) is a walk of the active frame's short open-upvalue list, and a
+// fresh Upvalue is prepended onto that same list so the frame can close it on return.
 func (vm *VM) captureUpvalue(location *Value) *Upvalue {
-	// O(1) lookup using map
-	if upvalue, exists := vm.openUpvalueMap[location]; exists {
-		return upvalue
+	if vm.frameCount == 0 {
+		// No active frame to own the upvalue; should not happen for real captures.
+		return &Upvalue{Location: location}
 	}
-
-	// If not found, create a new one
-	newUpvalue := &Upvalue{Location: location} // Closed field is zero-value (Undefined)
-	vm.openUpvalues = append(vm.openUpvalues, newUpvalue)
-	vm.openUpvalueMap[location] = newUpvalue // Add to map for future lookups
-	// Mark the active frame as owning at least one upvalue. This lets closeUpvalues
-	// skip the full-list scan entirely for frames that never actually captured a
-	// local (even if their bytecode's HasLocalCaptures flag is true due to an
-	// unexecuted branch).
-	if vm.frameCount > 0 {
-		vm.frames[vm.frameCount-1].hasOwnUpvalues = true
+	frame := &vm.frames[vm.frameCount-1]
+	for uv := frame.openUpvalues; uv != nil; uv = uv.next {
+		if uv.Location == location {
+			return uv
+		}
 	}
+	newUpvalue := &Upvalue{Location: location, next: frame.openUpvalues}
+	frame.openUpvalues = newUpvalue
 	return newUpvalue
 }
 
-// closeUpvalues closes all open upvalues that point to stack slots within the given
-// frame's registers (which are about to become invalid).
-// It takes the slice representing the frame's registers as input.
-func (vm *VM) closeUpvalues(frameRegisters []Value) {
-	if debugVM {
-		fmt.Printf("[DBG closeUpvalues] ENTER: frameRegs=%d, openUpvalues=%d\n", len(frameRegisters), len(vm.openUpvalues))
-	}
-	if len(frameRegisters) == 0 || len(vm.openUpvalues) == 0 {
-		if debugVM {
-			fmt.Printf("[DBG closeUpvalues] EXIT early: nothing to close\n")
+// closeFrameUpvalues closes every open upvalue owned by the given frame - its
+// registers AND spill slots - and clears the frame's list. O(this frame's captures);
+// callers gate on frame.openUpvalues != nil.
+func (vm *VM) closeFrameUpvalues(frame *CallFrame) {
+	for uv := frame.openUpvalues; uv != nil; {
+		next := uv.next
+		if uv.Location != nil {
+			uv.Closed = *uv.Location
+			uv.Location = nil
 		}
-		return // Nothing to close or no registers in frame
+		uv.next = nil // don't pin sibling upvalues via a dead frame list
+		uv = next
 	}
-
-	// Get the memory address range of the frame's register slice.
-	// This is somewhat fragile if the underlying array is reallocated,
-	// but should be okay as registerStack has fixed size.
-	frameStartPtr := uintptr(unsafe.Pointer(&frameRegisters[0]))
-	// Address of one past the last element
-	frameEndPtr := frameStartPtr + uintptr(len(frameRegisters))*unsafe.Sizeof(Value{})
-
-	if debugVM {
-		fmt.Printf("[DBG closeUpvalues] About to iterate %d upvalues\n", len(vm.openUpvalues))
-	}
-
-	// Iterate through openUpvalues and close those pointing into the frame.
-	// We also filter the openUpvalues list, removing the closed ones.
-	newOpenUpvalues := vm.openUpvalues[:0] // Reuse underlying array
-	for i, upvalue := range vm.openUpvalues {
-		if debugVM {
-			fmt.Printf("[DBG closeUpvalues] Processing upvalue %d/%d\n", i+1, len(vm.openUpvalues))
-		}
-		if upvalue.Location == nil { // Skip already closed upvalues
-			if debugVM {
-				fmt.Printf("[DBG closeUpvalues]   Skipping already-closed upvalue\n")
-			}
-			continue
-		}
-		upvaluePtr := uintptr(unsafe.Pointer(upvalue.Location))
-		// Check if the upvalue's location points within the memory range of frameRegisters
-		if upvaluePtr >= frameStartPtr && upvaluePtr < frameEndPtr {
-			// This upvalue points into the frame being popped, close it.
-			if debugVM {
-				fmt.Printf("[DBG closeUpvalues]   Closing upvalue (in frame range)\n")
-			}
-			location := upvalue.Location        // Save location for map removal
-			closedValue := *upvalue.Location    // Copy the value from the stack
-			upvalue.Closed = closedValue        // Store the value
-			upvalue.Location = nil              // Mark as closed
-			delete(vm.openUpvalueMap, location) // Remove from map
-			// Do NOT add it back to newOpenUpvalues
-		} else {
-			// This upvalue points elsewhere (e.g., higher up the stack), keep it open.
-			if debugVM {
-				fmt.Printf("[DBG closeUpvalues]   Keeping upvalue open (outside frame range)\n")
-			}
-			newOpenUpvalues = append(newOpenUpvalues, upvalue)
-		}
-	}
-	vm.openUpvalues = newOpenUpvalues
-	if debugVM {
-		fmt.Printf("[DBG closeUpvalues] EXIT: newOpenUpvalues=%d\n", len(vm.openUpvalues))
-	}
+	frame.openUpvalues = nil
 }
 
 // hasFunctionPrototypeProperty checks if FunctionPrototype has a property.
@@ -17265,6 +17212,7 @@ func (vm *VM) startGenerator(genObj *GeneratorObject, sentValue Value) (Value, e
 	sentinelFrame := &vm.frames[vm.frameCount]
 	sentinelFrame.isSentinelFrame = true
 	sentinelFrame.closure = nil               // Sentinel frames don't have closures
+	sentinelFrame.openUpvalues = nil          // Never captures; clear any stale head from prior slot use
 	sentinelFrame.targetRegister = destReg    // Target register in caller
 	sentinelFrame.registers = callerRegisters // Give it the caller registers for the result
 	vm.frameCount++
@@ -17420,6 +17368,7 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	sentinelFrame := &vm.frames[vm.frameCount]
 	sentinelFrame.isSentinelFrame = true
 	sentinelFrame.closure = nil               // Sentinel frames don't have closures
+	sentinelFrame.openUpvalues = nil          // Never captures; clear any stale head from prior slot use
 	sentinelFrame.targetRegister = destReg    // Target register in caller
 	sentinelFrame.registers = callerRegisters // Give it the caller registers for the result
 	vm.frameCount++
@@ -17446,12 +17395,13 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
 	frame.homeObject = genObj.Frame.homeObject // Restore [[HomeObject]] for super property access
 	frame.isConstructorCall = false
-	frame.isDirectCall = true         // Mark as direct call for proper return handling
-	frame.isSentinelFrame = false     // Ensure sentinel flag is clear (frame slot may have been reused)
-	frame.argCount = len(genObj.Args) // Restore argument count
-	frame.args = genObj.Args          // Restore arguments
-	frame.argumentsObject = Undefined // Initialize arguments object (will be created on first access)
-	frame.generatorObj = genObj       // Link frame to generator object
+	frame.isDirectCall = true                      // Mark as direct call for proper return handling
+	frame.isSentinelFrame = false                  // Ensure sentinel flag is clear (frame slot may have been reused)
+	frame.openUpvalues = genObj.Frame.openUpvalues // Restore open-upvalue list carried across the suspend
+	frame.argCount = len(genObj.Args)              // Restore argument count
+	frame.args = genObj.Args                       // Restore arguments
+	frame.argumentsObject = Undefined              // Initialize arguments object (will be created on first access)
+	frame.generatorObj = genObj                    // Link frame to generator object
 
 	if closureObj != nil {
 		frame.closure = closureObj
@@ -17679,6 +17629,7 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	sentinelFrame := &vm.frames[vm.frameCount]
 	sentinelFrame.isSentinelFrame = true
 	sentinelFrame.closure = nil               // Sentinel frames don't have closures
+	sentinelFrame.openUpvalues = nil          // Never captures; clear any stale head from prior slot use
 	sentinelFrame.targetRegister = destReg    // Target register in caller
 	sentinelFrame.registers = callerRegisters // Give it the caller registers for the result
 	vm.frameCount++
@@ -17705,12 +17656,13 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
 	frame.homeObject = genObj.Frame.homeObject // Restore [[HomeObject]] for super property access
 	frame.isConstructorCall = false
-	frame.isDirectCall = false        // Don't mark as direct call so exceptions can be caught
-	frame.isSentinelFrame = false     // Ensure sentinel flag is clear (frame slot may have been reused)
-	frame.argCount = len(genObj.Args) // Restore argument count
-	frame.args = genObj.Args          // Restore arguments
-	frame.argumentsObject = Undefined // Initialize arguments object (will be created on first access)
-	frame.generatorObj = genObj       // Link frame to generator object
+	frame.isDirectCall = false                     // Don't mark as direct call so exceptions can be caught
+	frame.isSentinelFrame = false                  // Ensure sentinel flag is clear (frame slot may have been reused)
+	frame.openUpvalues = genObj.Frame.openUpvalues // Restore open-upvalue list carried across the suspend
+	frame.argCount = len(genObj.Args)              // Restore argument count
+	frame.args = genObj.Args                       // Restore arguments
+	frame.argumentsObject = Undefined              // Initialize arguments object (will be created on first access)
+	frame.generatorObj = genObj                    // Link frame to generator object
 
 	if closureObj != nil {
 		frame.closure = closureObj
@@ -17848,6 +17800,7 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 	sentinelFrame := &vm.frames[vm.frameCount]
 	sentinelFrame.isSentinelFrame = true
 	sentinelFrame.closure = nil               // Sentinel frames don't have closures
+	sentinelFrame.openUpvalues = nil          // Never captures; clear any stale head from prior slot use
 	sentinelFrame.targetRegister = destReg    // Target register in caller
 	sentinelFrame.registers = callerRegisters // Give it the caller registers for the result
 	vm.frameCount++
@@ -17874,12 +17827,13 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
 	frame.homeObject = genObj.Frame.homeObject // Restore [[HomeObject]] for super property access
 	frame.isConstructorCall = false
-	frame.isDirectCall = false        // Don't mark as direct call so exceptions can be caught
-	frame.isSentinelFrame = false     // Ensure sentinel flag is clear (frame slot may have been reused)
-	frame.argCount = len(genObj.Args) // Restore argument count
-	frame.args = genObj.Args          // Restore arguments
-	frame.argumentsObject = Undefined // Initialize arguments object (will be created on first access)
-	frame.generatorObj = genObj       // Link frame to generator object
+	frame.isDirectCall = false                     // Don't mark as direct call so exceptions can be caught
+	frame.isSentinelFrame = false                  // Ensure sentinel flag is clear (frame slot may have been reused)
+	frame.openUpvalues = genObj.Frame.openUpvalues // Restore open-upvalue list carried across the suspend
+	frame.argCount = len(genObj.Args)              // Restore argument count
+	frame.args = genObj.Args                       // Restore arguments
+	frame.argumentsObject = Undefined              // Initialize arguments object (will be created on first access)
+	frame.generatorObj = genObj                    // Link frame to generator object
 
 	if closureObj != nil {
 		frame.closure = closureObj
@@ -18025,6 +17979,7 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 	sentinelFrame := &vm.frames[vm.frameCount]
 	sentinelFrame.isSentinelFrame = true
 	sentinelFrame.closure = nil               // Sentinel frames don't have closures
+	sentinelFrame.openUpvalues = nil          // Never captures; clear any stale head from prior slot use
 	sentinelFrame.targetRegister = destReg    // Target register in caller
 	sentinelFrame.registers = callerRegisters // Give it the caller registers for the result
 	vm.frameCount++
@@ -18051,9 +18006,10 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 	frame.thisValue = promiseObj.ThisValue         // Restore original this value
 	frame.homeObject = promiseObj.Frame.homeObject // Restore [[HomeObject]] for super property access
 	frame.isConstructorCall = false
-	frame.isDirectCall = true     // Mark as direct call for proper return handling
-	frame.isSentinelFrame = false // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
-	frame.generatorObj = nil      // Clear generator object when reusing frame
+	frame.isDirectCall = true                          // Mark as direct call for proper return handling
+	frame.isSentinelFrame = false                      // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
+	frame.openUpvalues = promiseObj.Frame.openUpvalues // Restore open-upvalue list carried across the await
+	frame.generatorObj = nil                           // Clear generator object when reusing frame
 	frame.argCount = 0
 	frame.promiseObj = promiseObj // Link frame to promise object
 
@@ -18149,6 +18105,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 	sentinelFrame := &vm.frames[vm.frameCount]
 	sentinelFrame.isSentinelFrame = true
 	sentinelFrame.closure = nil               // Sentinel frames don't have closures
+	sentinelFrame.openUpvalues = nil          // Never captures; clear any stale head from prior slot use
 	sentinelFrame.targetRegister = destReg    // Target register in caller
 	sentinelFrame.registers = callerRegisters // Give it the caller registers for the result
 	vm.frameCount++
@@ -18175,9 +18132,10 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 	frame.thisValue = promiseObj.ThisValue         // Restore original this value
 	frame.homeObject = promiseObj.Frame.homeObject // Restore [[HomeObject]] for super property access
 	frame.isConstructorCall = false
-	frame.isDirectCall = true     // Mark as direct call for proper return handling
-	frame.isSentinelFrame = false // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
-	frame.generatorObj = nil      // Clear generator object when reusing frame
+	frame.isDirectCall = true                          // Mark as direct call for proper return handling
+	frame.isSentinelFrame = false                      // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
+	frame.openUpvalues = promiseObj.Frame.openUpvalues // Restore open-upvalue list carried across the await
+	frame.generatorObj = nil                           // Clear generator object when reusing frame
 	frame.argCount = 0
 	frame.promiseObj = promiseObj // Link frame to promise object
 
@@ -18474,6 +18432,7 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	frame.allocatedRegSize = scriptRegSize // Track actual allocation for proper cleanup
 	frame.targetRegister = 0
 	frame.thisValue = Undefined
+	frame.openUpvalues = nil // frame slot may have been used before; start with no open upvalues
 	vm.nextRegSlot += scriptRegSize
 	vm.frameCount++
 

--- a/tests/scripts/frame_owned_upvalues_test.ts
+++ b/tests/scripts/frame_owned_upvalues_test.ts
@@ -1,0 +1,106 @@
+// expect: 3|131|0,1,2|20|20
+// Frame-owned open-upvalue list (github issue #84): closing a returning frame
+// walks only that frame's captures (registers AND spill slots), instead of
+// scanning a VM-wide list and missing spill captures entirely.
+//
+// 1. Sibling closures over the same local must share ONE Upvalue, so a write
+//    through one is visible through the other after the frame returns.
+// 2. A spill-slot capture (forced by >256 locals) that outlives its frame must
+//    read the value as of frame return, not a stale slot.
+// 3. Per-iteration `let` bindings (OpCloseUpvalue) must each capture their own i.
+
+function siblings(): number {
+  let x = 1;
+  const get = () => x;
+  const inc = () => {
+    x++;
+  };
+  inc();
+  inc();
+  return get(); // 3
+}
+
+function spillCapture(): number {
+  // 300 locals -> the tail spills to slots; `target` is among the spilled.
+  let v0 = 0, v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6, v7 = 7, v8 = 8, v9 = 9;
+  let a0 = 0, a1 = 1, a2 = 2, a3 = 3, a4 = 4, a5 = 5, a6 = 6, a7 = 7, a8 = 8, a9 = 9;
+  let b0 = 0, b1 = 1, b2 = 2, b3 = 3, b4 = 4, b5 = 5, b6 = 6, b7 = 7, b8 = 8, b9 = 9;
+  let c0 = 0, c1 = 1, c2 = 2, c3 = 3, c4 = 4, c5 = 5, c6 = 6, c7 = 7, c8 = 8, c9 = 9;
+  let d0 = 0, d1 = 1, d2 = 2, d3 = 3, d4 = 4, d5 = 5, d6 = 6, d7 = 7, d8 = 8, d9 = 9;
+  let e0 = 0, e1 = 1, e2 = 2, e3 = 3, e4 = 4, e5 = 5, e6 = 6, e7 = 7, e8 = 8, e9 = 9;
+  let f0 = 0, f1 = 1, f2 = 2, f3 = 3, f4 = 4, f5 = 5, f6 = 6, f7 = 7, f8 = 8, f9 = 9;
+  let g0 = 0, g1 = 1, g2 = 2, g3 = 3, g4 = 4, g5 = 5, g6 = 6, g7 = 7, g8 = 8, g9 = 9;
+  let h0 = 0, h1 = 1, h2 = 2, h3 = 3, h4 = 4, h5 = 5, h6 = 6, h7 = 7, h8 = 8, h9 = 9;
+  let i0 = 0, i1 = 1, i2 = 2, i3 = 3, i4 = 4, i5 = 5, i6 = 6, i7 = 7, i8 = 8, i9 = 9;
+  let j0 = 0, j1 = 1, j2 = 2, j3 = 3, j4 = 4, j5 = 5, j6 = 6, j7 = 7, j8 = 8, j9 = 9;
+  let k0 = 0, k1 = 1, k2 = 2, k3 = 3, k4 = 4, k5 = 5, k6 = 6, k7 = 7, k8 = 8, k9 = 9;
+  let l0 = 0, l1 = 1, l2 = 2, l3 = 3, l4 = 4, l5 = 5, l6 = 6, l7 = 7, l8 = 8, l9 = 9;
+  let m0 = 0, m1 = 1, m2 = 2, m3 = 3, m4 = 4, m5 = 5, m6 = 6, m7 = 7, m8 = 8, m9 = 9;
+  let n0 = 0, n1 = 1, n2 = 2, n3 = 3, n4 = 4, n5 = 5, n6 = 6, n7 = 7, n8 = 8, n9 = 9;
+  let o0 = 0, o1 = 1, o2 = 2, o3 = 3, o4 = 4, o5 = 5, o6 = 6, o7 = 7, o8 = 8, o9 = 9;
+  let p0 = 0, p1 = 1, p2 = 2, p3 = 3, p4 = 4, p5 = 5, p6 = 6, p7 = 7, p8 = 8, p9 = 9;
+  let q0 = 0, q1 = 1, q2 = 2, q3 = 3, q4 = 4, q5 = 5, q6 = 6, q7 = 7, q8 = 8, q9 = 9;
+  let r0 = 0, r1 = 1, r2 = 2, r3 = 3, r4 = 4, r5 = 5, r6 = 6, r7 = 7, r8 = 8, r9 = 9;
+  let s0 = 0, s1 = 1, s2 = 2, s3 = 3, s4 = 4, s5 = 5, s6 = 6, s7 = 7, s8 = 8, s9 = 9;
+  let s10 = 0, s11 = 0, s12 = 0, s13 = 0, s14 = 0, s15 = 0, s16 = 0, s17 = 0, s18 = 0, s19 = 0;
+  let s20 = 0, s21 = 0, s22 = 0, s23 = 0, s24 = 0, s25 = 0, s26 = 0, s27 = 0, s28 = 0, s29 = 0;
+  let s30 = 0, s31 = 0, s32 = 0, s33 = 0, s34 = 0, s35 = 0, s36 = 0, s37 = 0, s38 = 0, s39 = 0;
+  let s40 = 0, s41 = 0, s42 = 0, s43 = 0, s44 = 0, s45 = 0, s46 = 0, s47 = 0, s48 = 0, s49 = 0;
+  let s50 = 0, s51 = 0, s52 = 0, s53 = 0, s54 = 0, s55 = 0, s56 = 0, s57 = 0, s58 = 0, s59 = 0;
+  let target = 42;
+  const f = () => target + v9 + a0 + s59;
+  target = 122;
+  return f(); // 122 + 9 + 0 + 0 = 131
+}
+
+function loopBindings(): string {
+  const fns: Array<() => number> = [];
+  for (let i = 0; i < 3; i++) fns.push(() => i);
+  return fns[0]() + "," + fns[1]() + "," + fns[2]();
+}
+
+function noise(n: number): number {
+  const a = n;
+  return n <= 0 ? 0 : a + noise(n - 1);
+}
+
+// A closure captured before the first `yield` must stay live across every
+// suspend and be closed only on completion - so after the generator is done
+// and the register stack has been churned hard, get() still reads x (== 20 at
+// return), not a recycled register.
+function genCaptureAcrossChurn(): number {
+  function* g() {
+    let x = 10;
+    let get = () => x;
+    yield 1;
+    x = 20;
+    yield 2;
+    return get;
+  }
+  const it = g();
+  it.next();
+  it.next();
+  const r = it.next();
+  let getFn = r.value as () => number;
+  let churn = 0;
+  for (let i = 0; i < 2000; i++) churn += noise(30);
+  return getFn() + (churn - churn); // 20
+}
+
+function genCapture(): number {
+  function* g() {
+    let x = 10;
+    const get = () => x;
+    yield 1;
+    x = 20;
+    yield 2;
+    return get;
+  }
+  const it = g();
+  it.next();
+  it.next();
+  const r = it.next();
+  return (r.value as () => number)();
+}
+
+`${siblings()}|${spillCapture()}|${loopBindings()}|${genCapture()}|${genCaptureAcrossChurn()}`;


### PR DESCRIPTION
Fixes #84.

## Problem

`closeUpvalues` walked the VM-wide `openUpvalues` slice on every returning frame that had captured a local, pointer-range-checking each entry against the frame's register window. Capture was already O(1) via `openUpvalueMap`; close was **O(all live open upvalues)**.

The range check also structurally could not see `frame.spillSlots` (a separate heap slice), so **spill captures** (`OpClosure` `CaptureFromSpill`) were *never* closed. They accumulated on `openUpvalues` forever, and every subsequent frame return re-scanned the growing list — O(n²).

`Upvalue.next` already existed for a linked-list close that was sketched and never wired.

## Change

Track open upvalues **per frame** on `CallFrame.openUpvalues`, linked through `Upvalue.next`:

- **capture** — prepend onto the active frame's list. Every capture targets the currently-active frame's registers or spill slots by construction (verified: both `OpClosure` sites only ever `captureUpvalue(&registers[i])` / `captureUpvalue(&frame.spillSlots[i])`), so dedup of sibling closures is a walk of that short per-frame list and the VM-wide `openUpvalueMap` is removed.
- **return / TCO / generator+async completion** — `closeFrameUpvalues` walks this frame's list only, O(this frame's captures), closing registers **and** spill; no `uintptr` range check.
- **`OpCloseUpvalue`** (per-iteration `let`) — map-free walk + unlink.
- `hasOwnUpvalues` (a bool that was never reset on `prepareCall` / generator resume, so latently stale) → `frame.openUpvalues != nil`.

Generators / async functions must **not** close on suspend — a suspended closure over a `let` has to stay live — so the list head rides on `SuspendedFrame` across `yield`/`await` and is restored on resume, then closed on completion. The old code closed these only by accident of a stale `hasOwnUpvalues` persisting in the reused frame slot; a naive port regressed it (caught: `get()` returned a recycled register after churn), hence the save/restore.

## Verification

- `go test ./...` green; new regression test `tests/scripts/frame_owned_upvalues_test.ts` (sibling sharing, spill capture outliving its frame, per-iteration loop bindings, generator capture surviving churn to completion).
- test262 `-diff baseline.txt`, `language/**` and `built-ins/**`: **net +0** (no new passes, no new failures), re-checked after the generator fix. Post-commit baseline hook: 16154/7140, unchanged.

## Perf

**test262 wall time is flat** (`language/statements/**`: 16.8s → 17.0s, within noise) — scripts are tiny, the open list never grows, this was never a test262 bottleneck. The issue's own profile is `tsc`, where `closeUpvalues` was 14.7% flat.

The real win is on long-running programs, and it's the spill leak specifically. Microbenchmark — each call captures a spilled local into a returned closure:

| n | before | after | |
|---|--------|-------|---|
| 4,000 | 39 ms | 26 ms | 1.5× |
| 30,000 | ~800 ms | ~190 ms | **4.3×** |

Identical numeric results before/after — the O(n²) was entirely upvalues that never left the list.

## Not in this PR

Filed #85 — a pre-existing compiler panic (`Symbol not found in current scope for register update`) hit while writing the test, when a nested `function*` generator has a `const <name> = <arrow>` binding whose name collides with an outer-scope binding. Worked around in the test by avoiding the collision.
