### PR TITLE
Fix skip-typecheck ESM gaps, get/set class fields, and TLA try/catch

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -1772,15 +1772,23 @@ func (c *Compiler) compileTypeofExpression(node *parser.TypeofExpression, hint R
 		// Special handling: 'arguments' is available in function scope but not in symbol table
 		_, _, found := c.currentSymbolTable.Resolve(ident.Value)
 
-		if !found && ident.Value != "arguments" {
-			// Identifier doesn't exist (and it's not 'arguments') - emit special OpTypeofIdentifier that returns "undefined"
+		// Under skip-typecheck, imported bindings never make it into the compiler's
+		// symbol table (the checker normally defines them, and the checker never ran).
+		// Without this check, `typeof importedName` would wrongly take the "identifier
+		// doesn't exist" path below instead of resolving the real import binding.
+		isUnresolvedImport := !found && c.IsModuleMode() && c.moduleBindings != nil &&
+			c.moduleBindings.IsImported(ident.Value)
+
+		if !found && ident.Value != "arguments" && !isUnresolvedImport {
+			// Identifier doesn't exist (and it's not 'arguments' or an import) - emit
+			// special OpTypeofIdentifier that returns "undefined"
 			if hint == NoHint || hint == BadRegister {
 				hint = c.regAlloc.Alloc()
 			}
 			c.emitTypeofIdentifier(hint, ident.Value, node.Token.Line)
 			return hint, nil
 		}
-		// If identifier exists (or is 'arguments'), fall through to normal compilation
+		// If identifier exists (or is 'arguments'/an import), fall through to normal compilation
 	}
 
 	// For all other expressions, compile normally and then typeof

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4252,25 +4252,39 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 		return BadRegister, NewCompileError(node, fmt.Sprintf("Failed to load source module '%s' for re-export: %v", sourceModule, err))
 	}
 
-	// Get export names from the source module
-	// Try runtime values first, then fall back to export names
-	sourceExports := sourceModuleRecord.GetExportValues()
-	exportNames := sourceModuleRecord.GetExportNames()
-
-	debugPrintf("// [Compiler] Source module '%s' has %d runtime exports and %d export names\n", sourceModule, len(sourceExports), len(exportNames))
-
-	// If we have runtime exports, use those names (most reliable)
-	if len(sourceExports) > 0 {
-		exportNames = nil // Clear the names array
-		for exportName := range sourceExports {
-			exportNames = append(exportNames, exportName)
+	// "export * as ns from 'module'" binds a single namespace export; unlike bare
+	// "export *" it does NOT flatten the source module's names into this one.
+	if node.Exported != nil {
+		nsName := getExportSpecName(node.Exported)
+		if nsName == "" {
+			return BadRegister, NewCompileError(node, "invalid export name in 'export * as' declaration")
 		}
-		debugPrintf("// [Compiler] Using runtime export names: %v\n", exportNames)
-	} else if len(exportNames) > 0 {
-		debugPrintf("// [Compiler] Using export names from module record: %v\n", exportNames)
-	} else {
-		debugPrintf("// [Compiler] No exports found in source module\n")
+
+		globalIdx := int(c.GetOrAssignGlobalIndex(nsName))
+		c.moduleBindings.DefineExport(nsName, nsName, vm.Undefined, nil, globalIdx)
+
+		nsReg := c.regAlloc.Alloc()
+		c.emitEvalModule(sourceModule, node.Token.Line)
+		c.emitCreateNamespace(nsReg, sourceModule, node.Token.Line)
+		c.emitSetGlobal(uint16(globalIdx), nsReg, node.Token.Line)
+		c.regAlloc.Free(nsReg)
+
+		debugPrintf("// [Compiler] Bound namespace export '%s' from '%s'\n", nsName, sourceModule)
+		return BadRegister, nil
 	}
+
+	// Get export names from the source module. Try runtime/checker-populated data
+	// first (checkExportAllDeclaration normally fills this in), then fall back to
+	// harvesting names from the source module's AST -- needed under skip-typecheck,
+	// where the checker never ran and never populated either map (see #99).
+	//
+	// visited starts empty (NOT pre-seeded with this module's own path): a mutual
+	// cycle like d.ts "export * from e.ts" / e.ts "export * from d.ts" must still
+	// discover d.ts's own local names when the traversal loops back through e.ts.
+	// collectExportAllNames marks each module visited as it is entered, which is
+	// enough on its own to stop a module (including this one) from being expanded
+	// more than once.
+	exportNames := c.collectExportAllNames(sourceModuleRecord, sourceModule, make(map[string]bool))
 
 	debugPrintf("// [Compiler] Will re-export %d names from '%s'\n", len(exportNames), sourceModule)
 
@@ -4278,10 +4292,29 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 	// This transforms "export * from './math'" into:
 	// 1. Generate import resolution for each export
 	// 2. Store each imported value as a global (like normal exports do)
+	seen := make(map[string]bool, len(exportNames))
 	for _, exportName := range exportNames {
 		// Skip default exports for "export *" (TypeScript behavior)
 		if exportName == "default" {
 			debugPrintf("// [Compiler] Skipping default export '%s' in re-export all\n", exportName)
+			continue
+		}
+		if seen[exportName] {
+			// Diamond re-export (e.g. a barrel that export*s two modules which both
+			// transitively export*  the same shared module) - only emit it once.
+			continue
+		}
+		seen[exportName] = true
+
+		if c.moduleBindings.IsExported(exportName) {
+			// This module already exports this name itself (an own declaration
+			// exported earlier in source order, or - notably - a mutual re-export
+			// cycle where the "source" module's own name harvest looped back and
+			// picked up this module's name). Per spec, a module's own binding
+			// always wins over a star re-export of the same name; re-exporting it
+			// here would overwrite the correct value with a stale/self-referential
+			// one (see the "own local export vs. cyclic export *" case).
+			debugPrintf("// [Compiler] Skipping '%s' in re-export all: already exported locally\n", exportName)
 			continue
 		}
 
@@ -4299,8 +4332,71 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 		c.regAlloc.Free(tempReg)
 	}
 
-	debugPrintf("// [Compiler] Completed re-export transformation for %d exports\n", len(exportNames))
+	debugPrintf("// [Compiler] Completed re-export transformation for %d exports\n", len(seen))
 	return BadRegister, nil
+}
+
+// collectExportAllNames resolves the flattened set of names that "export * from
+// specifier" should re-export. It prefers already-populated data (runtime export
+// values, or export names the type checker's checkExportAllDeclaration recorded)
+// and falls back to harvesting names from the module's AST when neither is
+// available -- the case under skip-typecheck, where the checker never runs.
+//
+// It recurses into nested bare "export *" re-exports (a barrel re-exporting
+// another barrel is the common npm shape) and treats a nested "export * as ns"
+// as contributing exactly one name, "ns", per spec. visited guards against
+// re-export cycles by resolved module path.
+func (c *Compiler) collectExportAllNames(rec vm.ModuleRecord, specifier string, visited map[string]bool) []string {
+	resolvedPath := rec.GetResolvedPath()
+	if resolvedPath == "" {
+		resolvedPath = specifier
+	}
+	if visited[resolvedPath] {
+		return nil
+	}
+	visited[resolvedPath] = true
+
+	if exportValues := rec.GetExportValues(); len(exportValues) > 0 {
+		names := make([]string, 0, len(exportValues))
+		for name := range exportValues {
+			names = append(names, name)
+		}
+		return names
+	}
+	if exportNames := rec.GetExportNames(); len(exportNames) > 0 {
+		return exportNames
+	}
+
+	// Nothing populated yet - harvest from the source module's AST.
+	if c.moduleLoader == nil {
+		return nil
+	}
+	concreteRec := c.moduleLoader.GetModule(specifier)
+	if concreteRec == nil || concreteRec.AST == nil {
+		return nil
+	}
+
+	names := c.extractExportNamesFromAST(concreteRec.AST)
+	for _, stmt := range concreteRec.AST.Statements {
+		all, ok := stmt.(*parser.ExportAllDeclaration)
+		if !ok || all.Source == nil {
+			continue
+		}
+		if all.Exported != nil {
+			// "export * as ns from '...'" contributes exactly one name: ns.
+			if nsName := getExportSpecName(all.Exported); nsName != "" {
+				names = append(names, nsName)
+			}
+			continue
+		}
+		// Nested bare "export * from '...'" - recurse into the nested source.
+		nestedRec, err := c.moduleLoader.LoadModule(all.Source.Value, resolvedPath)
+		if err != nil {
+			continue
+		}
+		names = append(names, c.collectExportAllNames(nestedRec, all.Source.Value, visited)...)
+	}
+	return names
 }
 
 // extractExportNamesFromAST extracts export names from a module's AST

--- a/pkg/parser/parse_class.go
+++ b/pkg/parser/parse_class.go
@@ -480,19 +480,25 @@ func (p *Parser) parseClassBody() *ClassBody {
 		}
 
 		hasNewlineAfterCur := p.peekToken.Line > p.curToken.Line
-		if p.curTokenIs(lexer.GET) && !p.peekTokenIs(lexer.LPAREN) && !hasNewlineAfterCur {
+		// A same-line terminator after 'get'/'set' means it's a field named "get"/"set",
+		// not an accessor. Mirrors isFieldName() above but excludes LPAREN/LT, which for
+		// get/set specifically mean "method named get/set" and "generic method", not a field.
+		isGetSetFieldTerminator := p.peekTokenIs(lexer.SEMICOLON) || p.peekTokenIs(lexer.ASSIGN) ||
+			p.peekTokenIs(lexer.COLON) || p.peekTokenIs(lexer.QUESTION) ||
+			p.peekTokenIs(lexer.BANG) || p.peekTokenIs(lexer.RBRACE)
+		if p.curTokenIs(lexer.GET) && !p.peekTokenIs(lexer.LPAREN) && !hasNewlineAfterCur && !isGetSetFieldTerminator {
 			// Parse getter method: get propertyName() {}
 			// But NOT if followed by '(' - that's a method named "get": get() {}
-			// And NOT if there's a newline (ASI) - that's a field named "get"
+			// And NOT if there's a newline (ASI) or a field terminator - that's a field named "get"
 			method := p.parseGetter(isStatic, isPublic, isPrivate, isProtected, isOverride)
 			if method != nil {
 				attachDecorators(method)
 				methods = append(methods, method)
 			}
-		} else if p.curTokenIs(lexer.SET) && !p.peekTokenIs(lexer.LPAREN) && !hasNewlineAfterCur {
+		} else if p.curTokenIs(lexer.SET) && !p.peekTokenIs(lexer.LPAREN) && !hasNewlineAfterCur && !isGetSetFieldTerminator {
 			// Parse setter method: set propertyName(value) {}
 			// But NOT if followed by '(' - that's a method named "set": set() {}
-			// And NOT if there's a newline (ASI) - that's a field named "set"
+			// And NOT if there's a newline (ASI) or a field terminator - that's a field named "set"
 			method := p.parseSetter(isStatic, isPublic, isPrivate, isProtected, isOverride)
 			if method != nil {
 				attachDecorators(method)

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -467,7 +467,12 @@ func (vm *VM) handleUncaughtException() {
 
 	// Add the uncaught exception as a runtime error (with stack trace if available)
 	// Format: "Uncaught exception: ErrorType: message" with proper location info
-	errorMsg := fmt.Sprintf("Uncaught exception: %s", displayStr)
+	prefix := "Uncaught exception"
+	if vm.unhandledRejectionPrefix != "" {
+		prefix = vm.unhandledRejectionPrefix
+		vm.unhandledRejectionPrefix = ""
+	}
+	errorMsg := fmt.Sprintf("%s: %s", prefix, displayStr)
 	if stackTrace != "" {
 		errorMsg += "\n" + stackTrace
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -392,6 +392,15 @@ type VM struct {
 	helperCallDepth        int   // Track when we're inside helper functions like toPrimitive
 	handlerFound           bool  // True when a catch handler was invoked while in a helper function
 
+	// unhandledRejectionPrefix, when non-empty, overrides handleUncaughtException's
+	// default "Uncaught exception: " prefix for the very next uncaught report only
+	// (cleared as soon as it's consumed). Used by top-level await to preserve the
+	// established "Uncaught (in promise): " wording for a rejection that turns out
+	// to have no enclosing try/catch, while still routing through the normal
+	// throwException/unwindException path so a try/catch that IS present can catch
+	// it (see #102).
+	unhandledRejectionPrefix string
+
 	// Finally block state (Phase 3)
 	pendingAction   PendingAction // Action to perform after finally blocks complete
 	pendingValue    Value         // Value associated with pending action (e.g., return value)
@@ -14484,9 +14493,42 @@ startExecution:
 					registers[resultReg] = awaitedPromise.Result
 					continue
 				} else {
+					// A rejected top-level await must behave like a thrown exception:
+					// unwind into any enclosing try/catch in the module chunk, exactly
+					// as OpThrow does. Previously this went straight to an unconditional
+					// "Uncaught (in promise)" runtimeError, so a rejected await inside
+					// TLA try/catch skipped the catch block entirely (#102) even though
+					// the exact same rejection is caught fine inside an async function
+					// (which resumes via resumeAsyncFunction / rejectPromise instead of
+					// this top-level branch).
 					frame.ip = ip
-					status := vm.runtimeError("Uncaught (in promise): %s", awaitedPromise.Result.Inspect())
-					return status, Undefined
+					// Preserve the established "Uncaught (in promise)" wording IF this
+					// rejection turns out to have no handler at all; throwException clears
+					// this itself once consumed, and if a handler DOES exist it's simply
+					// never read (see handleUncaughtException).
+					vm.unhandledRejectionPrefix = "Uncaught (in promise)"
+					vm.throwException(awaitedPromise.Result)
+
+					if vm.frameCount == 0 || vm.unwindingCrossedNative {
+						// No handler anywhere - genuinely uncaught. throwException already
+						// printed/reported it via handleUncaughtException.
+						return InterpretRuntimeError, vm.currentException
+					}
+					// A handler exists somewhere - the prefix override was never
+					// consumed. Clear it so a later, unrelated uncaught exception in
+					// this same run doesn't inherit stale "(in promise)" wording.
+					vm.unhandledRejectionPrefix = ""
+					// A handler was found (vm.unwinding is now false) - resync every
+					// cached local the same way OpThrow's handler does, since the
+					// handler may be in a different frame with different registers/code.
+					frame = &vm.frames[vm.frameCount-1]
+					closure = frame.closure
+					function = closure.Fn
+					code = function.Chunk.Code
+					constants = function.Chunk.Constants
+					registers = frame.registers
+					ip = frame.ip
+					continue
 				}
 			}
 

--- a/tests/scripts/class_get_set_field_names.ts
+++ b/tests/scripts/class_get_set_field_names.ts
@@ -1,0 +1,66 @@
+// expect: 1,*,5,method-set,method-get,20,1,*
+// Regression test for #101: class fields named get/set with a same-line
+// terminator (';', not a newline) must parse as fields, not accessors.
+
+class Foo {
+  set;
+  pattern;
+  constructor() {
+    this.set = [1];
+    this.pattern = "*";
+  }
+}
+const foo = new Foo();
+
+class Bar {
+  get;
+  x = 5;
+}
+const bar = new Bar();
+
+class Baz {
+  set() {
+    return "method-set";
+  }
+}
+
+class Qux {
+  get() {
+    return "method-get";
+  }
+}
+
+// Real accessors must still work.
+class Real {
+  #v = 10;
+  get x() {
+    return this.#v;
+  }
+  set x(v: number) {
+    this.#v = v;
+  }
+}
+const real = new Real();
+real.x = 20;
+
+// Newline ASI form (already worked) must keep working.
+class Asi {
+  set
+  pattern
+  constructor() {
+    this.set = [1];
+    this.pattern = "*";
+  }
+}
+const asi = new Asi();
+
+[
+  foo.set[0],
+  foo.pattern,
+  bar.x,
+  new Baz().set(),
+  new Qux().get(),
+  real.x,
+  asi.set[0],
+  asi.pattern,
+].join(",");

--- a/tests/scripts/export_star_as_namespace.ts
+++ b/tests/scripts/export_star_as_namespace.ts
@@ -1,0 +1,11 @@
+// expect: Bar|default|foo|q,1,2,3
+// Regression test for #99: "export * as ns from" must bind a single
+// namespace export built from the source module's names, unlike bare
+// "export *" which flattens those names into the importer's own scope.
+// Unlike bare "export *", the namespace form DOES include "default" (it
+// behaves like "import * as ns from ...; export { ns };").
+import { ns } from "./export_star_helper_ns.ts";
+
+[Object.keys(ns).sort().join("|"), ns.foo(), new ns.Bar().baz(), ns.q].join(
+  ",",
+);

--- a/tests/scripts/export_star_flat.ts
+++ b/tests/scripts/export_star_flat.ts
@@ -1,0 +1,18 @@
+// expect: Bar|foo|q,1,2,3,undefined
+// skip-typecheck
+// Regression test for #99: "export * from" must re-export function, class,
+// and const names, and must NOT re-export "default". Needs skip-typecheck
+// (not just no-typecheck): the checker's own checkExportAllDeclaration
+// already populates export names when it runs at all, so only fully
+// skipping the checker exercises the AST-harvesting fallback this test
+// is actually guarding.
+import { foo, Bar, q, default as maybeDefault } from "./export_star_helper_b.ts";
+import * as ns from "./export_star_helper_b.ts";
+
+[
+  Object.keys(ns).sort().join("|"),
+  foo(),
+  new Bar().baz(),
+  q,
+  typeof maybeDefault,
+].join(",");

--- a/tests/scripts/export_star_helper_a.ts
+++ b/tests/scripts/export_star_helper_a.ts
@@ -1,0 +1,10 @@
+export function foo() {
+  return 1;
+}
+export class Bar {
+  baz() {
+    return 2;
+  }
+}
+export const q = 3;
+export default 42;

--- a/tests/scripts/export_star_helper_b.ts
+++ b/tests/scripts/export_star_helper_b.ts
@@ -1,0 +1,1 @@
+export * from "./export_star_helper_a.ts";

--- a/tests/scripts/export_star_helper_c.ts
+++ b/tests/scripts/export_star_helper_c.ts
@@ -1,0 +1,1 @@
+export * from "./export_star_helper_b.ts";

--- a/tests/scripts/export_star_helper_ns.ts
+++ b/tests/scripts/export_star_helper_ns.ts
@@ -1,0 +1,1 @@
+export * as ns from "./export_star_helper_a.ts";

--- a/tests/scripts/export_star_local_shadow.ts
+++ b/tests/scripts/export_star_local_shadow.ts
@@ -1,0 +1,6 @@
+// expect: from-y
+// Regression test: a module's own local export must win over a same-named
+// "export * from" candidate from another module. Per spec, star re-exports
+// never override a module's own bindings.
+import { shared } from "./export_star_local_shadow_barrel.ts";
+shared;

--- a/tests/scripts/export_star_local_shadow_barrel.ts
+++ b/tests/scripts/export_star_local_shadow_barrel.ts
@@ -1,0 +1,2 @@
+export const shared = "from-y";
+export * from "./export_star_local_shadow_helper.ts";

--- a/tests/scripts/export_star_local_shadow_helper.ts
+++ b/tests/scripts/export_star_local_shadow_helper.ts
@@ -1,0 +1,1 @@
+export const shared = "from-x";

--- a/tests/scripts/export_star_nested.ts
+++ b/tests/scripts/export_star_nested.ts
@@ -1,0 +1,10 @@
+// expect: Bar|foo|q,1,2,3
+// skip-typecheck
+// Regression test for #99: nested "export * from" (c re-exports b, which
+// re-exports a) must flatten all the way through - the common npm barrel
+// shape (a barrel re-exporting another barrel). Requires skip-typecheck to
+// exercise the AST-harvesting fallback (see export_star_flat.ts).
+import { foo, Bar, q } from "./export_star_helper_c.ts";
+import * as ns from "./export_star_helper_c.ts";
+
+[Object.keys(ns).sort().join("|"), foo(), new Bar().baz(), q].join(",");

--- a/tests/scripts/top_level_await_try_catch_rejection.ts
+++ b/tests/scripts/top_level_await_try_catch_rejection.ts
@@ -1,0 +1,37 @@
+// Regression test for #102: a rejected top-level await must be catchable by
+// a surrounding try/catch, exactly like inside an async function. Previously
+// the top-level-await branch of OpAwait went straight to an unconditional
+// "Uncaught (in promise)" error and never consulted the module's exception
+// table, so the catch block below was skipped entirely.
+// expect: caught:boom,inner-finally,outer:inner,async:boom
+
+const log: string[] = [];
+
+try {
+  await Promise.reject(new Error("boom"));
+  log.push("not-rejected");
+} catch (e) {
+  log.push("caught:" + (e as Error).message);
+}
+
+try {
+  try {
+    await Promise.reject(new Error("inner"));
+  } finally {
+    log.push("inner-finally");
+  }
+} catch (e) {
+  log.push("outer:" + (e as Error).message);
+}
+
+async function run() {
+  try {
+    await Promise.reject(new Error("boom"));
+    log.push("async-not-rejected");
+  } catch (e) {
+    log.push("async:" + (e as Error).message);
+  }
+}
+await run();
+
+log.join(",");

--- a/tests/scripts/typeof_import_binding.ts
+++ b/tests/scripts/typeof_import_binding.ts
@@ -1,0 +1,23 @@
+// expect: function,number,function,function,number,undefined,object,function
+// skip-typecheck
+// Regression test for #100: typeof on an ESM import binding must resolve
+// the real import, not fall through to the "identifier doesn't exist"
+// OpTypeofIdentifier path (which always reports "undefined" under
+// skip-typecheck, since imports never make it into the symbol table).
+import def, { foo, q, Bar, foo as f } from "./typeof_import_helper.ts";
+import * as ns from "./typeof_import_helper.ts";
+
+function closureOverImport() {
+  return typeof foo;
+}
+
+[
+  typeof foo,
+  typeof q,
+  typeof Bar,
+  typeof f,
+  typeof def,
+  typeof notDefined,
+  typeof ns,
+  closureOverImport(),
+].join(",");

--- a/tests/scripts/typeof_import_helper.ts
+++ b/tests/scripts/typeof_import_helper.ts
@@ -1,0 +1,10 @@
+export function foo() {
+  return 1;
+}
+export const q = 3;
+export class Bar {
+  baz() {
+    return 2;
+  }
+}
+export default 42;

--- a/tests/scripts_test.go
+++ b/tests/scripts_test.go
@@ -319,6 +319,14 @@ func compileAndInitializeVMNew(scriptPath string) *TestResult {
 	if strings.Contains(sourceCode, "// no-typecheck") {
 		paserati.SetIgnoreTypeErrors(true)
 	}
+	// "// skip-typecheck" runs the type checker not at all (SetSkipTypeCheck), as
+	// opposed to "// no-typecheck" which still runs it but tolerates its errors
+	// (SetIgnoreTypeErrors). This is the code path real npm JavaScript takes via
+	// `paserati --no-typecheck` / noderati (SetSkipTypeCheck(true)); some bugs
+	// only reproduce there because the checker never populates its own state.
+	if strings.Contains(sourceCode, "// skip-typecheck") {
+		paserati.SetSkipTypeCheck(true)
+	}
 
 	// Special handling for manual type import test
 	if filepath.Base(scriptPath) == "test_manual_type_import.ts" {


### PR DESCRIPTION
Four independent fixes, each isolated to its own commit, all found and scoped while loading real npm packages (minimatch, @earendil-works/pi-ai, @earendil-works/pi-agent-core) from noderati.

## Fixes #101 (parser)
Class fields named `get`/`set` terminated with `;` on the same line (`set;`) were misparsed as accessors. Extends the existing ASI-based "is this a field name" check to the same field-terminator set (`; = : ? ! }`) used elsewhere in class-body parsing.

## Fixes #100 (compiler)
`typeof importedName` always returned `"undefined"` under skip-typecheck (`paserati --no-typecheck`, any `SetSkipTypeCheck(true)` embedder), even though the value resolved correctly everywhere else. The `typeof`-on-unresolvable-identifier special case never checked module import bindings, only the compiler's symbol table — which the checker normally populates, and the checker never runs under skip-typecheck.

## Fixes #99 (compiler)
`export * from "./mod"` (and `export * as ns from`) re-exported nothing under skip-typecheck — real blocker for npm barrel files. Adds an AST-harvesting fallback for when the checker hasn't populated export names, with recursion through nested `export *` chains (the common npm barrel-of-barrels shape) and correct separate handling for the namespace form (`export * as ns` binds one namespace object; it does not flatten into the importer's scope like bare `export *`).

Also fixes two pre-existing correctness bugs surfaced while building the fallback (reproducible on unmodified code, typechecking on or off):
- A module's own local export now always wins over a same-named star re-export candidate (previously a later `export *` could silently clobber an earlier local declaration).
- Diamond re-exports (a barrel that `export *`s two modules which both transitively `export *` a shared module) now emit each name once instead of once per path.

## Fixes #102 (vm)
A rejected top-level `await` was reported as an unconditional "Uncaught (in promise)" and never entered a surrounding `try/catch`, even though the identical rejection is caught correctly inside an `async function`. The top-level-await branch of `OpAwait` bypassed the normal exception-unwinding path entirely; it now routes through it like `OpThrow` does, while preserving the established uncaught-rejection wording for the case where no handler exists at all.

## Also
Adds a `// skip-typecheck` smoke-test directive, distinct from the existing `// no-typecheck` (which still runs the checker and only tolerates its errors via `SetIgnoreTypeErrors`). Some of these bugs only reproduce under the real `SetSkipTypeCheck` path and the test harness had no way to exercise it.

## Deferred
#103 (`export class` still installs a heap global) turned out to be an architectural issue — module top-level bindings share one VM-wide global-by-name heap across functions, vars, classes, enums, and namespaces, not just classes as filed. Left for a separate PR; not included here.

## Verification
- Every fix reproduced against the issue's exact repro, then confirmed fixed.
- Each new smoke test verified to fail on the pre-fix binary and pass on the post-fix binary (not just "passes now").
- `go test ./tests -run TestScripts` green throughout and on the final branch.
- Test262 diffs against `baseline.txt` across `language/`, `built-ins/`, and `language/module-code/top-level-await/`: net change +0 for every commit — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)