### PR TITLE
fix(vm): stop the entry module from executing twice on a circular reference

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1164,11 +1164,25 @@ func (p *Paserati) runAsModule(sourceCode string, program *parser.Program, modul
 	// Set the module path in the VM so import.meta.url works correctly
 	p.vmInstance.SetCurrentModulePath(moduleName)
 
+	// Register this module as executing *before* running it, so that a dependency
+	// which circularly imports or re-exports back from this same path (most commonly:
+	// the entry module referenced by one of its own dependencies) recognizes it as
+	// already in flight instead of triggering an independent, divergent reload+re-run
+	// of the same source. See VM.RegisterExecutingModule.
+	p.vmInstance.RegisterExecutingModule(moduleName, chunk)
+
 	// Execute the chunk
 	finalValue, runtimeErrs := p.vmInstance.Interpret(chunk)
 
 	// Drain async work (microtasks, timers, etc.) until idle
 	p.vmInstance.DrainUntilIdle()
+
+	// Record the final exported values so a circular reference that read this module
+	// mid-execution (and got Undefined for anything not yet initialized) is corrected
+	// for any subsequent read, and so a later, separate call resolves correctly too.
+	if p.compiler.IsModuleMode() {
+		p.vmInstance.FinishExecutingModule(moduleName, p.collectExportedValues())
+	}
 
 	return finalValue, runtimeErrs
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/big"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -982,6 +983,66 @@ func (vm *VM) moduleFromPath() string {
 		return "."
 	}
 	return vm.currentModulePath
+}
+
+// RegisterExecutingModule pre-registers a module context for a module that the driver
+// is about to execute directly (the entry module: it never goes through executeModule's
+// own load-and-run path, since the driver already has its compiled chunk in hand).
+//
+// Without this, a dependency that imports or re-exports something back from the entry
+// module's own path -- a circular reference -- finds no cached context for it in
+// executeModule and triggers a completely independent reload+recompile+re-run of the
+// same source, duplicating the entry module's top-level side effects. Registering it
+// here with `executing: true` lets executeModule's alias check (see below) recognize
+// the entry module as already in flight and skip the duplicate run, exactly as it
+// already does for ordinary (non-entry) circular imports reached by their own path.
+//
+// Call FinishExecutingModule once the module has finished running.
+func (vm *VM) RegisterExecutingModule(resolvedPath string, chunk *Chunk) {
+	if resolvedPath == "" {
+		return
+	}
+	vm.moduleContexts[resolvedPath] = &ModuleContext{
+		chunk:        chunk,
+		exports:      make(map[string]Value),
+		executing:    true,
+		resolvedPath: resolvedPath,
+	}
+}
+
+// FinishExecutingModule marks a module registered via RegisterExecutingModule as fully
+// executed and records its final exported values, so later reads of this module's
+// exports resolve to the real, final values.
+func (vm *VM) FinishExecutingModule(resolvedPath string, exports map[string]Value) {
+	moduleCtx, exists := vm.moduleContexts[resolvedPath]
+	if !exists {
+		return
+	}
+	moduleCtx.executing = false
+	moduleCtx.executed = true
+	for name, value := range exports {
+		moduleCtx.exports[name] = value
+	}
+}
+
+// findExecutingModuleContext scans registered module contexts for one that is
+// currently in flight (executing, not yet finished) whose resolved path matches --
+// after path cleaning, since a dependency may reference it via a differently-spelled
+// but equivalent relative specifier than the one it was registered under (see
+// RegisterExecutingModule). Used to recognize a circular reference back into a module
+// that is still mid-evaluation without asking the module loader to resolve it, which
+// would risk compiling an independent, divergent copy of that module's bindings.
+func (vm *VM) findExecutingModuleContext(modulePath string) *ModuleContext {
+	cleaned := filepath.Clean(modulePath)
+	for _, ctx := range vm.moduleContexts {
+		if ctx == nil || !ctx.executing || ctx.resolvedPath == "" {
+			continue
+		}
+		if ctx.resolvedPath == modulePath || filepath.Clean(ctx.resolvedPath) == cleaned {
+			return ctx
+		}
+	}
+	return nil
 }
 
 // SetImportMetaBaseDir sets the directory used to absolutize relative filesystem
@@ -18296,6 +18357,19 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 
 	// Load the module if not cached
 	if _, exists := vm.moduleContexts[modulePath]; !exists {
+		// Before asking the module loader to resolve+compile this path, check whether
+		// it's actually a currently-executing module already registered under a
+		// different (but equivalent) specifier -- most commonly the entry module,
+		// reached here by one of its own dependencies via a relative path back to it.
+		// Aliasing the key to that same in-flight context avoids both a redundant
+		// re-execution of the same source and, just as importantly, avoids compiling
+		// an independent copy of it whose global-index bindings would diverge from
+		// the copy actually running.
+		if aliased := vm.findExecutingModuleContext(modulePath); aliased != nil {
+			vm.moduleContexts[modulePath] = aliased
+			return InterpretOK, Undefined
+		}
+
 		if vm.moduleLoader == nil {
 			return vm.runtimeError("No module loader available"), Undefined
 		}


### PR DESCRIPTION
## Summary

Fixes the duplicate-execution half of #97.

`runAsModule` (the path used by `--no-typecheck` CLI runs, the REPL, and eval-style module execution) executes the entry module's compiled chunk directly via `vm.Interpret`, never going through `executeModule`'s own load-and-run path. So the entry module was never registered in `vm.moduleContexts` under its own path.

If a dependency imported or re-exported something back from the entry module's own path — a circular reference — `executeModule` found no cached context for it and triggered a completely independent reload+recompile+re-run of the same source, duplicating the entry module's top-level side effects (`console.log` and all), with the first (nested) pass reading anything not yet initialized as `undefined`.

## Fix

- `VM.RegisterExecutingModule` / `VM.FinishExecutingModule`: register the entry module in `vm.moduleContexts` as `executing` before running it, mirroring what `executeModule` already does for every non-entry module.
- `VM.findExecutingModuleContext` + a check in `executeModule`: recognize an already-in-flight module reached via a different-but-equivalent specifier (e.g. the entry module referenced by a dependency's relative import), *without* asking the module loader to resolve it — doing so would risk compiling an independent, divergent copy of its bindings under a separate compiler instance (the module-loader's compiler factory mints a fresh compiler per load, with its own global-index assignments).

## Scope note

This lands the duplicate-execution fix only. The "stale `undefined` on the first (circular) read" half for modules using named re-exports needs the entry module's *compiled record* registered in the module loader's own registry (not just the VM's `moduleContexts`), so a circular re-export resolves the real, already-assigned global indices instead of Undefined on the first pass. That's tracked as a documented follow-up in #97 — `main` doesn't implement named re-exports yet, so it isn't independently testable here.

## Test plan

- `go test ./...` — all green.
- 2-file circular-import repro (`entry.js` imports `neighbor.js`, which imports back from `entry.js`) — previously printed the entry's side effects twice with the imported binding `undefined` on the first pass; now executes once, correctly.
- Full Test262 `language/` suite (23,523 tests) and `built-ins/` suite (23,294 tests): **zero change** vs. bare `main` — expected, since main lacks named re-exports, so the specific failures this fixes only become observable once combined with that feature (see #97).
- `tests/scripts` smoke suite: green.

Fixes #97 (partially — see scope note above).