### PR TITLE
fix(vm): clear stale frame.promiseObj on generator/async-generator resume

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -347,7 +347,21 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		newFrame.isSentinelFrame = false // Clear sentinel flag when reusing frame
 		newFrame.openUpvalues = nil      // Clear stale open-upvalue list from prior use of this slot
 		newFrame.generatorObj = nil      // Clear generator object when reusing frame
-		newFrame.argCount = argCount     // Store actual argument count for arguments object
+		// #133: clear promiseObj too. This path also sets up the frame that
+		// drives an async generator's underlying body (called with
+		// isGeneratorExecution=true from startGenerator/resumeGenerator), and
+		// that frame CAN reach OpAwait (an `async function*` body may itself
+		// contain `await`). Every genuine async-function frame sets
+		// frame.promiseObj explicitly right after this call
+		// (executeAsyncFunctionBody, resumeAsyncFunction), so clearing it
+		// here is safe for them - but for every other caller of this frame
+		// slot (plain calls, and specifically the generator/async-generator
+		// path), leaving a stale pointer from whatever async call last
+		// occupied this frame slot means OpAwait misattributes its suspend
+		// state to that unrelated, already-in-flight promise instead of
+		// staying nil (top-level-await-style draining) or being its own.
+		newFrame.promiseObj = nil
+		newFrame.argCount = argCount // Store actual argument count for arguments object
 		// Arguments handling:
 		//
 		// Historically we copied args here so OpGetArguments could build the `arguments` object

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -18320,6 +18320,12 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	frame.args = genObj.Args                       // Restore arguments
 	frame.argumentsObject = Undefined              // Initialize arguments object (will be created on first access)
 	frame.generatorObj = genObj                    // Link frame to generator object
+	// #133: clear a stale promiseObj left by a previous occupant of this
+	// frame slot. Only executeAsyncFunctionBody/resumeAsyncFunction
+	// legitimately set this field; a leftover pointer here would make an
+	// `await` inside this generator body (e.g. an async generator's own
+	// body) misattribute its suspend state to that unrelated promise.
+	frame.promiseObj = nil
 
 	if closureObj != nil {
 		frame.closure = closureObj
@@ -18581,6 +18587,12 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	frame.args = genObj.Args                       // Restore arguments
 	frame.argumentsObject = Undefined              // Initialize arguments object (will be created on first access)
 	frame.generatorObj = genObj                    // Link frame to generator object
+	// #133: clear a stale promiseObj left by a previous occupant of this
+	// frame slot. Only executeAsyncFunctionBody/resumeAsyncFunction
+	// legitimately set this field; a leftover pointer here would make an
+	// `await` inside this generator body (e.g. an async generator's own
+	// body) misattribute its suspend state to that unrelated promise.
+	frame.promiseObj = nil
 
 	if closureObj != nil {
 		frame.closure = closureObj
@@ -18752,6 +18764,12 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 	frame.args = genObj.Args                       // Restore arguments
 	frame.argumentsObject = Undefined              // Initialize arguments object (will be created on first access)
 	frame.generatorObj = genObj                    // Link frame to generator object
+	// #133: clear a stale promiseObj left by a previous occupant of this
+	// frame slot. Only executeAsyncFunctionBody/resumeAsyncFunction
+	// legitimately set this field; a leftover pointer here would make an
+	// `await` inside this generator body (e.g. an async generator's own
+	// body) misattribute its suspend state to that unrelated promise.
+	frame.promiseObj = nil
 
 	if closureObj != nil {
 		frame.closure = closureObj

--- a/tests/scripts/async_method_and_async_generator_method_same_object.ts
+++ b/tests/scripts/async_method_and_async_generator_method_same_object.ts
@@ -1,0 +1,40 @@
+// expect: ok
+
+// #133: an object literal with both a plain `async` method and an `async *`
+// generator method, driven sequentially from another async function, used to
+// panic the VM (index out of range) resuming the second one.
+//
+// Root cause: several manual generator-frame-resumption paths
+// (resumeGenerator/resumeGeneratorWithException/resumeGeneratorWithReturn in
+// pkg/vm/vm.go, plus the general call-setup path in pkg/vm/call.go used to
+// start a generator/async-generator body) never cleared frame.promiseObj
+// when reusing a frame slot. A stale pointer left over from an earlier,
+// unrelated async function call (here, obj.foo()'s completed promise) made
+// OpAwait inside the async generator's own body (gen()'s internal `await`)
+// write its suspend state into that unrelated promise instead of its own -
+// and a later resumption of the wrong promise ran the wrong function's
+// bytecode against the wrong register window, indexing out of range.
+const obj = {
+    async foo() {
+        return await Promise.resolve(42);
+    },
+    async *gen() {
+        yield await Promise.resolve(1);
+        yield await Promise.resolve(2);
+    },
+};
+
+async function run(): Promise<string> {
+    const value = await obj.foo();
+    if (value !== 42) return "bad-value:" + value;
+
+    const collected: number[] = [];
+    for await (const v of obj.gen()) {
+        collected.push(v);
+    }
+    if (collected.join(",") !== "1,2") return "bad-gen:" + collected.join(",");
+
+    return "ok";
+}
+
+await run();


### PR DESCRIPTION
## Problem

An object literal with both a plain `async` method and an `async *` generator method, driven sequentially from another async function, panics the VM with an out-of-range register index while resuming:

```ts
const obj = {
    async foo() {
        return await Promise.resolve(42);
    },
    async *gen() {
        yield await Promise.resolve(1);
        yield await Promise.resolve(2);
    },
};

async function run(): Promise<string> {
    const value = await obj.foo();          // fine on its own
    for await (const v of obj.gen()) { ... } // fine on its own
    return "ok";
}
```

Each method works fine called alone; the panic only appears when both exist on the same object and are driven sequentially.

Fixes #133.

## Root cause

`frame.promiseObj` links a `CallFrame` to the `PromiseObject` that `OpAwait` suspends into on that frame. It's only supposed to be set for genuine async-function frames — `executeAsyncFunctionBody` and `resumeAsyncFunction` both set it explicitly, right after they manually build the frame.

But three other frame-setup paths that **reuse** a `CallFrame` slot never cleared it:

- `resumeGenerator`, `resumeGeneratorWithException`, `resumeGeneratorWithReturn` (`pkg/vm/vm.go`) — the manual frame setup used to resume a suspended generator from a yield point
- `prepareCallWithGeneratorMode`'s general "set up new frame" path (`pkg/vm/call.go`) — also used, with `isGeneratorExecution=true`, to start/resume a generator or async generator's underlying body. An `async function*` body can itself contain `await`, so this path can legitimately reach `OpAwait`.

Sequence that triggers it:

1. `obj.foo()` runs to completion in some `CallFrame` slot, leaving that slot's `frame.promiseObj` pointing at foo's (now-resolved) `PromiseObject`.
2. `obj.gen()` starts, and its body eventually reuses that exact frame slot for its own execution. `frame.promiseObj` is stale — still foo's.
3. `gen()`'s own internal `await` runs. Async generators currently rely on `frame.promiseObj == nil` to take the synchronous "drain until settled" path (see `pkg/builtins/async_generator_init.go`'s comment: "treat AsyncGenerator like a regular Generator"). Because `frame.promiseObj` isn't nil here, `OpAwait` instead takes the async-function suspend path and writes gen's own PC/registers into **foo's** `PromiseObject.Frame`.
4. When a later microtask resumes foo's promise, it uses gen's saved PC against foo's (smaller) register window — indexing out of range.

## Fix

Clear `frame.promiseObj = nil` at all four sites, matching the existing pattern already used for `frame.generatorObj`/`openUpvalues`/`isSentinelFrame` clearing at the same call sites.

## Testing

- `tests/scripts/async_method_and_async_generator_method_same_object.ts` (new): the repro above, `// expect: ok`
- `go test ./tests -run TestScripts` — pass
- `go test ./...` — pass
- `golangci-lint run --timeout=5m` — clean
- Manually re-ran every `async_*`/`generator_*` smoke test individually to double check no interaction regressions
- Test262 `built-ins` and `language` sweeps vs. `baseline.txt` — net change 0, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)