### PR TITLE
ci: run each benchmark once, so a broken benchmark fails the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       # otherwise is how a perf check becomes a flaky check people learn to
       # ignore.
       - name: Benchmark smoke
-        run: go test -run '^$' -bench . -benchtime 1x ./pkg/vm ./tests
+        run: go test -run '^$' -bench . -benchtime 1x ./pkg/compiler ./pkg/modules ./pkg/vm ./tests
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,19 @@ jobs:
       - name: Test
         run: go test ./...
 
+      # Benchmarks are not run by `go test ./...` - it needs -bench - so a
+      # benchmark that stops working is invisible to every other check here.
+      # BenchmarkSetIndex was broken on main from 2026-08-30 while CI stayed
+      # green (#149).
+      #
+      # -benchtime 1x is deliberate: one iteration each, so this asks "does every
+      # benchmark still run?" and takes seconds. It is NOT a performance gate.
+      # Shared runners are far too noisy to gate timings on (#21), and pretending
+      # otherwise is how a perf check becomes a flaky check people learn to
+      # ignore.
+      - name: Benchmark smoke
+        run: go test -run '^$' -bench . -benchtime 1x ./pkg/vm ./tests
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`go test ./...` does not run benchmarks — that needs `-bench` — so a benchmark
that stops working is invisible to every check in CI. `BenchmarkSetIndex` has been
broken on `main` since 2026-08-30 with the whole pipeline green (#149, fix in
#151).

This adds one step that runs every benchmark exactly once.

## Expect this PR's own CI to fail

It does, right now, on `main`:

```
--- FAIL: BenchmarkSetIndex
FAIL    github.com/nooga/paserati/tests
```

That is the demonstration rather than a problem with the change — the step is
catching the live bug it was written for. **Merge #151 first and this goes
green.** I have deliberately not based this on #151 so the two stay independently
reviewable.

## Why `-benchtime 1x`, and what this is not

One iteration per benchmark. The question it asks is "does every benchmark still
run?", and it costs seconds.

**It is not a performance gate, and should not become one.** Shared runners are
far too noisy to gate timings on — measured on this repo, a no-op PR produced
deltas up to 26.8% on memory-bound families while the anchor never moved more
than 0.1% (#21). A perf check that fails randomly is a check people learn to
ignore, which is worse than no check. Timing belongs on the dedicated lanes;
this step only asks whether the code still executes.

## Scope

`./pkg/compiler`, `./pkg/modules`, `./pkg/vm`, and `./tests`, which is where the
benchmarks live. If a future package adds benchmarks it needs adding here — the
alternative, `./...`, would compile every package's test binary for no benefit.
