### PR TITLE
fix(vm): Object.defineProperty throws on a rejected redefinition (#126)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2948,6 +2948,29 @@ func objectFromEntriesImpl(args []vm.Value) (vm.Value, error) {
 	return result, nil
 }
 
+// definePropertyTarget returns the PlainObject that objectDefinePropertyWithVM
+// will ultimately define on: the object itself, or the side table for a
+// callable / RegExp / Map / Set. Returns nil for kinds with their own define
+// logic (arrays, typed arrays, dicts, proxies).
+func definePropertyTarget(vmInstance *vm.VM, obj vm.Value) *vm.PlainObject {
+	if obj.Type() == vm.TypeObject {
+		return obj.AsPlainObject()
+	}
+	return vm.OwnPropertiesTable(obj)
+}
+
+// definePropertyRejected builds the TypeError that DefinePropertyOrThrow
+// (ES2025 7.3.8) raises when [[DefineOwnProperty]] returns false - a redefinition
+// the property's current attributes don't permit. Reflect.defineProperty turns
+// this back into a false return; Object.defineProperty lets it throw.
+func definePropertyRejected(vmInstance *vm.VM, propName string, propSym vm.Value, keyIsSymbol bool) error {
+	key := propName
+	if keyIsSymbol {
+		key = propSym.ToString()
+	}
+	return vmInstance.NewTypeError("Cannot redefine property: " + key)
+}
+
 func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) < 3 {
 		return vm.Undefined, vmInstance.NewTypeError("Object.defineProperty requires 3 arguments")
@@ -3374,6 +3397,32 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		return vm.Undefined, vmInstance.NewTypeError("Invalid property descriptor. Cannot both specify accessors and a value or writable attribute")
 	}
 
+	// A callable's "length", "name" and "prototype" are synthesized on demand
+	// rather than stored, so defining over one would otherwise create a fresh
+	// property with all-false attributes instead of merging with the real
+	// descriptor - making a second defineProperty on it a rejection.
+	if obj.IsCallable() {
+		vm.MaterializeIntrinsicOwnProperties(vmInstance, obj)
+	}
+
+	// ValidateAndApplyPropertyDescriptor step 5 (ES2025 10.1.6.3): if every
+	// field of the descriptor is absent, redefining an *existing* property is a
+	// no-op that always succeeds - even a non-configurable one, which the
+	// rejection paths below would otherwise refuse.
+	if !hasValue && !hasWritable && !hasGetter && !hasSetter && enumerablePtr == nil && configurablePtr == nil {
+		if target := definePropertyTarget(vmInstance, obj); target != nil {
+			exists := false
+			if keyIsSymbol {
+				_, _, _, _, exists = target.GetOwnDescriptorByKey(vm.NewSymbolKey(propSym))
+			} else {
+				_, _, _, _, exists = target.GetOwnDescriptor(propName)
+			}
+			if exists {
+				return obj, nil
+			}
+		}
+	}
+
 	// Functions, RegExps, Maps and Sets keep their own properties in a side
 	// table; a brand-new property needs that table to be extensible, the same
 	// check the TypeObject path below makes on the object itself.
@@ -3400,18 +3449,22 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			if bf.Properties == nil {
 				bf.Properties = vm.EnsureOwnPropertiesTable(obj)
 			}
+			var defined bool
 			if hasGetter || hasSetter {
 				if keyIsSymbol {
-					bf.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = bf.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				} else {
-					bf.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = bf.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				}
 			} else {
 				if keyIsSymbol {
-					bf.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+					defined = bf.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
-					bf.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+					defined = bf.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
 		return obj, nil
@@ -3585,19 +3638,23 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
 				}
 			}
+			var defined bool
 			if hasGetter || hasSetter {
 				// Accessor path
 				if keyIsSymbol {
-					plainObj.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = plainObj.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				} else {
-					plainObj.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = plainObj.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				}
 			} else {
 				if keyIsSymbol {
-					plainObj.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+					defined = plainObj.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
-					plainObj.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+					defined = plainObj.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
 	} else if obj.Type() == vm.TypeDictObject {
@@ -3609,18 +3666,22 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		// NativeFunctionWithProps (like Function.prototype) stores properties in Properties
 		nfp := obj.AsNativeFunctionWithProps()
 		if nfp != nil && nfp.Properties != nil {
+			var defined bool
 			if hasGetter || hasSetter {
 				if keyIsSymbol {
-					nfp.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = nfp.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				} else {
-					nfp.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = nfp.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				}
 			} else {
 				if keyIsSymbol {
-					nfp.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+					defined = nfp.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
-					nfp.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+					defined = nfp.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
 	} else if obj.Type() == vm.TypeFunction {
@@ -3630,18 +3691,22 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			if fn.Properties == nil {
 				fn.Properties = vm.EnsureOwnPropertiesTable(obj)
 			}
+			var defined bool
 			if hasGetter || hasSetter {
 				if keyIsSymbol {
-					fn.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = fn.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				} else {
-					fn.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = fn.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				}
 			} else {
 				if keyIsSymbol {
-					fn.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+					defined = fn.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
-					fn.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+					defined = fn.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
 	} else if obj.Type() == vm.TypeClosure {
@@ -3653,18 +3718,22 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			if cl.Properties == nil {
 				cl.Properties = vm.EnsureOwnPropertiesTable(obj)
 			}
+			var defined bool
 			if hasGetter || hasSetter {
 				if keyIsSymbol {
-					cl.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = cl.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				} else {
-					cl.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+					defined = cl.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
 				}
 			} else {
 				if keyIsSymbol {
-					cl.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+					defined = cl.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
-					cl.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+					defined = cl.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
 	}

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"sync"
@@ -678,7 +679,7 @@ func (o *PlainObject) SetOwnNonEnumerable(name string, v Value) {
 
 // DefineOwnProperty defines or updates an own property with explicit attributes.
 // For existing properties, unspecified attributes (nil) will keep previous values.
-func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool, enumerable *bool, configurable *bool) {
+func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool, enumerable *bool, configurable *bool) bool {
 	// Update existing
 	for i, f := range o.shape.fields {
 		if f.keyKind == KeyKindString && f.name == name {
@@ -688,7 +689,7 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 			if f.isAccessor {
 				// Convert accessor to data property: only if configurable
 				if !f.configurable {
-					return
+					return false
 				}
 				newF.isAccessor = false
 				newF.writable = false // Default for new data property
@@ -705,19 +706,24 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 			// If current non-configurable, cannot change configurable or enumerable
 			if !f.configurable {
 				if configurable != nil && *configurable != f.configurable {
-					return
+					return false
 				}
 				if enumerable != nil && *enumerable != f.enumerable {
-					return
+					return false
 				}
 				// Non-configurable, non-writable properties cannot have writable changed to true
 				if !f.writable && writable != nil && *writable {
-					return
+					return false
 				}
 			}
-			// Update value: if configurable, always allow; otherwise only if writable
+			// Update value: if configurable, always allow; otherwise only if writable.
+			// A non-configurable, non-writable property may only be "redefined"
+			// with the value it already has (SameValue) - anything else is a
+			// rejection, not a silent no-op.
 			if f.configurable || convertingFromAccessor || f.writable {
 				o.properties[f.offset] = value
+			} else if !sameValue(o.properties[f.offset], value) {
+				return false
 			}
 			if writable != nil {
 				newF.writable = *writable
@@ -730,7 +736,7 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 			}
 			o.forkShape()
 			o.shape.fields[i] = newF
-			return
+			return true
 		}
 	}
 	// New property via descriptor: defaults false unless specified
@@ -752,6 +758,58 @@ func (o *PlainObject) DefineOwnProperty(name string, value Value, writable *bool
 	next := &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 	o.shape = next
 	o.properties = append(o.properties, value)
+	return true
+}
+
+// accessorRedefineAllowed applies the non-configurable half of
+// ValidateAndApplyPropertyDescriptor (ES2025 10.1.6.3) for an accessor
+// descriptor. A non-configurable property can still be "redefined" as long as
+// nothing actually changes: same getter, same setter, same enumerable. Anything
+// else - including turning a non-configurable data property into an accessor -
+// is a rejection.
+func (o *PlainObject) accessorRedefineAllowed(f Field, key PropertyKey, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable, configurable *bool) bool {
+	if f.configurable {
+		return true
+	}
+	if configurable != nil && *configurable {
+		return false
+	}
+	if enumerable != nil && *enumerable != f.enumerable {
+		return false
+	}
+	if !f.isAccessor {
+		// Data -> accessor conversion needs configurable.
+		return false
+	}
+	curGet, curSet, _, _, _ := o.GetOwnAccessorByKey(key)
+	if hasGetter && !sameValue(curGet, getter) {
+		return false
+	}
+	if hasSetter && !sameValue(curSet, setter) {
+		return false
+	}
+	return true
+}
+
+// sameValue implements the spec's SameValue abstract operation (7.2.11), which
+// differs from === on exactly two inputs: NaN is the same value as NaN, and +0
+// is not the same value as -0. DefineOwnProperty uses it for the one case where
+// redefining a non-configurable, non-writable property is allowed - restating
+// the value it already has.
+func sameValue(a, b Value) bool {
+	aNum := a.Type() == TypeIntegerNumber || a.Type() == TypeFloatNumber
+	bNum := b.Type() == TypeIntegerNumber || b.Type() == TypeFloatNumber
+	if aNum && bNum {
+		x, y := AsNumber(a), AsNumber(b)
+		if math.IsNaN(x) && math.IsNaN(y) {
+			return true
+		}
+		if x == 0 && y == 0 {
+			return math.Signbit(x) == math.Signbit(y)
+		}
+		return x == y
+	}
+	return a.StrictlyEquals(b)
 }
 
 // DefineFixedProperty defines name as a data property that is non-writable,
@@ -818,15 +876,14 @@ func noteAccessorKey(name string) {
 }
 
 // DefineAccessorProperty defines or updates an accessor own property.
-func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) bool {
 	noteAccessorKey(name)
 	// Wrapper using string name
 	// Find existing field
 	for i, f := range o.shape.fields {
 		if f.keyKind == KeyKindString && f.name == name {
-			// If existing field is not configurable, cannot change it to accessor or modify flags
-			if !f.configurable {
-				return
+			if !o.accessorRedefineAllowed(f, keyFromString(name), getter, hasGetter, setter, hasSetter, enumerable, configurable) {
+				return false
 			}
 			// Update to accessor kind
 			newF := f
@@ -852,7 +909,7 @@ func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGette
 			if hasSetter {
 				o.setters[keyFromString(name).hash()] = setter
 			}
-			return
+			return true
 		}
 	}
 	// New field - for accessors, always create a new shape (don't use transitions)
@@ -886,10 +943,11 @@ func (o *PlainObject) DefineAccessorProperty(name string, getter Value, hasGette
 	}
 	// Keep properties slice length consistent
 	o.properties = append(o.properties, Undefined)
+	return true
 }
 
 // DefineOwnPropertyByKey defines or updates an own property for arbitrary key kinds.
-func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writable *bool, enumerable *bool, configurable *bool) {
+func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writable *bool, enumerable *bool, configurable *bool) bool {
 	for i, f := range o.shape.fields {
 		match := (key.isString() && f.keyKind == KeyKindString && f.name == key.name) || (key.isSymbol() && f.keyKind == KeyKindSymbol && f.symbolVal.obj == key.symbolVal.obj)
 		if match {
@@ -897,25 +955,28 @@ func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writa
 			if f.isAccessor {
 				// Only allow conversion if configurable
 				if !f.configurable {
-					return
+					return false
 				}
 				newF.isAccessor = false
 				newF.writable = false
 			}
 			if !f.configurable {
 				if configurable != nil && *configurable != f.configurable {
-					return
+					return false
 				}
 				if enumerable != nil && *enumerable != f.enumerable {
-					return
+					return false
 				}
 			}
 			if !f.configurable && !f.writable && writable != nil && *writable {
-				return
+				return false
 			}
-			// Update value: if configurable, always allow; otherwise only if writable
+			// Update value: if configurable, always allow; otherwise only if
+			// writable. See DefineOwnProperty for the SameValue rule.
 			if f.configurable || f.writable {
 				o.properties[f.offset] = value
+			} else if !sameValue(o.properties[f.offset], value) {
+				return false
 			}
 			if writable != nil {
 				newF.writable = *writable
@@ -928,7 +989,7 @@ func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writa
 			}
 			o.forkShape()
 			o.shape.fields[i] = newF
-			return
+			return true
 		}
 	}
 	// New
@@ -953,6 +1014,7 @@ func (o *PlainObject) DefineOwnPropertyByKey(key PropertyKey, value Value, writa
 	next := &Shape{parent: cur, fields: newFields, version: cur.version + 1}
 	o.shape = next
 	o.properties = append(o.properties, value)
+	return true
 }
 
 // accessorTransitionKey builds the transitions-map key for adding an accessor
@@ -974,7 +1036,7 @@ func accessorTransitionKey(key PropertyKey, enumerable, configurable bool) strin
 }
 
 // DefineAccessorPropertyByKey defines or updates an accessor property for arbitrary key kinds.
-func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) bool {
 	if key.isString() {
 		noteAccessorKey(key.name)
 	}
@@ -983,9 +1045,8 @@ func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value,
 		match := (key.isString() && f.keyKind == KeyKindString && f.name == key.name) ||
 			(key.isSymbol() && f.keyKind == KeyKindSymbol && f.symbolVal.obj == key.symbolVal.obj)
 		if match {
-			// If existing field is not configurable, cannot modify
-			if !f.configurable {
-				return
+			if !o.accessorRedefineAllowed(f, key, getter, hasGetter, setter, hasSetter, enumerable, configurable) {
+				return false
 			}
 			newF := f
 			newF.isAccessor = true
@@ -1009,7 +1070,7 @@ func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value,
 			if hasSetter {
 				o.setters[key.hash()] = setter
 			}
-			return
+			return true
 		}
 	}
 	// New field. The cached transition must be keyed by the attributes as well
@@ -1062,6 +1123,7 @@ func (o *PlainObject) DefineAccessorPropertyByKey(key PropertyKey, getter Value,
 		o.setters[key.hash()] = setter
 	}
 	o.properties = append(o.properties, Undefined)
+	return true
 }
 
 // HasOwn reports whether an own property with the given name exists.

--- a/pkg/vm/properties_table.go
+++ b/pkg/vm/properties_table.go
@@ -193,7 +193,7 @@ func MaterializeIntrinsicOwnProperties(vmInst *VM, v Value) {
 		fn := v.AsFunction()
 		name, length = fn.Name, fn.Length
 		deletedName, deletedLength = fn.DeletedName, fn.DeletedLength
-		if !fn.IsArrowFunction {
+		if !fn.IsArrowFunction && !(fn.IsAsync && !fn.IsGenerator) {
 			prototype, hasPrototype = fn.GetOrCreatePrototypeWithVM(vmInst), true
 		}
 	case TypeClosure:
@@ -201,12 +201,12 @@ func MaterializeIntrinsicOwnProperties(vmInst *VM, v Value) {
 		fn := cl.Fn
 		name, length = fn.Name, fn.Length
 		deletedName, deletedLength = fn.DeletedName, fn.DeletedLength
-		// Same own-property test the descriptor fallback and
-		// getOwnPropertyNames use: everything but an arrow has a "prototype".
-		// (Methods shouldn't, but this runtime doesn't distinguish them yet and
-		// already reports one for them; matching that keeps freeze consistent
-		// with what the rest of the runtime says the own properties are.)
-		if !fn.IsArrowFunction {
+		// Everything but an arrow and a plain async function has a
+		// "prototype". (Methods shouldn't either, but this runtime doesn't
+		// distinguish them yet and already reports one for them; matching that
+		// keeps freeze consistent with what the rest of the runtime says the
+		// own properties are.)
+		if !fn.IsArrowFunction && !(fn.IsAsync && !fn.IsGenerator) {
 			prototype, hasPrototype = cl.GetPrototypeWithVM(vmInst), true
 		}
 	case TypeNativeFunction:

--- a/tests/scripts/define_property_reject.ts
+++ b/tests/scripts/define_property_reject.ts
@@ -1,0 +1,97 @@
+// Object.defineProperty must throw a TypeError when the redefinition is
+// rejected, instead of silently returning the object unchanged (issue #126).
+// The rejection rules are ValidateAndApplyPropertyDescriptor (ES2025 10.1.6.3),
+// including the cases where a *non-configurable* property may still be
+// redefined because nothing actually changes.
+// expect: pass
+
+const results: string[] = [];
+
+function check(name: string, actual: any, expected: any) {
+  if (actual !== expected) {
+    results.push(name + ": got " + String(actual) + ", want " + String(expected));
+  }
+}
+
+function threw(name: string, fn: () => void) {
+  let caught = false;
+  try {
+    fn();
+  } catch (e) {
+    caught = e instanceof TypeError;
+  }
+  check(name, caught, true);
+}
+
+function didNotThrow(name: string, fn: () => void) {
+  try {
+    fn();
+    check(name, true, true);
+  } catch (e) {
+    results.push(name + ": threw " + String(e));
+  }
+}
+
+// --- rejections that used to pass silently ----------------------------------
+const frozen: any = { a: 1 };
+Object.freeze(frozen);
+threw("redefine value on frozen", () => { Object.defineProperty(frozen, "a", { value: 9 }); });
+check("value unchanged", frozen.a, 1);
+threw("re-widen writable on frozen", () => { Object.defineProperty(frozen, "a", { writable: true }); });
+threw("re-widen configurable on frozen", () => { Object.defineProperty(frozen, "a", { configurable: true }); });
+threw("flip enumerable on frozen", () => { Object.defineProperty(frozen, "a", { enumerable: false }); });
+
+const locked: any = {};
+Object.defineProperty(locked, "b", { value: 1, configurable: false });
+threw("redefine non-configurable value", () => { Object.defineProperty(locked, "b", { value: 2 }); });
+threw("data to accessor when non-configurable", () => {
+  Object.defineProperty(locked, "b", { get: () => 3 });
+});
+
+// Same on a callable, whose properties live in a side table.
+const fn: any = function () {};
+fn.a = 1;
+Object.freeze(fn);
+threw("redefine value on frozen fn", () => { Object.defineProperty(fn, "a", { value: 9 }); });
+check("fn value unchanged", fn.a, 1);
+threw("add to frozen fn via defineProperty", () => { Object.defineProperty(fn, "n", { value: 1 }); });
+
+// --- redefinitions a non-configurable property must still allow -------------
+// SameValue on the value is a no-op, not a change.
+didNotThrow("restate same value", () => { Object.defineProperty(frozen, "a", { value: 1 }); });
+// ... and SameValue is not ===: NaN matches NaN, +0 does not match -0.
+const nan: any = {};
+Object.defineProperty(nan, "n", { value: NaN });
+didNotThrow("restate NaN", () => { Object.defineProperty(nan, "n", { value: NaN }); });
+const zero: any = {};
+Object.defineProperty(zero, "z", { value: 0 });
+threw("negative zero is a change", () => { Object.defineProperty(zero, "z", { value: -0 }); });
+
+// An empty descriptor never rejects an existing property.
+didNotThrow("empty descriptor on frozen", () => { Object.defineProperty(frozen, "a", {}); });
+
+// A non-configurable accessor accepts a redefinition that changes nothing:
+// filling in an absent setter with undefined, or restating the same getter.
+const acc: any = {};
+const getFunc = () => 0;
+Object.defineProperty(acc, "g", { get: getFunc });
+didNotThrow("set undefined on getter-only", () => { Object.defineProperty(acc, "g", { set: undefined }); });
+didNotThrow("restate same getter", () => { Object.defineProperty(acc, "g", { get: getFunc }); });
+didNotThrow("empty descriptor on accessor", () => { Object.defineProperty(acc, "g", {}); });
+check("getter survived", acc.g, 0);
+threw("different getter is a change", () => { Object.defineProperty(acc, "g", { get: () => 1 }); });
+threw("accessor to data when non-configurable", () => { Object.defineProperty(acc, "g", { value: 5 }); });
+
+// --- a callable's synthesized properties keep their real attributes ---------
+// "length" is configurable, so defining over it twice must work - it used to be
+// materialized with all-false attributes, making the second define a rejection.
+function target(a: any) { return a; }
+didNotThrow("define length once", () => { Object.defineProperty(target, "length", { value: undefined }); });
+didNotThrow("define length twice", () => { Object.defineProperty(target, "length", { value: null }); });
+
+// --- Reflect.defineProperty reports the same rejection as false -------------
+check("Reflect on frozen", Reflect.defineProperty(frozen, "a", { value: 9 }), false);
+check("Reflect no-op on frozen", Reflect.defineProperty(frozen, "a", { value: 1 }), true);
+check("Reflect on fresh", Reflect.defineProperty({}, "x", { value: 1 }), true);
+
+results.length === 0 ? "pass" : results.join("; ");


### PR DESCRIPTION
Fixes #126.

## The bug

Every rejection inside `PlainObject.DefineOwnProperty` and its three siblings
was a bare `return`, so a redefinition the property's attributes forbid silently
returned the object unchanged:

```js
var o = { a: 1 };
Object.freeze(o);
Object.defineProperty(o, "a", { value: 9 });   // Node: TypeError. Was: returns o
Reflect.defineProperty(o, "a", { value: 9 });  // Node: false.     Was: true
```

The *outcome* was never wrong — a rejected change was always correctly not
applied, so no integrity level was bypassable this way — but
`DefinePropertyOrThrow` (ES2025 7.3.8) has to throw, and `Reflect.defineProperty`
has to report `false`.

## Fix

The four `Define*` methods now return whether they applied the change. In Go
that's source-compatible for a call in statement position, so **all 395 existing
callers are untouched**; only `objectDefinePropertyWithVM` consumes it and turns
`false` into a TypeError. That one function is the single choke point
`Object.defineProperty`, `Object.defineProperties`, `Object.create`,
`__defineGetter__`, `Reflect.defineProperty` and the proxy path all funnel
through — and `Reflect` already converted a non-proxy error into a `false`
return, so it needed no change at all.

## The actual work: completing ValidateAndApplyPropertyDescriptor

Making the silent rejections loud exposed that four of them were
**over-rejections**, invisible precisely because they were silent. The first cut
was +49/−14; each regression was a missing rule in 10.1.6.3 for the
non-configurable cases:

- A non-configurable, non-writable data property may be redefined with the value
  it already has. That needs real **SameValue**, not `===`: `NaN` matches `NaN`,
  `+0` does not match `-0`. Without it the headline repro *still* wouldn't throw
  — the value assignment was skipped and the method fell through to success.
- A non-configurable **accessor** may be redefined when nothing changes —
  restating the same getter, or filling an absent setter with `undefined`. This
  alone was 12 of the 14 regressions.
- An **empty descriptor** never rejects an existing property (step 5).
- Defining over a callable's synthesized `length`/`name`/`prototype` created a
  fresh all-false property instead of merging with the real descriptor, making a
  *second* define on it a rejection. #123's `MaterializeIntrinsicOwnProperties`
  already does the right thing, so `defineProperty` on a callable now calls it —
  which in turn revealed that it wrongly hands a plain **async function** a
  `prototype` (async functions have none), now excluded.

## Not covered

`ArrayObject.DefineOwnProperty` has its own separate define logic and still
cannot report a rejection, so array index/length redefinitions stay silent.
Worth a follow-up; it's a different code path with a different signature.

## Verification

- test262 `built-ins`: **+50 / −0** against `baseline.txt`
- test262 `language`: **+0 / −0**, `annexB`: **+0 / −0** (against dumps from a
  binary built from `main`)
- Node 26 parity on every case in the new smoke test, including the SameValue
  edge cases and the `Reflect` boolean
- `tests/scripts/define_property_reject.ts` covers both halves — the rejections
  that must now throw, and the non-configurable redefinitions that must still be
  allowed
- `go test ./tests/... ./pkg/...`, `go test -race ./pkg/vm/... ./tests/...`, and
  `cmd/bench-ratchet` (0 regressions over budget) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)