### PR TITLE
fix(driver): compile package-level chunks against the builtins, not a bare compiler

### DIFF
--- a/pkg/driver/compile_chunk_test.go
+++ b/pkg/driver/compile_chunk_test.go
@@ -1,0 +1,121 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/builtins"
+	"github.com/nooga/paserati/pkg/lexer"
+	"github.com/nooga/paserati/pkg/parser"
+	"github.com/nooga/paserati/pkg/source"
+)
+
+func TestCompileStringChunkRunsOnFreshStandardSession(t *testing.T) {
+	chunk, compileErrs := CompileString(`const a = new Array(4); a.length;`)
+	if len(compileErrs) != 0 {
+		t.Fatalf("CompileString failed: %v", compileErrs)
+	}
+
+	result, runtimeErrs := NewPaserati().InterpretChunk(chunk)
+	if len(runtimeErrs) != 0 {
+		t.Fatalf("InterpretChunk failed: %v", runtimeErrs)
+	}
+	if got := result.ToString(); got != "4" {
+		t.Fatalf("expected 4, got %s", got)
+	}
+}
+
+func TestCompileFileChunkRunsOnFreshStandardSession(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "array.ts")
+	if err := os.WriteFile(filename, []byte(`const a = new Array(4); a.length;`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chunk, compileErrs := CompileFile(filename)
+	if len(compileErrs) != 0 {
+		t.Fatalf("CompileFile failed: %v", compileErrs)
+	}
+
+	result, runtimeErrs := NewPaserati().InterpretChunk(chunk)
+	if len(runtimeErrs) != 0 {
+		t.Fatalf("InterpretChunk failed: %v", runtimeErrs)
+	}
+	if got := result.ToString(); got != "4" {
+		t.Fatalf("expected 4, got %s", got)
+	}
+}
+
+func TestInterpretChunkRejectsCustomGlobalCollision(t *testing.T) {
+	chunk, compileErrs := CompileString(`let userGlobal = 1; userGlobal;`)
+	if len(compileErrs) != 0 {
+		t.Fatalf("CompileString failed: %v", compileErrs)
+	}
+
+	inits := append(builtins.GetStandardInitializers(), NewProcessInitializer(nil))
+	p := NewPaseratiWithInitializers(inits)
+	assertProcessGlobal(t, p)
+
+	_, runtimeErrs := p.InterpretChunk(chunk)
+	if len(runtimeErrs) != 1 || !strings.Contains(runtimeErrs[0].Error(), "incompatible global layout") {
+		t.Fatalf("expected incompatible-layout error, got %v", runtimeErrs)
+	}
+	assertProcessGlobal(t, p)
+}
+
+func TestInterpretChunkAllowsExtraCustomGlobalsWithoutCollision(t *testing.T) {
+	chunk, compileErrs := CompileString(`new Array(2).length;`)
+	if len(compileErrs) != 0 {
+		t.Fatalf("CompileString failed: %v", compileErrs)
+	}
+
+	inits := append(builtins.GetStandardInitializers(), NewProcessInitializer(nil))
+	p := NewPaseratiWithInitializers(inits)
+	result, runtimeErrs := p.InterpretChunk(chunk)
+	if len(runtimeErrs) != 0 {
+		t.Fatalf("InterpretChunk failed: %v", runtimeErrs)
+	}
+	if got := result.ToString(); got != "2" {
+		t.Fatalf("expected 2, got %s", got)
+	}
+	assertProcessGlobal(t, p)
+}
+
+func TestInterpretChunkAllowsMatchingCustomLayouts(t *testing.T) {
+	inits := append(builtins.GetStandardInitializers(), NewProcessInitializer(nil))
+	compilerSession := NewPaseratiWithInitializers(inits)
+	program := parseChunkTestProgram(t, `let userGlobal = 1; userGlobal;`)
+	chunk, compileErrs := compilerSession.CompileProgram(program)
+	if len(compileErrs) != 0 {
+		t.Fatalf("CompileProgram failed: %v", compileErrs)
+	}
+
+	runtimeSession := NewPaseratiWithInitializers(inits)
+	result, runtimeErrs := runtimeSession.InterpretChunk(chunk)
+	if len(runtimeErrs) != 0 {
+		t.Fatalf("InterpretChunk failed: %v", runtimeErrs)
+	}
+	if got := result.ToString(); got != "1" {
+		t.Fatalf("expected 1, got %s", got)
+	}
+	assertProcessGlobal(t, runtimeSession)
+}
+
+func assertProcessGlobal(t *testing.T, p *Paserati) {
+	t.Helper()
+	process, exists := p.GetVM().GetGlobal("process")
+	if !exists || !process.IsObject() {
+		t.Fatalf("process global was corrupted: value=%v exists=%v", process, exists)
+	}
+}
+
+func parseChunkTestProgram(t *testing.T, code string) *parser.Program {
+	t.Helper()
+	l := lexer.NewLexerWithSource(source.NewEvalSource(code))
+	p := parser.NewParser(l)
+	program, parseErrs := p.ParseProgram()
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse failed: %v", parseErrs)
+	}
+	return program
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -768,9 +768,15 @@ func CompileString(sourceCode string) (*vm.Chunk, []errors.PaseratiError) {
 	// --- Type Check is handled internally by Compile when no checker is set ---
 	// No need to call checker.Check() here.
 
-	comp := compiler.NewCompiler() // Fresh compiler
-	// Compile will create and use its own internal checker
-	chunk, compileAndTypeErrs := comp.Compile(program)
+	// A chunk's global indices are assigned by the compiler that produced it, so
+	// they are only meaningful against a VM whose globals were numbered the same
+	// way. A bare compiler.NewCompiler() has never seen the builtins, so it starts
+	// numbering user globals at 0 - straight over the slots NewPaserati() gives to
+	// Array, Map and friends. Compiling through an initialised instance numbers
+	// them behind the builtins, which is what every VM this chunk can run on
+	// expects. Builtin registration is deterministic, so the chunk stays portable
+	// across instances (#149).
+	chunk, compileAndTypeErrs := NewPaserati().CompileProgram(program)
 	if len(compileAndTypeErrs) > 0 {
 		return nil, compileAndTypeErrs
 	}
@@ -802,9 +808,15 @@ func CompileFile(filename string) (*vm.Chunk, []errors.PaseratiError) {
 	// Dump AST if enabled
 	parser.DumpAST(program, "CompileFile")
 
-	comp := compiler.NewCompiler() // Fresh compiler
-	// Compile will create and use its own internal checker
-	chunk, compileAndTypeErrs := comp.Compile(program)
+	// A chunk's global indices are assigned by the compiler that produced it, so
+	// they are only meaningful against a VM whose globals were numbered the same
+	// way. A bare compiler.NewCompiler() has never seen the builtins, so it starts
+	// numbering user globals at 0 - straight over the slots NewPaserati() gives to
+	// Array, Map and friends. Compiling through an initialised instance numbers
+	// them behind the builtins, which is what every VM this chunk can run on
+	// expects. Builtin registration is deterministic, so the chunk stays portable
+	// across instances (#149).
+	chunk, compileAndTypeErrs := NewPaserati().CompileProgram(program)
 	if len(compileAndTypeErrs) > 0 {
 		return nil, compileAndTypeErrs
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -55,6 +55,8 @@ type Paserati struct {
 	compiler         *compiler.Compiler
 	moduleLoader     modules.ModuleLoader
 	heapAlloc        *compiler.HeapAlloc   // Unified global heap allocator
+	builtinGlobals   []string              // Builtin names indexed by their unified heap slot
+	preparedChunk    *vm.Chunk             // Most recently checked chunk (avoids repeat validation without retaining every chunk)
 	nativeResolver   *NativeModuleResolver // *NativeModuleResolver - defined in native_module.go to avoid import cycles
 	ignoreTypeErrors bool                  // When true, type checking errors are ignored and compilation continues
 	skipTypeCheck    bool                  // When true, type checker is not run at all (for pure JS mode)
@@ -161,6 +163,8 @@ func (p *Paserati) Cleanup() {
 	p.compiler = nil
 	p.moduleLoader = nil
 	p.heapAlloc = nil
+	p.builtinGlobals = nil
+	p.preparedChunk = nil
 	p.nativeResolver = nil
 }
 
@@ -360,6 +364,10 @@ func (p *Paserati) CompileProgram(program *parser.Program) (*vm.Chunk, []errors.
 	p.compiler.SetIgnoreTypeErrors(p.ignoreTypeErrors)
 	p.compiler.SetSkipTypeCheck(p.skipTypeCheck)
 	chunk, errs := p.compiler.Compile(program)
+	if chunk != nil {
+		chunk.BuiltinGlobalNames = append([]string(nil), p.builtinGlobals...)
+		chunk.GlobalNames = indexedGlobalNames(p.heapAlloc.GetNameToIndexMap())
+	}
 	// Sync global names to VM so with statements can resolve global variable names
 	p.SyncGlobalNamesFromCompiler()
 	return chunk, errs
@@ -773,9 +781,9 @@ func CompileString(sourceCode string) (*vm.Chunk, []errors.PaseratiError) {
 	// way. A bare compiler.NewCompiler() has never seen the builtins, so it starts
 	// numbering user globals at 0 - straight over the slots NewPaserati() gives to
 	// Array, Map and friends. Compiling through an initialised instance numbers
-	// them behind the builtins, which is what every VM this chunk can run on
-	// expects. Builtin registration is deterministic, so the chunk stays portable
-	// across instances (#149).
+	// them behind the standard builtins. CompileProgram records that layout on the
+	// chunk so InterpretChunk can import compatible user mappings and reject a VM
+	// with colliding custom builtins before execution (#149).
 	chunk, compileAndTypeErrs := NewPaserati().CompileProgram(program)
 	if len(compileAndTypeErrs) > 0 {
 		return nil, compileAndTypeErrs
@@ -813,9 +821,9 @@ func CompileFile(filename string) (*vm.Chunk, []errors.PaseratiError) {
 	// way. A bare compiler.NewCompiler() has never seen the builtins, so it starts
 	// numbering user globals at 0 - straight over the slots NewPaserati() gives to
 	// Array, Map and friends. Compiling through an initialised instance numbers
-	// them behind the builtins, which is what every VM this chunk can run on
-	// expects. Builtin registration is deterministic, so the chunk stays portable
-	// across instances (#149).
+	// them behind the standard builtins. CompileProgram records that layout on the
+	// chunk so InterpretChunk can import compatible user mappings and reject a VM
+	// with colliding custom builtins before execution (#149).
 	chunk, compileAndTypeErrs := NewPaserati().CompileProgram(program)
 	if len(compileAndTypeErrs) > 0 {
 		return nil, compileAndTypeErrs
@@ -1425,7 +1433,96 @@ func (p *Paserati) GetCacheStats() vm.ExtendedCacheStats {
 
 // InterpretChunk executes a compiled chunk on the VM instance with initialized builtins
 func (p *Paserati) InterpretChunk(chunk *vm.Chunk) (vm.Value, []errors.PaseratiError) {
+	if err := p.prepareChunkGlobalLayout(chunk); err != nil {
+		return vm.Undefined, []errors.PaseratiError{err}
+	}
 	return p.vmInstance.Interpret(chunk)
+}
+
+// prepareChunkGlobalLayout verifies that the target session assigns every
+// compile-time builtin and global name to the same index as the chunk. New user
+// names can be imported into an unused target slot; an occupied or differently
+// indexed slot is rejected before any bytecode runs.
+func (p *Paserati) prepareChunkGlobalLayout(chunk *vm.Chunk) errors.PaseratiError {
+	if chunk == nil || len(chunk.GlobalNames) == 0 || p.heapAlloc == nil {
+		return nil
+	}
+	if p.preparedChunk == chunk {
+		return nil
+	}
+
+	targetNames := p.heapAlloc.GetNameToIndexMap()
+	targetByIndex := make(map[int]string, len(targetNames))
+	for name, idx := range targetNames {
+		targetByIndex[idx] = name
+	}
+
+	for idx, name := range chunk.BuiltinGlobalNames {
+		if name == "" {
+			continue
+		}
+		targetIdx, exists := targetNames[name]
+		if !exists || targetIdx != idx {
+			return incompatibleChunkGlobalLayout(idx, name, targetByIndex[idx])
+		}
+	}
+
+	for idx, name := range chunk.GlobalNames {
+		if name == "" {
+			continue
+		}
+		if targetIdx, exists := targetNames[name]; exists {
+			if targetIdx != idx {
+				return incompatibleChunkGlobalLayout(idx, name, targetByIndex[idx])
+			}
+			continue
+		}
+		if targetName, occupied := targetByIndex[idx]; occupied {
+			return incompatibleChunkGlobalLayout(idx, name, targetName)
+		}
+	}
+
+	for idx, name := range chunk.GlobalNames {
+		if name == "" {
+			continue
+		}
+		if _, exists := targetNames[name]; !exists {
+			p.heapAlloc.SetIndex(name, idx)
+		}
+	}
+	p.SyncGlobalNamesFromCompiler()
+	p.preparedChunk = chunk
+	return nil
+}
+
+func incompatibleChunkGlobalLayout(index int, chunkName, targetName string) errors.PaseratiError {
+	if targetName == "" {
+		targetName = "<unassigned>"
+	}
+	return &errors.RuntimeError{
+		Position: errors.Position{Line: 0, Column: 0},
+		Msg: fmt.Sprintf(
+			"cannot interpret chunk: incompatible global layout at index %d (chunk=%q, VM=%q)",
+			index, chunkName, targetName,
+		),
+	}
+}
+
+func indexedGlobalNames(nameToIndex map[string]int) []string {
+	maxIndex := -1
+	for _, idx := range nameToIndex {
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+	if maxIndex < 0 {
+		return nil
+	}
+	names := make([]string, maxIndex+1)
+	for name, idx := range nameToIndex {
+		names[idx] = name
+	}
+	return names
 }
 
 // initializeBuiltins sets up all builtin global variables in both the compiler and VM
@@ -1506,6 +1603,7 @@ func initializeBuiltinsWithCustom(paserati *Paserati, initializers []builtins.Bu
 	if err := vmInstance.SetBuiltinGlobals(globalVariables, indexMap); err != nil {
 		return err
 	}
+	paserati.builtinGlobals = indexedGlobalNames(indexMap)
 
 	return nil
 }

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -792,6 +792,12 @@ type Chunk struct {
 	Constants      []Value            // Constant pool (Now uses Value from vm package)
 	Lines          []int              // Line number for each byte in Code (parallel array)
 	ExceptionTable []ExceptionHandler // Exception handlers for try/catch blocks
+	// BuiltinGlobalNames and GlobalNames record the compiler's indexed global
+	// layout. InterpretChunk consumers use them to reject incompatible VMs before
+	// bytecode can read or overwrite a different binding at the same index.
+	// Empty metadata denotes a legacy chunk whose layout is unknown.
+	BuiltinGlobalNames []string
+	GlobalNames        []string
 	IsStrict              bool               // Whether this chunk runs in strict mode
 	HasSimpleParameterList bool              // True if all params are plain identifiers (no defaults, rest, or destructuring)
 	ScopeDesc             *ScopeDescriptor   // Scope info for direct eval (nil if not needed)


### PR DESCRIPTION
Fixes #149.

`CompileString` and `CompileFile` compile through `compiler.NewCompiler()` — a bare
compiler that has never registered the builtins. Global indices are assigned by
the compiler that produces the chunk, so that compiler starts numbering user
globals at 0, straight over the slots `NewPaserati()` gives to `Array`, `Map` and
friends. Run the resulting chunk on any real VM and a builtin reference resolves
to whatever now occupies that index:

```go
chunk, _ := driver.CompileString("const a = new Array(4); a.length;")
driver.NewPaserati().InterpretChunk(chunk)
// TypeError: object is not a constructor
```

Compiling through an initialised instance numbers user globals behind the standard
builtins. The chunk now records both its builtin layout and full global layout so
`InterpretChunk` can import compatible user mappings into a fresh session.
Standard chunks therefore remain portable across standard instances, and chunks
compiled with the same custom initializers remain portable across matching custom
instances.

A standard chunk can also run on a custom-initializer session when it only uses
the shared standard slots. If a chunk's user global would instead collide with a
custom builtin such as `process`, `InterpretChunk` rejects the incompatible
layout before executing any bytecode rather than silently overwriting the host
global.

## Why it surfaced now

The two numbering schemes only ever agreed by coincidence, and `983e308c` changed
global keying (`GetOrAssignGlobalIndex(name)` → `GetOrAssignGlobalIndex(
c.moduleGlobalKey(name))`) enough to break the agreement. Nothing about that
change is wrong; it disturbed an alignment that was never guaranteed.

I bisected to it rather than inferring it: `61fde8bb` passes, `983e308c` is the
first failure, `git bisect run` over the 34 commits between.

## Blast radius

`BenchmarkSetIndex` has been failing on `main` since 2026-08-30 — it is the only
corpus benchmark that constructs a builtin, which is why the others stayed green
and hid it. Anything embedding paserati through the package-level compile
functions is affected the same way.

**CI cannot see this.** Benchmarks only run under `-bench`, which `ci.yml` does not
pass, so `go test ./tests` and `go test ./pkg/...` are both green on the tip. That
is the part I would fix next, separately — a `-bench . -benchtime 1x` smoke step
costs seconds and would have caught it the day it landed. Happy to send that if
you want it.

## Verification

- The original `CompileString` repro returns `4` with no runtime errors.
- The equivalent `CompileFile` path also returns `4` on a fresh standard
  session.
- A conflicting standard-chunk/custom-builtin layout is rejected before execution,
  with the `process` global left intact.
- Non-conflicting standard/custom layouts and matching custom layouts execute
  successfully.
- `BenchmarkSetIndex` runs again; `Factorial`, `Add`, `Arith`, and `MatrixMult`
  are unaffected.
- `go test ./tests` and `go test ./pkg/...` are green locally.
- GitHub CI is green on Linux, macOS, and Windows, including lint.
