### PR TITLE
fix(vm): Object.freeze/seal/defineProperty mutated a shared Shape (#122)

### DIFF
--- a/pkg/builtins/abort_controller_init.go
+++ b/pkg/builtins/abort_controller_init.go
@@ -120,7 +120,7 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return createAbortSignalObject(vmInstance, signal, signalProto), nil
 	}))
 
-	signalConstructor.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(signalProto))
+	signalConstructor.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(signalProto))
 
 	if err := ctx.DefineGlobal("AbortSignal", vm.NewValueFromPlainObject(signalConstructor)); err != nil {
 		return err
@@ -145,7 +145,7 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 	controllerConstructor := vm.NewConstructorWithProps(0, false, "AbortController", controllerConstructorFn)
 	if controllerConstructor.Type() == vm.TypeNativeFunctionWithProps {
 		ctorProps := controllerConstructor.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(controllerProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(controllerProto))
 	}
 
 	controllerProto.SetOwnNonEnumerable("constructor", controllerConstructor)

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -2280,7 +2280,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Add prototype property
-	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(arrayProto))
+	ctorWithProps.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(arrayProto))
 
 	// Add static methods
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("isArray", vm.NewNativeFunction(1, false, "isArray", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/arraybuffer_init.go
+++ b/pkg/builtins/arraybuffer_init.go
@@ -369,7 +369,7 @@ func (a *ArrayBufferInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Add prototype property
-	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(arrayBufferProto))
+	ctorWithProps.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(arrayBufferProto))
 
 	// Add static methods
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("isView", vm.NewNativeFunction(1, false, "isView", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/bigint_init.go
+++ b/pkg/builtins/bigint_init.go
@@ -262,7 +262,7 @@ func (b *BigIntInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vm.NewBigInt(result), nil
 	}))
 
-	bigintConstructor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vmInstance.BigIntPrototype)
+	bigintConstructor.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vmInstance.BigIntPrototype)
 
 	// Set constructor property on prototype
 	bigintProto.SetOwnNonEnumerable("constructor", bigintConstructor)

--- a/pkg/builtins/blob_init.go
+++ b/pkg/builtins/blob_init.go
@@ -93,7 +93,7 @@ func (b *BlobInitializer) InitRuntime(ctx *RuntimeContext) error {
 	blobConstructor := vm.NewConstructorWithProps(2, false, "Blob", blobConstructorFn)
 	if blobConstructor.Type() == vm.TypeNativeFunctionWithProps {
 		ctorProps := blobConstructor.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(blobProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(blobProto))
 	}
 
 	blobProto.SetOwnNonEnumerable("constructor", blobConstructor)

--- a/pkg/builtins/boolean_init.go
+++ b/pkg/builtins/boolean_init.go
@@ -160,7 +160,7 @@ func (b *BooleanInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Add prototype property to constructor
-	booleanConstructor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vmInstance.BooleanPrototype)
+	booleanConstructor.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vmInstance.BooleanPrototype)
 
 	// Set constructor property on prototype
 	booleanProto.SetOwnNonEnumerable("constructor", booleanConstructor)

--- a/pkg/builtins/date_init.go
+++ b/pkg/builtins/date_init.go
@@ -1328,7 +1328,7 @@ func (d *DateInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Add prototype property
-	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(dateProto))
+	ctorWithProps.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(dateProto))
 
 	// Store Date prototype on VM for cross-realm support (GetPrototypeFromConstructor)
 	vmInstance.DatePrototype = vm.NewValueFromPlainObject(dateProto)

--- a/pkg/builtins/disposable_stack_init.go
+++ b/pkg/builtins/disposable_stack_init.go
@@ -335,7 +335,7 @@ func (d *DisposableStackInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vm.NewValueFromPlainObject(inst), nil
 	})
 	ctorProps := ctor.AsNativeFunctionWithProps()
-	ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
+	ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(proto))
 	proto.SetOwnNonEnumerable("constructor", ctor)
 
 	if realm := vmInstance.CurrentRealm(); realm != nil {
@@ -442,7 +442,7 @@ func (a *AsyncDisposableStackInitializer) InitRuntime(ctx *RuntimeContext) error
 		return vm.NewValueFromPlainObject(inst), nil
 	})
 	ctorProps := ctor.AsNativeFunctionWithProps()
-	ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
+	ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(proto))
 	proto.SetOwnNonEnumerable("constructor", ctor)
 
 	if realm := vmInstance.CurrentRealm(); realm != nil {

--- a/pkg/builtins/error_init.go
+++ b/pkg/builtins/error_init.go
@@ -179,7 +179,7 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
 
 		// Add prototype property
-		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(errorPrototype))
+		ctorPropsObj.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(errorPrototype))
 
 		// Add Error.isError static method (ES2024)
 		ctorPropsObj.Properties.SetOwnNonEnumerable("isError", vm.NewNativeFunction(1, false, "isError", func(args []vm.Value) (vm.Value, error) {
@@ -335,7 +335,7 @@ func (e *AggregateErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(proto))
 
 		if !vmInstance.ErrorConstructor.IsUndefined() {
 			ctorProps.Properties.SetPrototype(vmInstance.ErrorConstructor)
@@ -429,7 +429,7 @@ func (e *SuppressedErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(proto))
 
 		if !vmInstance.ErrorConstructor.IsUndefined() {
 			ctorProps.Properties.SetPrototype(vmInstance.ErrorConstructor)
@@ -498,7 +498,7 @@ func initErrorSubclass(ctx *RuntimeContext, name string) error {
 		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(proto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(proto))
 
 		// Per ECMAScript 19.5.6.2, the [[Prototype]] of a NativeError constructor is Error
 		if !vmInstance.ErrorConstructor.IsUndefined() {

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -185,7 +185,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 	headersConstructor := vm.NewConstructorWithProps(1, false, "Headers", headersConstructorFn)
 	if headersConstructor.Type() == vm.TypeNativeFunctionWithProps {
 		ctorProps := headersConstructor.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(headersProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(headersProto))
 	}
 
 	// Set constructor on prototype
@@ -256,7 +256,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 	responseConstructor := vm.NewConstructorWithProps(2, false, "Response", responseConstructorFn)
 	if responseConstructor.Type() == vm.TypeNativeFunctionWithProps {
 		ctorProps := responseConstructor.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(responseProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(responseProto))
 
 		// Response.error() - returns an error response
 		ctorProps.Properties.SetOwnNonEnumerable("error", vm.NewNativeFunction(0, false, "error", func(args []vm.Value) (vm.Value, error) {
@@ -447,7 +447,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 	requestConstructor := vm.NewConstructorWithProps(2, false, "Request", requestConstructorFn)
 	if requestConstructor.Type() == vm.TypeNativeFunctionWithProps {
 		ctorProps := requestConstructor.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(requestProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(requestProto))
 	}
 
 	requestProto.SetOwnNonEnumerable("constructor", requestConstructor)

--- a/pkg/builtins/formdata_init.go
+++ b/pkg/builtins/formdata_init.go
@@ -57,7 +57,7 @@ func (f *FormDataInitializer) InitRuntime(ctx *RuntimeContext) error {
 	formDataConstructor := vm.NewConstructorWithProps(0, false, "FormData", formDataConstructorFn)
 	if formDataConstructor.Type() == vm.TypeNativeFunctionWithProps {
 		ctorProps := formDataConstructor.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(formDataProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(formDataProto))
 	}
 
 	formDataProto.SetOwnNonEnumerable("constructor", formDataConstructor)

--- a/pkg/builtins/function_init.go
+++ b/pkg/builtins/function_init.go
@@ -143,7 +143,7 @@ func (f *FunctionInitializer) InitRuntime(ctx *RuntimeContext) error {
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
 
 		// Add prototype property
-		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", functionProtoFn)
+		ctorPropsObj.Properties.DefineFixedProperty("prototype", functionProtoFn)
 
 		functionCtor = ctorWithProps
 	}
@@ -170,7 +170,7 @@ func (f *FunctionInitializer) InitRuntime(ctx *RuntimeContext) error {
 		ctorObj := asyncFunctionCtor.AsNativeFunction()
 		ctorWithProps := vm.NewConstructorWithProps(ctorObj.Arity, ctorObj.Variadic, ctorObj.Name, ctorObj.Fn)
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
-		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", asyncFunctionProto)
+		ctorPropsObj.Properties.DefineFixedProperty("prototype", asyncFunctionProto)
 		asyncFunctionCtor = ctorWithProps
 
 		// Set constructor property on AsyncFunction.prototype

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -4656,6 +4656,31 @@ func objectPreventExtensionsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value
 	return obj, nil
 }
 
+// exoticOwnProperties returns the PlainObject holding the ordinary own
+// properties of a value that keeps them in a side table rather than being one
+// (functions of every flavour and RegExp objects). Returns nil when the value
+// has no such table - either because it isn't one of those kinds, or because
+// nothing has ever defined a property on it, in which case there is nothing to
+// apply an integrity level to. Object.isFrozen/isSealed reach into the same
+// tables.
+func exoticOwnProperties(obj vm.Value) *vm.PlainObject {
+	switch obj.Type() {
+	case vm.TypeFunction:
+		return obj.AsFunction().Properties
+	case vm.TypeClosure:
+		return obj.AsClosure().Properties
+	case vm.TypeNativeFunction:
+		return obj.AsNativeFunction().Properties
+	case vm.TypeNativeFunctionWithProps:
+		return obj.AsNativeFunctionWithProps().Properties
+	case vm.TypeBoundFunction:
+		return obj.AsBoundFunction().Properties
+	case vm.TypeRegExp:
+		return obj.AsRegExpObject().Properties
+	}
+	return nil
+}
+
 func objectFreezeWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, nil
@@ -4663,8 +4688,9 @@ func objectFreezeWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 
 	obj := args[0]
 
-	// If not an object, return as-is (primitives are already immutable)
-	if !obj.IsObject() {
+	// If not an object, return as-is (primitives are already immutable).
+	// Callables are objects even when Value.IsObject() says otherwise.
+	if !obj.IsObject() && !obj.IsCallable() {
 		return obj, nil
 	}
 
@@ -4682,6 +4708,11 @@ func objectFreezeWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		plainObj.SetExtensible(false)
 		// Use FreezeAllProperties to freeze ALL own properties (including non-enumerable and symbol)
 		plainObj.FreezeAllProperties()
+	} else if props := exoticOwnProperties(obj); props != nil {
+		// Functions and RegExps are objects too: their own properties live in a
+		// side table, which is what has to be frozen.
+		props.SetExtensible(false)
+		props.FreezeAllProperties()
 	}
 
 	return obj, nil
@@ -4694,8 +4725,9 @@ func objectSealWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 
 	obj := args[0]
 
-	// If not an object, return as-is
-	if !obj.IsObject() {
+	// If not an object, return as-is.
+	// Callables are objects even when Value.IsObject() says otherwise.
+	if !obj.IsObject() && !obj.IsCallable() {
 		return obj, nil
 	}
 
@@ -4712,6 +4744,9 @@ func objectSealWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		plainObj := obj.AsPlainObject()
 		plainObj.SetExtensible(false)
 		plainObj.SealAllProperties()
+	} else if props := exoticOwnProperties(obj); props != nil {
+		props.SetExtensible(false)
+		props.SealAllProperties()
 	}
 
 	return obj, nil

--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -203,7 +203,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 	props := promiseCtor.AsNativeFunctionWithProps().Properties
 
 	// Promise.prototype
-	props.SetOwnNonEnumerable("prototype", vmInstance.PromisePrototype)
+	props.DefineFixedProperty("prototype", vmInstance.PromisePrototype)
 
 	// Promise.resolve(value)
 	props.SetOwnNonEnumerable("resolve", vm.NewNativeFunction(1, false, "resolve", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/reference_error_init.go
+++ b/pkg/builtins/reference_error_init.go
@@ -111,7 +111,7 @@ func (r *ReferenceErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
 
 		// Add prototype property
-		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(referenceErrorPrototype))
+		ctorPropsObj.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(referenceErrorPrototype))
 
 		// Per ECMAScript 19.5.6.2, the [[Prototype]] of a NativeError constructor is Error
 		if !vmInstance.ErrorConstructor.IsUndefined() {

--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -1477,7 +1477,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Set up prototype relationship
 	regexpCtorProps := regexpCtor.AsNativeFunctionWithProps()
-	regexpCtorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(regexpProto))
+	regexpCtorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(regexpProto))
 
 	// RegExp.escape(string) - ES2025
 	regexpCtorProps.Properties.SetOwnNonEnumerable("escape", vm.NewNativeFunction(1, false, "escape", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -2173,7 +2173,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Add prototype property
-	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(stringProto))
+	ctorWithProps.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(stringProto))
 
 	// Add static methods
 	// ECMAScript spec: String.fromCharCode.length = 1

--- a/pkg/builtins/symbol_init.go
+++ b/pkg/builtins/symbol_init.go
@@ -179,7 +179,7 @@ func (s *SymbolInitializer) InitRuntime(ctx *RuntimeContext) error {
 	ctorWithProps.AsNativeFunctionWithProps().IsConstructor = true
 
 	// Add prototype property - use the VM's SymbolPrototype
-	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vmInstance.SymbolPrototype)
+	ctorWithProps.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vmInstance.SymbolPrototype)
 
 	// Symbol.prototype.constructor
 	symbolProto.SetOwnNonEnumerable("constructor", ctorWithProps)

--- a/pkg/builtins/syntax_error_init.go
+++ b/pkg/builtins/syntax_error_init.go
@@ -111,7 +111,7 @@ func (s *SyntaxErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
 
 		// Add prototype property
-		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(syntaxErrorPrototype))
+		ctorPropsObj.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(syntaxErrorPrototype))
 
 		// Per ECMAScript 19.5.6.2, the [[Prototype]] of a NativeError constructor is Error
 		if !vmInstance.ErrorConstructor.IsUndefined() {

--- a/pkg/builtins/text_codec_init.go
+++ b/pkg/builtins/text_codec_init.go
@@ -69,7 +69,7 @@ func (t *TextEncoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(encoderProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(encoderProto))
 		encoderProto.SetOwnNonEnumerable("constructor", withProps)
 		return ctx.DefineGlobal("TextEncoder", withProps)
 	}
@@ -148,7 +148,7 @@ func (t *TextDecoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 		nf := ctor.AsNativeFunction()
 		withProps := vm.NewConstructorWithProps(nf.Arity, nf.Variadic, nf.Name, nf.Fn)
 		ctorProps := withProps.AsNativeFunctionWithProps()
-		ctorProps.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(decoderProto))
+		ctorProps.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(decoderProto))
 		decoderProto.SetOwnNonEnumerable("constructor", withProps)
 		return ctx.DefineGlobal("TextDecoder", withProps)
 	}

--- a/pkg/builtins/type_error_init.go
+++ b/pkg/builtins/type_error_init.go
@@ -113,7 +113,7 @@ func (t *TypeErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		ctorPropsObj := ctorWithProps.AsNativeFunctionWithProps()
 
 		// Add prototype property
-		ctorPropsObj.Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(typeErrorPrototype))
+		ctorPropsObj.Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(typeErrorPrototype))
 
 		// Per ECMAScript 19.5.6.2, the [[Prototype]] of a NativeError constructor is Error
 		if !vmInstance.ErrorConstructor.IsUndefined() {

--- a/pkg/builtins/typedarray_base_init.go
+++ b/pkg/builtins/typedarray_base_init.go
@@ -135,7 +135,7 @@ func (i *TypedArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	// Add prototype property
-	typedArrayCtor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("prototype", vm.NewValueFromPlainObject(typedArrayProto))
+	typedArrayCtor.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(typedArrayProto))
 
 	// Add TypedArray.from() static method
 	typedArrayCtor.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("from", vm.NewNativeFunction(1, false, "from", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -110,25 +110,37 @@ type Shape struct {
 	//     chain of N shapes into O(N).
 	//   - childExtended: true once a child has claimed parent's backing; any
 	//     subsequent sibling branches must allocate a fresh slice.
-	//   - ownedFields: true if this shape's `fields` slice has a private
-	//     backing array. Mutation sites must call privatizeFields() before
-	//     modifying `fields` to avoid bleeding into shapes that share our
-	//     backing (ancestors we extended from, or children we extended to).
+	//
+	// Field *attributes* (writable/enumerable/configurable/isAccessor) are
+	// immutable once a Shape is reachable from more than the object that
+	// created it - which, thanks to the transition maps, is every shape in the
+	// tree. A Shape is shared by every object that transitioned through the
+	// same sequence of property additions, so mutating `fields` in place would
+	// retroactively re-attribute properties on unrelated objects (issue #122:
+	// Object.freeze(a) making an untouched sibling b's properties read-only).
+	// Sites that change an attribute must therefore call forkShape() first and
+	// mutate the private copy; sites that change *all* attributes at once
+	// (freeze/seal) go through attrTransition, which forks with a cache.
 	childExtended bool
-	ownedFields   bool
+
+	// frozenShape / sealedShape memoize attrTransition's result for this shape.
+	// The result depends only on the source field list, so objects that shared
+	// a shape before Object.freeze / Object.seal still share one afterwards and
+	// inline caches stay monomorphic. Protected by mu.
+	frozenShape *Shape
+	sealedShape *Shape
 }
 
 // extendFields returns a new fields slice equal to cur.fields with fld appended.
 // Attempts to reuse cur's backing array if available. Caller MUST hold cur.mu.Lock().
-// Returns the new slice and whether it shares backing with cur.
-func (cur *Shape) extendFields(fld Field) (newFields []Field, shared bool) {
+func (cur *Shape) extendFields(fld Field) (newFields []Field) {
 	n := len(cur.fields)
 	if !cur.childExtended && cap(cur.fields) > n {
 		// First successor: reuse cur's backing array.
 		newFields = cur.fields[:n+1]
 		newFields[n] = fld
 		cur.childExtended = true
-		return newFields, true
+		return newFields
 	}
 	// Fresh allocation with slack capacity so future transitions from the new
 	// shape can extend in-place.
@@ -144,26 +156,92 @@ func (cur *Shape) extendFields(fld Field) (newFields []Field, shared bool) {
 	newFields = make([]Field, n+1, newCap)
 	copy(newFields, cur.fields)
 	newFields[n] = fld
-	return newFields, false
+	return newFields
 }
 
-// privatizeFields ensures o.shape.fields has a private backing array before
-// callers mutate a Field in place. If the backing is already private, this is
-// a no-op. Must be called before any `o.shape.fields[i] = ...` mutation.
-func (o *PlainObject) privatizeFields() {
-	s := o.shape
-	if s.ownedFields {
-		return
+// forkShape gives o a private, unshared Shape with the same field list, so the
+// caller can mutate a Field in place. Every other object that reached the old
+// shape through the transition tree keeps pointing at it, unchanged.
+//
+// The fork is deliberately left out of any transition map: it is reachable only
+// from o (and from shapes o itself transitions to later), which is what makes
+// the in-place `o.shape.fields[i] = ...` that follows safe. This mirrors what
+// DeleteOwnByKey already does for property removal. Must be called before any
+// `o.shape.fields[i] = ...` mutation.
+func (o *PlainObject) forkShape() {
+	cur := o.shape
+	newFields := make([]Field, len(cur.fields))
+	copy(newFields, cur.fields)
+	o.shape = &Shape{
+		parent:  cur.parent,
+		fields:  newFields,
+		version: cur.version + 1,
 	}
-	// Clone the fields slice into a private backing. This severs any sharing
-	// with ancestors (our parent's backing) or descendants (children who
-	// extended from our backing).
-	newFields := make([]Field, len(s.fields))
-	copy(newFields, s.fields)
-	s.fields = newFields
-	s.ownedFields = true
-	// We have fresh backing, so a future child could potentially extend it.
-	s.childExtended = false
+}
+
+// attrTransition returns the shape equivalent to cur with every field made
+// non-configurable and, when freeze is true, every data field made
+// non-writable - i.e. the shape an object takes on under Object.seal /
+// Object.freeze. cur is never modified; the result is memoized on cur so that
+// freezing many objects that share a shape yields one shared frozen shape
+// rather than one per object.
+func (cur *Shape) attrTransition(freeze bool) *Shape {
+	cur.mu.RLock()
+	cached := cur.sealedShape
+	if freeze {
+		cached = cur.frozenShape
+	}
+	cur.mu.RUnlock()
+	if cached != nil {
+		return cached
+	}
+
+	newFields := make([]Field, len(cur.fields))
+	copy(newFields, cur.fields)
+	changed := false
+	for i := range newFields {
+		if newFields[i].configurable {
+			newFields[i].configurable = false
+			changed = true
+		}
+		if freeze && !newFields[i].isAccessor && newFields[i].writable {
+			newFields[i].writable = false
+			changed = true
+		}
+	}
+
+	next := cur
+	if changed {
+		next = &Shape{
+			parent:  cur.parent,
+			fields:  newFields,
+			version: cur.version + 1,
+		}
+		// Not published yet, so no lock needed. Re-applying the same operation
+		// to the result is a no-op; a frozen shape is also already sealed, but
+		// a sealed shape is *not* frozen (seal preserves writable).
+		next.sealedShape = next
+		if freeze {
+			next.frozenShape = next
+		}
+	}
+
+	cur.mu.Lock()
+	if freeze {
+		if cur.frozenShape != nil {
+			next = cur.frozenShape
+		} else {
+			cur.frozenShape = next
+		}
+	} else {
+		if cur.sealedShape != nil {
+			next = cur.sealedShape
+		} else {
+			cur.sealedShape = next
+		}
+	}
+	cur.mu.Unlock()
+	return next
 }
 
 type Object struct {
@@ -441,7 +519,7 @@ func (o *PlainObject) DeleteOwnByKey(key PropertyKey) bool {
 	// Create new shape without transitions for simplicity and bump version.
 	// Leave transition maps nil - they'll be lazily allocated if/when another
 	// property is added. Fields slice is freshly allocated so it's private.
-	o.shape = &Shape{parent: o.shape.parent, fields: newFields, ownedFields: true, version: o.shape.version + 1}
+	o.shape = &Shape{parent: o.shape.parent, fields: newFields, version: o.shape.version + 1}
 	o.properties = newProps
 
 	// If the deleted field was an accessor, also remove the getter/setter from the maps
@@ -536,8 +614,8 @@ func (o *PlainObject) SetOwn(name string, v Value) {
 	// Actually need to create new shape - allocate only when necessary
 	off := len(cur.fields)
 	fld := Field{offset: off, name: name, keyKind: KeyKindString, writable: true, enumerable: true, configurable: true}
-	newFields, shared := cur.extendFields(fld)
-	next = &Shape{parent: cur, fields: newFields, ownedFields: !shared, version: cur.version + 1}
+	newFields := cur.extendFields(fld)
+	next = &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 	if cur.stringTransitions == nil {
 		cur.stringTransitions = make(map[string]*Shape)
 	}
@@ -586,8 +664,8 @@ func (o *PlainObject) SetOwnNonEnumerable(name string, v Value) {
 		// Actually need to create new shape
 		off := len(cur.fields)
 		fld := Field{offset: off, name: name, keyKind: KeyKindString, writable: true, enumerable: false, configurable: true}
-		newFields, shared := cur.extendFields(fld)
-		next = &Shape{parent: cur, fields: newFields, ownedFields: !shared, version: cur.version + 1}
+		newFields := cur.extendFields(fld)
+		next = &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 		if cur.transitions == nil {
 			cur.transitions = make(map[string]*Shape)
 		}
@@ -650,9 +728,8 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 			if configurable != nil {
 				newF.configurable = *configurable
 			}
-			o.privatizeFields()
+			o.forkShape()
 			o.shape.fields[i] = newF
-			o.shape.version++
 			return
 		}
 	}
@@ -670,11 +747,24 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 		fld.configurable = *configurable
 	}
 	cur.mu.Lock()
-	newFields, shared := cur.extendFields(fld)
+	newFields := cur.extendFields(fld)
 	cur.mu.Unlock()
-	next := &Shape{parent: cur, fields: newFields, ownedFields: !shared, version: cur.version + 1}
+	next := &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 	o.shape = next
 	o.properties = append(o.properties, value)
+}
+
+// DefineFixedProperty defines name as a data property that is non-writable,
+// non-enumerable and non-configurable - the attributes the spec gives a
+// built-in constructor's "prototype" (e.g. ES2025 20.1.2.19 for
+// Object.prototype). Built-ins used to get these attributes by accident:
+// SetOwnNonEnumerable's shape transition was shared, so the first constructor
+// that locked its prototype down re-attributed every other constructor's too
+// (issue #122). Now that shapes fork on attribute changes, each site has to say
+// what it means.
+func (o *PlainObject) DefineFixedProperty(name string, v Value) {
+	no := false
+	o.DefineOwnProperty(name, v, &no, &no, &no)
 }
 
 // arrayIndexAccessorSeen latches to true the first time any accessor property is
@@ -748,9 +838,8 @@ func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGette
 			if configurable != nil {
 				newF.configurable = *configurable
 			}
-			o.privatizeFields()
+			o.forkShape()
 			o.shape.fields[i] = newF
-			o.shape.version++
 			if o.getters == nil {
 				o.getters = make(map[string]Value)
 			}
@@ -778,9 +867,9 @@ func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGette
 		fld.configurable = *configurable
 	}
 	cur.mu.Lock()
-	newFields, shared := cur.extendFields(fld)
+	newFields := cur.extendFields(fld)
 	cur.mu.Unlock()
-	next := &Shape{parent: cur, fields: newFields, ownedFields: !shared, version: cur.version + 1}
+	next := &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 	o.shape = next
 	// Ensure maps
 	if o.getters == nil {
@@ -837,9 +926,8 @@ func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writa
 			if configurable != nil {
 				newF.configurable = *configurable
 			}
-			o.privatizeFields()
+			o.forkShape()
 			o.shape.fields[i] = newF
-			o.shape.version++
 			return
 		}
 	}
@@ -860,11 +948,29 @@ func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writa
 		fld.configurable = *configurable
 	}
 	cur.mu.Lock()
-	newFields, shared := cur.extendFields(fld)
+	newFields := cur.extendFields(fld)
 	cur.mu.Unlock()
-	next := &Shape{parent: cur, fields: newFields, ownedFields: !shared, version: cur.version + 1}
+	next := &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 	o.shape = next
 	o.properties = append(o.properties, value)
+}
+
+// accessorTransitionKey builds the transitions-map key for adding an accessor
+// property. It folds the enumerable/configurable attributes into the key so a
+// cached transition is only reused for a define with the same attributes
+// (writable is always false on an accessor field, so it can't differ); the "a"
+// prefix keeps it disjoint from SetOwnNonEnumerable's "ne:" keys.
+func accessorTransitionKey(key PropertyKey, enumerable, configurable bool) string {
+	prefix := "a00:"
+	switch {
+	case enumerable && configurable:
+		prefix = "a11:"
+	case enumerable:
+		prefix = "a10:"
+	case configurable:
+		prefix = "a01:"
+	}
+	return prefix + key.hash()
 }
 
 // DefineAccessorPropertyByKey defines or updates an accessor property for arbitrary key kinds.
@@ -889,9 +995,8 @@ func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value,
 			if configurable != nil {
 				newF.configurable = *configurable
 			}
-			o.privatizeFields()
+			o.forkShape()
 			o.shape.fields[i] = newF
-			o.shape.version++
 			if o.getters == nil {
 				o.getters = make(map[string]Value)
 			}
@@ -907,35 +1012,39 @@ func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value,
 			return
 		}
 	}
-	// New field
+	// New field. The cached transition must be keyed by the attributes as well
+	// as the key: two defineProperty calls for the same key but different
+	// enumerable/configurable produce different shapes, and reusing the first
+	// one would silently give the second object the first one's attributes.
+	fld := Field{offset: 0, name: key.debugName(), keyKind: key.kind, writable: false, enumerable: false, configurable: false, isAccessor: true}
+	if key.isSymbol() {
+		fld.symbolVal = key.symbolVal
+	}
+	if enumerable != nil {
+		fld.enumerable = *enumerable
+	}
+	if configurable != nil {
+		fld.configurable = *configurable
+	}
 	cur := o.shape
+	hashKey := accessorTransitionKey(key, fld.enumerable, fld.configurable)
 	cur.mu.RLock()
-	next, ok := cur.transitions[key.hash()]
+	next, ok := cur.transitions[hashKey]
 	cur.mu.RUnlock()
 	if !ok {
 		cur.mu.Lock()
 		// Re-check under write lock: another goroutine might have added this
-		if existing, exists := cur.transitions[key.hash()]; exists {
+		if existing, exists := cur.transitions[hashKey]; exists {
 			next = existing
 			cur.mu.Unlock()
 		} else {
-			off := len(cur.fields)
-			fld := Field{offset: off, name: key.debugName(), keyKind: key.kind, writable: false, enumerable: false, configurable: false, isAccessor: true}
-			if key.isSymbol() {
-				fld.symbolVal = key.symbolVal
-			}
-			if enumerable != nil {
-				fld.enumerable = *enumerable
-			}
-			if configurable != nil {
-				fld.configurable = *configurable
-			}
-			newFields, shared := cur.extendFields(fld)
-			next = &Shape{parent: cur, fields: newFields, ownedFields: !shared, version: cur.version + 1}
+			fld.offset = len(cur.fields)
+			newFields := cur.extendFields(fld)
+			next = &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 			if cur.transitions == nil {
 				cur.transitions = make(map[string]*Shape)
 			}
-			cur.transitions[key.hash()] = next
+			cur.transitions[hashKey] = next
 			cur.mu.Unlock()
 		}
 	}
@@ -1348,28 +1457,13 @@ func (o *PlainObject) IsPrivateAccessor(name string) bool {
 // non-configurable. Data properties also become non-writable. Accessor properties keep
 // their getter/setter but become non-configurable.
 func (o *PlainObject) FreezeAllProperties() {
-	o.privatizeFields()
-	for i, f := range o.shape.fields {
-		newF := f
-		newF.configurable = false
-		if !f.isAccessor {
-			newF.writable = false
-		}
-		o.shape.fields[i] = newF
-	}
-	o.shape.version++
+	o.shape = o.shape.attrTransition(true)
 }
 
 // SealAllProperties makes all own properties (including non-enumerable and symbol-keyed)
 // non-configurable, but preserves the writable attribute of data properties.
 func (o *PlainObject) SealAllProperties() {
-	o.privatizeFields()
-	for i, f := range o.shape.fields {
-		newF := f
-		newF.configurable = false
-		o.shape.fields[i] = newF
-	}
-	o.shape.version++
+	o.shape = o.shape.attrTransition(false)
 }
 
 // IsFrozenProperty checks if all own properties are non-configurable and
@@ -1595,7 +1689,6 @@ func init() {
 	// Initialize RootShape first
 	RootShape = &Shape{
 		fields:            []Field{},
-		ownedFields:       true,
 		stringTransitions: make(map[string]*Shape),
 		transitions:       make(map[string]*Shape),
 	}

--- a/tests/scripts/frozen_shape_isolation.ts
+++ b/tests/scripts/frozen_shape_isolation.ts
@@ -1,0 +1,125 @@
+// Object.freeze / Object.seal / defineProperty must not re-attribute properties
+// on unrelated objects that merely share the same hidden shape (issue #122).
+// expect: pass
+
+const results: string[] = [];
+
+function check(name: string, actual: any, expected: any) {
+  if (actual !== expected) {
+    results.push(name + ": got " + String(actual) + ", want " + String(expected));
+  }
+}
+
+// The original repro: a frozen value flowing into obj.x used to leave the
+// (obj, "x") slot itself non-writable, so the second write was a silent no-op.
+const source = Object.freeze({ x: Object.freeze([1]) });
+const obj: any = {};
+obj.x = source.x;
+obj.x = [9, 9];
+obj.x.push(3);
+check("repro", JSON.stringify(obj.x), "[9,9,3]");
+
+// Freezing one object must not make a sibling's property read-only, whether the
+// sibling was created before or after the freeze.
+const before: any = { w: 1 };
+const frozen: any = { w: 1 };
+Object.freeze(frozen);
+const after: any = { w: 1 };
+before.w = 42;
+after.w = 43;
+check("before.w", before.w, 42);
+check("after.w", after.w, 43);
+check("frozen.w", frozen.w, 1);
+check("isFrozen(before)", Object.isFrozen(before), false);
+check("isFrozen(frozen)", Object.isFrozen(frozen), true);
+
+// ... and the descriptor of an untouched sibling stays fully default.
+const desc: any = Object.getOwnPropertyDescriptor(after, "w");
+check("desc.writable", desc.writable, true);
+check("desc.enumerable", desc.enumerable, true);
+check("desc.configurable", desc.configurable, true);
+
+// defineProperty making a property non-enumerable must not hide it elsewhere.
+const hidden: any = { k: 1 };
+const visible: any = { k: 1 };
+Object.defineProperty(hidden, "k", { enumerable: false });
+check("keys(visible)", JSON.stringify(Object.keys(visible)), '["k"]');
+check("keys(hidden)", JSON.stringify(Object.keys(hidden)), "[]");
+
+// Object.seal likewise.
+const sealed: any = { s: 1 };
+const open: any = { s: 1 };
+Object.seal(sealed);
+check("isSealed(open)", Object.isSealed(open), false);
+check("delete open.s", delete open.s, true);
+check("delete sealed.s", Object.isSealed(sealed), true);
+
+// Sealing preserves writable; freezing a sealed object still takes it away.
+const seal2: any = { p: 1 };
+Object.seal(seal2);
+seal2.p = 5;
+check("sealed writable", seal2.p, 5);
+check("isFrozen(sealed)", Object.isFrozen(seal2), false);
+Object.freeze(seal2);
+check("isFrozen after freeze", Object.isFrozen(seal2), true);
+// Test scripts run in strict mode, so the rejected write throws.
+let threw = false;
+try {
+  seal2.p = 7;
+} catch (e) {
+  threw = true;
+}
+check("frozen write throws", threw, true);
+check("frozen not writable", seal2.p, 5);
+
+// Freezing twice must be idempotent (the second freeze hits the memoized
+// transition and must not disturb the value).
+const twice: any = { t: 1 };
+Object.freeze(twice);
+Object.freeze(twice);
+check("double freeze", Object.isFrozen(twice), true);
+check("double freeze value", twice.t, 1);
+
+// Object.freeze / Object.seal reach a function's or a RegExp's own properties,
+// which live in a side table rather than on the value itself.
+const fn: any = function () {};
+fn.foo = 10;
+Object.seal(fn);
+const fnDesc: any = Object.getOwnPropertyDescriptor(fn, "foo");
+check("sealed fn configurable", fnDesc.configurable, false);
+check("sealed fn writable", fnDesc.writable, true);
+check("isSealed(fn)", Object.isSealed(fn), true);
+const re: any = /x/;
+re.bar = 10;
+Object.freeze(re);
+const reDesc: any = Object.getOwnPropertyDescriptor(re, "bar");
+check("frozen re configurable", reDesc.configurable, false);
+check("frozen re writable", reDesc.writable, false);
+
+// A built-in constructor's "prototype" is non-writable, non-enumerable and
+// non-configurable - each built-in now says so itself.
+const ctorDesc: any = Object.getOwnPropertyDescriptor(Array, "prototype");
+check("Array.prototype writable", ctorDesc.writable, false);
+check("Array.prototype enumerable", ctorDesc.enumerable, false);
+check("Array.prototype configurable", ctorDesc.configurable, false);
+// ... while an ordinary function's stays writable.
+const userDesc: any = Object.getOwnPropertyDescriptor(function () {}, "prototype");
+check("fn.prototype writable", userDesc.writable, true);
+
+// Accessor transitions are cached per shape; the cache key must include the
+// attributes, or the second define inherits the first one's.
+const sym = Symbol("k");
+const accEnum: any = {};
+Object.defineProperty(accEnum, sym, { get: () => 1, enumerable: true, configurable: true });
+const accPlain: any = {};
+Object.defineProperty(accPlain, sym, { get: () => 2, enumerable: false, configurable: false });
+const d1: any = Object.getOwnPropertyDescriptor(accEnum, sym);
+const d2: any = Object.getOwnPropertyDescriptor(accPlain, sym);
+check("acc1.enumerable", d1.enumerable, true);
+check("acc1.configurable", d1.configurable, true);
+check("acc2.enumerable", d2.enumerable, false);
+check("acc2.configurable", d2.configurable, false);
+check("acc1 value", accEnum[sym], 1);
+check("acc2 value", accPlain[sym], 2);
+
+results.length === 0 ? "pass" : results.join("; ");


### PR DESCRIPTION
Fixes #122.

## Root cause

Shapes are shared. Every object that adds the same properties in the same order
lands on the same `*Shape` through the transition maps — that's the whole point
of them. But `FreezeAllProperties`, `SealAllProperties` and the four
`DefineOwnProperty`/`DefineAccessorProperty` update paths all mutated
`o.shape.fields[i]` **in place**. `privatizeFields()` privatized the fields
*backing array*, not the Shape identity, so the attribute change was visible to
every object sharing that shape — before, after, and entirely unrelated:

```js
const a = { x: 1 }, b = { x: 1 };
Object.freeze(a);
b.x = 42;             // silently ignored — b's "x" is read-only too
console.log(b.x);     // 1
```

```js
const hidden = { k: 1 }, visible = { k: 1 };
Object.defineProperty(hidden, "k", { enumerable: false });
Object.keys(visible); // [] — should be ["k"]
```

That's what #122's repro hits: `obj.x = source.x` transitions `obj` onto the
shape `Object.freeze(source)` poisoned, so the *next* write to `obj.x` is
rejected and `obj.x` keeps the old frozen array.

## Fix

Attribute changes fork instead of mutating:

- **`forkShape()`** gives the object a private, unshared Shape (kept out of any
  transition map) before the in-place field write — the same thing
  `DeleteOwnByKey` already did for property removal.
- **`attrTransition()`** handles freeze/seal, forking with a memo on the source
  shape, so objects that shared a shape before `Object.freeze` still share one
  frozen shape afterwards and inline caches stay monomorphic.
- `ownedFields` is removed: it existed only to serve `privatizeFields`, and
  documented an invariant ("mutate `fields` in place after privatizing") that
  licensed the bug in the first place.

Inline caches guard on shape pointer *and* version, so a fresh shape is a clean
miss; the IC is the only consumer of `Shape.version`.

## Two more bugs of the same family, found on the way

- `DefineAccessorPropertyByKey` cached its new-field transition under
  `key.hash()` alone, so a second `defineProperty` for the same key with
  different `enumerable`/`configurable` silently inherited the first one's
  attributes. The cache key now folds the attributes in.
- Built-in constructors were getting `prototype` as `{writable: false,
  enumerable: false, configurable: false}` **by accident**: the first
  constructor to lock its prototype down re-attributed every other one's
  through the shared shape. Once shapes fork, each site has to say what it
  means, so the ~29 sites that only called `SetOwnNonEnumerable` now use
  `DefineFixedProperty`. (Without this the diff was -15; this is what took it
  back to positive.)

## Also: freeze/seal on functions and RegExps

`Object.freeze`/`Object.seal` were no-ops on callables and RegExps — their own
properties live in a side table that neither built-in looked at, even though
`Object.isFrozen`/`isSealed` already read it, so the two disagreed. Both now
reach the table.

This is also what fixed the last two `-` lines in the built-ins diff
(`Object/freeze/15.2.3.9-2-a-9.js` and `Object/seal/...function-object...`),
which had been passing only because the shared-shape leak poisoned the shape
they check — see #123 for why that counts as a fix rather than a restoration.

The remaining gaps there (`preventExtensions`/`isExtensible` on callables,
freezing a callable that has no properties yet) are pre-existing and filed
separately as #123 — confirmed against a pre-change build, not caused by this
PR.

## Verification

- `tests/scripts/frozen_shape_isolation.ts` covers the original repro plus the
  simpler root-cause shapes (sibling writability, `Object.keys` leak,
  seal-then-freeze, double freeze, accessor attributes, constructor
  `prototype`).
- `go test ./tests -run TestScripts` green; full `go test ./tests/... ./pkg/...`
  green; `go test -race ./pkg/vm/... ./tests/...` green.
- test262 `built-ins`: **+2 / -0** against `baseline.txt`.
- test262 `language`: **+1 / -0** against a dump from a pre-change binary
  (`baseline.txt` is built-ins only). `annexB`: +0 / -0.
- `cmd/bench-ratchet`: 0 regressions over budget (the tree at `main` reports 1
  on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
