### PR TITLE
fix(modules): export class, named re-exports, and per-module imports

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1651,7 +1651,8 @@ func objectDefinePropertiesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value,
 	}
 
 	obj := args[0]
-	if !obj.IsObject() {
+	// Functions are objects in JS (TypeFunction/TypeClosure sit outside the IsObject range).
+	if !obj.IsObject() && !obj.IsCallable() {
 		return vm.Undefined, vmInstance.NewTypeError("Object.defineProperties called on non-object")
 	}
 

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -653,14 +653,12 @@ func (c *Compiler) syncImportsFromTypeChecker() {
 			importType = ImportNamedRef // Default fallback
 		}
 
-		// Get or assign global index for this import
-		globalIndex := c.GetOrAssignGlobalIndex(localName)
+		// Imported names must not share unified-heap slots by export name
+		// (every module's `parse` / `default` / `SettingsManager` would collide).
+		c.moduleBindings.DefineImport(localName, binding.SourceModule, binding.SourceName, importType, -1)
 
-		// Add to module bindings
-		c.moduleBindings.DefineImport(localName, binding.SourceModule, binding.SourceName, importType, int(globalIndex))
-
-		debugPrintf("// [Compiler] Synced import: %s from %s (global index: %d)\n",
-			localName, binding.SourceModule, globalIndex)
+		debugPrintf("// [Compiler] Synced import: %s from %s via OpGetModuleExport\n",
+			localName, binding.SourceModule)
 	}
 }
 
@@ -3876,14 +3874,34 @@ func (c *Compiler) GetExportGlobalIndices() map[string]int {
 
 	// Handle default export if it exists
 	if c.moduleBindings.DefaultExport != nil {
-		defaultLocalName := c.moduleBindings.DefaultExport.LocalName
-		if globalIdx := c.GetGlobalIndex(defaultLocalName); globalIdx >= 0 {
+		if globalIdx := c.moduleBindings.DefaultExport.GlobalIndex; globalIdx >= 0 {
 			exportIndices["default"] = globalIdx
-			// fmt.Printf("// [Compiler] GetExportGlobalIndices: Default export '%s' maps to global[%d]\n", defaultLocalName, globalIdx)
+		} else {
+			defaultLocalName := c.moduleBindings.DefaultExport.LocalName
+			if globalIdx := c.GetGlobalIndex(defaultLocalName); globalIdx >= 0 {
+				exportIndices["default"] = globalIdx
+			}
 		}
 	}
 
 	return exportIndices
+}
+
+// GetReExports returns named re-exports (`export { x } from "./mod"`).
+func (c *Compiler) GetReExports() map[string]vm.ModuleReExport {
+	out := make(map[string]vm.ModuleReExport)
+	if !c.IsModuleMode() || c.moduleBindings == nil {
+		return out
+	}
+	for exportName, exportRef := range c.moduleBindings.ExportedNames {
+		if exportRef != nil && exportRef.IsReExport {
+			out[exportName] = vm.ModuleReExport{
+				SourceModule: exportRef.SourceModule,
+				SourceName:   exportRef.LocalName,
+			}
+		}
+	}
+	return out
 }
 
 // hasMethodInType checks if an object type has a method with the given name
@@ -4065,14 +4083,10 @@ func (c *Compiler) compileJSONImport(node *parser.ImportDeclaration, sourceModul
 func (c *Compiler) processImportBinding(localName, sourceModule, sourceName string, importType ImportReferenceType) {
 	// If we're in module mode, use the module bindings for proper tracking
 	if c.IsModuleMode() {
-		// Since we're using a unified heap, the import should resolve to the same global index
-		// as the export. The source name (what we're importing) should have a global index.
-		globalIdx := c.GetGlobalIndex(sourceName)
-		if globalIdx == -1 {
-			// If not found, assign a new index (this coordinates the global index across modules)
-			globalIdx = int(c.GetOrAssignGlobalIndex(sourceName))
-		}
-		c.moduleBindings.DefineImport(localName, sourceModule, sourceName, importType, globalIdx)
+		// Imported names must not share unified-heap slots by export name
+		// (every module's `parse` / `default` would collide). Read the
+		// per-module snapshot via OpGetModuleExport instead.
+		c.moduleBindings.DefineImport(localName, sourceModule, sourceName, importType, -1)
 
 		// Try to resolve the actual value from the source module
 		resolvedValue := c.moduleBindings.ResolveImportedValue(localName)
@@ -4122,6 +4136,7 @@ func (c *Compiler) compileExportNamedDeclaration(node *parser.ExportNamedDeclara
 			// Re-export: export { x } from "module"
 			sourceModule := node.Source.Value
 			debugPrintf("// [Compiler] Re-export from: %s\n", sourceModule)
+			c.emitEvalModule(sourceModule, node.Token.Line)
 
 			for _, spec := range node.Specifiers {
 				if exportSpec, ok := spec.(*parser.ExportNamedSpecifier); ok {
@@ -4188,8 +4203,11 @@ func (c *Compiler) compileExportDefaultDeclaration(node *parser.ExportDefaultDec
 
 	// Register the default export
 	if c.IsModuleMode() {
-		// Get or assign a global index for the default export
-		globalIdx := c.GetOrAssignGlobalIndex("default")
+		key := "default"
+		if c.moduleBindings != nil && c.moduleBindings.ModulePath != "" {
+			key = c.moduleBindings.ModulePath + "\x00default"
+		}
+		globalIdx := c.GetOrAssignGlobalIndex(key)
 		c.moduleBindings.DefineExport("default", "default", vm.Undefined, nil, int(globalIdx))
 
 		// IMPORTANT: Store the compiled value to the global slot
@@ -4269,33 +4287,15 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 
 		debugPrintf("// [Compiler] Re-exporting '%s' from '%s'\n", exportName, sourceModule)
 
-		// Get/assign global index for this re-export
 		globalIdx := int(c.GetOrAssignGlobalIndex(exportName))
-
-		// 1. Define the import binding (like processImportDeclaration does)
-		// Use -1 for GlobalIndex to force module export lookup instead of direct global access
 		c.moduleBindings.DefineImport(exportName, sourceModule, exportName, ImportNamedRef, -1)
-
-		// 2. Define the export binding (like processExportDeclaration does)
 		c.moduleBindings.DefineExport(exportName, exportName, vm.Undefined, nil, globalIdx)
 
-		// 3. Generate bytecode to import and re-export the value
-		// Allocate a temporary register for the imported value
 		tempReg := c.regAlloc.Alloc()
-
-		// First ensure the source module is loaded
 		c.emitEvalModule(sourceModule, node.Token.Line)
-
-		// Then get the specific export from the source module
 		c.emitGetModuleExport(tempReg, sourceModule, exportName, node.Token.Line)
-
-		// Store the imported value as a global (like normal exports do)
 		globalIdxUint16 := c.GetOrAssignGlobalIndex(exportName)
 		c.emitSetGlobal(globalIdxUint16, tempReg, node.Token.Line)
-
-		debugPrintf("// [Compiler] Stored re-exported '%s' as global at index %d\n", exportName, globalIdxUint16)
-
-		// Free the temporary register
 		c.regAlloc.Free(tempReg)
 	}
 
@@ -4331,9 +4331,12 @@ func (c *Compiler) extractExportNamesFromAST(program *parser.Program) []string {
 						exportNames = append(exportNames, decl.Name.Value)
 					}
 				case *parser.ExpressionStatement:
-					// Handle function declarations: export function foo() {}
 					if expr, ok := decl.Expression.(*parser.FunctionLiteral); ok && expr.Name != nil {
 						exportNames = append(exportNames, expr.Name.Value)
+					}
+				case *parser.ClassDeclaration:
+					if decl.Name != nil {
+						exportNames = append(exportNames, decl.Name.Value)
 					}
 				}
 			} else if len(node.Specifiers) > 0 {
@@ -4419,6 +4422,25 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 				c.moduleBindings.DefineExport(expr.Name.Value, expr.Name.Value, vm.Undefined, d, globalIdx)
 				debugPrintf("// [Compiler] Exported function: %s at global[%d]\n", expr.Name.Value, globalIdx)
 			}
+		} else if expr, ok := d.Expression.(*parser.ClassExpression); ok && expr.Name != nil {
+			if c.IsModuleMode() {
+				globalIdx := c.GetGlobalIndex(expr.Name.Value)
+				if globalIdx == -1 {
+					globalIdx = int(c.GetOrAssignGlobalIndex(expr.Name.Value))
+				}
+				c.moduleBindings.DefineExport(expr.Name.Value, expr.Name.Value, vm.Undefined, d, globalIdx)
+				debugPrintf("// [Compiler] Exported class expression: %s at global[%d]\n", expr.Name.Value, globalIdx)
+			}
+		}
+
+	case *parser.ClassDeclaration:
+		if c.IsModuleMode() && d.Name != nil {
+			globalIdx := c.GetGlobalIndex(d.Name.Value)
+			if globalIdx == -1 {
+				globalIdx = int(c.GetOrAssignGlobalIndex(d.Name.Value))
+			}
+			c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
+			debugPrintf("// [Compiler] Exported class: %s at global[%d]\n", d.Name.Value, globalIdx)
 		}
 
 	default:
@@ -4447,14 +4469,11 @@ func (c *Compiler) emitImportResolve(destReg Register, importName string, line i
 			if importRef.GlobalIndex != -1 {
 				c.emitSetGlobal(uint16(importRef.GlobalIndex), destReg, line)
 			}
-		} else if importRef.GlobalIndex != -1 {
-			// Direct global access - imported values should already be loaded
-			debugPrintf("// [Compiler] emitImportResolve: Using direct global access for '%s' at index %d\n",
-				importName, importRef.GlobalIndex)
-			c.emitGetGlobal(destReg, uint16(importRef.GlobalIndex), line)
 		} else {
-			// Fallback to module export lookup (for backwards compatibility)
-			debugPrintf("// [Compiler] emitImportResolve: Fallback to module export lookup for '%s'\n", importName)
+			// Named and default imports always read the per-module export
+			// snapshot. A unified-heap index here would collide across modules
+			// (SettingsManager, valid, parse, default, …).
+			debugPrintf("// [Compiler] emitImportResolve: Module export lookup for '%s'\n", importName)
 			c.emitGetModuleExport(destReg, importRef.SourceModule, importRef.SourceName, line)
 		}
 	} else {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -973,6 +973,7 @@ func (p *Paserati) RunModule(filename string) bool {
 			exportIndices[name] = uint16(idx)
 		}
 		moduleRecord.ExportIndices = exportIndices
+		moduleRecord.ReExports = p.compiler.GetReExports()
 		debugPrintf("// [Driver] Collected %d exported values from module\n", len(exportedValues))
 	}
 
@@ -1095,6 +1096,7 @@ func (p *Paserati) RunModuleWithValue(filename string) (vm.Value, []errors.Paser
 			exportIndices[name] = uint16(idx)
 		}
 		moduleRecord.ExportIndices = exportIndices
+		moduleRecord.ReExports = p.compiler.GetReExports()
 		debugPrintf("// [Driver] Collected %d exported values from module\n", len(exportedValues))
 	}
 

--- a/pkg/modules/interfaces.go
+++ b/pkg/modules/interfaces.go
@@ -148,6 +148,7 @@ type Compiler interface {
 	SetSkipTypeCheck(skip bool)
 	Compile(node parser.Node) (interface{}, []errors.PaseratiError)
 	GetExportGlobalIndices() map[string]int
+	GetReExports() map[string]vm.ModuleReExport
 }
 
 // DependencyAnalyzer tracks module dependencies during loading

--- a/pkg/modules/loader.go
+++ b/pkg/modules/loader.go
@@ -24,6 +24,16 @@ func debugPrintf(format string, args ...interface{}) {
 	}
 }
 
+func applyCompilerExports(record *ModuleRecord, moduleCompiler Compiler) {
+	exportGlobalIndices := moduleCompiler.GetExportGlobalIndices()
+	exportIndices := make(map[string]uint16, len(exportGlobalIndices))
+	for name, idx := range exportGlobalIndices {
+		exportIndices[name] = uint16(idx)
+	}
+	record.ExportIndices = exportIndices
+	record.ReExports = moduleCompiler.GetReExports()
+}
+
 // moduleLoader implements ModuleLoader interface
 type moduleLoader struct {
 	resolvers []ModuleResolver
@@ -255,15 +265,8 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 
 			record.CompiledChunk = vmChunk
 
-			// Store export indices for dynamic import support
-			// Convert map[string]int to map[string]uint16
-			exportGlobalIndices := moduleCompiler.GetExportGlobalIndices()
-			exportIndices := make(map[string]uint16, len(exportGlobalIndices))
-			for name, idx := range exportGlobalIndices {
-				exportIndices[name] = uint16(idx)
-			}
-			record.ExportIndices = exportIndices
-			debugPrintf("// [ModuleLoader] Stored %d export indices for module: %s\n", len(exportIndices), record.ResolvedPath)
+			applyCompilerExports(record, moduleCompiler)
+			debugPrintf("// [ModuleLoader] Stored %d export indices for module: %s\n", len(record.ExportIndices), record.ResolvedPath)
 		}
 		record.State = ModuleCompiled
 	} else if ml.config.SkipTypeCheck && ml.compilerFactory != nil {
@@ -300,14 +303,8 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 
 		record.CompiledChunk = vmChunk
 
-		// Store export indices for dynamic import support
-		exportGlobalIndices := moduleCompiler.GetExportGlobalIndices()
-		exportIndices := make(map[string]uint16, len(exportGlobalIndices))
-		for name, idx := range exportGlobalIndices {
-			exportIndices[name] = uint16(idx)
-		}
-		record.ExportIndices = exportIndices
-		debugPrintf("// [ModuleLoader] Stored %d export indices for module: %s\n", len(exportIndices), record.ResolvedPath)
+		applyCompilerExports(record, moduleCompiler)
+		debugPrintf("// [ModuleLoader] Stored %d export indices for module: %s\n", len(record.ExportIndices), record.ResolvedPath)
 		record.State = ModuleCompiled
 	} else {
 		// No checker factory, just mark as parsed
@@ -857,13 +854,7 @@ func (ml *moduleLoader) performDependencyOrderedTypeChecking(entryPoint string) 
 			// Store the compiled chunk
 			record.CompiledChunk = vmChunk
 
-			// Store export indices for dynamic import support
-			exportGlobalIndices := moduleCompiler.GetExportGlobalIndices()
-			exportIndices := make(map[string]uint16, len(exportGlobalIndices))
-			for name, idx := range exportGlobalIndices {
-				exportIndices[name] = uint16(idx)
-			}
-			record.ExportIndices = exportIndices
+			applyCompilerExports(record, moduleCompiler)
 
 			debugPrintf("// [ModuleLoader] Module '%s' compiled successfully\n", modulePath)
 		}

--- a/pkg/modules/types.go
+++ b/pkg/modules/types.go
@@ -75,6 +75,7 @@ type ModuleRecord struct {
 	Exports       map[string]types.Type // Exported types
 	ExportValues  map[string]vm.Value   // Exported runtime values
 	ExportIndices map[string]uint16     // Export name to global heap index mapping (for dynamic import)
+	ReExports     map[string]vm.ModuleReExport
 	Namespace     vm.Value              // Module namespace object
 
 	// Compilation results
@@ -303,6 +304,13 @@ func (mr *ModuleRecord) GetExportNames() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+func (mr *ModuleRecord) GetReExports() map[string]vm.ModuleReExport {
+	if mr.ReExports == nil {
+		return make(map[string]vm.ModuleReExport)
+	}
+	return mr.ReExports
 }
 
 // GetError returns the error associated with this module record

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -266,7 +266,8 @@ func NewParser(l *lexer.Lexer) *Parser {
 	p.registerPrefix(lexer.READONLY, p.parseIdentifier) // READONLY is a contextual keyword, can be used as identifier
 	p.registerPrefix(lexer.OVERRIDE, p.parseIdentifier) // OVERRIDE is a contextual keyword, can be used as identifier
 	p.registerPrefix(lexer.ABSTRACT, p.parseIdentifier) // ABSTRACT is a contextual keyword, can be used as identifier
-	p.registerPrefix(lexer.IS, p.parseIdentifier)       // IS is a contextual keyword (type predicates), can be used as identifier in JS
+	p.registerPrefix(lexer.IS, p.parseIdentifier)         // IS is a contextual keyword (type predicates), can be used as identifier in JS
+	p.registerPrefix(lexer.SATISFIES, p.parseIdentifier) // SATISFIES is a TS operator, but also a valid binding name (e.g. semver)
 	p.registerPrefix(lexer.FUNCTION, func() Expression { return p.parseFunctionLiteral(false) })
 	p.registerPrefix(lexer.ASYNC, p.parseAsyncExpression) // Added for async functions and async arrows
 	p.registerPrefix(lexer.CLASS, p.parseClassExpression)
@@ -4316,7 +4317,8 @@ func (p *Parser) curTokenIsIdentLike() bool {
 	switch p.curToken.Type {
 	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
 		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
+		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS,
+		lexer.SATISFIES:
 		return true
 	}
 	return false
@@ -4331,7 +4333,8 @@ func (p *Parser) expectPeekIdentifierOrKeyword() bool {
 	switch p.peekToken.Type {
 	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
 		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
+		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS,
+		lexer.SATISFIES:
 		p.nextToken()
 		return true
 	default:
@@ -11352,8 +11355,9 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 			}
 
 			// Handle different import name patterns
-			if p.curToken.Type == lexer.IDENT {
-				// Regular identifier: { name } or { name as alias }
+			if p.curToken.Type == lexer.IDENT || p.curToken.Type == lexer.SATISFIES {
+				// Regular identifier, or contextual keyword used as a binding name
+				// (semver exports `satisfies`).
 				imported = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
 				importedToken = p.curToken
 			} else if p.curToken.Type == lexer.STRING {
@@ -11419,7 +11423,8 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 
 			// Next specifier should be identifier, string, default, or type
 			if p.curToken.Type != lexer.IDENT && p.curToken.Type != lexer.STRING &&
-				p.curToken.Type != lexer.DEFAULT && p.curToken.Type != lexer.TYPE {
+				p.curToken.Type != lexer.DEFAULT && p.curToken.Type != lexer.TYPE &&
+				p.curToken.Type != lexer.SATISFIES {
 				p.addError(p.curToken, "Expected identifier, string literal, 'default', or 'type' in import specifier")
 				return nil
 			}
@@ -11621,7 +11626,7 @@ func isExportSpecifierName(t lexer.TokenType) bool {
 		lexer.THIS, lexer.SUPER, lexer.NULL, lexer.TRUE, lexer.FALSE,
 		lexer.IMPORT, lexer.EXPORT, lexer.EXTENDS, lexer.IMPLEMENTS,
 		lexer.STATIC, lexer.GET, lexer.SET, lexer.ASYNC, lexer.AWAIT, lexer.YIELD,
-		lexer.TYPE, lexer.INTERFACE, lexer.ENUM,
+		lexer.TYPE, lexer.INTERFACE, lexer.ENUM, lexer.SATISFIES,
 		lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.READONLY, lexer.ABSTRACT,
 		lexer.KEYOF, lexer.INFER, lexer.IS:
 		return true

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -129,6 +129,32 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 					}
 				}
 				proto = fn.Prototype
+			case TypeObject:
+				// Object.setPrototypeOf(fn, plainObject) — e.g. chalk's createChalk.prototype
+				po := proto.AsPlainObject()
+				if po == nil {
+					proto = Null
+					break
+				}
+				if getter, _, _, _, exists := po.GetOwnAccessor(propName); exists {
+					if getter.Type() != TypeUndefined {
+						res, err := vm.Call(getter, objVal, nil)
+						if err != nil {
+							if ee, ok := err.(ExceptionError); ok {
+								vm.throwException(ee.GetExceptionValue())
+							} else {
+								vm.throwException(NewString(err.Error()))
+							}
+							return Undefined, false
+						}
+						return res, true
+					}
+					return Undefined, true
+				}
+				if prop, exists := po.GetOwn(propName); exists {
+					return prop, true
+				}
+				proto = po.GetPrototype()
 			default:
 				// Stop at built-in prototypes (NativeFunctionWithProps like Function.prototype)
 				// These are handled by the FunctionPrototype lookup below

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -109,7 +109,13 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 	// Walk the closure's [[Prototype]] chain for inherited static properties (class inheritance)
 	// This handles `class C extends B { }` where C.staticMethod should find B.staticMethod
 	// Only walk user-defined class constructors (Closure/Function), stop at built-in prototypes
-	if closure != nil && closure.Fn.Prototype.Type() != TypeNull && closure.Fn.Prototype.Type() != TypeUndefined {
+	// NOTE: never resolve "prototype" itself here. closure.Fn.Prototype is the function's
+	// internal [[Prototype]] slot (e.g. GeneratorFunction.prototype for `function*(){}`), which
+	// is a distinct concept from the function's own visible `.prototype` property. Generator
+	// functions' [[Prototype]] carries an own "prototype" property pointing at the *shared*
+	// GeneratorPrototype singleton — matching on it here would hand out that shared object
+	// instead of lazily creating a fresh per-instance prototype below.
+	if closure != nil && propName != "prototype" && closure.Fn.Prototype.Type() != TypeNull && closure.Fn.Prototype.Type() != TypeUndefined {
 		proto := closure.Fn.Prototype
 		for proto.Type() != TypeNull && proto.Type() != TypeUndefined {
 			switch proto.Type() {

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -1838,6 +1838,16 @@ func (v Value) IsUndefined() bool {
 	return v.typ == TypeUndefined
 }
 
+// IsNull checks if the value is null.
+func (v Value) IsNull() bool {
+	return v.typ == TypeNull
+}
+
+// IsTrue checks if the value is the boolean true.
+func (v Value) IsTrue() bool {
+	return v.IsBoolean() && v.AsBoolean()
+}
+
 // --- Equality ---
 
 // Is compares two values for equality based on the ECMAScript SameValueZero algorithm.

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -89,10 +89,17 @@ type ModuleRecord interface {
 	GetExportIndices() map[string]uint16
 	GetCompiledChunk() *Chunk
 	GetExportNames() []string
+	GetReExports() map[string]ModuleReExport
 	GetError() error
 	IsJSONModule() bool
 	GetSource() string
 	GetResolvedPath() string
+}
+
+// ModuleReExport describes `export { SourceName as ExportName } from SourceModule`.
+type ModuleReExport struct {
+	SourceModule string
+	SourceName   string
 }
 
 // ModuleContext represents a cached module execution context
@@ -104,7 +111,8 @@ type ModuleContext struct {
 	globals      []Value          // Module-specific global variables (indices 0+ within module)
 	globalNames  []string         // Module-specific global variable names (for debugging)
 	namespace    Value            // Cached namespace object (ES6 9.4.6 Module Namespace Exotic Object)
-	resolvedPath string           // Canonical path, used as fromPath for nested relative imports
+	resolvedPath      string           // Canonical path, used as fromPath for nested relative imports
+	collectingExports bool             // Guard against re-export collection recursion
 }
 
 // PendingAction represents actions that should be performed after finally blocks complete
@@ -18606,91 +18614,110 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 
 // collectModuleExports collects exported values from a module's global table
 func (vm *VM) collectModuleExports(modulePath string, moduleCtx *ModuleContext) {
-	// Get the export values that were already collected by the driver during module execution
-	if vm.moduleLoader != nil {
-		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
-		if err == nil {
-			// Use the already-collected export values from the module record
-			// These were populated by the driver's collectExportedValues() function
-			exportValues := moduleRecord.GetExportValues()
+	if vm.moduleLoader == nil {
+		return
+	}
+	from := vm.moduleFromPath()
+	if moduleCtx != nil && moduleCtx.resolvedPath != "" {
+		from = moduleCtx.resolvedPath
+	}
+	moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, from)
+	if err != nil {
+		return
+	}
 
-			// If no export values were collected, try to collect them using export indices
-			if len(exportValues) == 0 {
-				exportIndices := moduleRecord.GetExportIndices()
+	if moduleCtx.collectingExports {
+		return
+	}
+	moduleCtx.collectingExports = true
+	defer func() { moduleCtx.collectingExports = false }()
 
-				if len(exportIndices) > 0 {
-					// Use the export indices mapping to collect values directly from the heap
-					// This is the proper way for dynamically imported modules
-					for exportName, globalIdx := range exportIndices {
-						if value, exists := vm.heap.Get(int(globalIdx)); exists {
-							moduleCtx.exports[exportName] = value
-						} else {
-							moduleCtx.exports[exportName] = Undefined
-						}
-					}
-				} else {
-					// Final fallback: manual heap scanning (legacy approach)
-					// fmt.Printf("// [VM DEBUG] collectModuleExports: No export indices found for module '%s', attempting manual collection\n", modulePath)
-					exportNames := moduleRecord.GetExportNames()
+	exportValues := moduleRecord.GetExportValues()
+	for exportName, exportValue := range exportValues {
+		if exportValue.Type() == TypeUndefined {
+			continue
+		}
+		moduleCtx.exports[exportName] = exportValue
+	}
 
-					manuallyCollected := make(map[string]Value)
-					for _, exportName := range exportNames {
-						// Skip type-only exports
-						if exportName == "Vector2D" {
-							manuallyCollected[exportName] = Undefined
-							continue
-						}
+	exportIndices := moduleRecord.GetExportIndices()
+	for exportName, globalIdx := range exportIndices {
+		value, exists := vm.heap.Get(int(globalIdx))
+		if exists && value.Type() != TypeUndefined {
+			moduleCtx.exports[exportName] = value
+			continue
+		}
+		if _, ok := moduleCtx.exports[exportName]; !ok {
+			moduleCtx.exports[exportName] = Undefined
+		}
+	}
 
-						// Try to find a global variable or heap value that corresponds to this export
-						foundValue := vm.findExportValueInHeap(exportName)
-						manuallyCollected[exportName] = foundValue
-					}
-
-					// Use the manually collected values
-					for exportName, exportValue := range manuallyCollected {
-						moduleCtx.exports[exportName] = exportValue
-					}
-				}
-			} else {
-				// Copy the export values directly to the module context
-				for exportName, exportValue := range exportValues {
-					moduleCtx.exports[exportName] = exportValue
-				}
-				// fmt.Printf("// [VM DEBUG] collectModuleExports: Collected %d export values for module '%s'\n", len(exportValues), modulePath)
-				// for name, value := range exportValues {
-				//	fmt.Printf("// [VM DEBUG] collectModuleExports: Export '%s' = %s (type %d)\n", name, value.ToString(), int(value.Type()))
-				// }
+	if reExports := moduleRecord.GetReExports(); len(reExports) > 0 {
+		prevFrom := vm.currentModulePath
+		if moduleCtx.resolvedPath != "" {
+			vm.currentModulePath = moduleCtx.resolvedPath
+		}
+		for exportName, re := range reExports {
+			_, _ = vm.executeModule(re.SourceModule)
+			val := vm.getModuleExport(re.SourceModule, re.SourceName)
+			if val.Type() != TypeUndefined {
+				moduleCtx.exports[exportName] = val
 			}
+		}
+		vm.currentModulePath = prevFrom
+	}
+
+	if len(moduleCtx.exports) == 0 {
+		for _, exportName := range moduleRecord.GetExportNames() {
+			if exportName == "Vector2D" {
+				moduleCtx.exports[exportName] = Undefined
+				continue
+			}
+			moduleCtx.exports[exportName] = vm.findExportValueInHeap(exportName)
 		}
 	}
 }
 
 // getModuleExport retrieves an exported value from a module
 func (vm *VM) getModuleExport(modulePath string, exportName string) Value {
-	// Check if module context exists
-	if moduleCtx, exists := vm.moduleContexts[modulePath]; exists {
-		// fmt.Printf("// [VM DEBUG] getModuleExport: Module '%s' found, executed=%v, exports count=%d\n",
-		//	modulePath, moduleCtx.executed, len(moduleCtx.exports))
-
-		// If module has been executed but exports not collected, collect them now
-		if moduleCtx.executed && len(moduleCtx.exports) == 0 {
-			// fmt.Printf("// [VM DEBUG] getModuleExport: Module '%s' executed but exports not collected, collecting now\n", modulePath)
-			vm.collectModuleExports(modulePath, moduleCtx)
-		}
-
-		// Return the exported value if it exists
-		if exportValue, found := moduleCtx.exports[exportName]; found {
-			// fmt.Printf("// [VM DEBUG] getModuleExport: Found export '%s' = %s\n", exportName, exportValue.ToString())
-			return exportValue
-		} else {
-			// fmt.Printf("// [VM DEBUG] getModuleExport: Export '%s' not found in exports map\n", exportName)
-		}
-	} else {
-		// fmt.Printf("// [VM DEBUG] getModuleExport: Module '%s' not found in contexts\n", modulePath)
+	moduleCtx, exists := vm.moduleContexts[modulePath]
+	if !exists {
+		moduleCtx, exists = vm.findModuleContextByResolved(modulePath)
+	}
+	if !exists || moduleCtx == nil {
+		return Undefined
 	}
 
-	// Module not found, not executed, or export not found
+	if moduleCtx.executed {
+		if _, found := moduleCtx.exports[exportName]; !found {
+			vm.collectModuleExports(modulePath, moduleCtx)
+		}
+	}
+
+	if exportValue, found := moduleCtx.exports[exportName]; found {
+		return exportValue
+	}
 	return Undefined
+}
+
+func (vm *VM) findModuleContextByResolved(modulePath string) (*ModuleContext, bool) {
+	if vm.moduleLoader == nil {
+		return nil, false
+	}
+	rec, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
+	if err != nil {
+		return nil, false
+	}
+	resolved := rec.GetResolvedPath()
+	if resolved == "" {
+		return nil, false
+	}
+	for _, ctx := range vm.moduleContexts {
+		if ctx != nil && ctx.resolvedPath == resolved {
+			return ctx, true
+		}
+	}
+	return nil, false
 }
 
 // createModuleNamespace creates a namespace object containing all exports from a module


### PR DESCRIPTION
## Summary
- Register `export class` (and class expressions) as module exports, and follow named `export { x } from` at collect time so skip-typecheck graphs like pi’s `uuidv7` / `Agent` re-exports actually bind.
- Stop sharing unified-heap slots by export name across modules (`parse`, `default`, `SettingsManager`, …); named/default imports always read the per-module snapshot via `OpGetModuleExport`.
- Treat `satisfies` as a valid binding/import name, allow `Object.defineProperties` on callables, and walk getters on a function’s object prototype (chalk-style `setPrototypeOf`).

Needed by noderati to load and run `@earendil-works/pi-coding-agent` (`--help` / `--print`).

## Test plan
- [ ] `go test ./pkg/compiler/ ./pkg/modules/ ./pkg/vm/ ./pkg/parser/ ./pkg/builtins/ -count=1`
- [ ] From noderati (replace → this branch): `go test ./internal/host/ -count=1`
- [ ] `noderati` can `import { uuidv7 } from` a named re-export and `export class Foo { static create() {} }`
- [ ] `semver` `import { satisfies }` parses; `Object.defineProperties` on a function does not throw


Made with [Cursor](https://cursor.com)