### PR TITLE
fix(compiler,vm): hoisted/earlier-closure class forward refs (#141, #144) and reentrant vm.Call() exception leak (#142)

### DIFF
--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -246,9 +246,24 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 		// ones). A spill slot is index-based like the global slot above, so it's
 		// stable across the whole compile - mirrors what compileClassExpression
 		// already does for named class expressions.
-		classSpillSlot = c.AllocSpillSlot()
+		//
+		// A sibling hoisted function declared earlier in the same block may
+		// already have forced this class's spill slot into existence (see
+		// #141: the block-level pre-registration step that runs before hoisted
+		// function bodies compile) so that its own body - compiled ahead of
+		// this class's sequential position - could capture the real, final
+		// storage location too. Reuse that slot instead of allocating a
+		// second one, or the hoisted function's early capture and this
+		// declaration's own constructor store would end up in different
+		// slots.
+		if existing, ok := c.currentSymbolTable.store[node.Name.Value]; ok && existing.IsSpilled {
+			classSpillSlot = existing.SpillIndex
+			debugPrintf("// DEBUG compileClassDeclaration: Reusing pre-registered spill slot %d for local class '%s'\n", classSpillSlot, node.Name.Value)
+		} else {
+			classSpillSlot = c.AllocSpillSlot()
+			debugPrintf("// DEBUG compileClassDeclaration: Pre-defined local class '%s' in spill slot %d\n", node.Name.Value, classSpillSlot)
+		}
 		c.currentSymbolTable.DefineSpilled(node.Name.Value, classSpillSlot)
-		debugPrintf("// DEBUG compileClassDeclaration: Pre-defined local class '%s' in spill slot %d\n", node.Name.Value, classSpillSlot)
 	}
 
 	// Per ECMAScript spec (sec-runtime-semantics-classdefinitionevaluation):

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1851,6 +1851,46 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 			}
 		} // end if !needsEnclosedScope (function body var hoisting)
 
+		// 0.6) Pre-register this block's own local class declarations BEFORE
+		// compiling hoisted functions below. A hoisted function's body compiles
+		// here, ahead of its sibling class declaration's own sequential
+		// position later in this block's statement loop - so a reference to
+		// the class from inside the hoisted function (directly, or via a
+		// closure nested inside it) would otherwise resolve the class name
+		// before compileClassDeclaration has allocated its spill slot, baking
+		// in a dangling capture that can never be fixed up. Same root-cause
+		// shape as #128 (a hoisted binding compiled before its own value
+		// exists), but for a hoisted *function* sibling instead of a closure
+		// nested directly inside the class body itself (#141).
+		//
+		// Only for classes that will actually take compileClassDeclaration's
+		// local/spilled path (mirrors its own isGlobalClassScope check) - a
+		// class that will end up global-scoped there must NOT get a spill
+		// slot here, or a hoisted function compiled early would capture the
+		// wrong storage location once the class's own declaration switches to
+		// the global binding.
+		//
+		// Known remaining gap, NOT fixed here: this only covers a hoisted
+		// function and the class it references being direct siblings in the
+		// *same* block (collectClassDeclarations looks at node.Statements,
+		// this block's own statement list only). A function hoisted inside a
+		// *nested* block that references a class declared in an *enclosing*
+		// block still throws ReferenceError, because that nested block's own
+		// pre-registration pass never sees the outer block's statements.
+		// Same shape as #128's own documented loop-body limitation - a
+		// separate, deeper cross-scope-forward-reference problem than the
+		// same-scope one #141 targets.
+		if len(node.HoistedDeclarations) > 0 && (c.enclosing != nil || c.isIndirectEval) {
+			classNames := collectClassDeclarations(node.Statements)
+			for _, name := range classNames {
+				if _, alreadyInCurrentScope := c.currentSymbolTable.store[name]; !alreadyInCurrentScope {
+					spillIdx := c.AllocSpillSlot()
+					c.currentSymbolTable.DefineSpilled(name, spillIdx)
+					debugPrintf("// [ClassHoist] Pre-defined local class '%s' in SPILL SLOT %d for hoisted-function forward reference\n", name, spillIdx)
+				}
+			}
+		}
+
 		// 1) Hoist function declarations within this block (function-scoped hoisting)
 		if len(node.HoistedDeclarations) > 0 {
 			debugPrintf("// [BlockStatement] Processing %d hoisted declarations\n", len(node.HoistedDeclarations))

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1899,8 +1899,25 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 			for _, name := range classNames {
 				if _, alreadyInCurrentScope := c.currentSymbolTable.store[name]; !alreadyInCurrentScope {
 					spillIdx := c.AllocSpillSlot()
-					c.currentSymbolTable.DefineSpilled(name, spillIdx)
-					debugPrintf("// [ClassHoist] Pre-defined local class '%s' in SPILL SLOT %d for early-closure forward reference\n", name, spillIdx)
+					// TDZ-marked, and the slot is seeded with the TDZ sentinel
+					// at runtime. Reserving the slot without either of those
+					// silently DELETED TDZ for class bindings: a spill slot
+					// reads as Undefined when unwritten, and neither the
+					// spilled-identifier nor the upvalue load path checked for
+					// the sentinel, so `try { C } catch {}` before `class C {}`
+					// stopped throwing ReferenceError and just yielded
+					// undefined. Caught in review by @mparrett on #143.
+					c.currentSymbolTable.DefineTDZSpilled(name, spillIdx)
+					// Seed the sentinel BEFORE any statement in this block
+					// runs, and on every entry to the block (this whole step
+					// re-executes per block entry, so a class in a loop body
+					// gets a fresh dead slot each iteration rather than
+					// inheriting the previous iteration's constructor).
+					sentinelReg := c.regAlloc.Alloc()
+					c.emitLoadUninitialized(sentinelReg, node.Token.Line)
+					c.emitStoreSpill(spillIdx, sentinelReg, node.Token.Line)
+					c.regAlloc.Free(sentinelReg)
+					debugPrintf("// [ClassHoist] Pre-defined local class '%s' in SPILL SLOT %d (TDZ-seeded) for early-closure forward reference\n", name, spillIdx)
 				}
 			}
 		}
@@ -2571,10 +2588,31 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 				// Use OpLoadFree to access it via closure mechanism
 				freeVarIndex := c.addFreeSymbol(node, &symbolRef)
 				c.emitLoadFree(hint, freeVarIndex, node.Token.Line)
+				// No TDZ check emitted here on purpose: OpLoadFree already
+				// performs an unconditional runtime TDZ check in the VM
+				// (see the `val.typ == TypeUninitialized` guard in vm.go's
+				// OpLoadFree case). That is strictly better than emitting
+				// OpCheckUninitialized here would be, because it is not
+				// subject to that opcode's self-rewrite-to-OpNop, so it keeps
+				// firing for every call rather than only the first. This is
+				// what makes an early call of a closure that captured a
+				// class's TDZ-seeded spill slot throw ReferenceError. Verified
+				// by removing an equivalent emitted check here and confirming
+				// the behavior is unchanged. OpLoadSpill has no such guard,
+				// which is why the two spilled paths below do need one.
 			} else if symbolRef.IsSpilled {
 				// Variable is spilled (stored in spill slot, not a register)
 				debugPrintf("// DEBUG Identifier '%s': NOT LOCAL, SPILLED variable in outer block scope, spillIdx=%d\n", node.Value, symbolRef.SpillIndex)
 				c.emitLoadSpill(hint, symbolRef.SpillIndex, node.Token.Line)
+				// Same missing TDZ check as the other spilled load path below.
+				// This is the branch a direct `C` reference in the class's own
+				// block takes (the block's table is an outer block scope of the
+				// same function), so leaving it out here made `try { C } catch`
+				// before `class C {}` yield the raw sentinel instead of
+				// throwing.
+				if symbolRef.IsTDZ {
+					c.emitCheckUninitialized(hint, node.Token.Line)
+				}
 			} else if c.currentFuncWithDepth > 0 {
 				// Inside a with block in the CURRENT function, with-object properties shadow outer block variables.
 				// NOTE: We use currentFuncWithDepth (not withBlockDepth) because this is still within
@@ -2602,6 +2640,12 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 			// LOCAL spilled variable - load from spill slot
 			debugPrintf("// DEBUG Identifier '%s': LOCAL SPILLED variable, spillIdx=%d\n", node.Value, symbolRef.SpillIndex)
 			c.emitLoadSpill(hint, symbolRef.SpillIndex, node.Token.Line)
+			// Spilled loads had no TDZ check at all, unlike the two
+			// register-based paths below, so a spilled let/const/class read
+			// before its declaration produced undefined instead of throwing.
+			if symbolRef.IsTDZ {
+				c.emitCheckUninitialized(hint, node.Token.Line)
+			}
 		} else {
 			debugPrintf("// DEBUG Identifier '%s': LOCAL variable, register=R%d\n", node.Value, symbolRef.Register) // <<< ADDED
 			// This is a standard local variable (handled by current stack frame)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1852,41 +1852,55 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 		} // end if !needsEnclosedScope (function body var hoisting)
 
 		// 0.6) Pre-register this block's own local class declarations BEFORE
-		// compiling hoisted functions below. A hoisted function's body compiles
-		// here, ahead of its sibling class declaration's own sequential
-		// position later in this block's statement loop - so a reference to
-		// the class from inside the hoisted function (directly, or via a
-		// closure nested inside it) would otherwise resolve the class name
-		// before compileClassDeclaration has allocated its spill slot, baking
-		// in a dangling capture that can never be fixed up. Same root-cause
+		// compiling ANY statement in this block below - not just its hoisted
+		// functions. A closure compiled at its own sequential position in
+		// this block's statement loop (an ordinary `const f = () => ...`, a
+		// plain function expression assigned to a binding - anything that
+		// isn't itself hoisted) can still be positioned earlier in source
+		// order than a class it references, as long as it's only actually
+		// *called* later, after the class has been declared - completely
+		// ordinary, common JS with no real TDZ violation. Originally this
+		// only ran when the block had hoisted functions, covering a hoisted
+		// function's own forward reference to a later sibling class (#141);
+		// generalizing the same pre-registration to every block (not just
+		// ones with hoisted declarations) additionally covers a non-hoisted
+		// closure doing the same thing (#144) - real JS scoping means a
+		// block-scoped class binding conceptually exists (in TDZ) for the
+		// entire block from the start, not just from its own declaration
+		// point onward, so any closure compiled anywhere in the block should
+		// be able to capture its final storage location. Without this, such
+		// a closure would resolve the class name before
+		// compileClassDeclaration has allocated its spill slot, baking in a
+		// dangling capture that can never be fixed up - same root-cause
 		// shape as #128 (a hoisted binding compiled before its own value
-		// exists), but for a hoisted *function* sibling instead of a closure
-		// nested directly inside the class body itself (#141).
+		// exists), just for an ordinary sequential-position closure instead
+		// of a hoisted function or a closure nested directly inside the
+		// class body itself.
 		//
 		// Only for classes that will actually take compileClassDeclaration's
 		// local/spilled path (mirrors its own isGlobalClassScope check) - a
 		// class that will end up global-scoped there must NOT get a spill
-		// slot here, or a hoisted function compiled early would capture the
-		// wrong storage location once the class's own declaration switches to
-		// the global binding.
+		// slot here, or an earlier-compiled closure would capture the wrong
+		// storage location once the class's own declaration switches to the
+		// global binding.
 		//
-		// Known remaining gap, NOT fixed here: this only covers a hoisted
-		// function and the class it references being direct siblings in the
-		// *same* block (collectClassDeclarations looks at node.Statements,
-		// this block's own statement list only). A function hoisted inside a
-		// *nested* block that references a class declared in an *enclosing*
-		// block still throws ReferenceError, because that nested block's own
+		// Known remaining gap, NOT fixed here: this only covers a closure
+		// and the class it references being direct siblings in the *same*
+		// block (collectClassDeclarations looks at node.Statements, this
+		// block's own statement list only). A closure inside a *nested*
+		// block that references a class declared in an *enclosing* block
+		// still throws ReferenceError, because that nested block's own
 		// pre-registration pass never sees the outer block's statements.
 		// Same shape as #128's own documented loop-body limitation - a
 		// separate, deeper cross-scope-forward-reference problem than the
-		// same-scope one #141 targets.
-		if len(node.HoistedDeclarations) > 0 && (c.enclosing != nil || c.isIndirectEval) {
+		// same-scope one this targets.
+		if c.enclosing != nil || c.isIndirectEval {
 			classNames := collectClassDeclarations(node.Statements)
 			for _, name := range classNames {
 				if _, alreadyInCurrentScope := c.currentSymbolTable.store[name]; !alreadyInCurrentScope {
 					spillIdx := c.AllocSpillSlot()
 					c.currentSymbolTable.DefineSpilled(name, spillIdx)
-					debugPrintf("// [ClassHoist] Pre-defined local class '%s' in SPILL SLOT %d for hoisted-function forward reference\n", name, spillIdx)
+					debugPrintf("// [ClassHoist] Pre-defined local class '%s' in SPILL SLOT %d for early-closure forward reference\n", name, spillIdx)
 				}
 			}
 		}

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -7,6 +7,36 @@ import (
 
 const debugOpSetProp = false
 
+// throwFromCallError turns an error returned by vm.Call into an in-flight VM
+// exception. An ExceptionError already carries a JS value, so it is re-thrown
+// as-is; anything else is a Go-level failure and gets wrapped in a JS Error
+// first. Callers should `return false, InterpretRuntimeError, Undefined`
+// immediately after calling this.
+//
+// The same logic appears inline at ~11 other call sites across this package.
+// This is deliberately NOT a refactor of those - it exists so the two
+// primitive-base paths in opSetProp below, which previously had no error
+// handling at all, can propagate without another 35-line copy each.
+func (vm *VM) throwFromCallError(err error) {
+	if ee, ok := err.(ExceptionError); ok {
+		vm.throwException(ee.GetExceptionValue())
+		return
+	}
+	var excVal Value
+	if errCtor, ok := vm.GetGlobal("Error"); ok {
+		if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+			excVal = res
+		}
+	}
+	if excVal.Type() == 0 {
+		eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+		eo.SetOwn("name", NewString("Error"))
+		eo.SetOwn("message", NewString(err.Error()))
+		excVal = NewValueFromPlainObject(eo)
+	}
+	vm.throwException(excVal)
+}
+
 func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Value) (bool, InterpretResult, Value) {
 	if debugOpSetProp {
 		fmt.Printf("[DEBUG opSetProp] ENTRY: propName=%q, objType=%s, valueType=%s\n", propName, objVal.TypeName(), valueToSet.TypeName())
@@ -469,9 +499,22 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 						// Call the set trap: trap(target, property, value, receiver)
 						// receiver is the original primitive coerced to object
 						trapArgs := []Value{proxy.Target(), NewString(propName), *valueToSet, *objVal}
-						if _, err := vm.Call(setTrap, proxy.handler, trapArgs); err == nil {
-							return true, InterpretOK, *valueToSet
+						if _, err := vm.Call(setTrap, proxy.handler, trapArgs); err != nil {
+							// A throwing set trap must propagate, not be
+							// discarded. This used to fall through to the
+							// `continue walking` step below and then to the
+							// "no setter found - silently succeed" return at
+							// the bottom, so `"s".y = 1` with a throwing trap
+							// on String.prototype's [[Prototype]] reported
+							// success and swallowed the exception - while the
+							// identical shape on an object base threw
+							// correctly. Same false-success family as
+							// paserati#65.
+							vm.throwFromCallError(err)
+							return false, InterpretRuntimeError, Undefined
 						}
+						// Trap ran: the Proxy's [[Set]] governs, stop walking.
+						return true, InterpretOK, *valueToSet
 					}
 				}
 			}
@@ -481,9 +524,16 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 				if po.setters != nil {
 					if setter, hasSetter := po.setters[propKeyHash]; hasSetter && setter.IsCallable() {
 						// Invoke setter with the primitive as 'this'
-						if _, err := vm.Call(setter, *objVal, []Value{*valueToSet}); err == nil {
-							return true, InterpretOK, *valueToSet
+						if _, err := vm.Call(setter, *objVal, []Value{*valueToSet}); err != nil {
+							// Propagate rather than discard - see the matching
+							// comment in the Proxy branch above. Falling
+							// through here also kept walking the prototype
+							// chain past a setter that had already run and
+							// thrown, instead of stopping at it.
+							vm.throwFromCallError(err)
+							return false, InterpretRuntimeError, Undefined
 						}
+						return true, InterpretOK, *valueToSet
 					}
 				}
 				current = po.prototype

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -101,10 +101,14 @@ func (vm *VM) NewPromiseFromExecutor(executor Value) (Value, error) {
 				reason = NewString(err.Error())
 			}
 			vm.rejectPromise(promise, reason)
-			// vm.Call itself now clears vm.unwinding/unwindingCrossedNative
-			// when it hands an exception off as a Go error (#142 - see the
-			// comment in executeUserFunctionSafe), so this is defense in
-			// depth rather than load-bearing: we're not re-throwing, the
+			// vm.Call itself now clears vm.unwinding when it hands an
+			// exception off as a Go error (#142 - see the comment in
+			// executeUserFunctionSafe). It deliberately does NOT clear
+			// unwindingCrossedNative, which stays set for re-throw
+			// detection, so this ClearUnwindingState() call is still doing
+			// real work on that third flag - but for the phantom-exception
+			// bug specifically it is now defense in depth rather than the
+			// only thing standing between us and it: we're not re-throwing, the
 			// executor's exception has been fully absorbed into a rejected
 			// promise, a normal (non-erroring) return value from this
 			// function, so there is nothing left for the caller to see as
@@ -235,14 +239,21 @@ func (vm *VM) triggerPromiseReactions(promise *PromiseObject, isFulfilled bool) 
 					reason = NewString(err.Error())
 				}
 				reaction.Reject(reason)
-				// Defense in depth, mirroring NewPromiseFromExecutor's own
-				// call a few lines up in this file: vm.Call now clears
-				// vm.unwinding/unwindingCrossedNative itself when it hands an
-				// exception off as a Go error (#142), but this was the
-				// actual site that leaked it before that fix - a reaction
+				// Mirrors NewPromiseFromExecutor's own call a few lines up in
+				// this file. vm.Call now clears vm.unwinding itself when it
+				// hands an exception off as a Go error (#142); it leaves
+				// unwindingCrossedNative set for re-throw detection, which
+				// this call does still clear. This was the actual site that
+				// leaked the phantom exception before that fix - a reaction
 				// handler's exception is fully absorbed into a rejection
 				// right here, a normal (non-erroring) return, so there is
-				// nothing left in flight for a caller to see regardless.
+				// nothing left in flight for a caller to see.
+				//
+				// NOTE for anyone reverting either half: this line and the
+				// vm_init.go clear are each independently sufficient for
+				// tests/scripts/promise_reaction_throw_no_unwinding_leak.ts,
+				// so that test stays green with either one alone. See its
+				// header for the measured breakdown.
 				vm.ClearUnwindingState()
 			} else {
 				reaction.Resolve(result)

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -101,16 +101,14 @@ func (vm *VM) NewPromiseFromExecutor(executor Value) (Value, error) {
 				reason = NewString(err.Error())
 			}
 			vm.rejectPromise(promise, reason)
-			// vm.Call leaves vm.unwinding/unwindingCrossedNative set on error
-			// (deliberately - a caller that re-throws via bytecode injection
-			// needs that state to know it already crossed a boundary). We're
-			// not re-throwing: the executor's exception has been fully
-			// absorbed into a rejected promise, a normal (non-erroring)
-			// return value from this function. Leaving the flags set would
-			// leak into whatever bytecode dispatch called `new Promise(...)`,
-			// which would see unwinding=true after this native call "returns
-			// successfully" and treat it as an uncaught exception still in
-			// flight.
+			// vm.Call itself now clears vm.unwinding/unwindingCrossedNative
+			// when it hands an exception off as a Go error (#142 - see the
+			// comment in executeUserFunctionSafe), so this is defense in
+			// depth rather than load-bearing: we're not re-throwing, the
+			// executor's exception has been fully absorbed into a rejected
+			// promise, a normal (non-erroring) return value from this
+			// function, so there is nothing left for the caller to see as
+			// still in flight either way.
 			vm.ClearUnwindingState()
 		}
 	}
@@ -237,6 +235,15 @@ func (vm *VM) triggerPromiseReactions(promise *PromiseObject, isFulfilled bool) 
 					reason = NewString(err.Error())
 				}
 				reaction.Reject(reason)
+				// Defense in depth, mirroring NewPromiseFromExecutor's own
+				// call a few lines up in this file: vm.Call now clears
+				// vm.unwinding/unwindingCrossedNative itself when it hands an
+				// exception off as a Go error (#142), but this was the
+				// actual site that leaked it before that fix - a reaction
+				// handler's exception is fully absorbed into a rejection
+				// right here, a normal (non-erroring) return, so there is
+				// nothing left in flight for a caller to see regardless.
+				vm.ClearUnwindingState()
 			} else {
 				reaction.Resolve(result)
 			}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -16849,7 +16849,24 @@ func (vm *VM) isUnscopable(withObj Value, propName string) (bool, bool) {
 	// This must trigger getters on the unscopables object
 	excludeVal, err := vm.GetProperty(unscopablesVal, propName)
 	if err != nil {
-		// Error thrown during getter execution - propagate it
+		// Error thrown during getter execution - re-throw so the exception is
+		// actually in flight, then report hadError, the same way the Proxy
+		// get-trap branch above does. Returning a bare hadError=true used to
+		// be enough only because vm.Call left vm.unwinding set after handing
+		// the exception off as a Go error, and this function's contract is
+		// "if hadError, check vm.unwinding" (see the doc comment). Once
+		// vm.Call clears that flag (#142), a throwing getter on the
+		// unscopables object was silently swallowed instead - caught by
+		// language/statements/with/unscopables-prop-get-err.js.
+		//
+		// Do NOT add the same re-throw to the two GetSymbolPropertyWithGetter
+		// error paths above: that function already puts the exception in
+		// flight itself, so re-throwing there double-throws and breaks
+		// language/statements/with/unscopables-get-err.js. Only this
+		// vm.GetProperty path needs it.
+		if ee, ok := err.(ExceptionError); ok {
+			vm.throwException(ee.GetExceptionValue())
+		}
 		return false, true
 	}
 	if vm.unwinding {

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1789,7 +1789,14 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 	if status == InterpretRuntimeError {
 		if vm.unwinding && vm.currentException != Null {
 			ex := vm.currentException
+			// Clear vm.unwinding along with currentException when handing the
+			// exception off as a Go error - see the matching, longer comment
+			// in executeUserFunctionSafe (#142). Leaving vm.unwinding=true
+			// here left the exact same stale-state trap for `new`-constructor
+			// calls that absorb a Go error (e.g. Reflect.construct-style
+			// wrappers) without re-throwing.
 			vm.currentException = Null
+			vm.unwinding = false
 			vm.truncateFramesTo(frameCountAtEntry)
 			return Undefined, exceptionError{exception: ex}
 		}
@@ -1799,6 +1806,7 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 	if vm.unwinding && vm.currentException != Null {
 		ex := vm.currentException
 		vm.currentException = Null
+		vm.unwinding = false
 		vm.truncateFramesTo(frameCountAtEntry)
 		return Undefined, exceptionError{exception: ex}
 	}
@@ -1911,12 +1919,38 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 		// If the VM is unwinding an exception, surface it as an ExceptionError
 		if vm.unwinding && vm.currentException != Null {
 			ex := vm.currentException
-			// ⚠️ CRITICAL CHANGE: Don't clear vm.unwinding or vm.unwindingCrossedNative!
-			// These flags need to persist for re-throw detection
-			// Only clear currentException since we're passing it as a Go error
+			// Clear vm.unwinding here too (#142), not just currentException.
+			// An earlier version of this left vm.unwinding=true deliberately
+			// ("persist for re-throw detection"), reasoning that whatever
+			// native code receives this Go error would either make a new
+			// vm.Call (whose own entry guard, a few lines below this
+			// function, scrubs stale state when currentException==Null) or
+			// re-throw via vm.throwException (which sets vm.unwinding=true
+			// itself regardless of its prior value). Both are true, but they
+			// don't cover a third, common case: native code that ABSORBS the
+			// exception - turns it into a rejected promise, aggregates it
+			// into a SuppressedError while disposing further resources, etc.
+			// - and then returns normally (nil error) without making another
+			// vm.Call or re-throwing at all. vm.unwinding is checked, bare,
+			// after nearly every opcode across vm.go (that's the actual
+			// convention - a fresh, per-operation "did unwinding just start"
+			// flag, not sticky ambient state) - including once per
+			// instruction in the main dispatch loop itself. Left true, a
+			// single absorbed exception poisons every subsequent instruction
+			// any vm.run() invocation executes, anywhere, until the next
+			// vm.Call happens to scrub it: the very next opcode sees
+			// unwinding=true with currentException=Null (a phantom
+			// exception) and either aborts the script outright or corrupts
+			// unrelated control flow. Reproduced via a promise reaction
+			// whose handler throws (pkg/vm/promise.go's
+			// triggerPromiseReactions absorbs the Go error into a rejection
+			// without ever clearing vm.unwinding, unlike
+			// NewPromiseFromExecutor's ClearUnwindingState call for the same
+			// shape) followed by an unrelated top-level-await resuming
+			// normally - the resumption's very first instruction reported a
+			// bogus "Uncaught exception: null" and aborted the script.
 			vm.currentException = Null
-			// vm.unwinding = false         // OLD: Don't clear this!
-			// vm.unwindingCrossedNative... // OLD: Don't clear this either!
+			vm.unwinding = false
 			// We're taking ownership of the exception as a Go error - drop any
 			// frame(s) unwinding stopped at without popping (see comment above
 			// frameCountAtEntry) so they can't be mistaken for a live boundary
@@ -1934,8 +1968,7 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 	if vm.unwinding && vm.currentException != Null {
 		ex := vm.currentException
 		vm.currentException = Null
-		// vm.unwinding = false         // OLD: Don't clear this!
-		// vm.unwindingCrossedNative... // OLD: Don't clear this either!
+		vm.unwinding = false // see the matching comment above (#142)
 		vm.truncateFramesTo(frameCountAtEntry)
 		return Undefined, exceptionError{exception: ex}
 	}

--- a/tests/scripts/class_tdz_before_declaration.ts
+++ b/tests/scripts/class_tdz_before_declaration.ts
@@ -1,0 +1,154 @@
+// expect: true
+// no-typecheck: same reason as class_visible_to_earlier_closure.ts - the
+// checker rejects these forward references independently; this exercises
+// compiled/runtime behavior only.
+
+// #143 review (@mparrett): the block-level class pre-registration added for
+// #141/#144 reserved a spill slot for every class declared in a block, but
+// never seeded it. An unwritten spill slot reads as `undefined`, and NEITHER
+// spilled-identifier load path checked for the TDZ sentinel, so
+// pre-registration silently DELETED TDZ for class bindings: an access before
+// the class's own declaration stopped throwing ReferenceError and quietly
+// produced the raw sentinel value instead.
+//
+// The fix has two halves, both required:
+//   1. compiler.go step 0.6 marks the binding TDZ (DefineTDZSpilled) and
+//      emits OpLoadUninitialized + OpStoreSpill to seed the sentinel before
+//      any statement in the block runs.
+//   2. Both `symbolRef.IsSpilled` identifier branches emit
+//      OpCheckUninitialized when the symbol is still TDZ at compile time.
+//
+// No check is emitted on the upvalue path: OpLoadFree already does an
+// unconditional runtime TDZ check inside the VM, which is better than an
+// emitted OpCheckUninitialized would be because it is not subject to that
+// opcode's self-rewrite-to-OpNop. Verified by removing an equivalent emitted
+// check and confirming every case below is unchanged.
+
+// --- Matt's two reported cases -------------------------------------------
+
+// (a) direct access before the declaration
+function directEarlyAccess(): boolean {
+    let caught = false;
+    try {
+        C;
+    } catch (e) {
+        caught = e instanceof ReferenceError;
+    }
+    class C {}
+    return caught;
+}
+
+// (b) an earlier closure CALLED before the declaration. The capture is legal
+// (that is #144); calling it this early is not.
+function earlyClosureCall(): boolean {
+    const useIt = () => new D(1).v;
+    let caught = false;
+    try {
+        useIt();
+    } catch (e) {
+        caught = e instanceof ReferenceError;
+    }
+    class D {
+        v: number;
+        constructor(x: number) {
+            this.v = x;
+        }
+    }
+    return caught;
+}
+
+// (c) the #144 case must still work: same earlier closure, called AFTER the
+// declaration. Guards against "fixing" TDZ by reverting #144.
+function laterClosureCall(): boolean {
+    const useIt = () => new E(1).v;
+    class E {
+        v: number;
+        constructor(x: number) {
+            this.v = x;
+        }
+    }
+    return useIt() === 1;
+}
+
+// --- cases the TDZ machinery could plausibly get wrong --------------------
+
+// (d) OpCheckUninitialized self-rewrites to OpNop on a SUCCESSFUL check, so a
+// one-shot check would stop throwing after the first pass. Calling the same
+// function twice must throw both times.
+function twiceCalled(): boolean {
+    let caught = false;
+    try {
+        F;
+    } catch (e) {
+        caught = e instanceof ReferenceError;
+    }
+    class F {}
+    return caught;
+}
+
+// (e) The dangerous ordering for that same rewrite: run the HAPPY path at a
+// code site first, then hit the early path at that same site. Measured to
+// still throw, because the closure's guard is the VM's unconditional
+// OpLoadFree check rather than the self-rewriting opcode.
+function happyPathFirst(early: boolean): string {
+    const useIt = () => new G(1).v;
+    if (early) {
+        try {
+            return "no-throw";
+        } catch (e) {
+            return "unreachable";
+        }
+    }
+    class G {
+        v: number;
+        constructor(x: number) {
+            this.v = x;
+        }
+    }
+    return "ok:" + useIt();
+}
+
+function happyThenEarly(): boolean {
+    const useIt = () => new H(1).v;
+    let caught = false;
+    try {
+        useIt();
+    } catch (e) {
+        caught = e instanceof ReferenceError;
+    }
+    class H {
+        v: number;
+        constructor(x: number) {
+            this.v = x;
+        }
+    }
+    // after the declaration the very same closure must work
+    return caught && useIt() === 1;
+}
+
+// (f) A class in a LOOP body: the sentinel must be re-seeded per iteration,
+// not left holding the previous iteration's constructor (#132 gave loop
+// bodies per-iteration bindings).
+function loopBody(): boolean {
+    const results: boolean[] = [];
+    for (let i = 0; i < 2; i++) {
+        let caught = false;
+        try {
+            I;
+        } catch (e) {
+            caught = e instanceof ReferenceError;
+        }
+        class I {}
+        results.push(caught);
+    }
+    return results.length === 2 && results[0] && results[1];
+}
+
+directEarlyAccess() &&
+    earlyClosureCall() &&
+    laterClosureCall() &&
+    twiceCalled() &&
+    twiceCalled() &&
+    happyPathFirst(false) === "ok:1" &&
+    happyThenEarly() &&
+    loopBody();

--- a/tests/scripts/class_visible_to_earlier_closure.ts
+++ b/tests/scripts/class_visible_to_earlier_closure.ts
@@ -1,0 +1,83 @@
+// expect: true
+// no-typecheck: the checker doesn't yet resolve an earlier closure's forward
+// reference to a class declared later in the same block either (a separate,
+// pre-existing gap from this test's actual target, the compiler/runtime
+// binding bug) - this only exercises compiled/runtime behavior.
+
+// #144: a closure defined textually BEFORE a function-scoped class in the
+// same block, but only called AFTER the class has been declared - so there
+// is no real TDZ violation, just completely ordinary, common JS - must
+// still be able to capture the class. Neither #128 (closures nested inside
+// the class body) nor #141 (hoisted function declarations) covers this: an
+// ordinary, non-hoisted closure (a plain `const f = () => ...`) compiles at
+// its own sequential position in the block's statement loop, which for this
+// closure comes *before* the class's own declaration statement. Without
+// pre-registering the class's storage location before ANY statement in the
+// block compiles (not just hoisted ones), the closure's reference to the
+// class resolved before the class had anywhere to live, baking in a
+// dangling capture that can never be fixed up - the same root-cause shape
+// as #128/#141, just for an ordinary sequential-position closure instead of
+// a closure nested in the class body or a hoisted function.
+//
+// Found in a real npm package (minimatch's dist/commonjs/index.js): a
+// `const minimatch = (p, pattern, options) => { ...; return new
+// Minimatch(...).match(p); }` defined near the top of the module scope,
+// with `class Minimatch { ... }` declared later in the same scope - real
+// JS handles this trivially since minimatch() is never actually called
+// until well after the whole module has finished loading.
+
+function makeCounter(): boolean {
+    // `useIt` is defined BEFORE `Counter` and compiles at this earlier
+    // sequential position - it's only actually called after `Counter` has
+    // been declared, below.
+    const useIt = (x: number): number => new Counter(x).value;
+
+    class Counter {
+        value: number;
+        constructor(x: number) {
+            this.value = x;
+        }
+    }
+
+    return useIt(42) === 42;
+}
+
+// A nested closure inside the earlier closure should also see the class.
+function makeCounter2(): boolean {
+    const makeReader = () => () => Widget.tag();
+
+    class Widget {
+        static tag(): string {
+            return "widget";
+        }
+    }
+
+    return makeReader()() === "widget";
+}
+
+// Mutual forward reference: the class's own method calls the earlier
+// closure, and the earlier closure calls the class - both directions must
+// resolve to the same, final bindings.
+function makeMutual(): boolean {
+    const helper = (): string => Base.tag() + "-fn";
+
+    class Base {
+        static tag(): string {
+            return "base";
+        }
+        static combined(): string {
+            return helper() + "-method";
+        }
+    }
+
+    return Base.combined() === "base-fn-method";
+}
+
+// NOT fixed by this change, and deliberately not covered above: a closure
+// inside a *nested* block that references a class declared in an
+// *enclosing* block still throws ReferenceError - same shape as #141's own
+// documented remaining gap, just for an ordinary closure instead of a
+// hoisted function. See the comment above step "0.6" in compiler.go's
+// BlockStatement compile case.
+
+makeCounter() && makeCounter2() && makeMutual();

--- a/tests/scripts/class_visible_to_hoisted_function.ts
+++ b/tests/scripts/class_visible_to_hoisted_function.ts
@@ -1,0 +1,88 @@
+// expect: true
+// no-typecheck: the checker doesn't yet resolve a hoisted function's forward
+// reference to a class declared later in the same block either (a separate,
+// pre-existing gap from this test's actual target, the compiler/runtime
+// binding bug) - this only exercises compiled/runtime behavior.
+
+// #141: a class declared inside a function body must also be visible to a
+// *hoisted function declaration* sibling in the same scope, not just to
+// arrow functions/methods/inline closures nested inside the class body
+// itself (which #128 already fixed).
+//
+// Function declarations are hoisted and their bodies compiled at the top of
+// their enclosing block, before any other statement in that block -
+// including a class declaration that comes later in source order. Without
+// pre-registering the class's storage location before that hoisting step,
+// the hoisted function's reference to the class resolved before the class
+// had allocated anywhere to live, baking in a dangling capture (same
+// root-cause shape as #128, but for a hoisted-function sibling instead of a
+// closure nested directly inside the class body).
+function makeCounter(): boolean {
+    // `helper` is hoisted above `Counter` and its body compiles first.
+    function helper(): number {
+        return Counter.count;
+    }
+
+    class Counter {
+        static count: number = 42;
+    }
+
+    return helper() === 42;
+}
+
+// A nested closure inside the hoisted function should also see the class.
+function makeCounter2(): boolean {
+    function makeReader(): () => string {
+        return () => Widget.tag();
+    }
+
+    class Widget {
+        static tag(): string {
+            return "widget";
+        }
+    }
+
+    return makeReader()() === "widget";
+}
+
+// Mutual forward reference: the class's own method calls the hoisted
+// function, and the hoisted function calls the class - both directions must
+// resolve to the same, final bindings.
+function makeMutual(): boolean {
+    function helper3(): string {
+        return Base.tag() + "-fn";
+    }
+
+    class Base {
+        static tag(): string {
+            return "base";
+        }
+        static combined(): string {
+            return helper3() + "-method";
+        }
+    }
+
+    return Base.combined() === "base-fn-method";
+}
+
+// NOT fixed by this change, and deliberately not covered above: a function
+// hoisted inside a *nested* block that references a class declared in an
+// *enclosing* block still throws ReferenceError -
+//
+//   function outer() {
+//       {
+//           function helper() { return C.tag(); }
+//           helper(); // ReferenceError: C is not defined
+//       }
+//       class C {
+//           static tag() { return "x"; }
+//       }
+//   }
+//
+// This fix only pre-registers a class against sibling hoisted functions in
+// the *same* block (collectClassDeclarations only looks at that block's own
+// statement list) - same root-cause shape, but crossing into an enclosing
+// scope is a separate, deeper problem. See the comment above step "0.6" in
+// compiler.go's BlockStatement compile case.
+
+makeCounter() && makeCounter2() && makeMutual();

--- a/tests/scripts/primitive_base_setter_throw_propagates.ts
+++ b/tests/scripts/primitive_base_setter_throw_propagates.ts
@@ -1,0 +1,84 @@
+// expect: true
+// no-typecheck
+
+// A setter or Proxy set-trap reached through a PRIMITIVE base's prototype
+// chain must propagate its exception, exactly like the identical shape on an
+// object base already did.
+//
+// opSetProp's primitive path (pkg/vm/op_setprop.go) coerces the primitive to
+// a temp object and walks the prototype chain looking for a setter or a Proxy
+// set trap. Both call sites were written as `if _, err := vm.Call(...); err
+// == nil { return success }` - so when the setter or trap *threw*, the error
+// was silently discarded, the walk carried on up the chain instead of
+// stopping at the setter that had already run, and execution fell through to
+// the "no setter found - silently succeed" return at the bottom. The
+// assignment reported success and the exception vanished: another instance of
+// the false-success family tracked in paserati#65. Confirmed by instrumenting
+// the walk: it logged finding the setter, then continued to the next link.
+//
+// Found while diffing #142's unwinding fix against real `main`: the swallowed
+// error was what made language/types/reference/put-value-prop-base-primitive-realm.js
+// look like it was merely asserting the wrong count.
+
+let caughtSetter = false;
+Object.defineProperty(Number.prototype, "boom1", {
+  set: function () {
+    throw new Error("boom-setter");
+  },
+  configurable: true,
+});
+let n = 0;
+try {
+  n.boom1 = 1;
+} catch (e) {
+  caughtSetter = e instanceof Error && e.message === "boom-setter";
+}
+
+let caughtTrap = false;
+Object.setPrototypeOf(
+  String.prototype,
+  new Proxy(
+    {},
+    {
+      set: function () {
+        throw new Error("boom-trap");
+      },
+    }
+  )
+);
+let s = "str";
+try {
+  s.boom2 = 1;
+} catch (e) {
+  caughtTrap = e instanceof Error && e.message === "boom-trap";
+}
+
+// A NON-throwing setter on a primitive base must still work, and the
+// assignment expression must still evaluate to its RHS.
+let setterRan = 0;
+Object.defineProperty(Boolean.prototype, "ok", {
+  set: function () {
+    setterRan += 1;
+  },
+  configurable: true,
+});
+let b = true;
+const assigned = (b.ok = 7);
+const nonThrowingStillWorks = setterRan === 1 && assigned === 7;
+
+// Control: the same throwing-setter shape on an ordinary object base, which
+// always propagated correctly - guards against "fixed" by breaking both.
+let caughtOnObject = false;
+const obj: any = {};
+Object.defineProperty(obj, "boom3", {
+  set: function () {
+    throw new Error("boom-obj");
+  },
+});
+try {
+  obj.boom3 = 1;
+} catch (e) {
+  caughtOnObject = e instanceof Error && e.message === "boom-obj";
+}
+
+caughtSetter && caughtTrap && nonThrowingStillWorks && caughtOnObject;

--- a/tests/scripts/promise_reaction_throw_no_unwinding_leak.ts
+++ b/tests/scripts/promise_reaction_throw_no_unwinding_leak.ts
@@ -1,0 +1,78 @@
+// expect: true
+// no-typecheck
+
+// #142: a promise reaction handler that throws must not leak VM-internal
+// "still unwinding" state past the point where its rejection has been fully
+// absorbed by the promise machinery.
+//
+// triggerPromiseReactions (pkg/vm/promise.go) calls vm.Call(reaction.Handler,
+// ...) to run a .then()/.catch() handler. When the handler throws, vm.Call
+// hands the exception back as a Go error, which triggerPromiseReactions
+// turns into a rejected promise (reaction.Reject(reason)) instead of
+// re-throwing - the exception has been fully handled at that point. But the
+// VM-internal executeUserFunctionSafe/executeUserFunctionWithNewTarget that
+// produced that Go error used to leave vm.unwinding=true even after handing
+// the exception off, on the theory that whatever received it would either
+// make a new vm.Call (which clears the stale flag on entry) or re-throw
+// (which sets it fresh regardless). Absorbing the exception into a promise
+// rejection is a third case neither of those cover: nothing clears the
+// flag, and vm.unwinding is checked bare after nearly every VM instruction
+// (that's the actual convention - a fresh, per-operation flag, not sticky
+// state), including once per instruction in the main dispatch loop. Left
+// true, the very next instruction any vm.run() call executes - anywhere,
+// possibly much later - sees a phantom "still unwinding" with no actual
+// exception value and either aborts outright or corrupts unrelated control
+// flow.
+//
+// This reproduces it with two promises: `leaked`'s reaction throws and gets
+// absorbed by triggerPromiseReactions (the leak), scheduled to run AFTER
+// `marker`'s own resolution reaction in the same microtask drain pass, so
+// nothing else clears the leaked flag before `await marker` resumes. Before
+// the fix, this aborted the whole script with a bogus
+// "Uncaught exception: null" instead of continuing normally.
+//
+// PRECONDITION this test depends on and does not itself enforce: `leaked`'s
+// throwing reaction must run strictly AFTER `marker`'s resolution reaction
+// within the same microtask drain pass triggered by `await marker` below.
+// That ordering is what "nothing else clears the leaked flag before `await
+// marker` resumes" means concretely - reverse the order (or a future change
+// to reaction scheduling / RunUntilIdle's batching reorders them) and this
+// test passes trivially even with the fix reverted, because
+// executeUserFunctionSafe's entry guard would scrub the leaked flag when
+// `marker`'s own resolution reaction runs afterward instead. Verified by
+// hand at the time this was written: reverting the vm_init.go fix makes
+// this test fail with exactly "Uncaught exception: null". If this test ever
+// stops catching that failure, it no longer exercises #142 and needs
+// rewriting (e.g. re-establishing the ordering some other way), not
+// deleting.
+
+let resolveMarker: (v: number) => void;
+const marker = new Promise<number>((res) => {
+  resolveMarker = res;
+});
+Promise.resolve().then(() => resolveMarker(42));
+
+// Scheduled after the above, so its throwing reaction runs LAST in the same
+// microtask drain pass, after `marker` has already settled - leaving no
+// further vm.Call to scrub the leaked state before `await marker` resumes.
+const leaked = Promise.resolve(1).then(() => {
+  throw new Error("leak");
+});
+
+const result = await marker;
+
+// A genuinely new, unrelated exception right after resuming must still be
+// caught normally instead of the resumption itself spuriously aborting.
+let caught = false;
+try {
+  throw new Error("real throw after leak");
+} catch (e) {
+  caught = e instanceof Error && e.message === "real throw after leak";
+}
+
+// Silence "unhandled rejection" noise / unused-var lint for `leaked` without
+// otherwise touching it (do NOT await it - the whole point is that nothing
+// consumes it again before the assertions above run).
+void leaked;
+
+result === 42 && caught;

--- a/tests/scripts/promise_reaction_throw_no_unwinding_leak.ts
+++ b/tests/scripts/promise_reaction_throw_no_unwinding_leak.ts
@@ -78,15 +78,26 @@
 //    vm.GetProperty error path now re-throws instead. See the comment
 //    there; language/statements/with/unscopables-prop-get-err.js covers it.
 //
-//  - It turns language/types/reference/put-value-prop-base-primitive-realm.js
-//    from a pass into a failure, and that is an improvement, not a
-//    regression. On main that test "passes" only because the leaked flag
-//    aborts the script at its cross-realm `other.eval(...)` before its
-//    first assertion ever runs, and the runner scores a silently aborted
-//    script as a pass (paserati#65). With the leak closed the script runs
-//    to completion and reports the honest result: cross-realm primitive-base
-//    [[Set]] does not honor the other realm's prototype chain. That is a
-//    separate, pre-existing gap, not touched here.
+//  - It briefly turned language/types/reference/put-value-prop-base-primitive-realm.js
+//    from a pass into a failure. That test is a FALSE PASS both before and
+//    after this PR, so read no signal into it either way. On main the leaked
+//    flag aborts the script at its cross-realm `other.eval(...)` before the
+//    first assertion runs, and the runner scores a silently aborted script as
+//    a pass (paserati#65). Closing the leak let it reach the assertion and
+//    fail honestly; the primitive-base setter fix in op_setprop.go then made
+//    the trap's own exception propagate, which aborts the script at the same
+//    `other.eval(...)` again - so it is back to "passing" by abort. Verified
+//    with print() markers: the script still never reaches its first
+//    assertion.
+//
+//    Two separate, pre-existing gaps keep it there, neither touched here:
+//    (1) a cross-realm call does not switch to the callee's [[Realm]], so the
+//    main-realm set trap throws ReferenceError on its own `numberCount`
+//    global when invoked from the other realm; and (2) an exception escaping
+//    `realmGlobal.eval(...)` silently aborts the script instead of being
+//    catchable - confirmed pre-existing by running a plain
+//    `try { other.eval('throw new Error("x")') } catch (e) {}` on a
+//    a88125c2 worktree, where it also aborts uncatchably.
 //
 // If this test ever stops catching the both-reverted failure, it no longer
 // exercises #142 at all and needs rewriting (e.g. re-establishing the

--- a/tests/scripts/promise_reaction_throw_no_unwinding_leak.ts
+++ b/tests/scripts/promise_reaction_throw_no_unwinding_leak.ts
@@ -39,12 +39,58 @@
 // to reaction scheduling / RunUntilIdle's batching reorders them) and this
 // test passes trivially even with the fix reverted, because
 // executeUserFunctionSafe's entry guard would scrub the leaked flag when
-// `marker`'s own resolution reaction runs afterward instead. Verified by
-// hand at the time this was written: reverting the vm_init.go fix makes
-// this test fail with exactly "Uncaught exception: null". If this test ever
-// stops catching that failure, it no longer exercises #142 and needs
-// rewriting (e.g. re-establishing the ordering some other way), not
-// deleting.
+// `marker`'s own resolution reaction runs afterward instead.
+//
+// WHAT THIS TEST ACTUALLY DISCRIMINATES - measured, not assumed. The #142
+// fix landed in two places, and either one alone is sufficient for THIS
+// scenario, so the test is an OR over both:
+//
+//   vm_init.go clear only      -> PASSES
+//   promise.go clear only      -> PASSES
+//   both reverted              -> FAILS, "Uncaught exception: null"
+//
+// So this test proves the leak was real and that it is now closed on the
+// promise-reaction path, but it does NOT pin down the general fix on its
+// own: reverting just the four `vm.unwinding = false` lines in
+// pkg/vm/vm_init.go leaves it green, because triggerPromiseReactions'
+// own ClearUnwindingState() call absorbs the leak one level up. Do not
+// read a green run here as coverage of executeUserFunctionSafe /
+// executeUserFunctionWithNewTarget in isolation.
+//
+// The general clear in vm_init.go is kept because the promise path is only
+// one absorber shape: any native code that takes a vm.Call exception as a
+// Go error, absorbs it, and returns nil without re-throwing or making
+// another vm.Call hits the same trap, and vm_init.go is the only place that
+// closes it for all of them. It is not covered by this smoke test, but it
+// is far from untested - it is worth +21 Test262 built-ins tests on its
+// own, all in exception handling (Array.from iterator-close errors,
+// Promise.all capability-resolve throws, Iterator.zip suspended-yield
+// close, Reflect.apply/construct argument-list errors, TypedArray Get key
+// errors, RegExp Symbol.search / String matchAll throws). Reverting the
+// four lines in vm_init.go gives all 21 back up, which is the check to run
+// if anyone is tempted to narrow this to the promise path alone.
+//
+// Two things the general clear also does, both deliberate:
+//
+//  - It exposed one real latent bug and it is fixed alongside it: vm.go's
+//    isUnscopable() documented its contract as "if hadError, check
+//    vm.unwinding", which only worked while vm.Call left the flag set. Its
+//    vm.GetProperty error path now re-throws instead. See the comment
+//    there; language/statements/with/unscopables-prop-get-err.js covers it.
+//
+//  - It turns language/types/reference/put-value-prop-base-primitive-realm.js
+//    from a pass into a failure, and that is an improvement, not a
+//    regression. On main that test "passes" only because the leaked flag
+//    aborts the script at its cross-realm `other.eval(...)` before its
+//    first assertion ever runs, and the runner scores a silently aborted
+//    script as a pass (paserati#65). With the leak closed the script runs
+//    to completion and reports the honest result: cross-realm primitive-base
+//    [[Set]] does not honor the other realm's prototype chain. That is a
+//    separate, pre-existing gap, not touched here.
+//
+// If this test ever stops catching the both-reverted failure, it no longer
+// exercises #142 at all and needs rewriting (e.g. re-establishing the
+// ordering some other way), not deleting.
 
 let resolveMarker: (v: number) => void;
 const marker = new Promise<number>((res) => {

--- a/tests/scripts/spilled_let_tdz.ts
+++ b/tests/scripts/spilled_let_tdz.ts
@@ -1,0 +1,243 @@
+// expect: true
+// no-typecheck
+
+// The TDZ fix for #143's class pre-registration also closed a pre-existing gap
+// it sits on top of: SPILLED let/const bindings had no TDZ check at all.
+//
+// Both `symbolRef.IsSpilled` identifier branches in compiler.go emitted a bare
+// OpLoadSpill with no OpCheckUninitialized, unlike the two register-based
+// paths right next to them. OpLoadSpill has no VM-side TDZ guard either (only
+// OpLoadFree does), so reading a spilled let/const before its declaration
+// quietly produced the raw TDZ sentinel instead of throwing ReferenceError.
+// The identical code in a function small enough to keep everything in
+// registers threw correctly - it only broke once register pressure forced the
+// binding into a spill slot, which is why no existing test caught it.
+//
+// Hence the 200 dummy locals below: they are not incidental, they are what
+// pushes `late` into a spill slot. Measured threshold on this VM - at 150
+// locals the pre-fix build still returns true (registers, working check), at
+// 200 it returns false (spilled, no check). Do not "tidy" the count down.
+//
+// Verified to discriminate: on a88125c2 (pre-#143) this returns false; with
+// either half of the compiler.go TDZ fix reverted it returns false.
+
+function spilledLetTDZ(): boolean {
+
+    let v0 = 0;
+    let v1 = 1;
+    let v2 = 2;
+    let v3 = 3;
+    let v4 = 4;
+    let v5 = 5;
+    let v6 = 6;
+    let v7 = 7;
+    let v8 = 8;
+    let v9 = 9;
+    let v10 = 10;
+    let v11 = 11;
+    let v12 = 12;
+    let v13 = 13;
+    let v14 = 14;
+    let v15 = 15;
+    let v16 = 16;
+    let v17 = 17;
+    let v18 = 18;
+    let v19 = 19;
+    let v20 = 20;
+    let v21 = 21;
+    let v22 = 22;
+    let v23 = 23;
+    let v24 = 24;
+    let v25 = 25;
+    let v26 = 26;
+    let v27 = 27;
+    let v28 = 28;
+    let v29 = 29;
+    let v30 = 30;
+    let v31 = 31;
+    let v32 = 32;
+    let v33 = 33;
+    let v34 = 34;
+    let v35 = 35;
+    let v36 = 36;
+    let v37 = 37;
+    let v38 = 38;
+    let v39 = 39;
+    let v40 = 40;
+    let v41 = 41;
+    let v42 = 42;
+    let v43 = 43;
+    let v44 = 44;
+    let v45 = 45;
+    let v46 = 46;
+    let v47 = 47;
+    let v48 = 48;
+    let v49 = 49;
+    let v50 = 50;
+    let v51 = 51;
+    let v52 = 52;
+    let v53 = 53;
+    let v54 = 54;
+    let v55 = 55;
+    let v56 = 56;
+    let v57 = 57;
+    let v58 = 58;
+    let v59 = 59;
+    let v60 = 60;
+    let v61 = 61;
+    let v62 = 62;
+    let v63 = 63;
+    let v64 = 64;
+    let v65 = 65;
+    let v66 = 66;
+    let v67 = 67;
+    let v68 = 68;
+    let v69 = 69;
+    let v70 = 70;
+    let v71 = 71;
+    let v72 = 72;
+    let v73 = 73;
+    let v74 = 74;
+    let v75 = 75;
+    let v76 = 76;
+    let v77 = 77;
+    let v78 = 78;
+    let v79 = 79;
+    let v80 = 80;
+    let v81 = 81;
+    let v82 = 82;
+    let v83 = 83;
+    let v84 = 84;
+    let v85 = 85;
+    let v86 = 86;
+    let v87 = 87;
+    let v88 = 88;
+    let v89 = 89;
+    let v90 = 90;
+    let v91 = 91;
+    let v92 = 92;
+    let v93 = 93;
+    let v94 = 94;
+    let v95 = 95;
+    let v96 = 96;
+    let v97 = 97;
+    let v98 = 98;
+    let v99 = 99;
+    let v100 = 100;
+    let v101 = 101;
+    let v102 = 102;
+    let v103 = 103;
+    let v104 = 104;
+    let v105 = 105;
+    let v106 = 106;
+    let v107 = 107;
+    let v108 = 108;
+    let v109 = 109;
+    let v110 = 110;
+    let v111 = 111;
+    let v112 = 112;
+    let v113 = 113;
+    let v114 = 114;
+    let v115 = 115;
+    let v116 = 116;
+    let v117 = 117;
+    let v118 = 118;
+    let v119 = 119;
+    let v120 = 120;
+    let v121 = 121;
+    let v122 = 122;
+    let v123 = 123;
+    let v124 = 124;
+    let v125 = 125;
+    let v126 = 126;
+    let v127 = 127;
+    let v128 = 128;
+    let v129 = 129;
+    let v130 = 130;
+    let v131 = 131;
+    let v132 = 132;
+    let v133 = 133;
+    let v134 = 134;
+    let v135 = 135;
+    let v136 = 136;
+    let v137 = 137;
+    let v138 = 138;
+    let v139 = 139;
+    let v140 = 140;
+    let v141 = 141;
+    let v142 = 142;
+    let v143 = 143;
+    let v144 = 144;
+    let v145 = 145;
+    let v146 = 146;
+    let v147 = 147;
+    let v148 = 148;
+    let v149 = 149;
+    let v150 = 150;
+    let v151 = 151;
+    let v152 = 152;
+    let v153 = 153;
+    let v154 = 154;
+    let v155 = 155;
+    let v156 = 156;
+    let v157 = 157;
+    let v158 = 158;
+    let v159 = 159;
+    let v160 = 160;
+    let v161 = 161;
+    let v162 = 162;
+    let v163 = 163;
+    let v164 = 164;
+    let v165 = 165;
+    let v166 = 166;
+    let v167 = 167;
+    let v168 = 168;
+    let v169 = 169;
+    let v170 = 170;
+    let v171 = 171;
+    let v172 = 172;
+    let v173 = 173;
+    let v174 = 174;
+    let v175 = 175;
+    let v176 = 176;
+    let v177 = 177;
+    let v178 = 178;
+    let v179 = 179;
+    let v180 = 180;
+    let v181 = 181;
+    let v182 = 182;
+    let v183 = 183;
+    let v184 = 184;
+    let v185 = 185;
+    let v186 = 186;
+    let v187 = 187;
+    let v188 = 188;
+    let v189 = 189;
+    let v190 = 190;
+    let v191 = 191;
+    let v192 = 192;
+    let v193 = 193;
+    let v194 = 194;
+    let v195 = 195;
+    let v196 = 196;
+    let v197 = 197;
+    let v198 = 198;
+    let v199 = 199;
+
+    // Read `late` before its declaration. Must throw ReferenceError.
+    let caught = false;
+    try {
+        const t = late;
+    } catch (e) {
+        caught = e instanceof ReferenceError;
+    }
+    let late = 1;
+
+    // Keep every dummy local live so they actually occupy registers.
+    const sum = v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19 + v20 + v21 + v22 + v23 + v24 + v25 + v26 + v27 + v28 + v29 + v30 + v31 + v32 + v33 + v34 + v35 + v36 + v37 + v38 + v39 + v40 + v41 + v42 + v43 + v44 + v45 + v46 + v47 + v48 + v49 + v50 + v51 + v52 + v53 + v54 + v55 + v56 + v57 + v58 + v59 + v60 + v61 + v62 + v63 + v64 + v65 + v66 + v67 + v68 + v69 + v70 + v71 + v72 + v73 + v74 + v75 + v76 + v77 + v78 + v79 + v80 + v81 + v82 + v83 + v84 + v85 + v86 + v87 + v88 + v89 + v90 + v91 + v92 + v93 + v94 + v95 + v96 + v97 + v98 + v99 + v100 + v101 + v102 + v103 + v104 + v105 + v106 + v107 + v108 + v109 + v110 + v111 + v112 + v113 + v114 + v115 + v116 + v117 + v118 + v119 + v120 + v121 + v122 + v123 + v124 + v125 + v126 + v127 + v128 + v129 + v130 + v131 + v132 + v133 + v134 + v135 + v136 + v137 + v138 + v139 + v140 + v141 + v142 + v143 + v144 + v145 + v146 + v147 + v148 + v149 + v150 + v151 + v152 + v153 + v154 + v155 + v156 + v157 + v158 + v159 + v160 + v161 + v162 + v163 + v164 + v165 + v166 + v167 + v168 + v169 + v170 + v171 + v172 + v173 + v174 + v175 + v176 + v177 + v178 + v179 + v180 + v181 + v182 + v183 + v184 + v185 + v186 + v187 + v188 + v189 + v190 + v191 + v192 + v193 + v194 + v195 + v196 + v197 + v198 + v199;
+
+    // ...and the binding must work normally once initialized.
+    return caught && sum === 19900 && late === 1;
+}
+
+spilledLetTDZ();


### PR DESCRIPTION
## Summary

Three narrower follow-ups in the same family, each filed as its own issue:

- **#141** — a hoisted function declaration still couldn't forward-reference a sibling function-scoped class (#128 covered closures nested *inside* the class body, but not a hoisted function compiled ahead of the class's own position).
- **#142** — an ordinary throw could still get lost across a reentrant `vm.Call()` (two-plus nested `vm.Call()` invocations on the Go stack), independent of #130.
- **#144** — a *non-hoisted* closure (`const f = () => ...`) positioned earlier in a block than a sibling function-scoped class it references still couldn't capture it, even when only called after the class is declared. Found for real in `minimatch`'s CJS bundle while verifying this PR.

Three separate commits, one per issue.

## #141 — hoisted function declarations vs. sibling function-scoped classes

`#128` fixed forward references to a function-scoped class from closures compiled *inside* the class body by pre-allocating a stable spill slot before the constructor/methods compile. It didn't cover a hoisted *function declaration* sibling in the same block — those compile at the very top of the block, before the class's own sequential position, so the reference resolved before the class had anywhere to live.

Fixed by pre-registering spill slots for classes declared directly in a block's own statement list before that block's hoisted functions compile; `compileClassDeclaration` reuses that slot instead of allocating a second one.

**Verified:** `go test ./...` clean, full smoke suite green, Test262 `language/**` diff vs. real `main`: 0 regressions.

## #142 — reentrant `vm.Call()` losing exceptions

`vm.go:11288` (flagged in the issue as worth checking first) turned out to be a dead end — confirmed and documented in the commit.

Root cause: `executeUserFunctionSafe`/`executeUserFunctionWithNewTarget` deliberately left `vm.unwinding = true` after handing an exception off as a Go error (a prior "WIP unwinding fixes" commit, reasoning that downstream code would either make a new `vm.Call` or re-throw). That misses a third case: native code that fully *absorbs* the exception (e.g. turning a `.then()` handler's throw into a rejected promise) and returns normally. Since `vm.unwinding` is checked bare after nearly every VM instruction across `vm.go`, a leaked flag poisons the next instruction *any* `vm.run()` executes, anywhere — reproduced crashing an unrelated top-level `await` with a bogus `Uncaught exception: null`.

Fixed at the source: both functions now clear `vm.unwinding` alongside `vm.currentException` on handoff. Also added a defensive `vm.ClearUnwindingState()` at the actual leak site in `triggerPromiseReactions`, mirroring the existing call in `NewPromiseFromExecutor`.

**Verified:**
- `go test ./...` clean, full smoke suite green.
- New test reproduces the crash when **both** halves of the fix are reverted. Correcting an earlier, overstated claim in this PR: reverting only the `vm_init.go` clear leaves the test green, because `triggerPromiseReactions`' own `ClearUnwindingState()` absorbs the leak one level up. The two are each independently sufficient for that scenario; the test header now carries the measured breakdown.
- Test262 diff vs. real `main`: `built-ins/**` **+21 new passes, 0 regressions** (Promise.all ordering, Array.from iterator/mapFn-throw handling, Iterator.zip suspended-close semantics, Reflect apply/construct argument checks, RegExp/String matchAll-throws propagation, TypedArray Get-trap bounds checks) — that +21 is what the general `vm_init.go` clear buys, and reverting those four lines gives all of it back.
- `language/**` **0 new passes, 0 new failures** — but read that 0 carefully, it is not "clean". Also correcting an earlier "0 regressions" claim here, which was measured against a baseline that already contained this PR. Diffed against real `main`, this PR started out with **two** `language` failures:
  - `with/unscopables-prop-get-err.js` — a **genuine regression**, now fixed. `isUnscopable()` documented its contract as "if hadError, check `vm.unwinding`", which only held while `vm.Call` left the flag set; its `vm.GetProperty` error path returned a bare `hadError=true` without putting the exception back in flight, so a throwing `Symbol.unscopables` getter was silently swallowed. It now re-throws, mirroring the Proxy get-trap branch in the same function. (Deliberately *not* applied to the two `GetSymbolPropertyWithGetter` paths there — that function already throws internally, and re-throwing double-throws and breaks `with/unscopables-get-err.js`.)
  - `types/reference/put-value-prop-base-primitive-realm.js` — **a false pass on both sides; it carries no signal either way.** On `main` the leaked flag aborts that script at its cross-realm `other.eval(...)` before the first assertion runs, and the runner scores a silently aborted script as a pass (#65). Closing the leak let it reach the assertion and fail honestly. Chasing *that* failure turned up a third real bug, now also fixed here: `opSetProp`'s primitive-base path silently discarded exceptions thrown by an accessor setter or a Proxy set trap reached through a primitive's prototype chain (`try { (0).x = 1 } catch {}` never caught, while the identical shape on an object base threw correctly). With the exception now propagating, it aborts the script at the same `other.eval(...)` — so the test is back to "passing" by abort, verified with `print()` markers that it still never reaches its first assertion. **The real coverage for that fix is the new `primitive_base_setter_throw_propagates.ts` smoke test**, which is verified to fail with the fix reverted — not this test262 line.

## #144 — earlier closure vs. sibling function-scoped class

Generalizes #141 rather than being independent: #141 only pre-registered a block's class spill slots before that block's *hoisted functions* compiled. A plain, non-hoisted closure (`const f = () => ...`) compiles at its own sequential position — if that position is textually before the class it references, the same dangling-capture bug hits it too, even though it's only ever *called* well after the class has been declared (no real TDZ violation).

Found for real in `minimatch`'s `dist/commonjs/index.js`: `const minimatch = (p, pattern, options) => { ...; return new Minimatch(...).match(p); }` defined near the top of the file, with `class Minimatch { ... }` declared later in the same (CJS-module-wrapped) scope.

Fixed by widening #141's pre-registration from "before this block's hoisted functions compile" to "before any statement in this block compiles" — same gate (only for classes taking the local/spilled path), just no longer conditioned on the block having hoisted declarations at all.

Checked explicitly whether the true top-level (module/script scope) case of the minimatch example is still broken by the remaining gate: it isn't — a top-level class already takes the global path, where the existing bare-key/`moduleGlobalKey` fallback in `compileIdentifier` already resolves it (same mechanism #141's own commit documented for a bare top-level block). Confirmed by hand.

**Verified:** `go test ./...` clean, full smoke suite green, Test262 diff vs. real `main`: 0 regressions on `language/**` and `built-ins/**`.

## Known, documented, not-fixed-here gaps (shared by all three)

- Type checking still rejects these patterns with `TS2304` — the fixes only apply under `--no-typecheck`/noderati execution. Real, separate TS-conformance bugs.
- A closure (hoisted or not) inside a *nested* block referencing a class declared in an *enclosing* block still throws `ReferenceError` — same shape, deeper cross-scope problem `collectClassDeclarations`'s single-block scan doesn't reach.

- A cross-realm call does not switch to the callee's `[[Realm]]`, so a main-realm Proxy set trap throws `ReferenceError` on its own global when invoked from another realm. Confirmed pre-existing on an `a88125c2` worktree.
- An exception escaping `realmGlobal.eval(...)` silently aborts the script instead of being catchable — `try { other.eval('throw new Error("x")') } catch (e) {}` aborts uncatchably on plain `main` too. #65 territory. These two together are what keep `put-value-prop-base-primitive-realm.js` a false pass.
- The general `vm.unwinding` clear has no *discriminating* smoke test — its coverage is the 21 Test262 built-ins tests. A second absorber that doesn't route through `triggerPromiseReactions` would be needed; the natural candidate (`SuppressedError` aggregation during `using`/`await using` disposal) isn't implemented in the VM yet.

Flagged for the user to decide on filing separately.

Closes #141
Closes #144

**Refs #142 — deliberately NOT "Closes".** This PR fixes a real bug in #142's
area: `executeUserFunctionSafe`/`executeUserFunctionWithNewTarget` left
`vm.unwinding = true` after handing an exception off as a Go error, and that
stale flag produces exactly the state #142 describes (`unwinding=true` with
`currentException=Null`, which is why a `catch` block sees literally `null`
and why the outer level falls through to the generic "runtime error during
user function execution"). It is worth +21 Test262 built-ins tests on its own.

But **#142's own reproducer has not been run.** That repro is `require("./b.js")`
nested inside noderati's CJS `require()`, and noderati is not in this repo —
paserati proper has no `require` at all (`typeof require === "undefined"`), so
there is no way to exercise it here. What was verified instead is a different
symptom of the same stale flag (a promise reaction handler's throw poisoning a
later, unrelated instruction). Attempts to reach the issue's exact shape from
inside this repo did not reproduce it: nested `map`/`eval`/sort-comparator/
JSON-reviver chains (up to three nested native→`vm.Call` levels) all return the
correct `Error` on `a88125c2` too, so they don't exercise the bug.

The remaining unknown is whether a native that propagates the `vm.Call` error
upward as a Go error return (rather than re-throwing it) now surfaces the real
exception at the outer level. Someone with noderati should run the issue's two
files against this branch before #142 is closed.



