### PR TITLE
fix(vm): remove dead code/constants assignments before goto reloadFrame (lint)

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4414,8 +4414,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -4512,8 +4510,6 @@ startExecution:
 								frame = &vm.frames[vm.frameCount-1]
 								closure = frame.closure
 								function = closure.Fn
-								code = function.Chunk.Code
-								constants = function.Chunk.Constants
 								registers = frame.registers
 								ip = frame.ip
 								goto reloadFrame
@@ -4864,8 +4860,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -4952,8 +4946,6 @@ startExecution:
 								frame = &vm.frames[vm.frameCount-1]
 								closure = frame.closure
 								function = closure.Fn
-								code = function.Chunk.Code
-								constants = function.Chunk.Constants
 								registers = frame.registers
 								ip = frame.ip
 								goto reloadFrame
@@ -5062,8 +5054,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -8898,8 +8888,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame
@@ -8959,8 +8947,6 @@ startExecution:
 									frame = &vm.frames[vm.frameCount-1]
 									closure = frame.closure
 									function = closure.Fn
-									code = function.Chunk.Code
-									constants = function.Chunk.Constants
 									registers = frame.registers
 									ip = frame.ip
 									goto reloadFrame


### PR DESCRIPTION
## Summary

Fixes the `lint` CI job, which currently fails on **every** open PR (#131, #134, #136) regardless of what they change — confirmed `main` itself already fails `golangci-lint run` with these same 14 findings before this fix, so it's unrelated to any in-flight work.

## What

Seven identical proxy-trap-error-handling sites in `pkg/vm/vm.go` set `code`/`constants` (along with `frame`/`closure`/`function`/`registers`/`ip`) immediately before `goto reloadFrame`. The `reloadFrame:` label unconditionally re-derives all of those same variables from `vm.frames[vm.frameCount-1]` right after the jump — so the `code = function.Chunk.Code` / `constants = function.Chunk.Constants` pair right before the `goto` is always overwritten before being read. `ineffassign` correctly flags this as dead code; removed the 14 dead lines. No behavior change.

## Testing

- `golangci-lint run --timeout=5m` — clean (was 14 findings)
- `go test ./...` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)