### PR TITLE
Fix #106-#109: module-scope global leaks, default-export-class crash, stale heap-name sync, disassembler bug

### DIFF
--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -3279,7 +3279,7 @@ func (c *Compiler) defineDestructuredVariableWithValue(name string, isConst bool
 	isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 	if isGlobalScope {
 		// Top-level: use global variable
-		globalIdx := c.GetOrAssignGlobalIndex(name)
+		globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 		c.emitSetGlobalInit(globalIdx, valueReg, line)
 		c.currentSymbolTable.DefineGlobal(name, globalIdx)
 	} else {

--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -208,23 +208,6 @@ func (c *Compiler) declareClassPrivateNames(node *parser.ClassDeclaration) {
 	}
 }
 
-// classModuleGlobalKey returns the heap-allocator key to use for a top-level
-// module-scope class declaration named name. When this compiler is compiling
-// a file resolved by the module loader (see SetLoadedViaModuleLoader), the
-// key is namespaced by the module's resolved path so that same-named classes
-// declared in unrelated modules don't alias the same global heap slot merely
-// because an importer references the bare, un-imported name (#103). The
-// persistent session compiler (RunString/REPL/eval, reused under a synthetic
-// module name across separate Compile() calls) keeps the plain name so
-// classes stay visible to later lines the way script-mode globals always
-// have.
-func (c *Compiler) classModuleGlobalKey(name string) string {
-	if c.IsModuleMode() && c.loadedViaModuleLoader && c.moduleBindings != nil && c.moduleBindings.ModulePath != "" {
-		return c.moduleBindings.ModulePath + "\x00" + name
-	}
-	return name
-}
-
 // compileClassDeclaration compiles a class declaration into a constructor function + prototype setup
 // This follows the approach of desugaring classes to constructor functions + prototypes
 func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint Register) (Register, errors.PaseratiError) {
@@ -245,7 +228,7 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 		// plain name (so intra-module references, including recursive
 		// self-reference and re-derivation by exports, resolve normally);
 		// only the underlying heap slot's key may be namespaced.
-		classGlobalIdx = c.GetOrAssignGlobalIndex(c.classModuleGlobalKey(node.Name.Value))
+		classGlobalIdx = c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 		c.currentSymbolTable.DefineGlobal(node.Name.Value, classGlobalIdx)
 		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined global class '%s' at index %d\n", node.Name.Value, classGlobalIdx)
 	} else {
@@ -346,7 +329,7 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 						// always reaches this branch. Resolve it as an import rather
 						// than falling through to the builtin/global guess below: a
 						// module-scope class's global slot may not even be plain-keyed
-						// (see classModuleGlobalKey, #103), so guessing wrong here would
+						// (see moduleGlobalKey, #103/#106), so guessing wrong here would
 						// silently read an unrelated, never-written slot.
 						superConstructorReg = c.regAlloc.Alloc()
 						needToFreeSuperReg = true

--- a/pkg/compiler/compile_enum.go
+++ b/pkg/compiler/compile_enum.go
@@ -101,8 +101,12 @@ func (c *Compiler) compileEnumDeclaration(node *parser.EnumDeclaration, hint Reg
 	enumConstIndex := c.chunk.AddConstant(enumObj)
 	c.emitLoadConstant(hint, enumConstIndex, node.Token.Line)
 
-	// Define the enum as a global symbol (like function declarations)
-	globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+	// Define the enum as a global symbol (like function declarations).
+	// Namespace the heap key the same way top-level classes/functions/vars do
+	// (see moduleGlobalKey, #103/#106): an enum always installs a global here
+	// regardless of nesting, so an un-namespaced key would leak across
+	// modules exactly like the class case #103 first found.
+	globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 	c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 	c.emitSetGlobal(globalIdx, hint, node.Token.Line)
 

--- a/pkg/compiler/compile_namespace.go
+++ b/pkg/compiler/compile_namespace.go
@@ -36,8 +36,10 @@ func (c *Compiler) compileNamespaceDeclaration(node *parser.NamespaceDeclaration
 	var accessExpr parser.Expression
 	if c.currentNamespaceAccess == nil {
 		// Top-level namespace: bind to a global slot, initialize on first
-		// declaration, merge on subsequent ones.
-		globalIdx := c.GetOrAssignGlobalIndex(nsName)
+		// declaration, merge on subsequent ones. Namespace the heap key the
+		// same way top-level classes/functions/vars do (see moduleGlobalKey,
+		// #103/#106).
+		globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(nsName))
 		_, _, alreadyDefined := c.currentSymbolTable.Resolve(nsName)
 		if !alreadyDefined {
 			c.currentSymbolTable.DefineGlobal(nsName, globalIdx)

--- a/pkg/compiler/compile_statement.go
+++ b/pkg/compiler/compile_statement.go
@@ -212,10 +212,18 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 			// Check if this is an eval-created binding that needs heap storage for deletion
 			useHeapForEval := c.ShouldUseHeapForEvalBinding(node.Name.Value)
 			if isGlobalScope || useHeapForEval {
-				// Global scope or eval-created binding: use heap storage
+				// Global scope or eval-created binding: use heap storage.
+				// Namespace the heap key only for a true top-level module
+				// declaration (isGlobalScope), not an eval-created binding
+				// (useHeapForEval) - eval's own bindings must stay plain-keyed
+				// (see moduleGlobalKey, #103/#106).
+				key := node.Name.Value
+				if isGlobalScope {
+					key = c.moduleGlobalKey(key)
+				}
 				undefReg := c.regAlloc.Alloc()
 				c.emitLoadUndefined(undefReg, node.Name.Token.Line)
-				globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+				globalIdx := c.GetOrAssignGlobalIndex(key)
 				c.emitSetGlobalInit(globalIdx, undefReg, node.Name.Token.Line) // TDZ init
 				c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 				c.regAlloc.Free(undefReg)
@@ -258,8 +266,14 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 			// Check if this is an eval-created binding that needs heap storage for deletion
 			useHeapForEval := c.ShouldUseHeapForEvalBinding(node.Name.Value)
 			if isGlobalScope || useHeapForEval {
-				// Global scope or eval-created binding: use heap storage
-				globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+				// Global scope or eval-created binding: use heap storage.
+				// Namespace only for a true top-level module declaration, not
+				// an eval-created binding (see moduleGlobalKey, #103/#106).
+				key := node.Name.Value
+				if isGlobalScope {
+					key = c.moduleGlobalKey(key)
+				}
+				globalIdx := c.GetOrAssignGlobalIndex(key)
 				c.emitSetGlobalInit(globalIdx, valueReg, node.Name.Token.Line)
 				c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 			} else {
@@ -280,8 +294,14 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 			// Check if this is an eval-created binding that needs heap storage for deletion
 			useHeapForEval := c.ShouldUseHeapForEvalBinding(node.Name.Value)
 			if isGlobalScope || useHeapForEval {
-				// Top-level function or eval-created binding: use heap storage
-				globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+				// Top-level function or eval-created binding: use heap storage.
+				// Namespace only for a true top-level module declaration, not
+				// an eval-created binding (see moduleGlobalKey, #103/#106).
+				key := node.Name.Value
+				if isGlobalScope {
+					key = c.moduleGlobalKey(key)
+				}
+				globalIdx := c.GetOrAssignGlobalIndex(key)
 				// Get the closure register from the symbol table
 				symbolRef, _, found := c.currentSymbolTable.Resolve(node.Name.Value)
 				if found && symbolRef.Register != nilRegister {
@@ -563,7 +583,7 @@ func (c *Compiler) compileVarStatement(node *parser.VarStatement, hint Register)
 				// debug disabled
 				if c.enclosing == nil {
 					// Top-level: use global variable
-					globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+					globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 					c.emitSetGlobal(globalIdx, valueReg, node.Name.Token.Line)
 					c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 					// Mark as non-configurable (DontDelete) only for true top-level var,
@@ -624,7 +644,7 @@ func (c *Compiler) compileVarStatement(node *parser.VarStatement, hint Register)
 				c.regAlloc.Free(valueReg)
 			} else if c.enclosing == nil {
 				// Top-level and not pre-defined: use global variable
-				globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 				c.emitSetGlobal(globalIdx, valueReg, node.Name.Token.Line)
 				c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 				// Mark as non-configurable (DontDelete) only for true top-level var,
@@ -644,7 +664,7 @@ func (c *Compiler) compileVarStatement(node *parser.VarStatement, hint Register)
 			}
 		} else if c.enclosing == nil && !handledInWithBlock {
 			// Top-level function: also set as global
-			globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+			globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 			// Get the closure register from the symbol table
 			symbolRef, _, found := c.currentSymbolTable.Resolve(node.Name.Value)
 			if found && symbolRef.Register != nilRegister {
@@ -813,7 +833,7 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 			isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil && !c.isIndirectEval
 			if isGlobalScope {
 				// True global scope: use global variable (const)
-				globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 				c.emitSetGlobalInit(globalIdx, valueReg, node.Name.Token.Line)
 				c.currentSymbolTable.DefineGlobalConst(node.Name.Value, globalIdx)
 			} else {
@@ -832,7 +852,7 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 			isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil && !c.isIndirectEval
 			if isGlobalScope {
 				// Top-level function: also set as global (const)
-				globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 				// Get the closure register from the symbol table
 				symbolRef, _, found := c.currentSymbolTable.Resolve(node.Name.Value)
 				if found && symbolRef.Register != nilRegister {
@@ -1122,7 +1142,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 					isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 					if isGlobalScope {
 						// True global scope: predefine as global so identifier resolves as global in condition/update
-						globalIdx := c.GetOrAssignGlobalIndex(d.Name.Value)
+						globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(d.Name.Value))
 						c.currentSymbolTable.DefineGlobal(d.Name.Value, globalIdx)
 					} else {
 						// Local scope: predefine local binding; register will be set by compileVarStatement
@@ -1133,7 +1153,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 				name := vs.Name.Value
 				isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 				if isGlobalScope {
-					globalIdx := c.GetOrAssignGlobalIndex(name)
+					globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 					c.currentSymbolTable.DefineGlobal(name, globalIdx)
 				} else {
 					c.currentSymbolTable.Define(name, nilRegister)
@@ -1147,7 +1167,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 				for _, d := range ls.Declarations {
 					isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 					if isGlobalScope {
-						globalIdx := c.GetOrAssignGlobalIndex(d.Name.Value)
+						globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(d.Name.Value))
 						c.currentSymbolTable.DefineGlobal(d.Name.Value, globalIdx)
 					} else {
 						reg, ok := c.regAlloc.TryAllocForVariable()
@@ -1168,7 +1188,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 				name := ls.Name.Value
 				isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 				if isGlobalScope {
-					globalIdx := c.GetOrAssignGlobalIndex(name)
+					globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 					c.currentSymbolTable.DefineGlobal(name, globalIdx)
 				} else {
 					reg, ok := c.regAlloc.TryAllocForVariable()
@@ -1192,7 +1212,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 				for _, d := range cs.Declarations {
 					isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 					if isGlobalScope {
-						globalIdx := c.GetOrAssignGlobalIndex(d.Name.Value)
+						globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(d.Name.Value))
 						c.currentSymbolTable.DefineGlobalConst(d.Name.Value, globalIdx)
 					} else {
 						reg, ok := c.regAlloc.TryAllocForVariable()
@@ -1211,7 +1231,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 				name := cs.Name.Value
 				isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
 				if isGlobalScope {
-					globalIdx := c.GetOrAssignGlobalIndex(name)
+					globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 					c.currentSymbolTable.DefineGlobalConst(name, globalIdx)
 				} else {
 					reg, ok := c.regAlloc.TryAllocForVariable()
@@ -1993,7 +2013,7 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 		if len(vs.Declarations) > 0 {
 			for _, d := range vs.Declarations {
 				if c.enclosing == nil {
-					idx := c.GetOrAssignGlobalIndex(d.Name.Value)
+					idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(d.Name.Value))
 					c.currentSymbolTable.DefineGlobal(d.Name.Value, idx)
 					// fmt.Printf("// [ForInPredefine] var %s as global idx=%d\n", d.Name.Value, idx)
 				} else {
@@ -2004,7 +2024,7 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 		} else if vs.Name != nil {
 			name := vs.Name.Value
 			if c.enclosing == nil {
-				idx := c.GetOrAssignGlobalIndex(name)
+				idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 				c.currentSymbolTable.DefineGlobal(name, idx)
 				// fmt.Printf("// [ForInPredefine] var %s as global idx=%d\n", name, idx)
 			} else {
@@ -2276,7 +2296,7 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 			if !found {
 				// As a fallback, predefine now mirroring regular for behavior
 				if c.enclosing == nil {
-					idx := c.GetOrAssignGlobalIndex(name)
+					idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 					c.currentSymbolTable.DefineGlobal(name, idx)
 					symbolRef, _, found = c.currentSymbolTable.Resolve(name)
 				} else {
@@ -2311,7 +2331,7 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 				// fmt.Printf("// [ForInAssign] unresolved %s, defining var in outermost scope\n", target.Value)
 				// Define a function/global-scoped binding (var semantics)
 				if c.enclosing == nil {
-					idx := c.GetOrAssignGlobalIndex(target.Value)
+					idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(target.Value))
 					c.currentSymbolTable.DefineGlobal(target.Value, idx)
 					c.emitSetGlobal(idx, currentKeyReg, node.Token.Line)
 				} else {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -564,6 +564,30 @@ func (c *Compiler) GetHeapAlloc() *HeapAlloc {
 	return c.heapAlloc
 }
 
+// moduleGlobalKey returns the heap-allocator key to use for a top-level
+// module-scope declaration named name - a class, function, var, let, const,
+// enum, or namespace declared directly at a module's top level. When this
+// compiler is compiling a file resolved by the module loader (see
+// SetLoadedViaModuleLoader), the key is namespaced by the module's resolved
+// path so that same-named declarations in unrelated modules don't alias the
+// same global heap slot merely because an importer references the bare,
+// un-imported name (#103, generalized beyond classes in #106). The symbol
+// table still binds the plain name for intra-module resolution; only the
+// underlying heap slot's key is namespaced.
+//
+// The persistent session compiler (RunString/REPL/eval, reused under a
+// synthetic module name across separate Compile() calls) keeps the plain
+// name so top-level bindings stay visible to later lines the way script-mode
+// globals always have - it never has loadedViaModuleLoader set (see that
+// field's own comment), which also means eval reusing that same compiler
+// (SetIndirectEval) can never reach the namespaced branch here either.
+func (c *Compiler) moduleGlobalKey(name string) string {
+	if c.IsModuleMode() && c.loadedViaModuleLoader && c.moduleBindings != nil && c.moduleBindings.ModulePath != "" {
+		return c.moduleBindings.ModulePath + "\x00" + name
+	}
+	return name
+}
+
 // GetAllGlobalNames returns a snapshot of every name registered in this
 // compiler's heap allocator, mapped to its heap index - not just this
 // compiler's own exports (see GetExportGlobalIndices for that).
@@ -960,17 +984,46 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 		// Pre-register var declarations
 		varNames := collectVarDeclarations(program.Statements)
 		for _, name := range varNames {
-			c.GetOrAssignGlobalIndex(name)
+			c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 		}
 		// Pre-register let/const declarations (except for eval which has different scoping)
 		if !c.isIndirectEval && c.callerScopeDesc == nil {
 			letConstNames := collectLetConstDeclarations(program.Statements)
 			for _, name := range letConstNames {
-				c.GetOrAssignGlobalIndex(name)
+				c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 			}
 			debugPrintf("[Compile] Pre-registered %d var and %d let/const names for strict mode checks\n", len(varNames), len(letConstNames))
 		} else {
 			debugPrintf("[Compile] Pre-registered %d var names for strict mode checks\n", len(varNames))
+		}
+
+		// Pre-register hoisted function names as full global symbol-table
+		// bindings (not just heap indices, unlike var/let/const above) so a
+		// hoisted function's body can forward-reference a sibling hoisted
+		// function compiled later in the (alphabetically) sorted order below.
+		//
+		// Before #106 namespaced these, this "just worked" by accident: an
+		// unresolved reference from an earlier-processed function fell
+		// through to the general "maybe it's a global" fallback (see the
+		// Identifier compile case), which allocated the SAME bare heap key
+		// the sibling's own later hoisting step would also use. Once the
+		// sibling's own key is namespaced (moduleGlobalKey) but that fallback
+		// intentionally stays bare - it also serves genuinely external/
+		// undeclared references, which must NOT be namespaced - the two
+		// diverge into two different heap slots. Pre-registering the real,
+		// namespaced index here (before any hoisted function body compiles)
+		// means the forward reference finds it via the symbol table's own
+		// IsGlobal/GlobalIndex instead of ever reaching that fallback.
+		if program.HoistedDeclarations != nil {
+			hoistedNames := make([]string, 0, len(program.HoistedDeclarations))
+			for name := range program.HoistedDeclarations {
+				hoistedNames = append(hoistedNames, name)
+			}
+			sort.Strings(hoistedNames)
+			for _, name := range hoistedNames {
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
+				c.currentSymbolTable.DefineGlobal(name, globalIdx)
+			}
 		}
 	}
 
@@ -1010,7 +1063,7 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 			closureReg := c.emitClosure(c.regAlloc.Alloc(), funcConstIndex, funcLit, freeSymbols) // Use actual freeSymbols
 
 			// 4. Get global index and define as global symbol
-			globalIdx := c.GetOrAssignGlobalIndex(name)
+			globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 
 			// Update the symbol table entry to mark it as global
 			c.currentSymbolTable.DefineGlobal(name, globalIdx)
@@ -1046,7 +1099,7 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 				continue
 			}
 			// Define as global with undefined value
-			globalIdx := c.GetOrAssignGlobalIndex(name)
+			globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 			c.currentSymbolTable.DefineGlobal(name, globalIdx)
 			// Emit code to initialize to undefined
 			tempReg := c.regAlloc.Alloc()
@@ -1078,7 +1131,7 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 					continue
 				}
 				// Define as global with Uninitialized value (TDZ)
-				globalIdx := c.GetOrAssignGlobalIndex(name)
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 				c.currentSymbolTable.DefineGlobal(name, globalIdx)
 				// Emit code to initialize to Uninitialized (TDZ marker)
 				tempReg := c.regAlloc.Alloc()
@@ -1804,7 +1857,7 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 
 			// 5. If at top level, also set as global variable
 			if c.enclosing == nil {
-				globalIdx := c.GetOrAssignGlobalIndex(funcLit.Name.Value)
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(funcLit.Name.Value))
 				c.emitSetGlobal(globalIdx, bindingReg, funcLit.Token.Line)
 				c.currentSymbolTable.DefineGlobal(funcLit.Name.Value, globalIdx)
 				// Mark as non-configurable (DontDelete) only for true top-level function declarations,
@@ -2255,8 +2308,13 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 				// This is a global recursive call - module mode top-level function
 				// The variable will be stored as a global, so use OpGetGlobal
 				debugPrintf("// DEBUG Identifier '%s': Recursive call to GLOBAL (IsGlobal=%v, isModuleLevelDef=%v), using OpGetGlobal\n", node.Value, symbolRef.IsGlobal, isModuleLevelDef)
-				// Get or assign the global index
-				globalIdx := c.GetOrAssignGlobalIndex(node.Value)
+				// Get or assign the global index. This name isn't marked
+				// IsGlobal yet (we're compiling its own initializer/body,
+				// before the real DefineGlobal call runs), but it WILL become
+				// one at this same module-level key - moduleGlobalKey must
+				// match here so this pre-derivation lands on the identical
+				// heap slot the real declaration later installs (#106).
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Value))
 				c.emitGetGlobal(hint, globalIdx, node.Token.Line)
 			} else {
 				// True local recursive call - needs upvalue capture
@@ -2296,7 +2354,10 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 				// This is a module-level variable that's being defined (let/const in module scope)
 				// It will become a global, so use OpGetGlobal
 				debugPrintf("// DEBUG Identifier '%s': NOT LOCAL, Register==nilRegister, treating as module-level global\n", node.Value)
-				globalIdx := c.GetOrAssignGlobalIndex(node.Value)
+				// Same pre-derivation reasoning as the recursive-self-call case
+				// above: this name will become global at its module-scoped key
+				// once its own DefineGlobal call runs (#106).
+				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Value))
 				c.emitGetGlobal(hint, globalIdx, node.Token.Line)
 			} else if c.enclosing != nil && c.isDefinedInEnclosingCompiler(definingTable) {
 				debugPrintf("// DEBUG Identifier '%s': NOT LOCAL, defined in OUTER FUNCTION, treating as FREE VARIABLE\n", node.Value)
@@ -3870,7 +3931,7 @@ func (c *Compiler) GetGlobalIndex(name string) int {
 // own record over a fresh heap-allocator lookup by that same plain name.
 //
 // This matters because a module-scope class's heap slot may be keyed by
-// something other than its plain name (see classModuleGlobalKey, #103):
+// something other than its plain name (see moduleGlobalKey, #103/#106):
 // GetGlobalIndex(plainName) would then miss it and silently allocate an
 // unrelated, never-written slot. The symbol table always binds the plain
 // name to the real index regardless of how the underlying heap key was
@@ -3940,12 +4001,22 @@ func (c *Compiler) GetExportGlobalIndices() map[string]int {
 					// fmt.Printf("// [Compiler] GetExportGlobalIndices: Re-export '%s' maps to local global[%d]\n", exportName, globalIdx)
 				}
 			}
+		} else if exportRef.GlobalIndex >= 0 {
+			// Local export: prefer the index recorded on the ExportReference
+			// itself (set at DefineExport time, when the caller had the exact
+			// index in hand - e.g. a namespaced module-scope key, see
+			// moduleGlobalKey #103/#106, or "export * from" re-exporting
+			// another module's value under this module's own global). A
+			// fresh lookupExportGlobalIndex(exportRef.LocalName) re-derivation
+			// would miss both of those: neither is bound in the symbol table
+			// under its plain local name, and the heap slot itself may not be
+			// plain-keyed either.
+			exportIndices[exportName] = exportRef.GlobalIndex
 		} else {
-			// Local export: The export name should correspond to the local name in globals.
-			// Prefer the symbol table's own record over a fresh by-name heap lookup: a
-			// module-scope class's heap slot may be keyed by something other than its
-			// plain name (see classModuleGlobalKey, #103), which GetGlobalIndex(plainName)
-			// would miss entirely.
+			// No index recorded on the reference (declaration compiled before
+			// this export was processed, or a legacy caller) - fall back to
+			// re-deriving it, preferring the symbol table's own record over a
+			// fresh by-name heap lookup for the same reason as above.
 			if globalIdx := c.lookupExportGlobalIndex(exportRef.LocalName); globalIdx >= 0 {
 				exportIndices[exportName] = globalIdx
 				// fmt.Printf("// [Compiler] GetExportGlobalIndices: Local export '%s' maps to global[%d]\n", exportName, globalIdx)
@@ -4338,7 +4409,12 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 			return BadRegister, NewCompileError(node, "invalid export name in 'export * as' declaration")
 		}
 
-		globalIdx := int(c.GetOrAssignGlobalIndex(nsName))
+		// Namespace the heap key the same way any other top-level module
+		// binding is (see moduleGlobalKey, #103/#106): "ns" is a real new
+		// binding this module installs, exactly like a class or function
+		// declaration, and must not alias an unrelated module's same-named
+		// bare global.
+		globalIdx := int(c.GetOrAssignGlobalIndex(c.moduleGlobalKey(nsName)))
 		c.moduleBindings.DefineExport(nsName, nsName, vm.Undefined, nil, globalIdx)
 
 		nsReg := c.regAlloc.Alloc()
@@ -4398,14 +4474,18 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 
 		debugPrintf("// [Compiler] Re-exporting '%s' from '%s'\n", exportName, sourceModule)
 
-		globalIdx := int(c.GetOrAssignGlobalIndex(exportName))
+		// Namespace the heap key the same way "export * as ns" does above:
+		// this module's own re-exported binding for exportName is a real new
+		// global this module installs (see moduleGlobalKey, #103/#106).
+		key := c.moduleGlobalKey(exportName)
+		globalIdx := int(c.GetOrAssignGlobalIndex(key))
 		c.moduleBindings.DefineImport(exportName, sourceModule, exportName, ImportNamedRef, -1)
 		c.moduleBindings.DefineExport(exportName, exportName, vm.Undefined, nil, globalIdx)
 
 		tempReg := c.regAlloc.Alloc()
 		c.emitEvalModule(sourceModule, node.Token.Line)
 		c.emitGetModuleExport(tempReg, sourceModule, exportName, node.Token.Line)
-		globalIdxUint16 := c.GetOrAssignGlobalIndex(exportName)
+		globalIdxUint16 := c.GetOrAssignGlobalIndex(key)
 		c.emitSetGlobal(globalIdxUint16, tempReg, node.Token.Line)
 		c.regAlloc.Free(tempReg)
 	}
@@ -4546,11 +4626,12 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 	case *parser.LetStatement:
 		if c.IsModuleMode() {
 			if d.Name != nil {
-				// Let/const declarations also get stored as globals at top-level
-				globalIdx := c.GetGlobalIndex(d.Name.Value)
-				if globalIdx == -1 {
-					globalIdx = int(c.GetOrAssignGlobalIndex(d.Name.Value))
-				}
+				// Let/const declarations also get stored as globals at top-level.
+				// Prefer the symbol table's own record over a fresh by-name heap
+				// lookup: a top-level let's heap slot may be keyed by something
+				// other than its plain name (see moduleGlobalKey, #103/#106),
+				// which GetGlobalIndex(plainName) would miss entirely.
+				globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
 				c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
 				debugPrintf("// [Compiler] Exported let: %s at global[%d]\n", d.Name.Value, globalIdx)
 			}
@@ -4559,11 +4640,10 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 	case *parser.VarStatement:
 		if c.IsModuleMode() {
 			if d.Name != nil {
-				// Var declarations also get stored as globals at top-level
-				globalIdx := c.GetGlobalIndex(d.Name.Value)
-				if globalIdx == -1 {
-					globalIdx = int(c.GetOrAssignGlobalIndex(d.Name.Value))
-				}
+				// Var declarations also get stored as globals at top-level.
+				// See the LetStatement case above for why resolveExportGlobalIndex
+				// (not a fresh plain-name lookup) is required here.
+				globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
 				c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
 				debugPrintf("// [Compiler] Exported var: %s at global[%d]\n", d.Name.Value, globalIdx)
 			}
@@ -4572,11 +4652,10 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 	case *parser.ConstStatement:
 		if c.IsModuleMode() {
 			if d.Name != nil {
-				// Let/const declarations also get stored as globals at top-level
-				globalIdx := c.GetGlobalIndex(d.Name.Value)
-				if globalIdx == -1 {
-					globalIdx = int(c.GetOrAssignGlobalIndex(d.Name.Value))
-				}
+				// Let/const declarations also get stored as globals at top-level.
+				// See the LetStatement case above for why resolveExportGlobalIndex
+				// (not a fresh plain-name lookup) is required here.
+				globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
 				c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
 				debugPrintf("// [Compiler] Exported const: %s at global[%d]\n", d.Name.Value, globalIdx)
 			}
@@ -4586,13 +4665,12 @@ func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 		// Handle function declarations in expression statements
 		if expr, ok := d.Expression.(*parser.FunctionLiteral); ok && expr.Name != nil {
 			if c.IsModuleMode() {
-				// Function declarations are automatically stored as globals at top-level
-				// Get the global index that was already assigned during function compilation
-				globalIdx := c.GetGlobalIndex(expr.Name.Value)
-				if globalIdx == -1 {
-					// If not found, assign a new one (though this shouldn't happen for functions)
-					globalIdx = int(c.GetOrAssignGlobalIndex(expr.Name.Value))
-				}
+				// Function declarations are automatically stored as globals at
+				// top-level. Get the global index that was already assigned
+				// during function compilation - via resolveExportGlobalIndex,
+				// not a fresh plain-name lookup, since a top-level function's
+				// heap slot may be namespaced (see moduleGlobalKey, #103/#106).
+				globalIdx := c.resolveExportGlobalIndex(expr.Name.Value)
 				c.moduleBindings.DefineExport(expr.Name.Value, expr.Name.Value, vm.Undefined, d, globalIdx)
 				debugPrintf("// [Compiler] Exported function: %s at global[%d]\n", expr.Name.Value, globalIdx)
 			}
@@ -4933,7 +5011,7 @@ func (c *Compiler) compileClassExpression(node *parser.ClassDeclaration, hint Re
 						// table, so an import always reaches this branch. Resolve it
 						// as an import rather than guessing it's a global/builtin: a
 						// module-scope class's global slot may not even be
-						// plain-keyed (see classModuleGlobalKey, #103).
+						// plain-keyed (see moduleGlobalKey, #103/#106).
 						superConstructorReg = c.regAlloc.Alloc()
 						needToFreeSuperReg = true
 						c.emitImportResolve(superConstructorReg, superClassName, node.Token.Line)
@@ -5052,8 +5130,13 @@ func (c *Compiler) compileClassExpression(node *parser.ClassDeclaration, hint Re
 	// Also skip if the name was inferred from assignment target (isNamedClassExpr is false).
 	if hint == BadRegister && isNamedClassExpr {
 		if c.enclosing == nil {
-			// Top-level class - define as global
-			globalIdx := c.GetOrAssignGlobalIndex(node.Name.Value)
+			// Top-level class - define as global. Namespace the heap key the
+			// same way compileClassDeclaration does (see moduleGlobalKey,
+			// #103/#106): this is the same "top-level module declaration"
+			// shape, just reached via `export default class Named {}` (or any
+			// other standalone named class expression at module top level)
+			// instead of a plain `class Named {}` declaration.
+			globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 			c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 			c.emitSetGlobal(globalIdx, constructorReg, node.Token.Line)
 			debugPrintf("// DEBUG compileClassExpression: Defined global class '%s' at index %d\n", node.Name.Value, globalIdx)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -564,6 +564,26 @@ func (c *Compiler) GetHeapAlloc() *HeapAlloc {
 	return c.heapAlloc
 }
 
+// GetAllGlobalNames returns a snapshot of every name registered in this
+// compiler's heap allocator, mapped to its heap index - not just this
+// compiler's own exports (see GetExportGlobalIndices for that).
+//
+// Every module compiler shares one process-wide *HeapAlloc instance (see
+// driver.go's compiler-factory setup), so this snapshot reflects every
+// top-level name any module has registered so far, regardless of which
+// compiler instance GetAllGlobalNames is called on. The module loader calls
+// this after each module it compiles and re-syncs it into the VM's heap
+// (VM.SyncGlobalNames), so lookups keyed on the VM's own copy - e.g.
+// OpTypeofIdentifier's "does this bare name exist at all" check - see a name
+// a lazily-compiled dependency module just registered, rather than only
+// whatever existed at the moment the entry module finished compiling (#107).
+func (c *Compiler) GetAllGlobalNames() map[string]int {
+	if c.heapAlloc == nil {
+		return nil
+	}
+	return c.heapAlloc.GetNameToIndexMap()
+}
+
 // isDefinedInEnclosingCompiler checks if a symbol table belongs to ANY enclosing compiler's scope chain.
 // This helps distinguish between:
 // - Variables from outer block scopes in the SAME function (return false) -> use direct register

--- a/pkg/modules/interfaces.go
+++ b/pkg/modules/interfaces.go
@@ -149,6 +149,14 @@ type Compiler interface {
 	Compile(node parser.Node) (interface{}, []errors.PaseratiError)
 	GetExportGlobalIndices() map[string]int
 	GetReExports() map[string]vm.ModuleReExport
+	// GetAllGlobalNames returns every name->heap-index mapping registered so
+	// far in the shared heap allocator all module compilers coordinate
+	// through - not just this compiler's own exports. See #107: the module
+	// loader re-syncs this into the VM's heap after each module it compiles,
+	// so name-existence checks keyed on the VM's copy stay current as
+	// dependency modules are lazily compiled, instead of reflecting only
+	// whatever existed when the entry module finished compiling.
+	GetAllGlobalNames() map[string]int
 }
 
 // DependencyAnalyzer tracks module dependencies during loading

--- a/pkg/modules/loader.go
+++ b/pkg/modules/loader.go
@@ -24,7 +24,18 @@ func debugPrintf(format string, args ...interface{}) {
 	}
 }
 
-func applyCompilerExports(record *ModuleRecord, moduleCompiler Compiler) {
+// applyCompilerExports records the just-compiled module's exports and
+// re-syncs the VM's global-name lookup with the shared heap allocator.
+//
+// The re-sync closes a staleness gap (#107): VM.SyncGlobalNames is otherwise
+// only called once, right after the entry module's own compile finishes, so
+// a name a lazily-compiled dependency module registers into the shared heap
+// allocator during *this* compile would stay invisible to name-existence
+// checks keyed on the VM's copy (e.g. OpTypeofIdentifier) for the rest of
+// the program. Every module compiler shares one heap allocator instance, so
+// this compiler's own view of it already reflects every name registered so
+// far, not just this module's.
+func (ml *moduleLoader) applyCompilerExports(record *ModuleRecord, moduleCompiler Compiler) {
 	exportGlobalIndices := moduleCompiler.GetExportGlobalIndices()
 	exportIndices := make(map[string]uint16, len(exportGlobalIndices))
 	for name, idx := range exportGlobalIndices {
@@ -32,6 +43,10 @@ func applyCompilerExports(record *ModuleRecord, moduleCompiler Compiler) {
 	}
 	record.ExportIndices = exportIndices
 	record.ReExports = moduleCompiler.GetReExports()
+
+	if ml.vmInstance != nil {
+		ml.vmInstance.SyncGlobalNames(moduleCompiler.GetAllGlobalNames())
+	}
 }
 
 // moduleLoader implements ModuleLoader interface
@@ -265,7 +280,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 
 			record.CompiledChunk = vmChunk
 
-			applyCompilerExports(record, moduleCompiler)
+			ml.applyCompilerExports(record, moduleCompiler)
 			debugPrintf("// [ModuleLoader] Stored %d export indices for module: %s\n", len(record.ExportIndices), record.ResolvedPath)
 		}
 		record.State = ModuleCompiled
@@ -303,7 +318,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 
 		record.CompiledChunk = vmChunk
 
-		applyCompilerExports(record, moduleCompiler)
+		ml.applyCompilerExports(record, moduleCompiler)
 		debugPrintf("// [ModuleLoader] Stored %d export indices for module: %s\n", len(record.ExportIndices), record.ResolvedPath)
 		record.State = ModuleCompiled
 	} else {
@@ -854,7 +869,7 @@ func (ml *moduleLoader) performDependencyOrderedTypeChecking(entryPoint string) 
 			// Store the compiled chunk
 			record.CompiledChunk = vmChunk
 
-			applyCompilerExports(record, moduleCompiler)
+			ml.applyCompilerExports(record, moduleCompiler)
 
 			debugPrintf("// [ModuleLoader] Module '%s' compiled successfully\n", modulePath)
 		}

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -1104,7 +1104,10 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 	case OpToPropertyKey:
 		return c.simpleInstruction(builder, instruction.String(), offset)
 	case OpTypeofIdentifier:
-		return c.registerConstantInstruction(builder, instruction.String(), offset, false)
+		// Rx NameIdx(16bit): a 1-byte register operand followed by a 2-byte
+		// constant index (see the VM's execution case), not the 1-byte
+		// constant index isUint16Const=false would decode (#109).
+		return c.registerConstantInstruction(builder, instruction.String(), offset, true)
 	case OpGetPrivateField:
 		return c.registerRegisterConstantInstruction(builder, instruction.String(), offset, "NameIdx")
 	case OpSetPrivateField:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -18613,6 +18613,17 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	frame.targetRegister = 0
 	frame.thisValue = Undefined
 	frame.openUpvalues = nil // frame slot may have been used before; start with no open upvalues
+	// Allocate this frame's spill slots, matching every other frame-setup site
+	// (Interpret, Call, Construct): a module whose top level spills a binding
+	// to a slot - e.g. a named class expression used as a module-scope value.
+	// such as `export default class Agent { ... }` - needs frame.spillSlots
+	// sized from the chunk, or OpStoreSpill/OpLoadSpill fault on a stale or
+	// nil slice left over from whatever previously used this frame slot (#108).
+	if chunk.NumSpillSlots > 0 {
+		frame.spillSlots = make([]Value, chunk.NumSpillSlots)
+	} else {
+		frame.spillSlots = nil
+	}
 	vm.nextRegSlot += scriptRegSize
 	vm.frameCount++
 
@@ -18623,10 +18634,20 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	resultStatus, result := vm.run()
 
 	// Capture any JavaScript exception that was thrown but not caught
-	// This happens when the module contains throw statements without try/catch
+	// This happens when the module contains throw statements without try/catch.
+	// hasModuleException tracks whether a real exception value was captured here,
+	// separately from moduleException's own value: a module can legally `throw
+	// undefined`, so testing "moduleException != Null" below to mean "was an
+	// exception captured" would also fire on moduleException's zero value (which
+	// is Undefined, same as a real `throw undefined`) whenever resultStatus is
+	// InterpretRuntimeError for some other reason - e.g. an internal panic
+	// recovered by vm.run() (see #108) - discarding the real error in vm.errors
+	// for a misleading, generic "Uncaught exception: undefined".
 	var moduleException Value
+	var hasModuleException bool
 	if vm.unwinding && vm.currentException != Null {
 		moduleException = vm.currentException
+		hasModuleException = true
 		// Clear the unwinding state since we're handling the exception here
 		vm.unwinding = false
 		vm.currentException = Null
@@ -18645,7 +18666,7 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	var errs []errors.PaseratiError
 	if resultStatus == InterpretRuntimeError {
 		// If we have a JS exception, that takes precedence
-		if moduleException != Null {
+		if hasModuleException {
 			// Create a RuntimeError from the exception - format like handleUncaughtException
 			displayStr := vm.formatExceptionDisplay(moduleException)
 			runtimeErr := &errors.RuntimeError{

--- a/tests/scripts/module_default_export_named_class.ts
+++ b/tests/scripts/module_default_export_named_class.ts
@@ -1,0 +1,21 @@
+// expect: 7
+// skip-typecheck
+// Regression test for #108: `export default class Agent { ... }` (a NAMED
+// class expression, per the grammar - `export default <expr>` parses the
+// class via the same prefix parser as any class expression) crashed at
+// runtime with "Uncaught exception: undefined" when imported.
+//
+// Root cause: a named class expression at the true top level of a module
+// stores its self-reference binding (for recursive references inside the
+// class body) in a spill slot via OpStoreSpill/OpLoadSpill. VM.executeModule
+// builds that top-level frame by hand (unlike Interpret/Call/Construct) and
+// never sized frame.spillSlots from the chunk, so the very first spill store
+// faulted with "invalid spill slot index 0". That runtime error then got
+// mislabeled: executeModule's exception-capture logic tested
+// `moduleException != Null` to decide whether a real exception was thrown,
+// but moduleException's zero value (Undefined) satisfies that same check,
+// so the real "invalid spill slot" error was discarded in favor of a
+// generic "Uncaught exception: undefined".
+import Agent from "./module_default_export_named_class_helper.ts";
+
+new Agent().getN();

--- a/tests/scripts/module_default_export_named_class_helper.ts
+++ b/tests/scripts/module_default_export_named_class_helper.ts
@@ -1,0 +1,9 @@
+export default class Agent {
+  n: number;
+  constructor() {
+    this.n = 7;
+  }
+  getN() {
+    return this.n;
+  }
+}

--- a/tests/scripts/module_toplevel_no_global_leak.ts
+++ b/tests/scripts/module_toplevel_no_global_leak.ts
@@ -1,0 +1,58 @@
+// expect: hi,41,3,old,7,undefined,undefined,undefined,undefined,undefined,ReferenceError,ReferenceError,9
+// skip-typecheck
+// Regression test for #106: every top-level function/let/const/var - and a
+// standalone named class expression used as `export default class Named {}`
+// (compileClassExpression, the one case #105's own class fix missed) - must
+// not install a bare-name heap global visible to every other module, exactly
+// like #103/#105 already fixed for `export class Name {}` declarations.
+//
+// Note: the local aliases below (g, c, pi, l, A) deliberately avoid the
+// helper's bare names (greet, counter, PI_ISH, legacy, Agent) so those bare
+// names stay genuinely un-imported in this module, for the checks below.
+import {
+  greet as g,
+  counter as c,
+  PI_ISH as pi,
+  legacy as l,
+} from "./module_toplevel_no_global_leak_helper.ts";
+import A from "./module_toplevel_no_global_leak_helper.ts";
+
+function unresolvedBareRefs() {
+  // References elsewhere in this module to the bare (never-imported) names
+  // must not "warm up" a shared slot for the checks below (see #103/#107).
+  return [typeof greet, typeof counter, typeof PI_ISH, typeof legacy, typeof Agent];
+}
+
+let bareCallThrew = false;
+try {
+  greet();
+} catch (e) {
+  bareCallThrew = e instanceof ReferenceError;
+}
+
+let bareConstructThrew = false;
+try {
+  new Agent();
+} catch (e) {
+  bareConstructThrew = e instanceof ReferenceError;
+}
+
+// A plain top-level class in a script (no imports/exports at all) is
+// unaffected and still installs a real global, as before this fix.
+class Local {
+  n() {
+    return 9;
+  }
+}
+
+[
+  g(),
+  c,
+  pi,
+  l,
+  new A().getN(),
+  ...unresolvedBareRefs(), // typeof greet, counter, PI_ISH, legacy, Agent: all "undefined"
+  bareCallThrew ? "ReferenceError" : "called",
+  bareConstructThrew ? "ReferenceError" : "constructed",
+  typeof Local === "function" ? new Local().n() : "not global",
+].join(",");

--- a/tests/scripts/module_toplevel_no_global_leak_helper.ts
+++ b/tests/scripts/module_toplevel_no_global_leak_helper.ts
@@ -1,0 +1,17 @@
+export function greet() {
+  return "hi";
+}
+
+export let counter = 41;
+export const PI_ISH = 3;
+export var legacy = "old";
+
+export default class Agent {
+  n: number;
+  constructor() {
+    this.n = 7;
+  }
+  getN() {
+    return this.n;
+  }
+}


### PR DESCRIPTION
Fixes #106, #107, #108, #109.

## #109 — `-bytecode` disassembler misdecodes `OpTypeofIdentifier`'s operand width
The disassembler treated `OpTypeofIdentifier`'s 2-byte constant index as absent, corrupting the displayed decode of every subsequent instruction in the chunk. VM execution itself was already correct — this was a display-only bug.

## #108 — `export default class NamedClass {}` + default import crashes ("Uncaught exception: undefined")
`VM.executeModule()` manually builds a top-level module frame (bypassing the normal `Interpret`/`Call`/`Construct` setup helpers) and skipped allocating `frame.spillSlots`, so a named class expression used as a module-scope value faulted on a stale/nil spill slot slice. Also fixed a related bug where a rejected/thrown top-level module body could be silently swallowed instead of surfaced. New regression tests: `module_default_export_named_class{,_helper}.ts`.

## #107 — stale heap-name snapshot masks cross-module global leaks
`SyncGlobalNames` snapshotted the heap allocator's name map once and never refreshed it as lazily-compiled dependency modules ran, making #103's own leak intermittent/order-dependent rather than reliably reproducible. Fixed by re-syncing after every lazily-compiled module via a new `GetAllGlobalNames()` on the compiler interface.

## #106 — every top-level function/let/const/var/enum/namespace/class-expression installs a bare-name heap global
#103/#105 fixed this only for `export class Name {}`. This generalizes that fix (`moduleGlobalKey`, generalized from `classModuleGlobalKey`) to every other top-level module binding: hoisted functions, `let`/`const`/`var` (including destructuring), `enum`, top-level `namespace`, and — the case #105's fix missed entirely — a named class *expression* used as a value (`export default class Agent { ... }`).

Two consequential fixes were required:
- Hoisted function names are now pre-registered as full global symbol-table bindings before any hoisted function body compiles, so alphabetically-earlier functions can still forward-reference alphabetically-later siblings now that their heap keys are namespaced.
- `GetExportGlobalIndices()`'s local-export branch now prefers the `ExportReference.GlobalIndex` recorded at `DefineExport` time instead of re-deriving a possibly-stale bare-name heap lookup.

New regression test: `module_toplevel_no_global_leak.ts`.

**Known, accepted test262 regression**: `language/module-code/instn-iee-star-cycle.js` now fails (previously passed). Isolated repro confirms this is *not* a statement-order issue — it's a pre-existing gap in circular `export * from` resolution (our implementation reads runtime state during flattening instead of implementing spec `ResolveExport` with a `resolveSet`), previously invisible only because bare-key collisions made every module's same-named binding alias one physical heap slot. Out of scope here; documented in the commit message.

## Verification
- `go test ./tests -run TestScripts` — green
- Test262 `language` (23,523 tests) and `built-ins` (23,294 tests) both run to completion cleanly (~1 min each), no unexpected regressions beyond the one documented above