### PR TITLE
perf(string): make UTF-16 offset conversion O(1), not a scan per call

### DIFF
--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -30,54 +30,30 @@ var ErrVMUnwinding = errors.New("VM unwinding")
 // charAt go through vm.StringToUTF16 — so this is about routing the rest of the
 // surface through the same coordinate system rather than inventing one.
 //
-// Offsets are converted rather than working in []uint16 throughout: conversion
-// is a linear scan, where materializing every string as UTF-16 to slice it would
-// allocate on every call for the ASCII case that dominates.
+// These three are thin wrappers over the cached primitives in pkg/vm. They were
+// once local scans, and that was the bug behind nooga#87: each one walked the
+// whole string on every call, so TypeScript's scanner — text.substring(tokenPos,
+// pos) over the entire source, once per token — made per-file parse quadratic in
+// length. A 4.5k-line .d.ts spent 53% of its parse CPU inside these two
+// functions.
+//
+// Keeping them as wrappers rather than deleting them is deliberate: the 46 call
+// sites read better in the local vocabulary, and one definition means there is
+// still exactly one UTF-16 coordinate system rather than a second, uncached one
+// living in builtins.
 
 // utf16Len is the string's length in UTF-16 code units — what .length reports.
-func utf16Len(s string) int {
-	n := 0
-	for _, r := range s {
-		n++
-		if r > 0xFFFF {
-			n++ // astral characters occupy a surrogate pair
-		}
-	}
-	return n
-}
+func utf16Len(s string) int { return vm.UTF16Length(s) }
 
 // utf16ToByteOffset maps a UTF-16 code unit offset to a byte offset, clamped to
 // the string. An offset landing between the halves of a surrogate pair rounds
 // up to the end of that character: a UTF-8 buffer cannot hold half of one, and
 // rounding up keeps the result a valid string rather than a broken sequence.
-func utf16ToByteOffset(s string, u16 int) int {
-	if u16 <= 0 {
-		return 0
-	}
-	n := 0
-	for i, r := range s {
-		if n >= u16 {
-			return i
-		}
-		n++
-		if r > 0xFFFF {
-			n++
-		}
-	}
-	return len(s)
-}
+func utf16ToByteOffset(s string, u16 int) int { return vm.UTF16ToByteOffset(s, u16) }
 
 // byteToUTF16Offset is the inverse, for reporting an index found by a byte-wise
 // search back to the caller in the units the caller thinks in.
-func byteToUTF16Offset(s string, b int) int {
-	if b <= 0 {
-		return 0
-	}
-	if b > len(s) {
-		b = len(s)
-	}
-	return utf16Len(s[:b])
-}
+func byteToUTF16Offset(s string, b int) int { return vm.ByteToUTF16Offset(s, b) }
 
 func requireObjectCoercible(vmInstance *vm.VM, val vm.Value, methodName string) error {
 	if val.Type() == vm.TypeNull {

--- a/pkg/vm/string_utf16.go
+++ b/pkg/vm/string_utf16.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"math"
+	"sort"
 	"sync/atomic"
 	"unsafe"
 )
@@ -41,6 +43,10 @@ type utf16Entry struct {
 	n       int      // length in UTF-16 code units
 	ascii   bool     // all code points < 0x80
 	units   []uint16 // materialised view; nil when ascii
+	// byteOff[u] is the byte offset of code unit u, with byteOff[n] == len(s).
+	// nil when ascii, where the mapping is the identity. Non-decreasing, so a
+	// byte offset can be mapped back with a binary search.
+	byteOff []int32
 }
 
 var utf16Cache [utf16CacheSlots]atomic.Pointer[utf16Entry]
@@ -65,8 +71,9 @@ func stringInfo(s string) *utf16Entry {
 	if IsASCII(s) {
 		e = &utf16Entry{ptr: ptr, byteLen: len(s), n: len(s), ascii: true}
 	} else {
-		units := stringToUTF16Uncached(s)
-		e = &utf16Entry{ptr: ptr, byteLen: len(s), n: len(units), ascii: false, units: units}
+		units, offs := stringToUTF16WithOffsets(s, len(s) <= math.MaxInt32)
+		e = &utf16Entry{ptr: ptr, byteLen: len(s), n: len(units), ascii: false,
+			units: units, byteOff: offs}
 	}
 	utf16Cache[slot].Store(e)
 	return e
@@ -144,6 +151,82 @@ func UTF16CodePointAt(s string, idx int) (uint32, bool) {
 	return (uint32(first)-0xD800)*0x400 + (uint32(second) - 0xDC00) + 0x10000, true
 }
 
+// UTF16ToByteOffset maps a UTF-16 code unit offset to a byte offset into s,
+// clamped to the string. An offset landing between the halves of a surrogate
+// pair rounds up to the end of that character: a UTF-8 buffer cannot hold half
+// of one, and rounding up keeps the result a valid string boundary.
+//
+// This is the conversion String.prototype.substring / slice / substr need. It
+// used to live in builtins as a fresh `for range s` from byte 0 on every call,
+// which made TypeScript's scanner - text.substring(tokenPos, pos) over the whole
+// source, once per token - quadratic in file length.
+func UTF16ToByteOffset(s string, u16 int) int {
+	if u16 <= 0 {
+		return 0
+	}
+	e := stringInfo(s)
+	if u16 >= e.n {
+		return len(s)
+	}
+	if e.ascii {
+		// One byte per code unit, so the two coordinate systems coincide.
+		return u16
+	}
+	if e.byteOff == nil {
+		return utf16ToByteOffsetUncached(s, u16)
+	}
+	// Both halves of a surrogate pair record their character's start, so a tie
+	// with the previous unit means u16 is a trail surrogate. It has no byte
+	// position of its own; round up to the end of the character, which is where
+	// the next one begins.
+	if u16 > 0 && e.byteOff[u16] == e.byteOff[u16-1] {
+		return int(e.byteOff[u16+1])
+	}
+	return int(e.byteOff[u16])
+}
+
+// ByteToUTF16Offset maps a byte offset into s to a UTF-16 code unit offset -
+// the inverse of UTF16ToByteOffset, and what the regex path needs to report
+// match positions in the units ECMAScript counts.
+//
+// For a byte offset that is not a character boundary the result is the index of
+// the unit whose character contains it. Callers pass boundaries in practice:
+// the offsets come from the regex engine and from strings.Index, both of which
+// return them.
+func ByteToUTF16Offset(s string, b int) int {
+	if b <= 0 {
+		return 0
+	}
+	e := stringInfo(s)
+	if b >= len(s) {
+		return e.n
+	}
+	if e.ascii {
+		return b
+	}
+	if e.byteOff == nil {
+		return len(stringToUTF16Uncached(s[:b]))
+	}
+	// byteOff is non-decreasing, so the first unit at or past b is the answer.
+	return sort.Search(e.n, func(u int) bool { return int(e.byteOff[u]) >= b })
+}
+
+// utf16ToByteOffsetUncached is the walking fallback, used only when the offset
+// index was not built (a string longer than MaxInt32 bytes).
+func utf16ToByteOffsetUncached(s string, u16 int) int {
+	n := 0
+	for i, r := range s {
+		if n >= u16 {
+			return i
+		}
+		n++
+		if r > 0xFFFF {
+			n++
+		}
+	}
+	return len(s)
+}
+
 // UTF16CharAt returns the one-code-unit substring at UTF-16 index idx (what
 // charAt and String.prototype.at hand back) and whether idx was in range. A
 // lone surrogate is re-encoded as WTF-8 via UTF16ToString rather than through
@@ -181,7 +264,39 @@ func StringToUTF16(s string) []uint16 {
 // encoded lone surrogates that our lexer produces. Callers should go through
 // StringToUTF16 / stringInfo so the result is cached.
 func stringToUTF16Uncached(s string) []uint16 {
+	units, _ := stringToUTF16WithOffsets(s, false)
+	return units
+}
+
+// stringToUTF16WithOffsets is the decoder above, optionally also recording where
+// each code unit begins in the byte string. The offsets exist so that the
+// UTF-16 <-> byte coordinate conversions can be O(1) after one classification
+// instead of re-walking the string on every call.
+//
+// A surrogate pair records the START of its character for the lead unit and its
+// END for the trail unit. That is deliberate: an offset landing between the
+// halves of a pair has no byte position of its own, and rounding it up keeps
+// every conversion a valid string boundary rather than a broken sequence.
+//
+// Both halves of a surrogate pair record the START of their character, so the
+// offsets are non-decreasing and a byte offset can be mapped back by searching
+// them. The round-up that a trail surrogate needs — it has no byte position of
+// its own — is applied in UTF16ToByteOffset, where the tie identifies it.
+//
+// The returned offsets have n+1 entries, the last being len(s), so the end of
+// the string is addressable without a special case.
+func stringToUTF16WithOffsets(s string, wantOffsets bool) ([]uint16, []int32) {
 	result := make([]uint16, 0, len(s))
+	var offs []int32
+	if wantOffsets {
+		offs = make([]int32, 0, len(s)+1)
+	}
+	// one records a single code unit that begins at byte i.
+	one := func(i int) {
+		if wantOffsets {
+			offs = append(offs, int32(i))
+		}
+	}
 	bytes := []byte(s)
 	i := 0
 
@@ -190,19 +305,23 @@ func stringToUTF16Uncached(s string) []uint16 {
 		if b < 0x80 {
 			// ASCII
 			result = append(result, uint16(b))
+			one(i)
 			i++
 		} else if b < 0xC0 {
 			// Invalid leading byte, treat as single byte
 			result = append(result, uint16(b))
+			one(i)
 			i++
 		} else if b < 0xE0 {
 			// 2-byte sequence
 			if i+1 < len(bytes) {
 				r := rune(b&0x1F)<<6 | rune(bytes[i+1]&0x3F)
 				result = append(result, uint16(r))
+				one(i)
 				i += 2
 			} else {
 				result = append(result, uint16(b))
+				one(i)
 				i++
 			}
 		} else if b < 0xF0 {
@@ -214,9 +333,11 @@ func stringToUTF16Uncached(s string) []uint16 {
 				r := rune(b&0x0F)<<12 | rune(b2&0x3F)<<6 | rune(b3&0x3F)
 				// This handles both regular BMP chars and WTF-8 surrogates
 				result = append(result, uint16(r))
+				one(i)
 				i += 3
 			} else {
 				result = append(result, uint16(b))
+				one(i)
 				i++
 			}
 		} else if b < 0xF8 {
@@ -229,17 +350,31 @@ func stringToUTF16Uncached(s string) []uint16 {
 				high := uint16(0xD800 + (r >> 10))
 				low := uint16(0xDC00 + (r & 0x3FF))
 				result = append(result, high, low)
+				if wantOffsets {
+					// BOTH halves record the start of their character. Encoding
+					// the trail as the character's END instead would collide
+					// with the next character's start, and the reverse mapping
+					// is a search over these offsets — it would land a unit
+					// early. The round-up a trail surrogate needs is applied in
+					// UTF16ToByteOffset, where a tie identifies it.
+					offs = append(offs, int32(i), int32(i))
+				}
 				i += 4
 			} else {
 				result = append(result, uint16(b))
+				one(i)
 				i++
 			}
 		} else {
 			// Invalid UTF-8 leading byte
 			result = append(result, uint16(b))
+			one(i)
 			i++
 		}
 	}
 
-	return result
+	if wantOffsets {
+		offs = append(offs, int32(len(bytes)))
+	}
+	return result, offs
 }

--- a/pkg/vm/string_utf16_offset_test.go
+++ b/pkg/vm/string_utf16_offset_test.go
@@ -1,0 +1,196 @@
+package vm
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The offset conversions used to live in pkg/builtins as these two walks. They
+// are reproduced here so the cached replacements can be checked against the
+// behaviour they inherited, rather than against a fresh reading of the spec.
+func legacyUTF16Len(s string) int {
+	n := 0
+	for _, r := range s {
+		n++
+		if r > 0xFFFF {
+			n++
+		}
+	}
+	return n
+}
+
+func legacyUTF16ToByteOffset(s string, u16 int) int {
+	if u16 <= 0 {
+		return 0
+	}
+	n := 0
+	for i, r := range s {
+		if n >= u16 {
+			return i
+		}
+		n++
+		if r > 0xFFFF {
+			n++
+		}
+	}
+	return len(s)
+}
+
+func legacyByteToUTF16Offset(s string, b int) int {
+	if b <= 0 {
+		return 0
+	}
+	if b > len(s) {
+		b = len(s)
+	}
+	return legacyUTF16Len(s[:b])
+}
+
+// Strings whose two coordinate systems disagree in every way that matters:
+// pure ASCII, Latin-1, a 3-byte BMP character, an astral pair, and mixtures.
+// Lone surrogates are handled separately - see TestOffsetsDivergeOnLoneSurrogate.
+var offsetCorpus = []string{
+	"",
+	"a",
+	"abcdef",
+	"abcédef",
+	"éé",
+	"日本語",
+	"a日b語c",
+	"𝄞",
+	"a𝄞b",
+	"𝄞𝄞𝄞",
+	"aé日𝄞z",
+	"  padded  ",
+}
+
+func TestUTF16ToByteOffsetMatchesLegacy(t *testing.T) {
+	for _, s := range offsetCorpus {
+		// Past the end and negative are both in range for callers.
+		for u16 := -2; u16 <= legacyUTF16Len(s)+2; u16++ {
+			want := legacyUTF16ToByteOffset(s, u16)
+			if got := UTF16ToByteOffset(s, u16); got != want {
+				t.Errorf("UTF16ToByteOffset(%q, %d) = %d, legacy = %d", s, u16, got, want)
+			}
+		}
+	}
+}
+
+func TestByteToUTF16OffsetMatchesLegacy(t *testing.T) {
+	for _, s := range offsetCorpus {
+		for b := -2; b <= len(s)+2; b++ {
+			// Only character boundaries are contractual; the legacy walk gave
+			// unspecified answers mid-character and no caller passes one.
+			if b > 0 && b < len(s) && !isBoundary(s, b) {
+				continue
+			}
+			want := legacyByteToUTF16Offset(s, b)
+			if got := ByteToUTF16Offset(s, b); got != want {
+				t.Errorf("ByteToUTF16Offset(%q, %d) = %d, legacy = %d", s, b, got, want)
+			}
+		}
+	}
+}
+
+func isBoundary(s string, b int) bool {
+	for i := range s {
+		if i == b {
+			return true
+		}
+	}
+	return b == len(s)
+}
+
+// The two conversions must compose back to identity on boundaries, which is the
+// property substring/slice actually depend on.
+func TestOffsetRoundTrip(t *testing.T) {
+	for _, s := range offsetCorpus {
+		n := UTF16Length(s)
+		for u16 := 0; u16 <= n; u16++ {
+			b := UTF16ToByteOffset(s, u16)
+			back := ByteToUTF16Offset(s, b)
+			// A trail surrogate rounds up to the end of its character, so it
+			// maps to the following unit rather than back to itself.
+			if back != u16 && !(back == u16+1 || back == u16-1) {
+				t.Errorf("round trip %q: %d -> byte %d -> %d", s, u16, b, back)
+			}
+			if b < 0 || b > len(s) {
+				t.Errorf("round trip %q: %d -> byte %d out of range", s, u16, b)
+			}
+		}
+	}
+}
+
+// A WTF-8 lone surrogate is where the new conversions deliberately DIVERGE from
+// the ones they replace. The legacy walk used Go's range, which yields one
+// RuneError per invalid byte and so counted a lone surrogate as three code
+// units. The engine's own decoder - the one behind .length and charCodeAt -
+// decodes it as the single unit it is. Routing builtins through the cache
+// therefore makes substring agree with .length, which it did not before.
+func TestOffsetsDivergeOnLoneSurrogate(t *testing.T) {
+	lone := string([]byte{0xED, 0xA0, 0x80}) // WTF-8 U+D800
+
+	if got, want := UTF16Length(lone), 1; got != want {
+		t.Fatalf("UTF16Length(lone) = %d, want %d", got, want)
+	}
+	if got := legacyUTF16Len(lone); got == 1 {
+		t.Fatalf("legacy agreed with the cache, so this test no longer documents a divergence")
+	} else {
+		t.Logf("documented divergence: legacy counted %d units, engine counts 1", got)
+	}
+
+	// The whole point: the end of the string is reachable, and slicing at the
+	// unit boundaries produces the same string back.
+	if got, want := UTF16ToByteOffset(lone, 1), len(lone); got != want {
+		t.Errorf("UTF16ToByteOffset(lone, 1) = %d, want %d", got, want)
+	}
+	if got, want := ByteToUTF16Offset(lone, len(lone)), 1; got != want {
+		t.Errorf("ByteToUTF16Offset(lone, %d) = %d, want %d", len(lone), got, want)
+	}
+}
+
+// The cache holds 8 slots, so a scanner alternating between more strings than
+// that must still be correct - just slower. Correctness must not depend on a hit.
+func TestOffsetsSurviveCacheEviction(t *testing.T) {
+	var strs []string
+	for i := 0; i < utf16CacheSlots*4; i++ {
+		strs = append(strs, fmt.Sprintf("é%d日%d", i, i))
+	}
+	for round := 0; round < 3; round++ {
+		for _, s := range strs {
+			for u16 := 0; u16 <= legacyUTF16Len(s); u16++ {
+				if got, want := UTF16ToByteOffset(s, u16), legacyUTF16ToByteOffset(s, u16); got != want {
+					t.Fatalf("after eviction, UTF16ToByteOffset(%q, %d) = %d, want %d", s, u16, got, want)
+				}
+			}
+		}
+	}
+}
+
+// BenchmarkScannerSubstring is the shape that made nooga#87 quadratic: a scanner
+// converting offsets into the WHOLE source once per token. What matters is the
+// SCALING — at 4x the input a linear implementation costs ~4x, where the walking
+// one cost ~16x. Run with -benchtime=1x over the sizes to see it.
+func BenchmarkScannerSubstring(b *testing.B) {
+	for _, n := range []int{1 << 14, 1 << 16, 1 << 18} {
+		src := makeASCII(n)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				pos := 0
+				for tok := 8; tok <= n; tok += 8 {
+					_ = UTF16ToByteOffset(src, pos)
+					_ = UTF16ToByteOffset(src, tok)
+					pos = tok
+				}
+			}
+		})
+	}
+}
+
+func makeASCII(n int) string {
+	buf := make([]byte, n)
+	for i := range buf {
+		buf[i] = byte('a' + i%26)
+	}
+	return string(buf)
+}


### PR DESCRIPTION
Fixes #87.

`substring`, `slice`, `substr`, `indexOf` and the regex match-position path all went through three helpers in `pkg/builtins/string_init.go` that walked the whole string on every call. Since TypeScript's scanner is `text.substring(tokenPos, pos)` over the entire source once per token, the sum over tokens was quadratic in file length — the 53% of `tsc` parse CPU you profiled into `utf16Len` and `utf16ToByteOffset`.

The engine already had the answer. #82 added a per-string classification cache with an ASCII fast path, and `charCodeAt` / `.length` / `charAt` use it; these helpers did not. They were the second, uncached UTF-16 coordinate system.

## What changed

The conversion moves into `pkg/vm` behind that cache, as `UTF16ToByteOffset` and `ByteToUTF16Offset`.

ASCII — every lib and `@types/node` `.d.ts` — is the identity, so `substring` becomes `s[start:end]` with no scan. Non-ASCII gets a byte-offset index built once at classification time, alongside the `[]uint16` view already materialised there, so it is a lookup rather than a walk. Cost is one `[]int32` per non-ASCII string, and nothing for ASCII.

The three builtins helpers remain as one-line wrappers. Deleting them would have churned 46 call sites that read better in the local vocabulary, and one definition means there is again exactly one coordinate system rather than a second uncached one.

One design point worth your eyes. Both halves of a surrogate pair record the **start** of their character. Encoding the trail as the character's **end** is the obvious choice and is wrong: it collides with the next character's start, and since the reverse mapping is a search over these offsets, it lands a unit early. The differential test caught it. The round-up a trail surrogate does need — it has no byte position of its own — is applied in `UTF16ToByteOffset`, where the tie identifies it.

## Scaling

End to end on a scanner-shaped script, min of 3:

| N | before | after |
|---|---|---|
| 20,000 | 0.07s | 0.01s |
| 40,000 | 0.29s | 0.01s |
| 80,000 | 1.16s | 0.01s |
| 160,000 | 4.76s | 0.03s |

Before quadruples per doubling; after is flat at the 0.01s startup floor, which is your success criterion. `BenchmarkScannerSubstring` in the test file measures the same property at the Go level.

I could not reproduce your `tsc` numbers directly — that needs noderati, which I do not have set up — so this is the scaling on the fixed path rather than a `crypto.d.ts` timing. Worth confirming on your side that parse is now linear in practice.

## Verification

Correctness is checked against the implementations being replaced rather than against a fresh reading of the spec: the old walks are kept in the test file and diffed over a corpus spanning ASCII, Latin-1, BMP, astral and a workload that overflows the 8-slot cache, so a miss cannot hide a wrong answer.

Test262 at `-timeout 2s`, compared as failing sets:

- `built-ins/String` 1127 → 1129 of 1223, no regressions.
- `built-ins/RegExp` unchanged at 999 of 1879, identical set.
- `language` unchanged at 23255, identical set.

The two newly passing tests are `isWellFormed/returns-boolean` and `toWellFormed/returns-well-formed-string`. They pass because the old helpers used Go's `range`, which yields one `RuneError` per byte of a WTF-8 lone surrogate and so counted it as three code units where the engine's own decoder counts one. `substring` and `.length` disagreed on such a string; now they do not.
