### PR TITLE
fix(vm): treat WeakMap/WeakSet/WeakRef/FinalizationRegistry as truthy

### DIFF
--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -1815,11 +1815,16 @@ func (v Value) IsFalsey() bool {
 		return v.AsBigInt().Cmp(bigZero) == 0
 	case TypeString:
 		return v.AsString() == ""
-	case TypeSymbol, TypeObject, TypeArray, TypeArguments, TypeFunction, TypeClosure, TypeNativeFunction, TypeRegExp, TypeProxy, TypePromise, TypeMap, TypeSet, TypeDictObject, TypeBoundFunction, TypeNativeFunctionWithProps, TypeAsyncNativeFunction, TypeGenerator, TypeAsyncGenerator, TypeArrayBuffer, TypeSharedArrayBuffer, TypeTypedArray, TypeDataView:
-		// All object types (including symbols, regex, proxies, promises, maps, sets, etc.) are truthy
-		return false
+	case TypeHole, TypeUninitialized:
+		// Internal markers; these should never reach ToBoolean, but keep them
+		// falsey defensively rather than reporting a garbage value as truthy.
+		return true
 	default:
-		return true // Unknown types assumed truthy? Or panic? Let's assume truthy.
+		// Everything else - every object type (WeakMap/WeakSet/WeakRef/
+		// FinalizationRegistry included), every function type, and symbols - is
+		// truthy per ECMA-262 ToBoolean. A new object ValueType is truthy here
+		// by default instead of silently becoming falsey.
+		return false
 	}
 }
 

--- a/pkg/vm/value_test.go
+++ b/pkg/vm/value_test.go
@@ -1059,6 +1059,12 @@ func TestIsFalsey(t *testing.T) {
 		{"Function", NewFunction(0, 0, 0, 0, false, "", nil, false, false, false, false), false},
 		{"Closure", NewClosure(createTestFunctionObject("", 0), nil), false},
 		{"NativeFunction", NewNativeFunction(0, false, "", nil), false},
+		{"Map", NewMap(), false},
+		{"Set", NewSet(), false},
+		{"WeakMap", NewWeakMap(), false},
+		{"WeakSet", NewWeakSet(), false},
+		{"WeakRef", NewWeakRef(NewObject(DefaultObjectPrototype)), false},
+		{"FinalizationRegistry", NewFinalizationRegistry(NewNativeFunction(0, false, "", nil), Undefined), false},
 	}
 
 	for _, tc := range testCases {

--- a/tests/scripts/weak_collections_truthy.ts
+++ b/tests/scripts/weak_collections_truthy.ts
@@ -1,0 +1,22 @@
+// Regression test for nooga#90: WeakMap, WeakSet, WeakRef and
+// FinalizationRegistry instances were falsey because Value.IsFalsey omitted
+// their ValueTypes and the default arm reported unknown object types as falsey.
+// Per ECMA-262 ToBoolean every object is truthy.
+// expect: true
+
+const checks = [
+  !!new Map(),
+  !!new Set(),
+  !!new WeakMap(),
+  !!new WeakSet(),
+  !!new WeakRef({}),
+  !!new FinalizationRegistry(() => {}),
+];
+
+// The guard idiom from the issue: a live WeakMap must not read as missing.
+const wm = new WeakMap();
+let cache: any = null;
+cache = cache || wm;
+const guardKeepsInstance = cache === wm;
+
+checks.every((x) => x === true) && guardKeepsInstance;


### PR DESCRIPTION
Closes #90.

## Problem

`!!new WeakMap()`, `!!new WeakSet()`, `!!new WeakRef({})` (and `FinalizationRegistry`) all returned `false`. Per ECMA-262 ToBoolean every object is truthy. Any `cache || (cache = new WeakMap())` or `if (!wm)` guard treated a live collection as missing and reallocated an empty one. Surfaced running TypeScript 5.8's `tsc` on noderati.

## Cause

`Value.IsFalsey` (`pkg/vm/value.go`) listed the truthy object types in an explicit `case`, and that list omitted `TypeWeakMap` / `TypeWeakSet` / `TypeWeakRef` / `TypeFinalizationRegistry`. They fell through to:

```go
default:
    return true // comment says "assume truthy" — but true means *falsey*
```

The comment and the return value disagreed, so every unlisted `ValueType` was falsey.

## Fix

The ECMA-262 falsey set is closed and small — `null`, `undefined`, `false`, `+0`, `-0`, `NaN`, `0n`, `""` — and every one of those already has its own arm. So the stale allow-list is deleted and the `default` arm is now truthy. A new object `ValueType` added later is truthy by default instead of silently becoming falsey. `TypeHole` / `TypeUninitialized` are kept explicitly falsey (internal markers that should never reach ToBoolean).

## Verification

- Repro from the issue: all five now print `true`; `if (!new WeakMap())` / `if (!new FinalizationRegistry(()=>{}))` no longer throw.
- `TestIsFalsey` gains Map, Set, WeakMap, WeakSet, WeakRef, FinalizationRegistry cases.
- New smoke test `tests/scripts/weak_collections_truthy.ts` (the `!!` checks plus the `cache || wm` guard idiom).
- `go test ./tests -run TestScripts` green; `go build ./...` clean.
- **Full before/after test262 sweeps are byte-identical** — `language` (23,523 tests, 23147 pass) and `built-ins` (23,294 tests, 16156 pass) show zero outcome changes with vs without the fix. Those suites verify Weak* via `sameValue` / `typeof` / `instanceof`, never by boolean-coercing a freshly constructed instance, so the win here is real-world code, not test262 numbers — and the identical sweeps double as the regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)