### PR TITLE
perf(bench): measure prototype access instead of engine startup

### DIFF
--- a/tests/benchmark_prototype_test.go
+++ b/tests/benchmark_prototype_test.go
@@ -3,11 +3,31 @@ package tests
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/nooga/paserati/pkg/driver"
 	"github.com/nooga/paserati/pkg/vm"
 )
+
+// compileString compiles inline benchmark source and handles errors, so
+// compilation can sit above b.ResetTimer() the way compileFile does for the
+// file-backed benchmarks.
+func compileString(tb testing.TB, code string) *vm.Chunk {
+	tb.Helper()
+	chunk, compileErrs := driver.CompileString(code)
+	if len(compileErrs) > 0 {
+		var errMsgs strings.Builder
+		for _, err := range compileErrs {
+			errMsgs.WriteString(err.Error() + "\n")
+		}
+		tb.Fatalf("Compile errors:\n%s", errMsgs.String())
+	}
+	if chunk == nil {
+		tb.Fatal("Compilation succeeded but returned nil chunk")
+	}
+	return chunk
+}
 
 // BenchmarkPrototypeMethodAccess benchmarks prototype method access performance
 func BenchmarkPrototypeMethodAccess(b *testing.B) {
@@ -58,7 +78,10 @@ obj.getValue();`,
 		for _, tc := range testCases {
 			benchName := fmt.Sprintf("%s/%s", config.name, tc.name)
 			b.Run(benchName, func(b *testing.B) {
-				// Set environment variables for this run
+				// Order matters: the cache configuration has to be applied before
+				// the engine is constructed, because NewPaserati reads these when
+				// it builds the VM. Hoisting construction without hoisting the
+				// config first would measure the wrong configuration.
 				os.Setenv("PASERATI_ENABLE_PROTO_CACHE", fmt.Sprintf("%v", config.protoCache))
 				os.Setenv("PASERATI_DETAILED_CACHE_STATS", fmt.Sprintf("%v", config.detailStats))
 
@@ -66,10 +89,37 @@ obj.getValue();`,
 				vm.EnablePrototypeCache = config.protoCache
 				vm.EnableDetailedCacheStats = config.detailStats
 
+				// Build and compile once. Both used to happen inside the loop, so
+				// every iteration paid for an engine and a compile and the
+				// prototype access this benchmark is named for was a rounding
+				// error on top (nooga#51). Reusing the engine also lets the
+				// prototype cache warm, which is the only way Baseline and
+				// WithPrototypeCache can separate at all.
+				chunk := compileString(b, tc.code)
+				p := driver.NewPaserati()
+
+				// Warm the caches before timing. Hoisting construction alone left
+				// the first iteration paying for cold prototype and inline caches;
+				// against a ~500ns steady state that made ns/op swing from 136,792
+				// at b.N=1 to 297 at b.N=4096, a worse N-dependence than the one
+				// being fixed.
+				//
+				// The count is deliberately a round number and NOT tuned against
+				// measurement: a warmup sweep on a loaded laptop returned
+				// non-monotone garbage (warmup=500 reading 3x slower at b.N=16 than
+				// warmup=25), which is the same single-sample trap that has cost
+				// this project retractions before. 100 is cheap — ~50us per b.Run —
+				// and comfortably past where the caches can still be cold. Whether
+				// ns/op is actually flat in N has to be confirmed on a quiet host.
+				for i := 0; i < 100; i++ {
+					if _, errs := p.InterpretChunk(chunk); len(errs) > 0 {
+						b.Fatalf("Warmup failed: %v", errs)
+					}
+				}
+
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					p := driver.NewPaserati()
-					_, errs := p.RunString(tc.code)
+					_, errs := p.InterpretChunk(chunk)
 					if len(errs) > 0 {
 						b.Fatalf("Evaluation failed: %v", errs)
 					}
@@ -91,20 +141,28 @@ a.length;`
 	vm.EnablePrototypeCache = true
 	vm.EnableDetailedCacheStats = true
 
+	// Same hoist as above (nooga#51). The stats reset moves out of the loop too:
+	// it is bookkeeping rather than workload, and accumulating across iterations
+	// is what makes the reported rate a hit rate rather than a first-access
+	// measurement repeated N times.
+	chunk := compileString(b, code)
+	p := driver.NewPaserati()
+
+	// Warm before timing, for the same reason and with the same caveat as above.
+	// The stats reset comes after the warmup so the reported rate covers the
+	// timed iterations only.
+	for i := 0; i < 100; i++ {
+		if _, errs := p.InterpretChunk(chunk); len(errs) > 0 {
+			b.Fatalf("Warmup failed: %v", errs)
+		}
+	}
+	vm.ResetExtendedStats()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// Reset cache stats
-		vm.ResetExtendedStats()
-
-		p := driver.NewPaserati()
-		_, errs := p.RunString(code)
+		_, errs := p.InterpretChunk(chunk)
 		if len(errs) > 0 {
 			b.Fatalf("Evaluation failed: %v", errs)
-		}
-
-		// Print cache stats after each run (only on last iteration)
-		if i == b.N-1 {
-			b.Logf("Benchmark completed %d iterations", b.N)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #51.

`BenchmarkPrototypeMethodAccess` (×9) and `BenchmarkPrototypeCacheHitRate` construct
an engine and compile their snippet **inside** the timed loop, so all ten measure
`NewPaserati()` plus compiling three tokens. The prototype access they are named for
is a rounding error on top.

The clearest symptom is that the benchmark cannot see its own subject. `Baseline`
and `WithPrototypeCache` exist to be compared, and before this change they are
indistinguishable:

| | before | after |
|---|---|---|
| `Baseline/ArrayPrototypeMethod` | 3,988,858 ns | 2,205 ns |
| `WithPrototypeCache/ArrayPrototypeMethod` | 3,911,380 ns | 862 ns |
| **cache effect** | **−1.9%** | **−60.9%** |

Both columns are one machine, `-benchtime 500x`, this branch versus its parent.
Before, all ten cases sit in a 3.0–6.6 ms band regardless of workload or cache
configuration. After, they span 862 ns to 8.9 µs and separate by configuration.

## What changed

Construction and compilation move above `b.ResetTimer()`, the way
`tests/bench_test.go` already does. The config assignment stays ahead of
construction, because `NewPaserati()` reads those globals when it builds the VM —
setting them after construction would leave every case measuring the same
configuration.

Reusing one engine across iterations is also what lets the prototype cache warm.
A cache that is rebuilt every iteration cannot demonstrate a hit rate, which is
why `WithPrototypeCache` could not separate from `Baseline` no matter how many
iterations it ran.

## Why it is worth landing rather than leaving

`bench-ratchet`'s default scope is `pkg/vm` **and** `./tests`, so these ten cases
are in the perf corpus and on the timeline — ten of the thirty-five benchmarks
there, contributing to any suite aggregate while measuring engine startup under a
name that says prototype access. Any suite-level number computed since they were
added includes them.

## Provenance

This has been running on my fork since 2026-08-05 and is what my own measurements
have used since; I should have sent it up then. The before/after above is fresh
against current `main` rather than the numbers from that day, since the engine has
moved a long way in between.
