### PR TITLE
fix(vm): grow call/register stack to 4096 frames; reclaim leaked register windows on unwind (#94)

### DIFF
--- a/pkg/vm/async.go
+++ b/pkg/vm/async.go
@@ -108,7 +108,7 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 	vm.frameCount++
 
 	// Check if we have space for the async function frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		vm.frameCount = savedFrameCount // Restore
 		return Undefined, fmt.Errorf("Stack overflow")
 	}

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -278,7 +278,7 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		}
 
 		// Check frame limit
-		if vm.frameCount == MaxFrames {
+		if vm.frameCount >= len(vm.frames) {
 			currentFrame.ip = callerIP
 			trace := vm.CaptureStackTrace()
 			fmt.Printf("\n=== VM Stack (overflow) ===\n%s\n===========================\n", trace)

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -263,6 +263,40 @@ func (vm *VM) unwindException() bool {
 	return false
 }
 
+// reclaimUnwoundRegisters restores the register-file invariant after
+// unwindException has popped one or more frames to reach a handler.
+//
+// unwindException's pop loop decrements vm.frameCount without giving back the
+// popped frames' register windows (doing it there risks double-counting against
+// the ad-hoc `nextRegSlot -= regSize` reclamation in the native-boundary error
+// paths - see issue #61 / the note in truncateFramesTo). Instead, once we've
+// settled on the frame that will actually resume bytecode execution, snap
+// vm.nextRegSlot back to the top of that frame's window. This only ever *lowers*
+// nextRegSlot (reclaiming leaked windows); it never raises it, and it no-ops for
+// frames whose registers are not carved from vm.registerStack (sentinel/native).
+func (vm *VM) reclaimUnwoundRegisters() {
+	if vm.frameCount == 0 {
+		return
+	}
+	frame := &vm.frames[vm.frameCount-1]
+	if frame.closure == nil || frame.isSentinelFrame || frame.isNativeFrame {
+		return
+	}
+	if len(frame.registers) == 0 {
+		return
+	}
+	// frame.registers was formed as vm.registerStack[base : base+n] (a 2-index
+	// slice), so cap(frame.registers) == len(vm.registerStack) - base.
+	base := len(vm.registerStack) - cap(frame.registers)
+	if base < 0 || base > len(vm.registerStack) {
+		return // not a registerStack-backed window; leave nextRegSlot untouched
+	}
+	top := base + frame.allocatedRegSize
+	if top >= 0 && top < vm.nextRegSlot {
+		vm.nextRegSlot = top
+	}
+}
+
 // handleCatchBlock transfers control to a catch block
 func (vm *VM) handleCatchBlock(handler *ExceptionHandler) {
 	frame := &vm.frames[vm.frameCount-1]
@@ -284,6 +318,9 @@ func (vm *VM) handleCatchBlock(handler *ExceptionHandler) {
 	if debugExceptions {
 		fmt.Printf("[DEBUG handleCatchBlock] Jumped to catch handler at PC %d\n", handler.HandlerPC)
 	}
+
+	// Reclaim register windows of any frames unwindException popped to get here.
+	vm.reclaimUnwoundRegisters()
 
 	// Clear exception state
 	vm.currentException = Null
@@ -318,6 +355,9 @@ func (vm *VM) handleFinallyBlock(handler *ExceptionHandler) {
 	// Jump to finally handler
 	frame.ip = handler.HandlerPC
 	vm.finallyDepth++
+
+	// Reclaim register windows of any frames unwindException popped to get here.
+	vm.reclaimUnwoundRegisters()
 
 	// fmt.Printf("[DEBUG] handleFinallyBlock: Set IP to %d, finallyDepth=%d\n", handler.HandlerPC, vm.finallyDepth)
 

--- a/pkg/vm/op_spreadnew.go
+++ b/pkg/vm/op_spreadnew.go
@@ -72,7 +72,7 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		}
 
 		// Check stack limits
-		if vm.frameCount == MaxFrames {
+		if vm.frameCount >= len(vm.frames) {
 			frame.ip = callerIP
 			status := vm.runtimeError("Stack overflow during constructor call.")
 			return status, Undefined
@@ -174,7 +174,7 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		constructorFunc := constructorClosure.Fn
 
 		// Check stack limits
-		if vm.frameCount == MaxFrames {
+		if vm.frameCount >= len(vm.frames) {
 			frame.ip = callerIP
 			status := vm.runtimeError("Stack overflow during constructor call.")
 			return status, Undefined

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -19,9 +19,28 @@ import (
 )
 
 const RegFileSize = 256 // Max registers per function call frame
-const MaxFrames = 512   // Max call stack depth
-// NOTE: Total stack = RegFileSize * MaxFrames = ~3MB. For dynamic expansion in the future,
-// upvalues would need to change from raw pointers to indices. See docs/bucketlist.md.
+
+// MaxFrames is the maximum call stack depth (number of simultaneously live
+// activations) and, multiplied by RegFileSize, the size of the VM-wide register
+// file. It is a var, not a const, so embedders can tune it before creating a VM
+// (see SetMaxFrames); the backing arrays (VM.frames, VM.registerStack) are
+// allocated once in NewVM from its then-current value and never reallocated, so
+// raw *Value pointers held by open upvalues stay valid for the VM's lifetime.
+//
+// Total register file = RegFileSize * MaxFrames * sizeof(Value) (~24B):
+// 4096 frames => ~24MB, allocated lazily per VM. Deep recursive workloads (e.g.
+// running tsc's binder) need more than the historical 512.
+var MaxFrames = 4096
+
+// SetMaxFrames overrides the call-stack depth / register-file size used by VMs
+// created afterwards. It has no effect on already-constructed VMs. A value < 64
+// is clamped to 64.
+func SetMaxFrames(n int) {
+	if n < 64 {
+		n = 64
+	}
+	MaxFrames = n
+}
 
 // Debug flags - set these to control debug output
 const debugVM = false              // VM execution tracing
@@ -153,13 +172,16 @@ type BytecodeCall struct {
 
 // VM represents the virtual machine state.
 type VM struct {
-	// The call stack
-	frames     [MaxFrames]CallFrame
+	// The call stack. Allocated once in NewVM (len == MaxFrames) and never
+	// reallocated, so &frames[i] stays stable for the VM's lifetime.
+	frames     []CallFrame
 	frameCount int
 
 	// Register file, treated as a stack. Each CallFrame gets a window into this.
-	// This avoids reallocating register arrays for every call.
-	registerStack [RegFileSize * MaxFrames]Value
+	// This avoids reallocating register arrays for every call. Allocated once in
+	// NewVM (len == RegFileSize*MaxFrames) and never reallocated, so raw *Value
+	// pointers held by open upvalues stay valid for the VM's lifetime.
+	registerStack []Value
 	nextRegSlot   int // Points to the next available slot in registerStack
 
 	// sentinelRegPool is a LIFO free-list of 1-element register slices reused as
@@ -446,6 +468,8 @@ func dumpFrameStack(vm *VM, context string) {
 func NewVM() *VM {
 	vm := &VM{
 		// frameCount and nextRegSlot initialized to 0
+		frames:                  make([]CallFrame, MaxFrames),         // Call stack (never reallocated)
+		registerStack:           make([]Value, RegFileSize*MaxFrames), // VM-wide register file (never reallocated)
 		propCache:               make(map[int]*PropInlineCache),  // Initialize inline cache
 		cacheStats:              ICacheStats{},                   // Initialize cache statistics
 		emptyRestArray:          NewArray(),                      // Initialize singleton empty array for rest params
@@ -1134,7 +1158,7 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 
 	// --- Sanity Check: Ensure enough stack space BEFORE pushing frame ---
 	// We need space for the new frame in frames array and registers in registerStack.
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		// Cannot add another frame.
 		placeholderToken := errors.Position{Line: 0, Column: 0} // TODO: Better position?
 		runtimeErr := &errors.RuntimeError{
@@ -10240,7 +10264,7 @@ startExecution:
 				// JavaScript allows passing more arguments than the function declares - they are
 				// simply ignored or can be accessed via the arguments object
 				// No arity checking needed for extra arguments
-				if vm.frameCount == MaxFrames {
+				if vm.frameCount >= len(vm.frames) {
 					frame.ip = callerIP
 					status := vm.runtimeError("Stack overflow during constructor call.")
 					return status, Undefined
@@ -10428,7 +10452,7 @@ startExecution:
 				// JavaScript allows passing more arguments than the function declares - they are
 				// simply ignored or can be accessed via the arguments object
 				// No arity checking needed for extra arguments
-				if vm.frameCount == MaxFrames {
+				if vm.frameCount >= len(vm.frames) {
 					frame.ip = callerIP
 					status := vm.runtimeError("Stack overflow during constructor call.")
 					return status, Undefined
@@ -10906,7 +10930,7 @@ startExecution:
 						vm.ThrowTypeError("Generator functions cannot be used as constructors")
 						return InterpretRuntimeError, Undefined
 					}
-					if vm.frameCount == MaxFrames {
+					if vm.frameCount >= len(vm.frames) {
 						frame.ip = callerIP
 						status := vm.runtimeError("Stack overflow during constructor call.")
 						return status, Undefined
@@ -17383,7 +17407,7 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	vm.frameCount++
 
 	// Check if we have space for the generator frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		vm.frameCount-- // Remove sentinel frame
 		return Undefined, fmt.Errorf("Stack overflow")
 	}
@@ -17644,7 +17668,7 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	vm.frameCount++
 
 	// Check if we have space for the generator frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		vm.frameCount-- // Remove sentinel frame
 		return Undefined, fmt.Errorf("Stack overflow")
 	}
@@ -17815,7 +17839,7 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 	vm.frameCount++
 
 	// Check if we have space for the generator frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		vm.frameCount-- // Remove sentinel frame
 		return Undefined, fmt.Errorf("Stack overflow")
 	}
@@ -17994,7 +18018,7 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 	vm.frameCount++
 
 	// Check if we have space for the async function frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		vm.frameCount = savedFrameCount // Restore
 		return Undefined, fmt.Errorf("Stack overflow")
 	}
@@ -18120,7 +18144,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 	vm.frameCount++
 
 	// Check if we have space for the async function frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		vm.frameCount = savedFrameCount // Restore
 		return Undefined, fmt.Errorf("Stack overflow")
 	}

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -124,7 +124,7 @@ func (vm *VM) executeAsyncNativeFunction(asyncFn *AsyncNativeFunctionObject, arg
 func (vm *VM) executeUserFunctionReentrant(fn Value, thisValue Value, args []Value) (Value, error) {
 
 	// Check if we have space for another frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		return Undefined, fmt.Errorf("stack overflow during re-entrant call")
 	}
 
@@ -216,7 +216,7 @@ func (vm *VM) CallFunctionDirectly(fn Value, thisValue Value, args []Value) (Val
 	}
 
 	// Check if we have space for another frame
-	if vm.frameCount >= MaxFrames {
+	if vm.frameCount >= len(vm.frames) {
 		return Undefined, fmt.Errorf("stack overflow during direct function call")
 	}
 

--- a/tests/scripts/deep_recursion_test.ts
+++ b/tests/scripts/deep_recursion_test.ts
@@ -6,5 +6,5 @@ function recurse(n) {
     if (n <= 0) return 0;
     return 1 + recurse(n - 1);
 }
-// 2000 exceeds the 1024 frame limit
-console.log(recurse(2000));
+// 20000 exceeds the VM's maximum call-stack depth (MaxFrames)
+console.log(recurse(20000));

--- a/tests/scripts/exception_register_reclaim_test.ts
+++ b/tests/scripts/exception_register_reclaim_test.ts
@@ -1,0 +1,26 @@
+// Regression: exception unwinding must reclaim the register windows of the
+// frames it pops to reach a catch/finally handler (issue #61).
+//
+// Before the fix, each caught exception leaked ~depth register windows off the
+// VM-wide register file. Recursing 300 deep and catching 600 times leaks well
+// over the ~1M-slot register file, so this aborted mid-run with "VM Stack
+// (register overflow)" even though frameCount returned to ~0 between iterations.
+//
+// no-typecheck
+// expect: 600
+
+function deep(n: number): number {
+  if (n <= 0) throw new Error("bottom");
+  let a = n, b = n * 2, c = n * 3, d = a + b + c;
+  return deep(n - 1) + d;
+}
+
+let caught = 0;
+for (let i = 0; i < 600; i++) {
+  try {
+    deep(300);
+  } catch (e) {
+    caught++;
+  }
+}
+caught;


### PR DESCRIPTION
Fixes #94. Partially addresses #61.

## Problem

Deep recursive workloads (e.g. running `tsc`'s binder) hit `VM Stack (register overflow)` with `frameCount` still well under the 512-frame limit. Two causes:

1. The VM-wide register file was a fixed `[256 * 512]Value`. Every live frame carves `RegisterSize` slots off it; a deep chain of wide functions (`bind`, `forEachChild*`) exhausts it.
2. **#61 leak:** `unwindException` pops frames to reach a `catch`/`finally` handler by decrementing `frameCount` **without** returning those frames' register windows. `nextRegSlot` ratchets up across every caught exception until "register overflow" fires even with `frameCount` near zero.

## Changes

### Grow the stack
- `MaxFrames` is now a `var` (default **4096**, was `const 512`) with a `SetMaxFrames(n)` knob for embedders (effective for VMs constructed afterwards).
- `VM.frames` and `VM.registerStack` move from inline fixed arrays to heap slices allocated **once** in `NewVM` and never reallocated — so the raw `*Value` pointers open upvalues hold stay valid (the blocker called out in the old `vm.go` comment). No upvalue rework required.
- All `frameCount` overflow guards now compare `len(vm.frames)` instead of the `MaxFrames` global, so the "Stack overflow" guard cannot drift from the actual allocation.
- Register file at 4096 ≈ 24 MB/VM, mostly virtual-until-touched.

### #61 — reclaim unwound register windows
- New `reclaimUnwoundRegisters()` (`pkg/vm/exceptions.go`), called at the end of `handleCatchBlock` / `handleFinallyBlock`. Snaps `nextRegSlot` back down to the resuming frame's window top (`cap(frame.registers)` → base offset).
- Only ever *lowers* `nextRegSlot`; no-ops for sentinel/native frames. Avoids the per-frame-in-the-pop-loop approach that previously drove `nextRegSlot` negative by double-counting against the native-boundary paths' own `nextRegSlot -= regSize`.
- **Still leaks on the native-boundary unwind path** (`unwindingCrossedNative` return, generator/async resume pops). #61 is narrowed, not closed — the durable fix there is likely a segmented/chunked register stack.

## Tests

- **New** `tests/scripts/exception_register_reclaim_test.ts` — deep recurse + `catch` in a loop; overflows on the pre-fix binary, returns `600` after. Verified both directions.
- `tests/scripts/deep_recursion_test.ts` bumped 2000 → 20000 (2000 now fits).
- `go test ./pkg/... ./tests/...` all green. `BenchmarkRatchetAnchor` 1.263 → 1.263 ns/op.
- test262 `-diff baseline.txt`: `language/statements` ±0, `language/expressions` ±0, `built-ins/{Promise,Function}` ±0, **`built-ins/RegExp` +3** (deep property-escape recursion now fits), 0 new failures.

## Not verified

#94's stated success criterion — full `tsc -p tsconfig.connect.json` past `initializeTypeChecker` on noderati — was not run locally (no noderati/connect setup). Verified via 3000-deep non-tail recursion, the new catch-loop regression, and test262 sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)