### PR TITLE
fix(compiler): function-scoped classes are now visible to closures in their body (#128)

### DIFF
--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -218,11 +218,11 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 
 	// 1. Pre-define the class name in the OUTER scope so the constructor can reference it
 	// This is needed for cases like: constructor() { Counter.increment(); }
-	// We temporarily define it with nilRegister, then update it later
 	// For eval code (isIndirectEval=true), class declarations should be local
 	// to the eval's lexical environment, not global.
 	isGlobalClassScope := c.enclosing == nil && !c.isIndirectEval
 	var classGlobalIdx uint16 // only meaningful when isGlobalClassScope
+	var classSpillSlot uint16 // only meaningful when !isGlobalClassScope
 	if isGlobalClassScope {
 		// Top-level class declaration. The symbol table always binds the
 		// plain name (so intra-module references, including recursive
@@ -232,29 +232,40 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 		c.currentSymbolTable.DefineGlobal(node.Name.Value, classGlobalIdx)
 		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined global class '%s' at index %d\n", node.Name.Value, classGlobalIdx)
 	} else {
-		// Local class declaration (or eval-scoped class)
-		c.currentSymbolTable.Define(node.Name.Value, nilRegister)
-		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined local class '%s'\n", node.Name.Value)
+		// Local class declaration (or eval-scoped class).
+		// Pre-allocate a stable spill slot for the binding right now, before the
+		// constructor/methods compile, so any closure compiled while the class body
+		// compiles (the constructor's own self-reference, other methods, or nested
+		// functions inside them) captures the real, final storage location via
+		// CaptureFromSpill. The old approach defined this with a nilRegister
+		// placeholder that wasn't updated to the real register until after the
+		// whole class body - including all its methods - had already compiled, so
+		// any closure captured as an upvalue baked in a dangling nilRegister that
+		// never got fixed up (#128, same root-cause shape as #117/#119 but for
+		// function-scoped classes captured by upvalue instead of module-level
+		// ones). A spill slot is index-based like the global slot above, so it's
+		// stable across the whole compile - mirrors what compileClassExpression
+		// already does for named class expressions.
+		classSpillSlot = c.AllocSpillSlot()
+		c.currentSymbolTable.DefineSpilled(node.Name.Value, classSpillSlot)
+		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined local class '%s' in spill slot %d\n", node.Name.Value, classSpillSlot)
 	}
 
 	// Per ECMAScript spec (sec-runtime-semantics-classdefinitionevaluation):
 	// Create an inner scope with an immutable binding of the class name.
 	// This ensures methods inside the class see the immutable binding.
-	// NOTE: We don't allocate a separate register for the inner binding - that would
-	// cause register leaks when closures capture it. Instead, the inner binding shares
-	// storage with the outer binding (global or outer register). The TDZ case
-	// (class x extends x {}) is handled specially in heritage resolution.
+	// The inner binding shares storage with the outer binding (global index or
+	// spill slot). The TDZ case (class x extends x {}) is handled specially in
+	// heritage resolution.
 	var prevSymbolTable *SymbolTable
 	if node.Name.Value != "" {
 		prevSymbolTable = c.currentSymbolTable
 		c.currentSymbolTable = NewEnclosedSymbolTable(c.currentSymbolTable)
 		// The inner binding shares storage with the outer binding but has IsStrictImmutable set.
-		// For globals, we use the same global index. For locals, we use nilRegister for now
-		// (will be updated to constructorReg later when the outer binding is updated).
 		if isGlobalClassScope {
 			c.currentSymbolTable.DefineGlobalStrictImmutable(node.Name.Value, classGlobalIdx)
 		} else {
-			c.currentSymbolTable.DefineStrictImmutable(node.Name.Value, nilRegister)
+			c.currentSymbolTable.DefineSpilledStrictImmutable(node.Name.Value, classSpillSlot)
 		}
 		debugPrintf("// DEBUG compileClassDeclaration: Created inner immutable binding for class '%s'\n", node.Name.Value)
 	}
@@ -475,27 +486,21 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 	}
 	c.currentClassDecorators = nil
 
-	// 5. Update the class constructor register/global
-	// For local classes, update BOTH the inner and outer bindings before restoring the outer scope
+	// 5. Store the finished constructor into the class binding.
+	// For local classes, the inner and outer bindings already share the same
+	// spill slot (defined up front in step 1), so a single store satisfies both.
 	if isGlobalClassScope {
 		// Top-level class declaration - set the global value
 		c.emitSetGlobal(classGlobalIdx, constructorReg, node.Token.Line)
 		debugPrintf("// DEBUG compileClassDeclaration: Set global class '%s' to R%d\n", node.Name.Value, constructorReg)
 	} else {
-		// Local class declaration - update the inner binding's register first (while inner scope is active)
-		c.currentSymbolTable.UpdateRegister(node.Name.Value, constructorReg)
-		debugPrintf("// DEBUG compileClassDeclaration: Updated inner binding for class '%s' to R%d\n", node.Name.Value, constructorReg)
+		c.emitStoreSpill(classSpillSlot, constructorReg, node.Token.Line)
+		debugPrintf("// DEBUG compileClassDeclaration: Stored local class '%s' constructor into spill slot %d\n", node.Name.Value, classSpillSlot)
 	}
 
 	// Restore outer scope
 	if prevSymbolTable != nil {
 		c.currentSymbolTable = prevSymbolTable
-	}
-
-	// For local classes, also update the outer binding
-	if !isGlobalClassScope {
-		c.currentSymbolTable.UpdateRegister(node.Name.Value, constructorReg)
-		debugPrintf("// DEBUG compileClassDeclaration: Updated outer binding for class '%s' to R%d\n", node.Name.Value, constructorReg)
 	}
 
 	// Class declarations don't produce a value for the hint register

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4414,8 +4414,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -4512,8 +4510,6 @@ startExecution:
 								frame = &vm.frames[vm.frameCount-1]
 								closure = frame.closure
 								function = closure.Fn
-								code = function.Chunk.Code
-								constants = function.Chunk.Constants
 								registers = frame.registers
 								ip = frame.ip
 								goto reloadFrame
@@ -4864,8 +4860,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -4952,8 +4946,6 @@ startExecution:
 								frame = &vm.frames[vm.frameCount-1]
 								closure = frame.closure
 								function = closure.Fn
-								code = function.Chunk.Code
-								constants = function.Chunk.Constants
 								registers = frame.registers
 								ip = frame.ip
 								goto reloadFrame
@@ -5062,8 +5054,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -8898,8 +8888,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -8959,8 +8947,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame

--- a/tests/scripts/class_visible_to_closures_in_function.ts
+++ b/tests/scripts/class_visible_to_closures_in_function.ts
@@ -1,0 +1,64 @@
+// expect: true
+
+// #128: a class declared inside a function body must be visible to every
+// closure nested in that function, not just the constructor's own body -
+// methods, getters/setters, and further-nested arrow functions all close
+// over the class name the same way any other local binding would.
+function makeCounter(): boolean {
+    class Counter {
+        static count: number = 0;
+
+        constructor() {
+            // Constructor self-reference (referencing the class from its own body).
+            this.ctorSelfRef = Counter;
+        }
+
+        // A regular method referencing the class name is itself a nested
+        // closure (its own function/compiler), distinct from the constructor.
+        inc(): number {
+            Counter.count++;
+            return Counter.count;
+        }
+
+        // An arrow function nested *inside* a method - two closure boundaries
+        // away from the class declaration.
+        makeIncrementer(): () => number {
+            return () => {
+                Counter.count++;
+                return Counter.count;
+            };
+        }
+
+        ctorSelfRef: unknown;
+    }
+
+    const c = new Counter();
+    const ctorOk = c.ctorSelfRef === Counter;
+    const methodOk = c.inc() === 1;
+    const nestedArrowOk = c.makeIncrementer()() === 2;
+
+    // A sibling closure declared after the class, in the same function scope.
+    const siblingReadsClass = () => Counter.count;
+    const siblingOk = siblingReadsClass() === 2;
+
+    return ctorOk && methodOk && nestedArrowOk && siblingOk;
+}
+
+function makeDerived(): boolean {
+    class Base {
+        static tag(): string {
+            return "base";
+        }
+    }
+    class Derived extends Base {
+        static tag(): string {
+            return super.tag() + "+derived";
+        }
+        method(): () => string {
+            return () => Derived.tag() + "|" + Base.tag();
+        }
+    }
+    return new Derived().method()() === "base+derived|base";
+}
+
+makeCounter() && makeDerived();


### PR DESCRIPTION
## Summary

Fixes #128.

`compileClassDeclaration` pre-defined a local (function-scoped) class's own name with a `nilRegister` placeholder, updated to the real constructor register only *after* the whole class body — including all its methods — had already compiled. Any closure compiled in between (the constructor's own self-reference, other methods, or functions nested further inside them) resolved the class name as a free variable while it still held `nilRegister`, baking a dangling capture into the closure that could never be fixed up. At runtime this surfaced as `ReferenceError: X is not defined` from inside the class's own methods.

Same root-cause shape as #117/#119 (a hoisted binding compiled before its own value exists), but for function-scoped classes captured by upvalue instead of module-level ones reached via a stable global index.

## Fix

Same approach `compileClassExpression` already uses for named class expressions: allocate a stable spill slot for the class binding up front, before the constructor/methods compile, so every closure captures the real, final storage location via `CaptureFromSpill` instead of a register number that isn't decided yet. The inner (class-body-only) immutable binding and the outer (post-declaration) binding now share that one slot from the start, so the previous two-phase register handoff (and its `UpdateRegister` calls) is no longer needed.

## Testing

- `go test ./...` — all green
- Full TS conformance suite: 70.8% pass (consistent with the ~70.4% baseline, no regression)
- Test262 `language/statements/class` subsuite — no regressions
- Added [tests/scripts/class_visible_to_closures_in_function.ts](tests/scripts/class_visible_to_closures_in_function.ts) covering constructor self-reference, method self-reference, an arrow function nested inside a method, a sibling closure declared after the class in the same function scope, and a derived class referencing itself via `super` in a static method.

## Known pre-existing limitation (not introduced or regressed by this fix)

Closures capturing a `let`/`const`/`class` declared inside a **loop body** do not get a fresh per-iteration binding (all iterations share one slot/register) — verified this is broken identically for plain `let` on `main` before this change. That's a separate, likely high-impact bug worth its own issue; flagging it here for visibility but leaving it out of scope for #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)