### PR TITLE
Fix #103: stop export class from installing a bare-name heap global

### DIFF
--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -208,6 +208,23 @@ func (c *Compiler) declareClassPrivateNames(node *parser.ClassDeclaration) {
 	}
 }
 
+// classModuleGlobalKey returns the heap-allocator key to use for a top-level
+// module-scope class declaration named name. When this compiler is compiling
+// a file resolved by the module loader (see SetLoadedViaModuleLoader), the
+// key is namespaced by the module's resolved path so that same-named classes
+// declared in unrelated modules don't alias the same global heap slot merely
+// because an importer references the bare, un-imported name (#103). The
+// persistent session compiler (RunString/REPL/eval, reused under a synthetic
+// module name across separate Compile() calls) keeps the plain name so
+// classes stay visible to later lines the way script-mode globals always
+// have.
+func (c *Compiler) classModuleGlobalKey(name string) string {
+	if c.IsModuleMode() && c.loadedViaModuleLoader && c.moduleBindings != nil && c.moduleBindings.ModulePath != "" {
+		return c.moduleBindings.ModulePath + "\x00" + name
+	}
+	return name
+}
+
 // compileClassDeclaration compiles a class declaration into a constructor function + prototype setup
 // This follows the approach of desugaring classes to constructor functions + prototypes
 func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint Register) (Register, errors.PaseratiError) {
@@ -222,11 +239,15 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 	// For eval code (isIndirectEval=true), class declarations should be local
 	// to the eval's lexical environment, not global.
 	isGlobalClassScope := c.enclosing == nil && !c.isIndirectEval
+	var classGlobalIdx uint16 // only meaningful when isGlobalClassScope
 	if isGlobalClassScope {
-		// Top-level class declaration
-		globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
-		c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
-		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined global class '%s' at index %d\n", node.Name.Value, globalIdx)
+		// Top-level class declaration. The symbol table always binds the
+		// plain name (so intra-module references, including recursive
+		// self-reference and re-derivation by exports, resolve normally);
+		// only the underlying heap slot's key may be namespaced.
+		classGlobalIdx = c.GetOrAssignGlobalIndex(c.classModuleGlobalKey(node.Name.Value))
+		c.currentSymbolTable.DefineGlobal(node.Name.Value, classGlobalIdx)
+		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined global class '%s' at index %d\n", node.Name.Value, classGlobalIdx)
 	} else {
 		// Local class declaration (or eval-scoped class)
 		c.currentSymbolTable.Define(node.Name.Value, nilRegister)
@@ -248,8 +269,7 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 		// For globals, we use the same global index. For locals, we use nilRegister for now
 		// (will be updated to constructorReg later when the outer binding is updated).
 		if isGlobalClassScope {
-			globalIdx := c.GetGlobalIndex(node.Name.Value)
-			c.currentSymbolTable.DefineGlobalStrictImmutable(node.Name.Value, uint16(globalIdx))
+			c.currentSymbolTable.DefineGlobalStrictImmutable(node.Name.Value, classGlobalIdx)
 		} else {
 			c.currentSymbolTable.DefineStrictImmutable(node.Name.Value, nilRegister)
 		}
@@ -320,9 +340,21 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 							superConstructorReg = symbol.Register
 							needToFreeSuperReg = false
 						}
+					} else if c.IsModuleMode() && c.moduleBindings != nil && c.moduleBindings.IsImported(superClassName) {
+						// Imported names are tracked in moduleBindings, never in the
+						// symbol table (see syncImportsFromTypeChecker), so an import
+						// always reaches this branch. Resolve it as an import rather
+						// than falling through to the builtin/global guess below: a
+						// module-scope class's global slot may not even be plain-keyed
+						// (see classModuleGlobalKey, #103), so guessing wrong here would
+						// silently read an unrelated, never-written slot.
+						superConstructorReg = c.regAlloc.Alloc()
+						needToFreeSuperReg = true
+						c.emitImportResolve(superConstructorReg, superClassName, node.Token.Line)
 					} else {
-						// Not in symbol table - might be a built-in class (Object, Array, etc.)
-						// Emit code to look up the global variable at runtime
+						// Not in symbol table and not an import - might be a built-in
+						// class (Object, Array, etc.). Emit code to look up the global
+						// variable at runtime.
 						globalIdx := c.GetOrAssignGlobalIndex(superClassName)
 						superConstructorReg = c.regAlloc.Alloc()
 						needToFreeSuperReg = true
@@ -464,8 +496,7 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 	// For local classes, update BOTH the inner and outer bindings before restoring the outer scope
 	if isGlobalClassScope {
 		// Top-level class declaration - set the global value
-		globalIdx := c.GetGlobalIndex(node.Name.Value)
-		c.emitSetGlobal(uint16(globalIdx), constructorReg, node.Token.Line)
+		c.emitSetGlobal(classGlobalIdx, constructorReg, node.Token.Line)
 		debugPrintf("// DEBUG compileClassDeclaration: Set global class '%s' to R%d\n", node.Name.Value, constructorReg)
 	} else {
 		// Local class declaration - update the inner binding's register first (while inner scope is active)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -369,6 +369,16 @@ type Compiler struct {
 	globalCount int
 	// Unified heap allocator for coordinating global indices across modules
 	heapAlloc *HeapAlloc
+	// loadedViaModuleLoader is true when this compiler instance was created by
+	// the module loader's compiler factory to compile a specific file resolved
+	// by import (or the entry file under RunFile/RunModule). It is false for
+	// the persistent session compiler used by RunString/REPL/eval, where a
+	// synthetic module name is reused across separate Compile() calls and
+	// top-level bindings must stay plain-name-keyed for that sharing to work.
+	// See #103: only compilers with this flag set namespace a top-level
+	// module-scope class's heap slot by module path, so same-named classes in
+	// unrelated modules don't alias the same global.
+	loadedViaModuleLoader bool
 	// line tracking
 	line int
 	// Anonymous class counter for generating unique names
@@ -521,6 +531,21 @@ func (c *Compiler) SetSkipTypeCheck(skip bool) {
 // SetHeapAlloc sets the heap allocator for coordinating global indices
 func (c *Compiler) SetHeapAlloc(heapAlloc *HeapAlloc) {
 	c.heapAlloc = heapAlloc
+}
+
+// SetLoadedViaModuleLoader marks this compiler as compiling a specific file
+// resolved by the module loader (an import target, or the entry file under
+// RunFile/RunModule), as opposed to the persistent session compiler reused
+// across separate RunString/REPL/eval calls under a synthetic module name.
+// See the loadedViaModuleLoader field comment and #103.
+func (c *Compiler) SetLoadedViaModuleLoader(v bool) {
+	c.loadedViaModuleLoader = v
+}
+
+// IsLoadedViaModuleLoader reports whether this compiler was created by the
+// module loader's compiler factory (see SetLoadedViaModuleLoader).
+func (c *Compiler) IsLoadedViaModuleLoader() bool {
+	return c.loadedViaModuleLoader
 }
 
 // AllocSpillSlot allocates a new spill slot for storing a variable when registers are exhausted.
@@ -3820,6 +3845,38 @@ func (c *Compiler) GetGlobalIndex(name string) int {
 	return -1
 }
 
+// resolveExportGlobalIndex returns the heap index that a plain top-level name
+// currently resolves to for export purposes, preferring the symbol table's
+// own record over a fresh heap-allocator lookup by that same plain name.
+//
+// This matters because a module-scope class's heap slot may be keyed by
+// something other than its plain name (see classModuleGlobalKey, #103):
+// GetGlobalIndex(plainName) would then miss it and silently allocate an
+// unrelated, never-written slot. The symbol table always binds the plain
+// name to the real index regardless of how the underlying heap key was
+// derived, so consulting it first is correct for every top-level binding
+// kind, not just classes, and changes nothing for the plain-keyed ones.
+func (c *Compiler) resolveExportGlobalIndex(name string) int {
+	if globalIdx := c.lookupExportGlobalIndex(name); globalIdx >= 0 {
+		return globalIdx
+	}
+	return int(c.GetOrAssignGlobalIndex(name))
+}
+
+// lookupExportGlobalIndex is the non-allocating counterpart to
+// resolveExportGlobalIndex: it returns -1 (never allocates a fresh index) when
+// name isn't already bound anywhere. GetExportGlobalIndices relies on that -1
+// to skip names it can't resolve, falling back to findExportValueInHeap's
+// by-value heap scan; resolveExportGlobalIndex's "assign one if missing"
+// behavior would silently paper over that miss with an unrelated, never
+// -written slot instead of letting the fallback run.
+func (c *Compiler) lookupExportGlobalIndex(name string) int {
+	if sym, _, found := c.currentSymbolTable.Resolve(name); found && sym.IsGlobal {
+		return int(sym.GlobalIndex)
+	}
+	return c.GetGlobalIndex(name)
+}
+
 // SetGlobalIndex forces a global variable name to use a specific index
 // This is used to coordinate global indices between different compiler instances
 func (c *Compiler) SetGlobalIndex(name string, index int) {
@@ -3864,8 +3921,12 @@ func (c *Compiler) GetExportGlobalIndices() map[string]int {
 				}
 			}
 		} else {
-			// Local export: The export name should correspond to the local name in globals
-			if globalIdx := c.GetGlobalIndex(exportRef.LocalName); globalIdx >= 0 {
+			// Local export: The export name should correspond to the local name in globals.
+			// Prefer the symbol table's own record over a fresh by-name heap lookup: a
+			// module-scope class's heap slot may be keyed by something other than its
+			// plain name (see classModuleGlobalKey, #103), which GetGlobalIndex(plainName)
+			// would miss entirely.
+			if globalIdx := c.lookupExportGlobalIndex(exportRef.LocalName); globalIdx >= 0 {
 				exportIndices[exportName] = globalIdx
 				// fmt.Printf("// [Compiler] GetExportGlobalIndices: Local export '%s' maps to global[%d]\n", exportName, globalIdx)
 			}
@@ -4168,10 +4229,7 @@ func (c *Compiler) compileExportNamedDeclaration(node *parser.ExportNamedDeclara
 							// For now, we can't get the runtime value until execution
 							// So we register it with undefined and resolve later
 							// Get the global index for this export
-							globalIdx := c.GetGlobalIndex(localName)
-							if globalIdx == -1 {
-								globalIdx = int(c.GetOrAssignGlobalIndex(localName))
-							}
+							globalIdx := c.resolveExportGlobalIndex(localName)
 							c.moduleBindings.DefineExport(localName, exportName, vm.Undefined, nil, globalIdx)
 						}
 						debugPrintf("// [Compiler] Exported: %s as %s\n", localName, exportName)
@@ -4520,10 +4578,7 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 			}
 		} else if expr, ok := d.Expression.(*parser.ClassExpression); ok && expr.Name != nil {
 			if c.IsModuleMode() {
-				globalIdx := c.GetGlobalIndex(expr.Name.Value)
-				if globalIdx == -1 {
-					globalIdx = int(c.GetOrAssignGlobalIndex(expr.Name.Value))
-				}
+				globalIdx := c.resolveExportGlobalIndex(expr.Name.Value)
 				c.moduleBindings.DefineExport(expr.Name.Value, expr.Name.Value, vm.Undefined, d, globalIdx)
 				debugPrintf("// [Compiler] Exported class expression: %s at global[%d]\n", expr.Name.Value, globalIdx)
 			}
@@ -4531,10 +4586,7 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 
 	case *parser.ClassDeclaration:
 		if c.IsModuleMode() && d.Name != nil {
-			globalIdx := c.GetGlobalIndex(d.Name.Value)
-			if globalIdx == -1 {
-				globalIdx = int(c.GetOrAssignGlobalIndex(d.Name.Value))
-			}
+			globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
 			c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
 			debugPrintf("// [Compiler] Exported class: %s at global[%d]\n", d.Name.Value, globalIdx)
 		}
@@ -4856,8 +4908,17 @@ func (c *Compiler) compileClassExpression(node *parser.ClassDeclaration, hint Re
 							superConstructorReg = symbol.Register
 							needToFreeSuperReg = false
 						}
+					} else if c.IsModuleMode() && c.moduleBindings != nil && c.moduleBindings.IsImported(superClassName) {
+						// Imported names live in moduleBindings, never in the symbol
+						// table, so an import always reaches this branch. Resolve it
+						// as an import rather than guessing it's a global/builtin: a
+						// module-scope class's global slot may not even be
+						// plain-keyed (see classModuleGlobalKey, #103).
+						superConstructorReg = c.regAlloc.Alloc()
+						needToFreeSuperReg = true
+						c.emitImportResolve(superConstructorReg, superClassName, node.Token.Line)
 					} else {
-						// Not in symbol table - might be a built-in class
+						// Not in symbol table and not an import - might be a built-in class
 						globalIdx := c.GetOrAssignGlobalIndex(superClassName)
 						superConstructorReg = c.regAlloc.Alloc()
 						needToFreeSuperReg = true

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -244,6 +244,11 @@ func NewPaseratiWithInitializersAndBaseDir(customInitializers []builtins.Builtin
 		// CRITICAL: Give module compiler the SAME heap allocator instance
 		// This ensures all compilers coordinate on the exact same global indices
 		newCompiler.SetHeapAlloc(paserati.heapAlloc)
+		// This compiler compiles one specific file resolved by the module
+		// loader (an import target, or the entry file under RunFile), unlike
+		// the persistent session compiler reused across RunString/REPL calls.
+		// See #103.
+		newCompiler.SetLoadedViaModuleLoader(true)
 
 		// Return a wrapper that adapts the return type to interface{}
 		return &compilerAdapter{newCompiler}
@@ -329,6 +334,11 @@ func NewPaseratiWithBaseDir(baseDir string) *Paserati {
 		// CRITICAL: Give module compiler the SAME heap allocator instance
 		// This ensures all compilers coordinate on the exact same global indices
 		newCompiler.SetHeapAlloc(paserati.heapAlloc)
+		// This compiler compiles one specific file resolved by the module
+		// loader (an import target, or the entry file under RunFile), unlike
+		// the persistent session compiler reused across RunString/REPL calls.
+		// See #103.
+		newCompiler.SetLoadedViaModuleLoader(true)
 
 		// Return a wrapper that adapts the return type to interface{}
 		return &compilerAdapter{newCompiler}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1101,6 +1101,15 @@ func (vm *VM) SyncHeapToGlobalObject() {
 
 	// Sync all named heap variables to GlobalObject
 	for name, idx := range nameToIndex {
+		// A module-scope class's heap slot is keyed as "modulePath\x00Name"
+		// rather than its plain name, to keep same-named classes in unrelated
+		// modules from aliasing the same slot (#103). That key is an internal
+		// heap-allocator detail, never a real property name - skip it here so
+		// it can't leak onto globalThis as an enumerable property.
+		if strings.Contains(name, "\x00") {
+			continue
+		}
+
 		// Get the value from heap
 		val, ok := vm.heap.Get(idx)
 		if !ok {
@@ -13113,6 +13122,14 @@ startExecution:
 				// ECMAScript requires global var declarations to be enumerable properties on the global object
 				if cur == vm.GlobalObject {
 					for name, idx := range vm.heap.nameToIndex {
+						// A module-scope class's heap slot is keyed as "modulePath\x00Name"
+						// rather than its plain name, to keep same-named classes in unrelated
+						// modules from aliasing the same slot (#103). That key is an internal
+						// heap-allocator detail, never a real property name - skip it here so
+						// it can't leak into for-in enumeration of the global object.
+						if strings.Contains(name, "\x00") {
+							continue
+						}
 						// Global var declarations are enumerable
 						// Builtins are typically non-enumerable, but we include user-defined globals
 						// Check if the variable is user-defined (index >= builtinCount) AND initialized

--- a/tests/scripts/module_class_no_global_leak.ts
+++ b/tests/scripts/module_class_no_global_leak.ts
@@ -1,0 +1,40 @@
+// expect: function,7,undefined,undefined,ReferenceError,9
+// skip-typecheck
+// Regression test for #103: a top-level `export class` must not install a
+// heap global visible to every other module by its bare name. Before the
+// fix, `import { Agent as A }` (note: NOT importing the bare name `Agent`)
+// left `Agent` constructible and `typeof Agent === "function"` in the
+// importer, purely because the defining module's class declaration and any
+// unrelated module's implicit-global fallback shared the same global heap
+// slot by name.
+import { Agent as A } from "./module_class_no_global_leak_helper.ts";
+
+function unresolvedBareRef() {
+  // A reference elsewhere in this module to the bare (never-imported) name
+  // must not "warm up" a shared slot for the earlier typeof/new checks below.
+  return typeof Agent;
+}
+
+let bareConstructThrew = false;
+try {
+  new Agent();
+} catch (e) {
+  bareConstructThrew = e instanceof ReferenceError;
+}
+
+// A plain top-level class in a script (no imports/exports at all) is
+// unaffected and still installs a real global, as before this fix.
+class Local {
+  n() {
+    return 9;
+  }
+}
+
+[
+  typeof A, // the actual import alias: still constructs
+  new A().getN(),
+  typeof Agent, // bare, un-imported name: must stay "undefined"
+  unresolvedBareRef(),
+  bareConstructThrew ? "ReferenceError" : "constructed",
+  typeof Local === "function" ? new Local().n() : "not global",
+].join(",");

--- a/tests/scripts/module_class_no_global_leak_helper.ts
+++ b/tests/scripts/module_class_no_global_leak_helper.ts
@@ -1,0 +1,8 @@
+export class Agent {
+  constructor() {
+    this.state = { n: 7 };
+  }
+  getN() {
+    return this.state.n;
+  }
+}

--- a/tests/scripts/module_class_sibling_names.ts
+++ b/tests/scripts/module_class_sibling_names.ts
@@ -1,0 +1,18 @@
+// expect: log1,log2,undefined
+// skip-typecheck
+// Regression test for #103: two unrelated modules each declaring `export
+// class Logger` must not alias the same global heap slot. Before the fix,
+// a module-scope class's heap slot was keyed by its plain name, so both
+// siblings' OpSetGlobal wrote the same slot and an unrelated, never-imported
+// bare `Logger` reference elsewhere in this module (forced into the heap
+// allocator here via an unreachable reference, so the check doesn't depend
+// on incidental compile/sync ordering) would leak whichever sibling ran
+// last as a constructible global.
+import { Logger as L1 } from "./module_class_sibling_names_helper1.ts";
+import { Logger as L2 } from "./module_class_sibling_names_helper2.ts";
+
+function unreachableBareRef() {
+  return Logger;
+}
+
+[new L1().tag(), new L2().tag(), typeof Logger].join(",");

--- a/tests/scripts/module_class_sibling_names_helper1.ts
+++ b/tests/scripts/module_class_sibling_names_helper1.ts
@@ -1,0 +1,5 @@
+export class Logger {
+  tag() {
+    return "log1";
+  }
+}

--- a/tests/scripts/module_class_sibling_names_helper2.ts
+++ b/tests/scripts/module_class_sibling_names_helper2.ts
@@ -1,0 +1,5 @@
+export class Logger {
+  tag() {
+    return "log2";
+  }
+}


### PR DESCRIPTION
Fixes #103. Stacked on #104 (uses the `// skip-typecheck` smoke-test directive it introduces), which explicitly deferred this issue as a separate PR.

## The bug

A top-level `export class X` wrote its constructor into the VM's global heap keyed only by the plain name `"X"`. Every module shares that one heap by name, so an importer that never imported `X` (only an alias, or nothing at all) could still see it: `typeof X === "function"` and `new X()` both worked, purely because some other module happened to declare a class with that spelling.

## The fix

Namespace the heap key for a top-level class by module path (`modulePath\x00Name`) when the compiler is one the module loader created to compile a specific file (an import target, or the entry file under `RunFile`/`RunModule`) — a new `loadedViaModuleLoader` flag, set at the two compiler-factory call sites in `driver.go`. The symbol table still binds the plain name for intra-module resolution (recursive self-reference, static self-reference, re-export by name), so nothing changes for code within the declaring module.

Left un-namespaced: the persistent session compiler used by `RunString`/REPL/eval, which reuses one synthetic module name across separate `Compile()` calls (each of which resets the symbol table) — a class declared on one REPL line staying visible to a later line depends on that plain-name sharing, and namespacing it would have broken that working, tested behavior for no benefit (there's only one file in a REPL session, so no cross-module collision to prevent there anyway).

Three places that independently re-derived "the global index for a top-level name" via a fresh heap lookup on the plain name needed to prefer the symbol table's own record instead (a namespaced class's slot would otherwise be missed entirely): `processExportDeclaration`'s `ClassDeclaration`/`ClassExpression` cases, `GetExportGlobalIndices`'s local-export branch (kept non-allocating — the allocating helper would have silently defeated the legacy `findExportValueInHeap` fallback that only runs when export index lookups miss), and the named `export { x }` list-syntax branch.

## Two bugs this surfaced

- `class Dog extends ImportedAnimal` never consulted `moduleBindings.IsImported` for the superclass name — it only "worked" today because the imported class's plain-keyed global happened to collide with the importer's unresolved-identifier fallback. Namespacing broke that coincidence and exposed the real gap (caught by `go test ./tests -run TestScripts`, not by manual repro). Both `compileClassDeclaration` and `compileClassExpression`'s superclass resolution now check `IsImported` and resolve through `emitImportResolve`, matching how the general identifier-compile path already treats imports.
- A namespaced key is an internal heap-allocator detail, never a real property name, but two paths were copying heap names verbatim onto `globalThis`: for-in enumeration of the global object (`OpGetOwnKeys`) and the heap-to-`GlobalObject` sync that runs after non-strict indirect eval. Both now skip any name containing the NUL separator.

## Verification

- `go test ./...` and `go test ./tests -run TestScripts` green.
- test262 `built-ins` and `language`: 23137/23523 passing, byte-identical pass/fail sets before and after (the namespaced path is never exercised there — test262's driver uses `RunString`, whose persistent compiler keeps plain keys by design).
- New smoke tests (`module_class_no_global_leak`, `module_class_sibling_names`) each verified to fail on the pre-fix binary and pass on the post-fix binary.

## Not fixed here (filed as follow-up issues)

- The same unguarded plain-name `DefineGlobal` exists for top-level `function`/`let`/`const`/`var` in module mode — `export class` was just the one filed. Currently masked by the `SyncGlobalNames` staleness below, which is why it wasn't already visible.
- `SyncGlobalNames` snapshots the heap-allocator's name map right after the entry module's own compile, before any lazily-compiled dependency module's names exist — this currently *masks* some cross-module leaks by accident rather than preventing them correctly.
- `export default class Foo {}` + default import already throws (`Uncaught exception: undefined`) independent of this change — confirmed identical on the pre-fix binary.
- The `-bytecode` disassembler misdecodes `OpTypeofIdentifier`'s operand width, producing garbled output for any program that uses `typeof` on a possibly-undefined identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
