### PR TITLE
perf(bench): escape BenchmarkGetOwn's results so the loop cannot be elided

### DIFF
--- a/pkg/vm/object_bench_test.go
+++ b/pkg/vm/object_bench_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -38,10 +39,19 @@ func benchGetOwn(b *testing.B, fieldCount int, accessPattern string) {
 	}
 
 	b.ReportAllocs()
+	var sink Value
+	var found bool
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = obj.GetOwn(lookup(i))
+		sink, found = obj.GetOwn(lookup(i))
 	}
+	// (*PlainObject).GetOwn costs 179 against an inline budget of 80, so the call
+	// survives today — but (*ArrayObject).GetOwn sits at 84 against that same
+	// budget, having crossed it from 73 while this benchmark was in use. Discarding
+	// both results is what makes the difference load-bearing: once the callee
+	// inlines, nothing observes the work and the loop can be optimised away.
+	runtime.KeepAlive(sink)
+	runtime.KeepAlive(found)
 }
 
 func BenchmarkGetOwn(b *testing.B) {


### PR DESCRIPTION
`BenchmarkGetOwn` discards both of its results:

```go
for i := 0; i < b.N; i++ {
    _, _ = obj.GetOwn(lookup(i))
}
```

Nothing observes the work, so the loop is only preserved because the callee does
not inline. That is a property of the callee, not of the benchmark, and it is
close to the edge:

```
(*PlainObject).GetOwn   cost 179  exceeds budget 80    <- what this benchmark calls
(*ArrayObject).GetOwn   cost  84  exceeds budget 80    <- four over
```

`(*ArrayObject).GetOwn` reached 84 having crossed that budget from 73 while this
benchmark was in the corpus. The sibling method has already made the trip this
benchmark's correctness depends on not making.

## To be clear about what is and is not broken

**The current numbers are fine.** `(*PlainObject).GetOwn` at 179 is not close to
inlining, so the loop is doing real work today and nothing measured so far needs
re-reading. This is insurance, not a repair.

What makes it worth taking anyway is the failure mode. If a future change brings
the callee under budget, the benchmark does not break loudly — it reports a large
improvement, which is exactly what a successful optimisation looks like. Eighteen
cases (six sizes × three access patterns) would go quiet at once, all in the
direction that reads as good news.

## What changed

Assign the results and `runtime.KeepAlive` them after the loop, so the work is
observed regardless of inlining. `KeepAlive` after the loop rather than inside it
keeps it out of the timed region.

Measured either way at `-benchtime 200000x`, `n=1` through `n=64`: unchanged, and
still 0 allocs. The escape costs nothing today, which is the point — it only ever
costs something on the day it starts mattering.

## Provenance

This has been in my fork's pinned benchmark corpus since 2026-08-06. The
companion escapes for `isobject_bench_test.go` and `tointeger_bench_test.go`
reached `main` already; this file was missed, which is why it is a PR on its own
rather than part of that change.
