### PR TITLE
fix(compiler): let/const/class declared in a loop body now get per-iteration bindings

### DIFF
--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -496,6 +496,11 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 	} else {
 		c.emitStoreSpill(classSpillSlot, constructorReg, node.Token.Line)
 		debugPrintf("// DEBUG compileClassDeclaration: Stored local class '%s' constructor into spill slot %d\n", node.Name.Value, classSpillSlot)
+		// #132: a class declared directly in a loop body needs the same
+		// per-iteration treatment as a let/const there - each iteration's
+		// closures over the class name should see that iteration's class,
+		// not whichever one the loop ends on.
+		c.declareLoopBodyLocalSpill(classSpillSlot)
 	}
 
 	// Restore outer scope

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -439,6 +439,9 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	for _, reg := range perIterationRegs {
 		c.emitCloseUpvalue(reg, node.Token.Line)
 	}
+	// #132: same treatment for let/const/class declared directly in the loop's
+	// own body (as opposed to the header binding above).
+	c.closeLoopBodyPerIterationBindings(loopContext, node.Token.Line)
 
 	// 16. Jump back to loop start
 	jumpBackPos := len(c.chunk.Code) + 1 + 2

--- a/pkg/compiler/compile_statement.go
+++ b/pkg/compiler/compile_statement.go
@@ -155,6 +155,7 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 				c.emitStoreSpill(sym.SpillIndex, valueReg, node.Name.Token.Line)
 				c.regAlloc.Free(valueReg)
 				c.currentSymbolTable.InitializeTDZ(node.Name.Value)
+				c.trackIfLoopBodyLocal(node.Name.Value) // #132
 				continue
 			}
 
@@ -199,6 +200,7 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 				c.regAlloc.Free(targetReg)
 				// Define the variable as spilled
 				c.currentSymbolTable.DefineSpilled(node.Name.Value, spillIdx)
+				c.trackIfLoopBodyLocal(node.Name.Value) // #132
 				// Skip normal valueReg assignment since we've handled it
 				continue
 			}
@@ -314,6 +316,7 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 		}
 		// Mark TDZ as initialized now that the let declaration has been processed
 		c.currentSymbolTable.InitializeTDZ(node.Name.Value)
+		c.trackIfLoopBodyLocal(node.Name.Value) // #132
 	} // end for declarator
 
 	return BadRegister, nil
@@ -790,6 +793,7 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 				c.emitStoreSpill(csym.SpillIndex, valueReg, node.Name.Token.Line)
 				c.regAlloc.Free(valueReg)
 				c.currentSymbolTable.InitializeTDZ(node.Name.Value)
+				c.trackIfLoopBodyLocal(node.Name.Value) // #132
 				continue
 			}
 
@@ -806,6 +810,7 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 			c.emitStoreSpill(sym.SpillIndex, tempReg, node.Name.Token.Line)
 			c.regAlloc.Free(tempReg)
 			c.currentSymbolTable.InitializeTDZ(node.Name.Value)
+			c.trackIfLoopBodyLocal(node.Name.Value) // #132
 			continue
 		} else {
 			// Compile other value types normally
@@ -865,6 +870,7 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 		}
 		// Mark TDZ as initialized now that the const declaration has been processed
 		c.currentSymbolTable.InitializeTDZ(node.Name.Value)
+		c.trackIfLoopBodyLocal(node.Name.Value) // #132
 	} // end for declarator
 	return BadRegister, nil
 }
@@ -1039,6 +1045,15 @@ func (c *Compiler) compileWhileStatementLabeled(node *parser.WhileStatement, lab
 		return BadRegister, NewCompileError(node, "error compiling while body").CausedBy(err)
 	}
 
+	// #132: continue must land here, BEFORE closing this iteration's
+	// body-declared per-iteration bindings (let/const/class declared directly
+	// in the loop body) - otherwise a `continue` would skip the close and the
+	// next iteration's closures would end up sharing this iteration's value.
+	// (There's no header binding to close for `while` - only for/for-in/for-of
+	// have one - so unlike those loops this is the only closing done here.)
+	continueLandingPos := len(c.chunk.Code)
+	c.closeLoopBodyPerIterationBindings(loopContext, line)
+
 	// --- Jump Back To Start ---
 	jumpBackInstructionEndPos := len(c.chunk.Code) + 1 + 2 // OpCode + 16bit offset
 	backOffset := loopStartPos - jumpBackInstructionEndPos
@@ -1058,10 +1073,11 @@ func (c *Compiler) compileWhileStatementLabeled(node *parser.WhileStatement, lab
 	}
 
 	// --- NEW: Patch continue jumps ---
-	// Continue jumps back to the condition check (loopStartPos)
+	// Continue jumps to continueLandingPos (just before the per-iteration close
+	// and the jump back to the condition check).
 	for _, continuePos := range poppedContext.ContinuePlaceholderPosList {
 		jumpInstructionEndPos := continuePos + 1 + 2 // OpCode + 16bit offset
-		targetOffset := poppedContext.LoopStartPos - jumpInstructionEndPos
+		targetOffset := continueLandingPos - jumpInstructionEndPos
 
 		if targetOffset > math.MaxInt16 || targetOffset < math.MinInt16 {
 			return BadRegister, NewCompileError(node, fmt.Sprintf("internal compiler error: continue jump offset %d exceeds 16-bit limit", targetOffset))
@@ -1318,6 +1334,10 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 	for _, reg := range perIterationRegs {
 		c.emitCloseUpvalue(reg, node.Token.Line)
 	}
+	// #132: same treatment for let/const/class declared directly in the loop's
+	// own body (as opposed to the header above) - see BodyPerIterationRegs'
+	// doc comment on LoopContext.
+	c.closeLoopBodyPerIterationBindings(loopContext, node.Token.Line)
 
 	// *** Compile Update Expression (Optional) ***
 	if node.Update != nil {
@@ -1683,6 +1703,10 @@ func (c *Compiler) compileDoWhileStatementLabeled(node *parser.DoWhileStatement,
 	for _, continuePos := range loopContext.ContinuePlaceholderPosList {
 		c.patchJump(continuePos)
 	}
+
+	// #132: close per-iteration bindings for let/const/class declared directly
+	// in the loop body, same as for/for-in/for-of/while.
+	c.closeLoopBodyPerIterationBindings(loopContext, line)
 
 	// 4. Mark Condition Position (for clarity, not used directly in jump calcs below)
 	_ = len(c.chunk.Code) // conditionPos := len(c.chunk.Code)
@@ -2404,6 +2428,9 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 	for _, reg := range perIterationRegs {
 		c.emitCloseUpvalue(reg, node.Token.Line)
 	}
+	// #132: same treatment for let/const/class declared directly in the loop's
+	// own body (as opposed to the header binding above).
+	c.closeLoopBodyPerIterationBindings(loopContext, node.Token.Line)
 
 	// 9. Increment key index
 	oneReg := c.regAlloc.Alloc()

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -358,6 +358,20 @@ type LoopContext struct {
 	IteratorCleanup *IteratorCleanupInfo
 	// Completion value register for this loop (for break/continue to set to undefined per UpdateEmpty)
 	CompletionReg Register
+	// #132: registers/spill slots backing a let/const/class declared directly
+	// in this loop's body (at any nesting depth, but not crossing into a
+	// nested function or a nested loop's own body - those register/track
+	// against their own, innermost LoopContext instead). ECMAScript's
+	// CreatePerIterationEnvironment gives each iteration of the body a fresh
+	// copy of these bindings; closing any open upvalue pointing at them right
+	// before the next iteration starts achieves the same effect: a closure
+	// created in one iteration keeps that iteration's value instead of
+	// sharing the register/slot's final value with every other iteration's
+	// closures. Populated while the body compiles (see declareLoopBodyLocal*
+	// helpers) and closed alongside the loop header's own per-iteration
+	// registers.
+	BodyPerIterationRegs   []Register
+	BodyPerIterationSpills []uint16
 }
 
 // IteratorCleanupInfo tracks iterator objects that need cleanup on early exit
@@ -3461,6 +3475,72 @@ func (c *Compiler) currentLoopContext() *LoopContext {
 		return nil
 	}
 	return c.loopContextStack[len(c.loopContextStack)-1]
+}
+
+// declareLoopBodyLocalRegister records that reg backs a let/const/class binding
+// declared directly in the innermost currently-compiling loop's body (#132),
+// so the loop can close any open upvalue pointing at it once each iteration
+// finishes - giving that iteration's closures their own captured value instead
+// of all iterations sharing whatever the register holds when the loop ends.
+// A no-op outside of a loop body. The register is pinned like a loop header's
+// per-iteration registers, for the same reason: it must not be handed to a
+// different declaration later in the same loop body, or closing it at the
+// iteration boundary could close the wrong variable's upvalue.
+func (c *Compiler) declareLoopBodyLocalRegister(reg Register) {
+	lc := c.currentLoopContext()
+	if lc == nil {
+		return
+	}
+	c.regAlloc.Pin(reg)
+	lc.BodyPerIterationRegs = append(lc.BodyPerIterationRegs, reg)
+}
+
+// declareLoopBodyLocalSpill is declareLoopBodyLocalRegister's spill-slot
+// counterpart, for a class declared directly in a loop body - local class
+// name bindings always live in a spill slot (#128), never a register. Spill
+// slots are never reused (AllocSpillSlot is a monotonic counter), so unlike
+// the register case there's no need to pin anything against reuse.
+func (c *Compiler) declareLoopBodyLocalSpill(spillIdx uint16) {
+	lc := c.currentLoopContext()
+	if lc == nil {
+		return
+	}
+	lc.BodyPerIterationSpills = append(lc.BodyPerIterationSpills, spillIdx)
+}
+
+// trackIfLoopBodyLocal looks up name in the current symbol table and, if it
+// resolved to a local (non-global) register- or spill-backed binding, records
+// it against the innermost currently-compiling loop's body for per-iteration
+// closing (#132). Call this once a let/const/class declaration's binding has
+// reached its final form in the symbol table. A no-op if name didn't resolve
+// to a local binding, or outside of a loop body.
+func (c *Compiler) trackIfLoopBodyLocal(name string) {
+	sym, _, found := c.currentSymbolTable.Resolve(name)
+	if !found || sym.IsGlobal {
+		return
+	}
+	if sym.IsSpilled {
+		c.declareLoopBodyLocalSpill(sym.SpillIndex)
+	} else if sym.Register != nilRegister {
+		c.declareLoopBodyLocalRegister(sym.Register)
+	}
+}
+
+// closeLoopBodyPerIterationBindings emits OpCloseUpvalue(Spill) for every
+// body-declared per-iteration binding tracked on lc (#132). Called at the
+// same point in each loop's compile where its own header per-iteration
+// registers are closed - once continues have been patched to land there, and
+// before the update/next-iteration step runs.
+func (c *Compiler) closeLoopBodyPerIterationBindings(lc *LoopContext, line int) {
+	if lc == nil {
+		return
+	}
+	for _, reg := range lc.BodyPerIterationRegs {
+		c.emitCloseUpvalue(reg, line)
+	}
+	for _, spillIdx := range lc.BodyPerIterationSpills {
+		c.emitCloseUpvalueSpill(spillIdx, line)
+	}
 }
 
 // --- Private Field Brand Tracking ---

--- a/pkg/compiler/emit.go
+++ b/pkg/compiler/emit.go
@@ -910,6 +910,22 @@ func (c *Compiler) emitCloseUpvalue(reg Register, line int) {
 	c.emitByte(byte(reg))
 }
 
+// emitCloseUpvalueSpill emits OpCloseUpvalueSpill(16) to close any open upvalue
+// pointing at a spill slot. Spill-slot counterpart to emitCloseUpvalue, needed
+// for per-iteration bindings that live in a spill slot instead of a register -
+// e.g. a class declared inside a loop body, whose name binding is always
+// spill-based (#128). Uses 8-bit opcode for indices 0-255, 16-bit for larger.
+func (c *Compiler) emitCloseUpvalueSpill(spillIdx uint16, line int) {
+	if spillIdx <= 255 {
+		c.emitOpCode(vm.OpCloseUpvalueSpill, line)
+		c.emitByte(byte(spillIdx))
+	} else {
+		c.emitOpCode(vm.OpCloseUpvalueSpill16, line)
+		c.emitByte(byte(spillIdx >> 8))   // High byte
+		c.emitByte(byte(spillIdx & 0xFF)) // Low byte
+	}
+}
+
 // emitIteratorCleanupAbrupt emits OpIteratorCleanupAbrupt for exception-triggered iterator cleanup.
 // Per ECMAScript spec, when an exception propagates out of a for-of loop, iterator.return()
 // must be called with error suppression - any errors from getting/calling return are ignored.

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -213,6 +213,13 @@ const (
 	// throws TypeError if the private field already exists on Rx; unlike OpSetPrivateField,
 	// which requires the field to already exist)
 	OpDefinePrivateField OpCode = 176
+	// SpillIdx: Close any open upvalue pointing at spillSlots[SpillIdx] (8-bit
+	// index). Spill-slot counterpart to OpCloseUpvalue, needed for per-iteration
+	// bindings that live in a spill slot instead of a register - e.g. a class
+	// declared inside a loop body, whose name binding is always spill-based (#128).
+	OpCloseUpvalueSpill OpCode = 177
+	// SpillIdxHi SpillIdxLo: Like OpCloseUpvalueSpill but with a 16-bit spill index.
+	OpCloseUpvalueSpill16 OpCode = 178
 
 	// --- NEW: Global Variable Operations ---
 	OpGetGlobal     OpCode = 46 // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
@@ -511,6 +518,10 @@ func (op OpCode) String() string {
 		return "OpCheckUninitialized"
 	case OpCloseUpvalue:
 		return "OpCloseUpvalue"
+	case OpCloseUpvalueSpill:
+		return "OpCloseUpvalueSpill"
+	case OpCloseUpvalueSpill16:
+		return "OpCloseUpvalueSpill16"
 	case OpIteratorCleanupAbrupt:
 		return "OpIteratorCleanupAbrupt"
 	case OpIteratorCleanupAbruptIfNotDone:
@@ -1376,6 +1387,26 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 		srcReg := c.Code[offset+3]
 		builder.WriteString(fmt.Sprintf("%-16s Spill[%d], R%d\n", "OpStoreSpill16", spillIdx, srcReg))
 		return offset + 4
+
+	case OpCloseUpvalueSpill:
+		// SpillIdx: Close any open upvalue pointing at spillSlots[SpillIdx]
+		if offset+1 >= len(c.Code) {
+			builder.WriteString("OpCloseUpvalueSpill (missing operands)\n")
+			return offset + 1
+		}
+		spillIdx := c.Code[offset+1]
+		builder.WriteString(fmt.Sprintf("%-16s Spill[%d]\n", "OpCloseUpvalueSpill", spillIdx))
+		return offset + 2
+
+	case OpCloseUpvalueSpill16:
+		// SpillIdxHi SpillIdxLo: Close any open upvalue pointing at spillSlots[SpillIdx] (16-bit index)
+		if offset+2 >= len(c.Code) {
+			builder.WriteString("OpCloseUpvalueSpill16 (missing operands)\n")
+			return offset + 1
+		}
+		spillIdx := uint16(c.Code[offset+1])<<8 | uint16(c.Code[offset+2])
+		builder.WriteString(fmt.Sprintf("%-16s Spill[%d]\n", "OpCloseUpvalueSpill16", spillIdx))
+		return offset + 3
 
 	case OpArrayCopy:
 		// Rx, DestOffset(16), StartReg, Count

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1707,6 +1707,43 @@ startExecution:
 				prev = uv
 			}
 
+		case OpCloseUpvalueSpill, OpCloseUpvalueSpill16:
+			// Spill-slot counterpart to OpCloseUpvalue (#132): a per-iteration
+			// binding that lives in a spill slot instead of a register - e.g. a
+			// class declared inside a loop body, whose name binding is always
+			// spill-based (#128) - needs the same "close on iteration boundary"
+			// treatment so each iteration's closures capture their own value
+			// instead of all sharing the loop's final one.
+			var spillIdx int
+			if OpCode(code[ip-1]) == OpCloseUpvalueSpill16 {
+				spillIdx = int(code[ip])<<8 | int(code[ip+1])
+				ip += 2
+			} else {
+				spillIdx = int(code[ip])
+				ip++
+			}
+			if spillIdx >= len(frame.spillSlots) {
+				frame.ip = ip
+				status := vm.runtimeError("Invalid spill slot index %d for upvalue close.", spillIdx)
+				return status, Undefined
+			}
+			targetPtr := &frame.spillSlots[spillIdx]
+			var prevSpill *Upvalue
+			for uv := frame.openUpvalues; uv != nil; uv = uv.next {
+				if uv.Location == targetPtr {
+					uv.Closed = *uv.Location
+					uv.Location = nil
+					if prevSpill == nil {
+						frame.openUpvalues = uv.next
+					} else {
+						prevSpill.next = uv.next
+					}
+					uv.next = nil
+					break
+				}
+				prevSpill = uv
+			}
+
 		case OpIteratorCleanupAbrupt:
 			// Call iterator.return() for exception/return cleanup.
 			// Per ECMAScript spec 7.4.6 IteratorClose:

--- a/tests/scripts/loop_body_class_per_iteration.ts
+++ b/tests/scripts/loop_body_class_per_iteration.ts
@@ -1,0 +1,22 @@
+// expect: 0,1,2
+
+// #132: a class declared directly inside a loop body must also get a fresh
+// binding each iteration. Local class name bindings always live in a spill
+// slot rather than a register (#128), so this needs its own per-iteration
+// close mechanism (OpCloseUpvalueSpill) alongside the register-based one
+// used for plain let/const. Before this fix, all three closures shared the
+// loop's single spill slot and returned [2, 2, 2].
+function f(): number[] {
+    let out: (() => number)[] = [];
+    for (let i = 0; i < 3; i++) {
+        class C {
+            static id() {
+                return i;
+            }
+        }
+        out.push(() => C.id());
+    }
+    return out.map(g => g());
+}
+
+f().join(",");

--- a/tests/scripts/loop_body_let_per_iteration.ts
+++ b/tests/scripts/loop_body_let_per_iteration.ts
@@ -1,0 +1,17 @@
+// expect: 0,10,20
+
+// #132: a `let` declared directly in a `for` loop's body must get a fresh
+// binding each iteration, so closures created in different iterations each
+// capture their own iteration's value - the classic reason `let` was added
+// to the language over `var`. Before this fix, all three closures shared the
+// loop's single, final register/binding and returned [2, 2, 2].
+function f(): number[] {
+    let out: (() => number)[] = [];
+    for (let i = 0; i < 3; i++) {
+        let x = i * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g());
+}
+
+f().join(",");

--- a/tests/scripts/loop_body_let_per_iteration_all_loop_types.ts
+++ b/tests/scripts/loop_body_let_per_iteration_all_loop_types.ts
@@ -1,0 +1,148 @@
+// expect: for=0,10,20 while=0,10,20 doWhile=0,10,20 forOf=0,10,20 forIn=0,10,20 forContinue=10,30 whileContinue=10,30,50 nested=0,1,10,11 siblingIfElse=1,2 labeledContinue=10,20,30,40,50 forConstBody=0,10,20
+
+// #132: per-iteration bindings for a body-declared let must hold for every
+// loop construct that repeats its body (for, while, do-while, for-of,
+// for-in), survive a `continue` (which must still close the current
+// iteration's binding before moving on - it must not skip straight past the
+// close the way it skips the update/increment), and nest correctly (an inner
+// loop's body-local must not be attributed to the outer loop's per-iteration
+// list, and vice versa). Also checks that ordinary (non-loop) sibling blocks
+// reusing a name - never broken by this issue, but worth pinning down as a
+// non-regression - still resolve correctly.
+
+function testFor(): string {
+    let out: (() => number)[] = [];
+    for (let i = 0; i < 3; i++) {
+        let x = i * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testWhile(): string {
+    let out: (() => number)[] = [];
+    let i = 0;
+    while (i < 3) {
+        let x = i * 10;
+        out.push(() => x);
+        i++;
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testDoWhile(): string {
+    let out: (() => number)[] = [];
+    let i = 0;
+    do {
+        let x = i * 10;
+        out.push(() => x);
+        i++;
+    } while (i < 3);
+    return out.map(g => g()).join(",");
+}
+
+function testForOf(): string {
+    let out: (() => number)[] = [];
+    for (const i of [0, 1, 2]) {
+        let x = i * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testForIn(): string {
+    let out: (() => number)[] = [];
+    let obj: Record<string, number> = { a: 0, b: 1, c: 2 };
+    for (const k in obj) {
+        let x = obj[k] * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testForContinue(): string {
+    let out: (() => number)[] = [];
+    for (let i = 0; i < 5; i++) {
+        if (i % 2 === 0) continue;
+        let x = i * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testWhileContinue(): string {
+    let out: (() => number)[] = [];
+    let i = 0;
+    while (i < 5) {
+        i++;
+        if (i % 2 === 0) continue;
+        let x = i * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testNestedLoop(): string {
+    let out: (() => number)[] = [];
+    for (let i = 0; i < 2; i++) {
+        for (let j = 0; j < 2; j++) {
+            let x = i * 10 + j;
+            out.push(() => x);
+        }
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testSiblingIfElse(): string {
+    function pick(flag: boolean): () => number {
+        if (flag) {
+            let x = 1;
+            return () => x;
+        } else {
+            let x = 2;
+            return () => x;
+        }
+    }
+    return [pick(true)(), pick(false)()].join(",");
+}
+
+function testLabeledContinue(): string {
+    // A labeled continue on an OUTER while must land at the same
+    // post-close, pre-jump-back position as an unlabeled one - it goes
+    // through the same ContinuePlaceholderPosList, just resolved by label
+    // instead of "nearest enclosing loop" (see compileContinueStatement).
+    let out: (() => number)[] = [];
+    let i = 0;
+    outer: while (i < 5) {
+        i++;
+        let x = i * 10;
+        out.push(() => x);
+        if (i % 2 === 0) continue outer;
+    }
+    return out.map(g => g()).join(",");
+}
+
+function testForConstBody(): string {
+    // Exercises compileConstStatement's tracking hooks specifically -
+    // testFor above only exercises compileLetStatement's.
+    let out: (() => number)[] = [];
+    for (let i = 0; i < 3; i++) {
+        const x = i * 10;
+        out.push(() => x);
+    }
+    return out.map(g => g()).join(",");
+}
+
+[
+    "for=" + testFor(),
+    "while=" + testWhile(),
+    "doWhile=" + testDoWhile(),
+    "forOf=" + testForOf(),
+    "forIn=" + testForIn(),
+    "forContinue=" + testForContinue(),
+    "whileContinue=" + testWhileContinue(),
+    "nested=" + testNestedLoop(),
+    "siblingIfElse=" + testSiblingIfElse(),
+    "labeledContinue=" + testLabeledContinue(),
+    "forConstBody=" + testForConstBody(),
+].join(" ");


### PR DESCRIPTION
## Problem

A closure created inside a loop body that captures a `let`/`const`/`class` declared *inside that same loop body* saw the same, final shared value for every closure, instead of the value from its own iteration — the classic "let in a for-loop" pattern block-scoping was specifically designed to support:

```ts
function f() {
  let out = [];
  for (let i = 0; i < 3; i++) {
    let x = i * 10;
    out.push(() => x);
  }
  return out.map(g => g());
}
f(); // was [2, 2, 2], should be [0, 10, 20]
```

Same bug for a class declared directly in the loop body:

```ts
for (let i = 0; i < 3; i++) {
  class C { static id() { return i; } }
  out.push(() => C.id());
}
// was [2, 2, 2], should be [0, 1, 2]
```

Fixes #132.

## Root cause

The compiler already implements `CreatePerIterationEnvironment` (ECMAScript 13.7.4.9) for a for-loop's own **header** bindings (`for (let i = ...)`) — it closes any open upvalue pointing at the header variable's register once per iteration, so a closure captured in one iteration doesn't share the register with the next.

But this per-iteration closing only ever covered the header. A `let`/`const`/`class` declared inside the **body** got no such treatment at all — every iteration's closures shared the exact same register (or, for a class, the exact same spill slot — local class name bindings are always spill-based since #128) for the entire loop's lifetime.

## Fix

- Track every register- or spill-backed local (`let`/`const`/`class`) declared anywhere inside the innermost currently-compiling loop's body (at any nesting depth, but not crossing into a nested function or a nested loop's own body) on that loop's `LoopContext` (new `BodyPerIterationRegs`/`BodyPerIterationSpills` fields). Hooked into `compileLetStatement`, `compileConstStatement`, and `compileClassDeclaration`'s local-binding paths.
- Close all of them at the same point each loop already closes its header bindings — after `continue`s are patched to land there, before the update/next-iteration step — for `for`/`for-in`/`for-of`. `do-while` already had an equivalent landing point; `while` didn't (continue jumped straight to the condition), so it gained one (`continueLandingPos`) that a labeled `continue` targeting it also resolves through correctly, since labeled and unlabeled continue both go through the same `ContinuePlaceholderPosList`.
- Added `OpCloseUpvalueSpill`/`OpCloseUpvalueSpill16`, the spill-slot counterpart to the existing (register-only) `OpCloseUpvalue`, since a local class binding needs the same per-iteration closing but lives in a spill slot, not a register.

Registers tracked this way are pinned (matching the existing header mechanism) so a later declaration in the same loop body can't reuse the slot before it's closed; spill slots need no such protection since `AllocSpillSlot` is a monotonic counter and never reused.

## Testing

- `tests/scripts/loop_body_let_per_iteration.ts` and `loop_body_class_per_iteration.ts` (new): the two repros from the issue
- `tests/scripts/loop_body_let_per_iteration_all_loop_types.ts` (new): `for`/`while`/`do-while`/`for-of`/`for-in`, `continue`, labeled `continue`, nested loops, a `const`-in-body variant, and a non-loop sibling-block sanity check
- `go test ./tests -run TestScripts` — pass
- `go test ./...` — pass
- `golangci-lint run --timeout=5m` — clean
- Test262 `built-ins` and `language` sweeps vs. `baseline.txt` — net change 0, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)