### PR TITLE
Resolve nested ESM from the importing module

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4227,7 +4227,11 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 		return BadRegister, nil
 	}
 
-	sourceModuleRecord, err := c.moduleLoader.LoadModule(sourceModule, ".")
+	fromPath := "."
+	if c.moduleBindings != nil && c.moduleBindings.ModulePath != "" {
+		fromPath = c.moduleBindings.ModulePath
+	}
+	sourceModuleRecord, err := c.moduleLoader.LoadModule(sourceModule, fromPath)
 	if err != nil {
 		return BadRegister, NewCompileError(node, fmt.Sprintf("Failed to load source module '%s' for re-export: %v", sourceModule, err))
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -625,6 +625,29 @@ func (p *Paserati) AddResolver(resolver modules.ModuleResolver) {
 	p.moduleLoader.AddResolver(resolver)
 }
 
+// PreloadAllNativeModules loads every declared native module and registers
+// its exports on the shared heap so nested ESM files can import them.
+func (p *Paserati) PreloadAllNativeModules() error {
+	if p.nativeResolver == nil {
+		return nil
+	}
+	seen := make(map[*NativeModule]bool)
+	for name, mod := range p.nativeResolver.modules {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		rec, err := p.LoadModule(name, ".")
+		if err != nil {
+			return err
+		}
+		if concrete, ok := rec.(*modules.ModuleRecord); ok {
+			p.registerNativeModuleExports(concrete)
+		}
+	}
+	return nil
+}
+
 // CompileModule compiles a module file with proper dependency resolution
 // This is used by the test framework to compile modules with full module loading
 func (p *Paserati) CompileModule(filename string) (*vm.Chunk, []errors.PaseratiError) {

--- a/pkg/modules/types.go
+++ b/pkg/modules/types.go
@@ -322,3 +322,8 @@ func (mr *ModuleRecord) GetSource() string {
 	}
 	return mr.Source.Content
 }
+
+// GetResolvedPath returns the canonical resolved path for this module.
+func (mr *ModuleRecord) GetResolvedPath() string {
+	return mr.ResolvedPath
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -266,6 +266,7 @@ func NewParser(l *lexer.Lexer) *Parser {
 	p.registerPrefix(lexer.READONLY, p.parseIdentifier) // READONLY is a contextual keyword, can be used as identifier
 	p.registerPrefix(lexer.OVERRIDE, p.parseIdentifier) // OVERRIDE is a contextual keyword, can be used as identifier
 	p.registerPrefix(lexer.ABSTRACT, p.parseIdentifier) // ABSTRACT is a contextual keyword, can be used as identifier
+	p.registerPrefix(lexer.IS, p.parseIdentifier)       // IS is a contextual keyword (type predicates), can be used as identifier in JS
 	p.registerPrefix(lexer.FUNCTION, func() Expression { return p.parseFunctionLiteral(false) })
 	p.registerPrefix(lexer.ASYNC, p.parseAsyncExpression) // Added for async functions and async arrows
 	p.registerPrefix(lexer.CLASS, p.parseClassExpression)
@@ -1798,7 +1799,7 @@ func (p *Parser) parseLetStatement() Statement {
 		return p.parseObjectDestructuringDeclaration(letToken, false, true)
 	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
 		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT:
+		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
 		// Regular identifier: let x = ... or let x = ..., y = ... (including contextual keywords and FutureReservedWords)
 		stmt := &LetStatement{Token: letToken}
 		firstDeclarator := &VarDeclarator{}
@@ -1895,7 +1896,7 @@ func (p *Parser) parseConstStatement() Statement {
 		return p.parseObjectDestructuringDeclaration(constToken, true, true)
 	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
 		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT:
+		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
 		// Regular identifier: const x = ... or const x = ..., y = ... (including contextual keywords and FutureReservedWords)
 		stmt := &ConstStatement{Token: constToken}
 		firstDeclarator := &VarDeclarator{}
@@ -4177,7 +4178,7 @@ func (p *Parser) isContextualKeywordAsIdent() bool {
 	switch p.curToken.Type {
 	case lexer.SET, lexer.GET, lexer.FROM, lexer.OF, lexer.AS,
 		lexer.ASYNC, lexer.STATIC, lexer.TYPE, lexer.READONLY,
-		lexer.OVERRIDE, lexer.ABSTRACT, lexer.UNDEFINED:
+		lexer.OVERRIDE, lexer.ABSTRACT, lexer.UNDEFINED, lexer.IS:
 		return true
 	}
 	return false
@@ -4193,7 +4194,7 @@ func (p *Parser) peekIsIdentifierLike() bool {
 	switch p.peekToken.Type {
 	case lexer.IDENT, lexer.SET, lexer.GET, lexer.FROM, lexer.OF, lexer.AS,
 		lexer.ASYNC, lexer.STATIC, lexer.TYPE, lexer.READONLY,
-		lexer.OVERRIDE, lexer.ABSTRACT:
+		lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
 		return true
 	}
 	return false
@@ -4315,7 +4316,7 @@ func (p *Parser) curTokenIsIdentLike() bool {
 	switch p.curToken.Type {
 	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
 		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT:
+		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
 		return true
 	}
 	return false
@@ -4330,7 +4331,7 @@ func (p *Parser) expectPeekIdentifierOrKeyword() bool {
 	switch p.peekToken.Type {
 	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
 		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT:
+		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
 		p.nextToken()
 		return true
 	default:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -73,17 +73,19 @@ type ModuleRecord interface {
 	GetError() error
 	IsJSONModule() bool
 	GetSource() string
+	GetResolvedPath() string
 }
 
 // ModuleContext represents a cached module execution context
 type ModuleContext struct {
-	chunk       *Chunk           // Compiled module chunk
-	exports     map[string]Value // Module's exported values
-	executed    bool             // Whether module has been executed
-	executing   bool             // Whether module is currently being executed
-	globals     []Value          // Module-specific global variables (indices 0+ within module)
-	globalNames []string         // Module-specific global variable names (for debugging)
-	namespace   Value            // Cached namespace object (ES6 9.4.6 Module Namespace Exotic Object)
+	chunk        *Chunk           // Compiled module chunk
+	exports      map[string]Value // Module's exported values
+	executed     bool             // Whether module has been executed
+	executing    bool             // Whether module is currently being executed
+	globals      []Value          // Module-specific global variables (indices 0+ within module)
+	globalNames  []string         // Module-specific global variable names (for debugging)
+	namespace    Value            // Cached namespace object (ES6 9.4.6 Module Namespace Exotic Object)
+	resolvedPath string           // Canonical path, used as fromPath for nested relative imports
 }
 
 // PendingAction represents actions that should be performed after finally blocks complete
@@ -949,6 +951,13 @@ func (vm *VM) IsOriginalEval(v Value) bool {
 // SetCurrentModulePath sets the current module path for module-specific features like import.meta
 func (vm *VM) SetCurrentModulePath(modulePath string) {
 	vm.currentModulePath = modulePath
+}
+
+func (vm *VM) moduleFromPath() string {
+	if vm.currentModulePath == "" {
+		return "."
+	}
+	return vm.currentModulePath
 }
 
 // SetImportMetaBaseDir sets the directory used to absolutize relative filesystem
@@ -18267,8 +18276,9 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 			return vm.runtimeError("No module loader available"), Undefined
 		}
 
-		// Load the module using the module loader
-		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, ".")
+		// Load the module using the module loader. Relative specifiers must
+		// resolve against the importing module, not cwd.
+		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
 		if err != nil {
 			return vm.runtimeError("Failed to load module '%s': %s", modulePath, err.Error()), Undefined
 		}
@@ -18290,9 +18300,10 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 
 			// Create module context for JSON module with default export
 			vm.moduleContexts[modulePath] = &ModuleContext{
-				chunk:    nil, // JSON modules don't have chunks
-				exports:  map[string]Value{"default": jsonValue},
-				executed: true, // JSON modules are immediately "executed"
+				chunk:        nil, // JSON modules don't have chunks
+				exports:      map[string]Value{"default": jsonValue},
+				executed:     true, // JSON modules are immediately "executed"
+				resolvedPath: moduleRecord.GetResolvedPath(),
 			}
 			return InterpretOK, Undefined
 		}
@@ -18308,11 +18319,12 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 		// Create module context without module-scoped globals
 		// All modules now use the unified heap
 		vm.moduleContexts[modulePath] = &ModuleContext{
-			chunk:       chunk,
-			exports:     make(map[string]Value),
-			executed:    false,
-			globals:     nil, // No longer used - unified heap replaces this
-			globalNames: nil, // No longer used - unified heap replaces this
+			chunk:        chunk,
+			exports:      make(map[string]Value),
+			executed:     false,
+			globals:      nil, // No longer used - unified heap replaces this
+			globalNames:  nil, // No longer used - unified heap replaces this
+			resolvedPath: moduleRecord.GetResolvedPath(),
 		}
 	}
 
@@ -18352,9 +18364,12 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 		// fmt.Printf("// [VM] executeModule: Saved execution context with %d registers deep copied\n", registerCount)
 	}
 
-	// Set current module context for module-scoped globals
-	// savedPath := vm.currentModulePath
-	vm.currentModulePath = modulePath
+	// Set current module context for nested relative imports and import.meta
+	if moduleCtx.resolvedPath != "" {
+		vm.currentModulePath = moduleCtx.resolvedPath
+	} else {
+		vm.currentModulePath = modulePath
+	}
 	// fmt.Printf("// [VM DEBUG] executeModule: Context switch from '%s' to '%s'\n", savedPath, modulePath)
 
 	// Execute the module with isolated error handling
@@ -18569,7 +18584,7 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 func (vm *VM) collectModuleExports(modulePath string, moduleCtx *ModuleContext) {
 	// Get the export values that were already collected by the driver during module execution
 	if vm.moduleLoader != nil {
-		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, ".")
+		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
 		if err == nil {
 			// Use the already-collected export values from the module record
 			// These were populated by the driver's collectExportedValues() function


### PR DESCRIPTION
## Summary
- Load relative specifiers (`./dep.js`) against the importing module’s resolved path instead of cwd, and expose `GetResolvedPath()` so nested `import.meta` / `export * from` follow the same rule.
- Add `PreloadAllNativeModules()` so a host can put native exports (`fs`, `path`, …) on the shared heap before compiling files that are not the entry module.
- Treat `is` as a JS identifier (it is only a TypeScript type-predicate keyword), which unblocks packages such as `which`.

These seams showed up while driving Paserati from noderati against real npm ESM graphs.

## Test plan
- [ ] `go test ./pkg/parser ./pkg/vm ./pkg/compiler ./pkg/driver ./pkg/modules`
- [ ] From noderati: run a script outside cwd that `import`s `./lib.js`
- [ ] From noderati: entry `app.js` imports `./lib.js` which `import { join } from "path"`
- [ ] Parse `const is = true` and `(er, is) => is` without syntax errors


Made with [Cursor](https://cursor.com)