### PR TITLE
fix(vm): executeUserFunctionSafe surfaces the real internal diagnostic instead of a fixed string (#130)

### DIFF
--- a/pkg/driver/host_call_error_test.go
+++ b/pkg/driver/host_call_error_test.go
@@ -1,0 +1,92 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestHostCallSurfacesInternalDiagnostic verifies #130: when a JS function
+// invoked directly by an embedder via vm.Call() fails through
+// vm.runtimeError() (an internal-invariant failure with no JS exception
+// value to hand back - e.g. a stack overflow mid-construction, a corrupted
+// register/constant index, a recovered Go panic) rather than a real thrown
+// exception, executeUserFunctionSafe must surface the VM's own recorded
+// diagnostic instead of discarding it for a fixed, uninformative string.
+func TestHostCallSurfacesInternalDiagnostic(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+class Foo {
+  constructor(n) {
+    new Foo(n + 1);
+  }
+}
+function trigger() {
+  new Foo(0);
+}
+`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	vmInst := p.GetVM()
+	fn, ok := vmInst.GetGlobal("trigger")
+	if !ok {
+		t.Fatal("global 'trigger' not found")
+	}
+
+	result, err := vmInst.Call(fn, vm.Undefined, nil)
+	t.Logf("result=%v err=%v", result, err)
+	if err == nil {
+		t.Fatal("expected an error from vm.Call, got nil")
+	}
+	if err.Error() == "runtime error during user function execution" {
+		t.Errorf("vm.Call lost the real diagnostic and returned the generic fallback string: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Stack overflow during constructor call") {
+		t.Errorf("expected the real diagnostic to survive, got: %v", err)
+	}
+}
+
+// TestHostRunCodeStillReportsInternalDiagnosticCleanly guards against a
+// regression found while fixing #130: an earlier version of the fix had
+// executeUserFunctionSafe *consume* (pop) the diagnostic from vm.errors when
+// surfacing it as a Go error. That's correct only when executeUserFunctionSafe
+// is the terminal consumer (as it is for a direct embedder vm.Call(), see
+// above). Here the same runtimeError() fires inside a callback invoked from
+// bytecode that is itself running under RunCode's own top-level Interpret(),
+// which reports vm.errors wholesale once the (re-wrapped, re-thrown)
+// exception finishes propagating. Popping the entry left that top-level
+// report with nothing to show but the newly-thrown wrapper exception's own
+// multi-thousand-frame stack trace (from constructing `new Error(...)` while
+// the VM's frame stack was still at the depth the overflow itself left it at)
+// instead of the one-line diagnostic RunCode reports today.
+func TestHostRunCodeStillReportsInternalDiagnosticCleanly(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+class Foo {
+  constructor(n) {
+    new Foo(n + 1);
+  }
+}
+[1].forEach(() => { new Foo(0); });
+`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) == 0 {
+		t.Fatal("expected RunCode to report an error")
+	}
+	joined := errs[0].Error()
+	t.Logf("error: %s", joined)
+	if len(joined) > 2000 {
+		t.Errorf("error message is suspiciously long (%d chars) - looks like the garbage-stack-trace regression, not a clean diagnostic", len(joined))
+	}
+	if !strings.Contains(joined, "Stack overflow during constructor call") {
+		t.Errorf("expected the real diagnostic in the reported error, got: %s", joined)
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4414,8 +4414,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -4512,8 +4510,6 @@ startExecution:
 								frame = &vm.frames[vm.frameCount-1]
 								closure = frame.closure
 								function = closure.Fn
-								code = function.Chunk.Code
-								constants = function.Chunk.Constants
 								registers = frame.registers
 								ip = frame.ip
 								goto reloadFrame
@@ -4864,8 +4860,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -4952,8 +4946,6 @@ startExecution:
 								frame = &vm.frames[vm.frameCount-1]
 								closure = frame.closure
 								function = closure.Fn
-								code = function.Chunk.Code
-								constants = function.Chunk.Constants
 								registers = frame.registers
 								ip = frame.ip
 								goto reloadFrame
@@ -5062,8 +5054,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -8898,8 +8888,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -8959,8 +8947,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1806,6 +1806,39 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 	return result, nil
 }
 
+// lastRecordedErrorMessage returns the message of the most recently recorded
+// internal diagnostic in vm.errors, without consuming it. Returns "" if
+// nothing was recorded.
+//
+// vm.runtimeError() - used for internal-invariant failures (a stack overflow
+// mid-construction, a corrupted register/constant index, a recovered Go
+// panic) - records the real diagnostic here and returns InterpretRuntimeError
+// *without* ever setting vm.unwinding/vm.currentException, because there is
+// no JS-level exception *value* to hand back (see runtimeError's callers in
+// vm.go). A caller of vm.run() that only checks
+// `vm.unwinding && vm.currentException != Null` to decide it got a real
+// exception therefore has nothing to report for this case and, before this
+// helper existed, fell back to a fixed generic string - discarding the one
+// piece of real information the VM actually recorded (#130).
+//
+// Deliberately a peek, not a pop (unlike the similar-looking vm.errors
+// fallback in the OpDynamicImport handling in vm.go, which *does* consume the
+// entry because it owns turning this into a terminal promise rejection):
+// executeUserFunctionSafe is not always the terminal consumer. When this
+// runtimeError fired inside a callback invoked from bytecode that is itself
+// running under the driver's own top-level Interpret(), popping here would
+// remove the entry Interpret() is still going to report from vm.errors
+// wholesale once the (re-wrapped, re-thrown) exception finishes propagating -
+// verified by hand: popping left a real top-level failure printing as a
+// multi-thousand-line garbage dump instead of the one-line diagnostic it
+// prints today.
+func (vm *VM) lastRecordedErrorMessage() string {
+	if len(vm.errors) == 0 {
+		return ""
+	}
+	return vm.errors[len(vm.errors)-1].Error()
+}
+
 // executeUserFunctionSafe executes a user function from a native function using sentinel frames
 // This allows proper nested calls without infinite recursion
 func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (Value, error) {
@@ -1890,6 +1923,9 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 			// by a later, unrelated throw.
 			vm.truncateFramesTo(frameCountAtEntry)
 			return Undefined, exceptionError{exception: ex}
+		}
+		if msg := vm.lastRecordedErrorMessage(); msg != "" {
+			return Undefined, fmt.Errorf("%s", msg)
 		}
 		return Undefined, fmt.Errorf("runtime error during user function execution")
 	}


### PR DESCRIPTION
## Summary

Fixes #130.

When `vm.run()` returns `InterpretRuntimeError`, `executeUserFunctionSafe` only had one way to explain why: check `vm.unwinding`/`vm.currentException` for a real thrown JS exception. That check is correctly `false` for a whole class of failures that never go through `vm.throwException()` at all — `vm.runtimeError()` (a stack overflow mid-construction, a corrupted register/constant index, a recovered Go panic) records the real message in `vm.errors` and returns `InterpretRuntimeError` directly, with no JS exception value to hand back. `executeUserFunctionSafe` had nothing to report for this case and fell back to a fixed, uninformative string — discarding the one piece of real information the VM actually recorded.

## What I investigated and did *not* find

The issue hypothesized a reentrancy-specific state-corruption root cause (two `vm.Call()`s active on the Go call stack corrupting `vm.unwinding`/`vm.unwindingCrossedNative` between them). I could not confirm this: `truncateFramesTo` unconditionally resets `unwindingCrossedNative` on every `executeUserFunctionSafe` exit, so a stale flag from a resolved nested call can't leak into a later, unrelated throw's boundary-stopping logic — confirmed with an exception-tracing run showing three sequential throws each starting from a clean `crossedNative=false` and reaching the correct handler.

The actual trigger needs **no second `executeUserFunctionSafe` on the Go stack at all**: a single embedder `vm.Call()` whose own nested *bytecode* hits a `runtimeError()` path (e.g. deep recursive `new Foo()` construction) is sufficient — that's what the added tests exercise.

## The fix, and a regression I caught along the way

Peek (not pop) the last entry in `vm.errors` and surface its message instead of the generic fallback, only when there's no real exception to report.

An earlier version of this fix *popped* the entry, matching the precedent in `OpDynamicImport`'s module-load error handling. That precedent is a **terminal** consumer (turning the diagnostic into a promise rejection), but `executeUserFunctionSafe` is not always terminal: when the `runtimeError` fires inside a callback invoked from bytecode that is itself running under the driver's own top-level `Interpret()`, `Interpret()` reports `vm.errors` wholesale once the re-wrapped, re-thrown exception finishes propagating. Popping removed the entry `Interpret()` was about to report, degrading a clean one-line diagnostic into a **multi-thousand-line dump** (the newly-thrown wrapper `Error`'s own stack trace, captured while the VM's frame stack was still at the depth the overflow left it at) with exit code 0 instead of a proper failure.

Peeking leaves the entry for whichever consumer actually terminates it. Side effect: the driver-level diagnostic for this case now prints once instead of twice (both prints already agreed on the same message, so no information is lost) — a small, deliberate behavior change worth flagging for review.

## Deliberately out of scope

The sibling generator/async resumption fallbacks (`vm.go` around lines 18456, 18664, 18848, 19007, 19178) share the same defect shape, but they return `exceptionError{exception: NewString(...)}` — the string becomes a **thrown JS value**, not just a Go error message. Swapping in a `vm.errors` message there would change what a user `catch` block receives, which is a behavior change, not a diagnostic improvement.

## Testing

- `go test ./...` — all green
- Added [pkg/driver/host_call_error_test.go](pkg/driver/host_call_error_test.go) with one test per consumption path:
  - `TestHostCallSurfacesInternalDiagnostic` — a direct embedder `vm.Call()`
  - `TestHostRunCodeStillReportsInternalDiagnosticCleanly` — the same failure reached under `RunCode`'s top-level `Interpret()`; also guards against the peek-vs-pop regression described above

## Related follow-ups filed while investigating

- [#133](https://github.com/nooga/paserati/issues/133) — an unrelated, pre-existing VM panic (index out of range) found while first trying to reproduce #130 via async methods
- [#135](https://github.com/nooga/paserati/issues/135) — constructor stack overflow isn't a catchable `RangeError` (found via the repro used here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)