### PR TITLE
fix(vm): constructor stack overflow is now a catchable RangeError

### DIFF
--- a/pkg/driver/host_call_error_test.go
+++ b/pkg/driver/host_call_error_test.go
@@ -7,39 +7,38 @@ import (
 	"github.com/nooga/paserati/pkg/vm"
 )
 
+// newCorruptedConstantFunction builds a minimal, hand-assembled function value
+// whose bytecode is deliberately corrupt: its one instruction loads a constant
+// at an index past the end of an empty constant pool. Executing it always hits
+// vm.runtimeError("Invalid constant index %d", ...) - not a real JS exception,
+// just an internal-invariant failure with no exception *value* to report - the
+// same shape #130 is about, but deliberately synthetic and stable, so this
+// test doesn't need a real, currently-uncaught engine bug as its fixture (an
+// earlier version of this test used deep recursive `new Foo()` construction,
+// which stopped exercising this code path once #135 made that catchable).
+func newCorruptedConstantFunction() vm.Value {
+	chunk := &vm.Chunk{
+		Code: []byte{
+			byte(vm.OpLoadConst), 0, 0xFF, 0xFF, // R0 = Constants[65535] - always out of range
+			byte(vm.OpReturnUndefined),
+		},
+		Constants: nil, // empty pool: any non-negative index is out of range
+		Lines:     []int{1, 1, 1, 1, 1},
+	}
+	return vm.NewFunction(0, 0, 0, 4, false, "corrupted", chunk, false, false, false, false)
+}
+
 // TestHostCallSurfacesInternalDiagnostic verifies #130: when a JS function
 // invoked directly by an embedder via vm.Call() fails through
 // vm.runtimeError() (an internal-invariant failure with no JS exception
-// value to hand back - e.g. a stack overflow mid-construction, a corrupted
-// register/constant index, a recovered Go panic) rather than a real thrown
-// exception, executeUserFunctionSafe must surface the VM's own recorded
-// diagnostic instead of discarding it for a fixed, uninformative string.
+// value to hand back) rather than a real thrown exception,
+// executeUserFunctionSafe must surface the VM's own recorded diagnostic
+// instead of discarding it for a fixed, uninformative string.
 func TestHostCallSurfacesInternalDiagnostic(t *testing.T) {
 	p := NewPaserati()
-	p.SetSkipTypeCheck(true)
-
-	js := `
-class Foo {
-  constructor(n) {
-    new Foo(n + 1);
-  }
-}
-function trigger() {
-  new Foo(0);
-}
-`
-	_, errs := p.RunCode(js, RunOptions{})
-	if len(errs) > 0 {
-		t.Fatalf("RunCode failed: %v", errs[0])
-	}
-
 	vmInst := p.GetVM()
-	fn, ok := vmInst.GetGlobal("trigger")
-	if !ok {
-		t.Fatal("global 'trigger' not found")
-	}
 
-	result, err := vmInst.Call(fn, vm.Undefined, nil)
+	result, err := vmInst.Call(newCorruptedConstantFunction(), vm.Undefined, nil)
 	t.Logf("result=%v err=%v", result, err)
 	if err == nil {
 		t.Fatal("expected an error from vm.Call, got nil")
@@ -47,7 +46,7 @@ function trigger() {
 	if err.Error() == "runtime error during user function execution" {
 		t.Errorf("vm.Call lost the real diagnostic and returned the generic fallback string: %v", err)
 	}
-	if !strings.Contains(err.Error(), "Stack overflow during constructor call") {
+	if !strings.Contains(err.Error(), "Invalid constant index") {
 		t.Errorf("expected the real diagnostic to survive, got: %v", err)
 	}
 }
@@ -69,15 +68,14 @@ func TestHostRunCodeStillReportsInternalDiagnosticCleanly(t *testing.T) {
 	p := NewPaserati()
 	p.SetSkipTypeCheck(true)
 
-	js := `
-class Foo {
-  constructor(n) {
-    new Foo(n + 1);
-  }
-}
-[1].forEach(() => { new Foo(0); });
-`
-	_, errs := p.RunCode(js, RunOptions{})
+	// Inject the corrupted function as a global directly on GlobalObject -
+	// OpGetGlobal falls back to it by name when the heap slot for an
+	// otherwise-unresolved identifier doesn't exist (the same fallback that
+	// makes `Object.defineProperty(this, ...)`-style globals visible).
+	vmInst := p.GetVM()
+	vmInst.GlobalObject.SetOwn("__trigger", newCorruptedConstantFunction())
+
+	_, errs := p.RunCode(`[1].forEach(() => { __trigger(); });`, RunOptions{})
 	if len(errs) == 0 {
 		t.Fatal("expected RunCode to report an error")
 	}
@@ -86,7 +84,7 @@ class Foo {
 	if len(joined) > 2000 {
 		t.Errorf("error message is suspiciously long (%d chars) - looks like the garbage-stack-trace regression, not a clean diagnostic", len(joined))
 	}
-	if !strings.Contains(joined, "Stack overflow during constructor call") {
+	if !strings.Contains(joined, "Invalid constant index") {
 		t.Errorf("expected the real diagnostic in the reported error, got: %s", joined)
 	}
 }

--- a/pkg/vm/op_spreadnew.go
+++ b/pkg/vm/op_spreadnew.go
@@ -91,14 +91,24 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		// Check stack limits
 		if vm.frameCount >= len(vm.frames) {
 			frame.ip = callerIP
-			status := vm.runtimeError("Stack overflow during constructor call.")
-			return status, Undefined
+			// #135: a catchable RangeError, not an internal runtimeError - deep
+			// constructor recursion is a normal (if buggy) JS program state, not
+			// a VM invariant violation, so it must be try/catch-able like
+			// V8/Node's "Maximum call stack size exceeded".
+			vm.ThrowRangeError("Maximum call stack size exceeded")
+			if !vm.unwinding {
+				return InterpretOK, Undefined
+			}
+			return InterpretRuntimeError, Undefined
 		}
 		requiredRegs := constructorFunc.RegisterSize
 		if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
 			frame.ip = callerIP
-			status := vm.runtimeError("Register stack overflow during constructor call.")
-			return status, Undefined
+			vm.ThrowRangeError("Maximum call stack size exceeded")
+			if !vm.unwinding {
+				return InterpretOK, Undefined
+			}
+			return InterpretRuntimeError, Undefined
 		}
 
 		// Determine the new.target value for this constructor call
@@ -196,14 +206,24 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		// Check stack limits
 		if vm.frameCount >= len(vm.frames) {
 			frame.ip = callerIP
-			status := vm.runtimeError("Stack overflow during constructor call.")
-			return status, Undefined
+			// #135: a catchable RangeError, not an internal runtimeError - deep
+			// constructor recursion is a normal (if buggy) JS program state, not
+			// a VM invariant violation, so it must be try/catch-able like
+			// V8/Node's "Maximum call stack size exceeded".
+			vm.ThrowRangeError("Maximum call stack size exceeded")
+			if !vm.unwinding {
+				return InterpretOK, Undefined
+			}
+			return InterpretRuntimeError, Undefined
 		}
 		requiredRegs := constructorFunc.RegisterSize
 		if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
 			frame.ip = callerIP
-			status := vm.runtimeError("Register stack overflow during constructor call.")
-			return status, Undefined
+			vm.ThrowRangeError("Maximum call stack size exceeded")
+			if !vm.unwinding {
+				return InterpretOK, Undefined
+			}
+			return InterpretRuntimeError, Undefined
 		}
 
 		// Determine the new.target value for this constructor call

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -10759,14 +10759,40 @@ startExecution:
 				// No arity checking needed for extra arguments
 				if vm.frameCount >= len(vm.frames) {
 					frame.ip = callerIP
-					status := vm.runtimeError("Stack overflow during constructor call.")
-					return status, Undefined
+					// #135: a catchable RangeError, not an internal runtimeError -
+					// deep constructor recursion is a normal (if buggy) JS program
+					// state, not a VM invariant violation, so it must be
+					// try/catch-able like V8/Node's "Maximum call stack size
+					// exceeded".
+					vm.ThrowRangeError("Maximum call stack size exceeded")
+					if !vm.unwinding {
+						// Exception was caught by a handler, reload frame and continue
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					return InterpretRuntimeError, Undefined
 				}
 				requiredRegs := constructorFunc.RegisterSize
 				if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
 					frame.ip = callerIP
-					status := vm.runtimeError("Register stack overflow during constructor call.")
-					return status, Undefined
+					vm.ThrowRangeError("Maximum call stack size exceeded")
+					if !vm.unwinding {
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					return InterpretRuntimeError, Undefined
 				}
 
 				// Determine the new.target value for this constructor call
@@ -10969,14 +10995,40 @@ startExecution:
 				// No arity checking needed for extra arguments
 				if vm.frameCount >= len(vm.frames) {
 					frame.ip = callerIP
-					status := vm.runtimeError("Stack overflow during constructor call.")
-					return status, Undefined
+					// #135: a catchable RangeError, not an internal runtimeError -
+					// deep constructor recursion is a normal (if buggy) JS program
+					// state, not a VM invariant violation, so it must be
+					// try/catch-able like V8/Node's "Maximum call stack size
+					// exceeded".
+					vm.ThrowRangeError("Maximum call stack size exceeded")
+					if !vm.unwinding {
+						// Exception was caught by a handler, reload frame and continue
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					return InterpretRuntimeError, Undefined
 				}
 				requiredRegs := constructorFunc.RegisterSize
 				if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
 					frame.ip = callerIP
-					status := vm.runtimeError("Register stack overflow during constructor call.")
-					return status, Undefined
+					vm.ThrowRangeError("Maximum call stack size exceeded")
+					if !vm.unwinding {
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					return InterpretRuntimeError, Undefined
 				}
 
 				// Determine the new.target value for this constructor call
@@ -11469,14 +11521,36 @@ startExecution:
 					}
 					if vm.frameCount >= len(vm.frames) {
 						frame.ip = callerIP
-						status := vm.runtimeError("Stack overflow during constructor call.")
-						return status, Undefined
+						// #135: a catchable RangeError, not an internal runtimeError -
+						// see the identical comment on the other constructor-call sites.
+						vm.ThrowRangeError("Maximum call stack size exceeded")
+						if !vm.unwinding {
+							frame = &vm.frames[vm.frameCount-1]
+							closure = frame.closure
+							function = closure.Fn
+							code = function.Chunk.Code
+							constants = function.Chunk.Constants
+							registers = frame.registers
+							ip = frame.ip
+							continue
+						}
+						return InterpretRuntimeError, Undefined
 					}
 					requiredRegs := constructorFunc.RegisterSize
 					if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
 						frame.ip = callerIP
-						status := vm.runtimeError("Register stack overflow during constructor call.")
-						return status, Undefined
+						vm.ThrowRangeError("Maximum call stack size exceeded")
+						if !vm.unwinding {
+							frame = &vm.frames[vm.frameCount-1]
+							closure = frame.closure
+							function = closure.Fn
+							code = function.Chunk.Code
+							constants = function.Chunk.Constants
+							registers = frame.registers
+							ip = frame.ip
+							continue
+						}
+						return InterpretRuntimeError, Undefined
 					}
 
 					// For bound function construction, new.target is the original constructor

--- a/tests/scripts/ctor_stack_overflow_catchable.ts
+++ b/tests/scripts/ctor_stack_overflow_catchable.ts
@@ -1,0 +1,20 @@
+// expect: true
+
+// #135: constructor recursion that overflows the call stack must raise a
+// catchable RangeError ("Maximum call stack size exceeded"), matching
+// V8/Node semantics - not an internal, uncatchable engine error.
+function f(): boolean {
+    class Foo {
+        constructor(n: number) {
+            new Foo(n + 1);
+        }
+    }
+    try {
+        new Foo(0);
+        return false;
+    } catch (e) {
+        return e instanceof RangeError;
+    }
+}
+
+f();


### PR DESCRIPTION
## Problem

Deep constructor recursion — a plain `new Foo()` recursing, `super()` recursion in a derived class, recursion through a bound constructor, or recursion through a spread-argument `new`ing — overflows the VM's frame stack or register stack, but it does so through `vm.runtimeError()`.

`vm.runtimeError()` is meant for internal-invariant violations (corrupted bytecode, an out-of-range constant index, etc.): it records a message in `vm.errors` and returns `InterpretRuntimeError` **without** setting `vm.unwinding`/`vm.currentException`. There is no JS exception *value*, so the failure isn't catchable — it blows straight through any surrounding `try`/`catch`.

But deep constructor recursion is a normal (if buggy) JS program state, not an engine invariant violation. V8 and Node raise a catchable `RangeError: Maximum call stack size exceeded` for it, and user code frequently relies on being able to catch that.

```ts
class Foo {
    constructor(n: number) { new Foo(n + 1); }
}
try {
    new Foo(0);
} catch (e) {
    console.log(e instanceof RangeError); // should be true, was uncatchable
}
```

Fixes #135.

## Fix

Switched all ten overflow-check call sites (frame-stack and register-stack checks, ×2, across all four constructor-call paths) from `vm.runtimeError(...)` to the pre-existing `vm.ThrowRangeError("Maximum call stack size exceeded")` helper, using each site's existing unwind-then-reload-or-return idiom:

- `pkg/vm/vm.go`: plain `new`/cached-closure constructor path, and bound-function constructor path (3 pairs)
- `pkg/vm/op_spreadnew.go`: spread-argument constructor path (2 pairs)

## Collateral: #130 test fixture

Two regression tests added for #130 (`pkg/driver/host_call_error_test.go`) used deep recursive `new Foo()` as their fixture for triggering `vm.runtimeError()`. This fix makes that scenario stop reaching `vm.runtimeError()` at all — it now throws a real exception instead — so both tests broke.

Rather than find a different live bug to depend on, I replaced the fixture with a permanent, synthetic one: `newCorruptedConstantFunction()` hand-assembles a minimal, deliberately corrupt bytecode chunk (an `OpLoadConst` reading a constant index against an empty pool) that reliably trips `vm.runtimeError("Invalid constant index...")` regardless of what other engine bugs get fixed later. Both tests now use it and still pass.

## Testing

- `tests/scripts/ctor_stack_overflow_catchable.ts` (new): asserts the thrown value is `instanceof RangeError`
- `go test ./tests -run TestScripts` — pass
- `go test ./...` — pass
- `golangci-lint run --timeout=5m` — clean
- Manually verified all four trigger paths (plain recursive constructor, `super()` recursion, bound-function-call recursion, spread-constructor-call recursion) throw a catchable `RangeError`
- Test262 `built-ins` and `language` sweeps vs. `baseline.txt` — net change 0, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)