### PR TITLE
fix: #147, #148, #115 — and the object-conversion protocol behind them

### DIFF
--- a/cmd/paserati/main.go
+++ b/cmd/paserati/main.go
@@ -195,7 +195,7 @@ func runFileWithTypes(filename string, scriptArgs []string, showCacheStats bool,
 		paserati.SetSkipTypeCheck(true)
 	}
 
-	options := driver.RunOptions{ShowCacheStats: showCacheStats, ShowBytecode: showBytecode, ModuleName: filename, DisasmFilter: disasmFilter}
+	options := driver.RunOptions{ShowCacheStats: showCacheStats, ShowBytecode: showBytecode, ModuleName: filename, Filename: filename, DisasmFilter: disasmFilter}
 	value, errs := paserati.RunCode(source, options)
 	ok := paserati.DisplayResult(source, value, errs)
 	if !ok {

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -2559,8 +2559,11 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Check if asyncItems is undefined or null
 		if asyncItems.Type() == vm.TypeUndefined || asyncItems.Type() == vm.TypeNull {
 			// Return a rejected promise with TypeError
+			// Reject with the real TypeError object, not its message string
+			// (#147): vm.NewString(reason.Error()) handed .catch() a bare
+			// string, so e instanceof TypeError and e.message were both wrong.
 			reason := vmInstance.NewTypeError("Cannot convert undefined or null to object")
-			return vmInstance.NewRejectedPromise(vm.NewString(reason.Error())), nil
+			return vmInstance.NewRejectedPromise(vmInstance.ExceptionValueFromError(reason)), nil
 		}
 
 		// Get mapfn (optional)
@@ -2578,7 +2581,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// If mapfn is not undefined and not callable, throw TypeError
 		if mapfn.Type() != vm.TypeUndefined && !mapfn.IsCallable() {
 			reason := vmInstance.NewTypeError(fmt.Sprintf("%s is not a function", mapfn.Type().String()))
-			return vmInstance.NewRejectedPromise(vm.NewString(reason.Error())), nil
+			return vmInstance.NewRejectedPromise(vmInstance.ExceptionValueFromError(reason)), nil
 		}
 
 		// Get C (the this value - for subclass support)

--- a/pkg/builtins/async_generator_init.go
+++ b/pkg/builtins/async_generator_init.go
@@ -95,11 +95,7 @@ func (g *AsyncGeneratorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			vmInstance.ClearErrors()
 
 			// Extract exception value and wrap in rejected promise
-			if ee, ok := err.(vm.ExceptionError); ok {
-				return vmInstance.NewRejectedPromise(ee.GetExceptionValue()), nil
-			}
-			// Fallback for other errors
-			return vmInstance.NewRejectedPromise(vm.NewString(err.Error())), nil
+			return vmInstance.NewRejectedPromise(vmInstance.ExceptionValueFromError(err)), nil
 		}
 
 		return vmInstance.NewResolvedPromise(result), nil

--- a/pkg/builtins/date_init.go
+++ b/pkg/builtins/date_init.go
@@ -1248,45 +1248,37 @@ func (d *DateInitializer) InitRuntime(ctx *RuntimeContext) error {
 			// new Date() - current time
 			timestamp = float64(time.Now().UnixMilli())
 		} else if len(args) == 1 {
+			// Per ECMAScript 21.4.2.1 step 3: a Date argument is copied from its
+			// own [[DateValue]]; anything else goes through ToPrimitive first,
+			// and only *then* is a String parsed as a date and everything else
+			// run through ToNumber.
+			//
+			// The ToPrimitive step used to be missing for object arguments: they
+			// went straight to arg.ToString(), so new Date({valueOf: () => 0})
+			// and new Date([0]) tried to parse "[object Object]" / "0" as a date
+			// string instead of converting through valueOf, and the prototype's
+			// valueOf/toString were never consulted at all. The same shortcut in
+			// Number() is fixed alongside this.
 			arg := args[0]
-			if arg.IsNumber() {
-				// new Date(timestamp)
-				timestamp = arg.ToFloat()
-			} else if arg.IsObject() {
-				// Check if it's a Date object by looking for __timestamp__
-				if ts, ok := getDateTimestamp(arg); ok {
-					// new Date(dateObject) - copy constructor
-					timestamp = ts
-				} else {
-					// Not a Date object, try string parsing
-					dateStr := arg.ToString()
-					if parsedTime, err := time.Parse(time.RFC3339, dateStr); err == nil {
-						timestamp = float64(parsedTime.UnixMilli())
-					} else if parsedTime, err := time.Parse("2006-01-02", dateStr); err == nil {
-						// Date-only format per ECMAScript spec defaults to UTC
-						timestamp = float64(parsedTime.UTC().UnixMilli())
-					} else if parsedTime, err := time.Parse("2006", dateStr); err == nil {
-						// Year-only format per ECMAScript spec defaults to January 1st UTC
-						timestamp = float64(parsedTime.UTC().UnixMilli())
-					} else {
-						// Invalid date string - use NaN to indicate invalid date
-						timestamp = float64(0x7FF8000000000000) // NaN value
+			if ts, ok := getDateTimestamp(arg); ok {
+				// new Date(dateObject) - copy constructor
+				timestamp = ts
+			} else {
+				if arg.IsObject() || arg.IsCallable() {
+					vmInstance.EnterHelperCall()
+					arg = vmInstance.ToPrimitive(arg, "default")
+					vmInstance.ExitHelperCall()
+					if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
+						return vm.Undefined, nil
 					}
 				}
-			} else {
-				// new Date(dateString) - simplified parsing
-				dateStr := arg.ToString()
-				if parsedTime, err := time.Parse(time.RFC3339, dateStr); err == nil {
-					timestamp = float64(parsedTime.UnixMilli())
-				} else if parsedTime, err := time.Parse("2006-01-02", dateStr); err == nil {
-					// Date-only format per ECMAScript spec defaults to UTC
-					timestamp = float64(parsedTime.UTC().UnixMilli())
-				} else if parsedTime, err := time.Parse("2006", dateStr); err == nil {
-					// Year-only format per ECMAScript spec defaults to January 1st UTC
-					timestamp = float64(parsedTime.UTC().UnixMilli())
+				if arg.Type() == vm.TypeString {
+					timestamp = parseDateString(arg.ToString())
 				} else {
-					// Invalid date string - use NaN to indicate invalid date
-					timestamp = math.NaN()
+					// ToNumber for every other primitive, so new Date(true),
+					// new Date(null) and new Date(1n) follow the same rule as
+					// new Date(0) rather than being parsed as text.
+					timestamp = vmInstance.ToNumber(arg)
 				}
 			}
 		} else {
@@ -1548,6 +1540,29 @@ func thisTimeValue(vmInstance *vm.VM, dateValue vm.Value) (float64, error) {
 
 // getDateTimestamp is a legacy helper that returns (timestamp, ok).
 // For new code, prefer thisTimeValue which properly throws TypeError.
+// parseDateString turns a date string into a timestamp, returning NaN for
+// anything it cannot parse - the spec's "unrecognizable String" result. Shared
+// by the Date constructor and Date.parse so the two cannot drift.
+//
+// It also replaces a float64(0x7FF8000000000000) that used to stand in for NaN
+// on one of the two paths: that converts the bit pattern as an *integer*,
+// producing ~9.22e18 rather than a NaN, which is why new Date(someObject)
+// reported a huge timestamp instead of an Invalid Date.
+func parseDateString(dateStr string) float64 {
+	if parsedTime, err := time.Parse(time.RFC3339, dateStr); err == nil {
+		return float64(parsedTime.UnixMilli())
+	}
+	// Date-only format per ECMAScript spec defaults to UTC
+	if parsedTime, err := time.Parse("2006-01-02", dateStr); err == nil {
+		return float64(parsedTime.UTC().UnixMilli())
+	}
+	// Year-only format per ECMAScript spec defaults to January 1st UTC
+	if parsedTime, err := time.Parse("2006", dateStr); err == nil {
+		return float64(parsedTime.UTC().UnixMilli())
+	}
+	return math.NaN()
+}
+
 func getDateTimestamp(dateValue vm.Value) (float64, bool) {
 	if dateValue.Type() == vm.TypeObject {
 		obj := dateValue.AsPlainObject()

--- a/pkg/builtins/date_init.go
+++ b/pkg/builtins/date_init.go
@@ -1334,36 +1334,8 @@ func (d *DateInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if len(args) < 1 {
 			return vm.NaN, nil
 		}
-		dateStr := args[0].ToString()
-
-		// Try common date formats (UTC formats first per ECMAScript spec)
-		// Year-only and date-only formats default to UTC
-		if parsedTime, err := time.Parse(time.RFC3339, dateStr); err == nil {
-			return vm.NumberValue(float64(parsedTime.UnixMilli())), nil
-		}
-		if parsedTime, err := time.Parse("2006-01-02T15:04:05Z", dateStr); err == nil {
-			return vm.NumberValue(float64(parsedTime.UnixMilli())), nil
-		}
-		if parsedTime, err := time.Parse("2006-01-02", dateStr); err == nil {
-			// Date-only per spec defaults to UTC
-			return vm.NumberValue(float64(parsedTime.UTC().UnixMilli())), nil
-		}
-		if parsedTime, err := time.Parse("2006", dateStr); err == nil {
-			// Year-only per spec defaults to January 1st UTC
-			return vm.NumberValue(float64(parsedTime.UTC().UnixMilli())), nil
-		}
-		// Try other common formats (local time)
-		otherFormats := []string{
-			"01/02/2006",
-			"January 2, 2006",
-		}
-		for _, format := range otherFormats {
-			if parsedTime, err := time.Parse(format, dateStr); err == nil {
-				return vm.NumberValue(float64(parsedTime.UnixMilli())), nil
-			}
-		}
-
-		return vm.NaN, nil // Invalid date
+		// Same ladder as new Date(string) - see parseDateString.
+		return vm.NumberValue(parseDateString(args[0].ToString())), nil
 	}))
 
 	ctorWithProps.AsNativeFunctionWithProps().Properties.SetOwnNonEnumerable("UTC", vm.NewNativeFunction(7, true, "UTC", func(args []vm.Value) (vm.Value, error) {
@@ -1541,24 +1513,40 @@ func thisTimeValue(vmInstance *vm.VM, dateValue vm.Value) (float64, error) {
 // getDateTimestamp is a legacy helper that returns (timestamp, ok).
 // For new code, prefer thisTimeValue which properly throws TypeError.
 // parseDateString turns a date string into a timestamp, returning NaN for
-// anything it cannot parse - the spec's "unrecognizable String" result. Shared
-// by the Date constructor and Date.parse so the two cannot drift.
+// anything it cannot parse - the spec's "unrecognizable String" result.
 //
-// It also replaces a float64(0x7FF8000000000000) that used to stand in for NaN
-// on one of the two paths: that converts the bit pattern as an *integer*,
-// producing ~9.22e18 rather than a NaN, which is why new Date(someObject)
-// reported a huge timestamp instead of an Invalid Date.
+// Shared by `new Date(string)` and Date.parse, which per spec 21.4.3.2 must
+// accept exactly the same formats. They did not: the constructor had its own
+// shorter ladder, so new Date("01/02/2006") and new Date("January 2, 2006")
+// were Invalid Date while Date.parse of the same strings worked.
+//
+// It also replaces a float64(0x7FF8000000000000) the constructor used to store
+// for an unparseable string: that converts the NaN bit pattern as an *integer*,
+// producing ~9.22e18 rather than a NaN, so the result read as a real timestamp
+// instead of an Invalid Date.
 func parseDateString(dateStr string) float64 {
+	// UTC formats first per ECMAScript spec; year-only and date-only default to UTC.
 	if parsedTime, err := time.Parse(time.RFC3339, dateStr); err == nil {
 		return float64(parsedTime.UnixMilli())
 	}
-	// Date-only format per ECMAScript spec defaults to UTC
+	if parsedTime, err := time.Parse("2006-01-02T15:04:05Z", dateStr); err == nil {
+		return float64(parsedTime.UnixMilli())
+	}
 	if parsedTime, err := time.Parse("2006-01-02", dateStr); err == nil {
 		return float64(parsedTime.UTC().UnixMilli())
 	}
-	// Year-only format per ECMAScript spec defaults to January 1st UTC
 	if parsedTime, err := time.Parse("2006", dateStr); err == nil {
+		// Year-only defaults to January 1st UTC
 		return float64(parsedTime.UTC().UnixMilli())
+	}
+	// Other common formats, interpreted as local time.
+	for _, format := range []string{
+		"01/02/2006",
+		"January 2, 2006",
+	} {
+		if parsedTime, err := time.Parse(format, dateStr); err == nil {
+			return float64(parsedTime.UnixMilli())
+		}
 	}
 	return math.NaN()
 }

--- a/pkg/builtins/disposable_stack_init.go
+++ b/pkg/builtins/disposable_stack_init.go
@@ -18,10 +18,7 @@ import (
 // vmInstance.Call/native helpers, falling back to a plain string for Go
 // errors that never went through the exception machinery.
 func exceptionValue(vmInstance *vm.VM, err error) vm.Value {
-	if ee, ok := err.(vm.ExceptionError); ok {
-		return ee.GetExceptionValue()
-	}
-	return vm.NewString(err.Error())
+	return vmInstance.ExceptionValueFromError(err)
 }
 
 // newSuppressedError builds a SuppressedError instance directly against the

--- a/pkg/builtins/number_init.go
+++ b/pkg/builtins/number_init.go
@@ -587,11 +587,23 @@ func (n *NumberInitializer) InitRuntime(ctx *RuntimeContext) error {
 		} else {
 			arg := args[0]
 
-			// Handle boxed primitives by extracting primitive value
-			if arg.Type() == vm.TypeObject {
-				obj := arg.AsPlainObject()
-				if primVal, found := obj.GetOwn("[[PrimitiveValue]]"); found && primVal != vm.Undefined {
-					arg = primVal
+			// Convert an object argument the way the spec does: ToNumber(obj)
+			// is ToNumber(ToPrimitive(obj, number)). This used to reach into
+			// [[PrimitiveValue]] for a wrapper and fall through to NaN for
+			// everything else, which meant Number(obj) never converted an
+			// ordinary object at all - Number([5]), Number(new Date(0)) and
+			// Number({valueOf: () => 7}) were all NaN - while unary + on the
+			// same values was correct, because that path goes through the VM's
+			// own ToPrimitive. Reading the slot directly also skipped the
+			// prototype's valueOf/toString entirely, so an override of either
+			// was ignored and the spec's "throw TypeError when neither is
+			// callable" never fired (#115's second half).
+			if arg.IsObject() || arg.IsCallable() {
+				vmInstance.EnterHelperCall()
+				arg = vmInstance.ToPrimitive(arg, "number")
+				vmInstance.ExitHelperCall()
+				if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
+					return vm.Undefined, nil
 				}
 			}
 

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -951,46 +951,30 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			wrapper := vm.NewObject(vmInstance.BigIntPrototype).AsPlainObject()
 			// Store the primitive value internally
 			wrapper.SetOwnNonEnumerable("[[PrimitiveValue]]", arg)
-			// Add valueOf method that returns the primitive
-			wrapper.SetOwnNonEnumerable("valueOf", vm.NewNativeFunction(0, false, "valueOf", func(args []vm.Value) (vm.Value, error) {
-				return arg, nil
-			}))
 			return vm.NewValueFromPlainObject(wrapper), nil
 
 		case vm.TypeFloatNumber, vm.TypeIntegerNumber:
 			// Create Number wrapper object
 			wrapper := vm.NewObject(vmInstance.NumberPrototype).AsPlainObject()
 			wrapper.SetOwnNonEnumerable("[[PrimitiveValue]]", arg)
-			wrapper.SetOwnNonEnumerable("valueOf", vm.NewNativeFunction(0, false, "valueOf", func(args []vm.Value) (vm.Value, error) {
-				return arg, nil
-			}))
 			return vm.NewValueFromPlainObject(wrapper), nil
 
 		case vm.TypeString:
 			// Create String wrapper object
 			wrapper := vm.NewObject(vmInstance.StringPrototype).AsPlainObject()
 			wrapper.SetOwnNonEnumerable("[[PrimitiveValue]]", arg)
-			wrapper.SetOwnNonEnumerable("valueOf", vm.NewNativeFunction(0, false, "valueOf", func(args []vm.Value) (vm.Value, error) {
-				return arg, nil
-			}))
 			return vm.NewValueFromPlainObject(wrapper), nil
 
 		case vm.TypeBoolean:
 			// Create Boolean wrapper object
 			wrapper := vm.NewObject(vmInstance.BooleanPrototype).AsPlainObject()
 			wrapper.SetOwnNonEnumerable("[[PrimitiveValue]]", arg)
-			wrapper.SetOwnNonEnumerable("valueOf", vm.NewNativeFunction(0, false, "valueOf", func(args []vm.Value) (vm.Value, error) {
-				return arg, nil
-			}))
 			return vm.NewValueFromPlainObject(wrapper), nil
 
 		case vm.TypeSymbol:
 			// Create Symbol wrapper object
 			wrapper := vm.NewObject(vmInstance.SymbolPrototype).AsPlainObject()
 			wrapper.SetOwnNonEnumerable("[[PrimitiveValue]]", arg)
-			wrapper.SetOwnNonEnumerable("valueOf", vm.NewNativeFunction(0, false, "valueOf", func(args []vm.Value) (vm.Value, error) {
-				return arg, nil
-			}))
 			return vm.NewValueFromPlainObject(wrapper), nil
 
 		default:

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -821,8 +821,9 @@ func (c *Compiler) GetModuleExports() map[string]vm.Value {
 func newFunctionCompiler(enclosingCompiler *Compiler) *Compiler {
 	// Pass the checker and module bindings down to nested compilers
 	chunk := vm.NewChunk()
-	// Inherit strict mode from enclosing compiler
+	// Inherit strict mode and the source file from enclosing compiler
 	chunk.IsStrict = enclosingCompiler.chunk.IsStrict
+	chunk.Source = enclosingCompiler.chunk.Source
 	return &Compiler{
 		chunk:                    chunk,
 		regAlloc:                 NewRegisterAllocator(),
@@ -924,6 +925,10 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 
 	// --- Bytecode Compilation Step ---
 	c.chunk = vm.NewChunk()
+	// Remember which file this bytecode came from, so a runtime error raised
+	// while executing it can quote that file rather than the entry script
+	// (#148). Nested function compilers inherit it in newFunctionCompiler.
+	c.chunk.Source = program.Source
 	c.regAlloc = NewRegisterAllocator()
 	c.currentSymbolTable = NewSymbolTable()
 	c.allLocalNames = make(map[Register]string) // Reset local name tracking

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1374,7 +1374,16 @@ func scriptFilename(options RunOptions) string {
 // Module mode is the default; set Script to run as a Script (see RunScript).
 func (p *Paserati) RunCode(sourceCode string, options RunOptions) (vm.Value, []errors.PaseratiError) {
 	sourceFile := source.NewEvalSource(sourceCode)
-	if options.Script {
+	// Name the source after the file it came from whenever the caller told us
+	// one, in module mode as well as Script mode. Errors raised while running
+	// it now carry this SourceFile (#148), so leaving it as "<eval>" would
+	// label a file the user ran by name with a placeholder. Callers that
+	// genuinely have no file (the REPL, -e) set neither field and keep
+	// "<eval>"; ModuleName alone is not enough, since it is often a synthetic
+	// specifier rather than a path.
+	if filename := options.Filename; filename != "" {
+		sourceFile = source.NewSourceFile(filepath.Base(filename), filename, sourceCode)
+	} else if options.Script {
 		filename := scriptFilename(options)
 		sourceFile = source.NewSourceFile(filepath.Base(filename), filename, sourceCode)
 	}

--- a/pkg/driver/error_position_test.go
+++ b/pkg/driver/error_position_test.go
@@ -1,0 +1,131 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	paseratiErrors "github.com/nooga/paserati/pkg/errors"
+)
+
+// positionOfDiagnostic recovers a diagnostic's structured position.
+func positionOfDiagnostic(err error) (paseratiErrors.Position, bool) {
+	return paseratiErrors.PositionOf(err)
+}
+
+// runFileForErrors runs a file the way cmd/paserati does - module mode, with
+// the entry's own filename supplied - and returns the diagnostics without
+// printing anything. dir becomes the module resolver's base.
+func runFileForErrors(t *testing.T, dir, name string) []error {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	p := NewPaseratiWithBaseDir(dir)
+	_, errs := p.RunCode(string(src), RunOptions{ModuleName: name, Filename: path})
+	out := make([]error, len(errs))
+	for i, e := range errs {
+		out[i] = e
+	}
+	return out
+}
+
+// TestModuleLoadFailureReportsFailingModulePosition covers #148: when an
+// imported module fails to compile, the reported error's *structured* position
+// - the one errors.DisplayErrors renders its caret and source snippet against
+// - must point at the failing module's own line, column and file. It used to be
+// synthesized from the importing frame's bytecode with the column hardcoded to
+// 1 and no Source attached at all, so the snippet came from the entry script
+// (via DisplayErrors' fallbackSource) even though the message text alongside it
+// already named the module's real 4:11.
+func TestModuleLoadFailureReportsFailingModulePosition(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.ts")
+	entry := filepath.Join(dir, "entry.ts")
+	mustWrite(t, bad, "export const ok = 1;\nexport const also = 2;\nexport function broken() {\n  return (;\n}\n")
+	mustWrite(t, entry, "import { ok } from \"./bad.ts\";\nok;\n")
+
+	errs := runFileForErrors(t, dir, "entry.ts")
+	if len(errs) == 0 {
+		t.Fatal("expected a diagnostic for the unparseable module, got none")
+	}
+	pos, ok := positionOfDiagnostic(errs[0])
+	if !ok {
+		t.Fatalf("diagnostic carries no position: %v", errs[0])
+	}
+	if pos.Source == nil {
+		t.Fatalf("diagnostic has no Source, so DisplayErrors would fall back to the entry script: %v", errs[0])
+	}
+	if got := pos.Source.DisplayPath(); filepath.Base(got) != "bad.ts" {
+		t.Errorf("snippet would come from %q, want the failing module bad.ts", got)
+	}
+	if pos.Line != 4 || pos.Column != 11 {
+		t.Errorf("position is %d:%d, want 4:11 (the `return (;` in bad.ts)", pos.Line, pos.Column)
+	}
+	// The message already named the real location before this fix; make sure
+	// it still does, so the two can't drift apart again.
+	if !strings.Contains(errs[0].Error(), "4:11") {
+		t.Errorf("message no longer names the real location: %v", errs[0])
+	}
+}
+
+// TestRuntimeErrorInsideModuleReportsThatModulesSource covers the other half of
+// #148: a runtime exception thrown inside an imported module reported a line
+// number from that module's own line table but no Source, so DisplayErrors
+// quoted that line number out of the entry script instead.
+func TestRuntimeErrorInsideModuleReportsThatModulesSource(t *testing.T) {
+	dir := t.TempDir()
+	lib := filepath.Join(dir, "lib.ts")
+	entry := filepath.Join(dir, "entry.ts")
+	mustWrite(t, lib, "export function boom(): number {\n  const o: any = null;\n  return o.x;\n}\n")
+	// Padding statements so a position taken from the entry script would land
+	// on a different line than the one in lib.ts, making a mix-up visible.
+	mustWrite(t, entry, "import { boom } from \"./lib.ts\";\nconst a = 1;\nconst b = 2;\nconst c = 3;\nboom();\n")
+
+	errs := runFileForErrors(t, dir, "entry.ts")
+	if len(errs) == 0 {
+		t.Fatal("expected a runtime diagnostic, got none")
+	}
+	pos, ok := positionOfDiagnostic(errs[0])
+	if !ok {
+		t.Fatalf("diagnostic carries no position: %v", errs[0])
+	}
+	if pos.Source == nil {
+		t.Fatalf("diagnostic has no Source, so DisplayErrors would quote the entry script: %v", errs[0])
+	}
+	if got := pos.Source.DisplayPath(); filepath.Base(got) != "lib.ts" {
+		t.Errorf("snippet would come from %q, want the throwing module lib.ts", got)
+	}
+	if pos.Line != 3 {
+		t.Errorf("position is line %d, want 3 (`return o.x;` in lib.ts)", pos.Line)
+	}
+}
+
+// TestEvalSourceStaysAnonymous guards the other direction: a caller with no
+// file (the REPL, paserati -e) must keep the "<eval>" identity rather than
+// borrowing a name from ModuleName, which is often a synthetic specifier.
+func TestEvalSourceStaysAnonymous(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	_, errs := p.RunCode("const o = null; o.x;", RunOptions{})
+	if len(errs) == 0 {
+		t.Fatal("expected a runtime diagnostic, got none")
+	}
+	pos, ok := positionOfDiagnostic(errs[0])
+	if !ok {
+		t.Fatalf("diagnostic carries no position: %v", errs[0])
+	}
+	if pos.Source != nil && pos.Source.DisplayPath() != "<eval>" {
+		t.Errorf("eval'd code took on the identity %q", pos.Source.DisplayPath())
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}

--- a/pkg/driver/host_async_function_test.go
+++ b/pkg/driver/host_async_function_test.go
@@ -3,6 +3,8 @@ package driver
 import (
 	"errors"
 	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
 )
 
 func TestHostAsyncFunctionReturnsPromise(t *testing.T) {
@@ -56,5 +58,55 @@ func TestHostAsyncFunctionRejectsOnError(t *testing.T) {
 	}
 	if result.ToString() != "caught" {
 		t.Errorf("expected catch of rejected promise, got %v", result.ToString())
+	}
+}
+
+// richExceptionError is a host-supplied Go error that carries a real JS value,
+// exactly the shape a host uses to throw a Node-style SystemError with .code /
+// .errno / .syscall attached (noderati's fs/promises is the motivating case).
+type richExceptionError struct{ v vm.Value }
+
+func (e *richExceptionError) Error() string               { return "boom" }
+func (e *richExceptionError) GetExceptionValue() vm.Value { return e.v }
+
+// TestHostAsyncFunctionRejectsWithRealExceptionValue covers #147: an
+// AsyncFunction's Go error that implements vm.ExceptionError must reject the
+// promise with the *real* value it carries, the way the synchronous
+// ModuleBuilder.Function path already throws it. It used to be flattened to
+// vm.NewString(err.Error()), so a rejection handler received a bare JS string
+// and every property the host had put on its Error object was gone.
+func TestHostAsyncFunctionRejectsWithRealExceptionValue(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	newRich := func() error {
+		vmInst := p.GetVM()
+		obj := vm.NewObject(vmInst.ErrorPrototype).AsPlainObject()
+		obj.SetOwn("name", vm.NewString("Error"))
+		obj.SetOwn("message", vm.NewString("no such file or directory"))
+		obj.SetOwn("code", vm.NewString("ENOENT"))
+		return &richExceptionError{v: vm.NewValueFromPlainObject(obj)}
+	}
+
+	p.DeclareModule("io", func(m *ModuleBuilder) {
+		m.Function("statSync", func() (interface{}, error) { return nil, newRich() })
+		m.AsyncFunction("stat", func() (interface{}, error) { return nil, newRich() })
+	})
+
+	js := `
+		import { stat, statSync } from "io";
+		let sync = "no-throw";
+		try { statSync(); } catch (e) { sync = typeof e + ":" + e.code; }
+		let async = "no-throw";
+		try { await stat(); } catch (e) { async = typeof e + ":" + e.code; }
+		sync + "|" + async
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	// Both paths must agree, and both must hand back the real Error object.
+	if got := result.ToString(); got != "object:ENOENT|object:ENOENT" {
+		t.Errorf("sync|async rejection value mismatch: got %q, want %q", got, "object:ENOENT|object:ENOENT")
 	}
 }

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -152,7 +152,13 @@ func wrapNativeAsAsync(vmInst *vm.VM, name string, inner vm.Value) vm.Value {
 	return vm.NewNativeFunction(arity, variadic, name, func(args []vm.Value) (vm.Value, error) {
 		result, err := vmInst.Call(inner, vm.Undefined, args)
 		if err != nil {
-			return vmInst.NewRejectedPromise(vm.NewString(err.Error())), nil
+			// Reject with the real thrown value when the inner function threw
+			// one (#147). Flattening it to vm.NewString(err.Error()) used to
+			// drop everything a host had built onto its Error object - .code,
+			// .errno, .syscall - so an async native API's rejection reason
+			// arrived in .catch() as a bare string while its synchronous
+			// counterpart, built the identical way, threw the real object.
+			return vmInst.NewRejectedPromise(vmInst.ExceptionValueFromError(err)), nil
 		}
 		return vmInst.NewResolvedPromise(result), nil
 	})

--- a/pkg/errors/positioned.go
+++ b/pkg/errors/positioned.go
@@ -1,0 +1,77 @@
+package errors
+
+// PositionedError carries a PaseratiError - and therefore its structured
+// Position, including the Source file it came from - across an API boundary
+// that only speaks the standard `error` interface.
+//
+// It exists because stringifying a diagnostic with
+// fmt.Errorf("<prefix>: %s", diag.Error()) is lossy in a way that isn't
+// visible until much later: the message keeps the real "line:column" as text,
+// but the structured position - the only thing errors.DisplayErrors can
+// actually render a caret and a source snippet against - is gone. A consumer
+// that then rebuilds an error from the string has no choice but to invent a
+// position, and the snippet it prints comes from whatever unrelated file
+// happened to be the display fallback (#148: a module that failed to compile
+// reported its own correct 4:11 in the message while underlining line 1 of the
+// entry script).
+//
+// The rendered message is unchanged from the fmt.Errorf form it replaces, so
+// this is safe to introduce anywhere a caller only ever reads .Error().
+// Consumers that want the real location type-assert for Positioned.
+type PositionedError struct {
+	Prefix string        // e.g. "parsing failed", "compilation failed"
+	Diag   PaseratiError // the diagnostic whose position must survive
+}
+
+// Positioned is the minimal contract a consumer needs to recover a real
+// position from an opaque error. PaseratiError itself satisfies it, so a
+// consumer can assert for this one interface and accept either a bare
+// diagnostic or a PositionedError wrapping one.
+type Positioned interface {
+	error
+	Pos() Position
+}
+
+// NewPositionedError wraps diag, keeping prefix as the message's leading
+// context. Returns a nil error (not a typed-nil *PositionedError, which would
+// read as non-nil once assigned to an error field) if diag is nil, so call
+// sites can stay unconditional.
+func NewPositionedError(prefix string, diag PaseratiError) error {
+	if diag == nil {
+		return nil
+	}
+	return &PositionedError{Prefix: prefix, Diag: diag}
+}
+
+func (e *PositionedError) Error() string {
+	if e.Prefix == "" {
+		return e.Diag.Error()
+	}
+	return e.Prefix + ": " + e.Diag.Error()
+}
+
+// Pos returns the wrapped diagnostic's real position, Source included.
+func (e *PositionedError) Pos() Position { return e.Diag.Pos() }
+
+// Unwrap exposes the diagnostic to errors.Is/errors.As.
+func (e *PositionedError) Unwrap() error { return e.Diag }
+
+// PositionOf recovers a real source position from an arbitrary error,
+// unwrapping as far as needed. ok is false when nothing in the chain carries
+// one, or when the one it carries has no line information to render.
+func PositionOf(err error) (Position, bool) {
+	for err != nil {
+		if p, isPositioned := err.(Positioned); isPositioned {
+			pos := p.Pos()
+			if pos.Line > 0 {
+				return pos, true
+			}
+		}
+		u, hasUnwrap := err.(interface{ Unwrap() error })
+		if !hasUnwrap {
+			break
+		}
+		err = u.Unwrap()
+	}
+	return Position{}, false
+}

--- a/pkg/modules/loader.go
+++ b/pkg/modules/loader.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	paseratiErrors "github.com/nooga/paserati/pkg/errors"
 	"github.com/nooga/paserati/pkg/lexer"
 	"github.com/nooga/paserati/pkg/parser"
 	"github.com/nooga/paserati/pkg/source"
@@ -240,7 +241,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 		// If type checking failed and we're not ignoring errors, still allow compilation
 		// but store the error for later reporting
 		if len(checkErrors) > 0 && !ml.config.IgnoreTypeErrors {
-			record.Error = fmt.Errorf("type checking failed: %s", checkErrors[0].Error())
+			record.Error = paseratiErrors.NewPositionedError("type checking failed", checkErrors[0])
 			record.State = ModuleError
 			debugPrintf("// [ModuleLoader] Type check error in %s (exports still extracted): %s\n", specifier, checkErrors[0].Error())
 			return record, nil
@@ -259,7 +260,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 			chunk, compileErrors := moduleCompiler.Compile(record.AST)
 			if len(compileErrors) > 0 {
 				debugPrintf("// [ModuleLoader] Compilation error: %s\n", compileErrors[0].Error())
-				record.Error = fmt.Errorf("compilation failed: %s", compileErrors[0].Error())
+				record.Error = paseratiErrors.NewPositionedError("compilation failed", compileErrors[0])
 				record.State = ModuleError
 				return record, nil
 			}
@@ -297,7 +298,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 		chunk, compileErrors := moduleCompiler.Compile(record.AST)
 		if len(compileErrors) > 0 {
 			debugPrintf("// [ModuleLoader] Compilation error: %s\n", compileErrors[0].Error())
-			record.Error = fmt.Errorf("compilation failed: %s", compileErrors[0].Error())
+			record.Error = paseratiErrors.NewPositionedError("compilation failed", compileErrors[0])
 			record.State = ModuleError
 			return record, nil
 		}
@@ -435,7 +436,7 @@ func (ml *moduleLoader) parseModuleSequential(record *ModuleRecord, resolved *Re
 
 	program, parseErrs := parserInstance.ParseProgram()
 	if len(parseErrs) > 0 {
-		return fmt.Errorf("parsing failed: %s", parseErrs[0].Error())
+		return paseratiErrors.NewPositionedError("parsing failed", parseErrs[0])
 	}
 
 	// Store the parsed AST and source
@@ -812,7 +813,7 @@ func (ml *moduleLoader) performDependencyOrderedTypeChecking(entryPoint string) 
 			errors := moduleChecker.Check(record.AST)
 			if len(errors) > 0 && !ml.config.IgnoreTypeErrors {
 				// Store the first error (can be enhanced to store all errors)
-				record.Error = fmt.Errorf("type checking failed: %s", errors[0].Error())
+				record.Error = paseratiErrors.NewPositionedError("type checking failed", errors[0])
 				record.State = ModuleError
 				continue
 			}
@@ -847,7 +848,7 @@ func (ml *moduleLoader) performDependencyOrderedTypeChecking(entryPoint string) 
 			// Compile the module to bytecode
 			chunk, compileErrors := moduleCompiler.Compile(record.AST)
 			if len(compileErrors) > 0 {
-				record.Error = fmt.Errorf("compilation failed: %s", compileErrors[0].Error())
+				record.Error = paseratiErrors.NewPositionedError("compilation failed", compileErrors[0])
 				record.State = ModuleError
 				continue
 			}

--- a/pkg/modules/worker_pool.go
+++ b/pkg/modules/worker_pool.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	paseratiErrors "github.com/nooga/paserati/pkg/errors"
 	"github.com/nooga/paserati/pkg/lexer"
 	"github.com/nooga/paserati/pkg/parser"
 )
@@ -287,7 +288,7 @@ func (w *parseWorker) processJob(job *ParseJob) *ParseResult {
 	program, parseErrs := w.parserInstance.ParseProgram()
 	if len(parseErrs) > 0 {
 		// Take the first error
-		result.Error = fmt.Errorf("parsing failed: %s", parseErrs[0].Error())
+		result.Error = paseratiErrors.NewPositionedError("parsing failed", parseErrs[0])
 		result.ParseDuration = time.Since(startTime)
 		return result
 	}

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -2,9 +2,9 @@ package vm
 
 import (
 	"fmt"
-	// "github.com/nooga/paserati/pkg/value" // No longer needed
-	//"github.com/nooga/paserati/pkg/value"
 	"strings"
+
+	"github.com/nooga/paserati/pkg/source"
 )
 
 // OpCode defines the type for bytecode instructions.
@@ -34,8 +34,8 @@ const (
 	OpStringConcat OpCode = 49 // Rx Ry Rz: Rx = Ry + Rz (optimized string concatenation)
 
 	// Unary
-	OpNegate         OpCode = 11 // Rx Ry: Rx = -Ry
-	OpNot            OpCode = 12 // Rx Ry: Rx = !Ry (logical not)
+	OpNegate         OpCode = 11  // Rx Ry: Rx = -Ry
+	OpNot            OpCode = 12  // Rx Ry: Rx = !Ry (logical not)
 	OpTypeof         OpCode = 48  // Rx Ry: Rx = typeof Ry (returns string)
 	OpToNumber       OpCode = 50  // Rx Ry: Rx = Number(Ry) (unary plus conversion)
 	OpToNumeric      OpCode = 123 // Rx Ry: Rx = ToNumeric(Ry) (preserves BigInt, converts others to Number)
@@ -107,12 +107,12 @@ const (
 	OpTypeofIdentifier OpCode = 88 // Rx NameIdx(16bit): Rx = typeof identifier - returns "undefined" if identifier doesn't exist (no ReferenceError)
 
 	// --- Private Field Operations (ECMAScript # fields) ---
-	OpGetPrivateField     OpCode = 91  // Rx Ry NameIdx(16bit): Rx = Ry.#field (private field access)
-	OpSetPrivateField     OpCode = 92  // Rx Ry NameIdx(16bit): Rx.#field = Ry (private field assignment)
-	OpSetPrivateMethod    OpCode = 98  // Rx Ry NameIdx(16bit): Rx.#method = Ry (private method - not writable)
-	OpHasPrivateField     OpCode = 99  // Rx Ry NameIdx(16bit): Rx = #field in Ry (check private field presence)
-	OpSetPrivateAccessor  OpCode = 106 // Rx GetterReg SetterReg NameIdx(16bit): Set up private getter/setter on Rx
-	OpCallPrivateSetter   OpCode = 161 // Rx Ry NameIdx(16bit): Rx.#setter = Ry (calls setter, throws if not exist)
+	OpGetPrivateField    OpCode = 91  // Rx Ry NameIdx(16bit): Rx = Ry.#field (private field access)
+	OpSetPrivateField    OpCode = 92  // Rx Ry NameIdx(16bit): Rx.#field = Ry (private field assignment)
+	OpSetPrivateMethod   OpCode = 98  // Rx Ry NameIdx(16bit): Rx.#method = Ry (private method - not writable)
+	OpHasPrivateField    OpCode = 99  // Rx Ry NameIdx(16bit): Rx = #field in Ry (check private field presence)
+	OpSetPrivateAccessor OpCode = 106 // Rx GetterReg SetterReg NameIdx(16bit): Set up private getter/setter on Rx
+	OpCallPrivateSetter  OpCode = 161 // Rx Ry NameIdx(16bit): Rx.#setter = Ry (calls setter, throws if not exist)
 
 	// --- Type Guards for Runtime Validation ---
 	OpTypeGuardIterable       OpCode = 93 // Rx: Throw TypeError if Rx is not iterable
@@ -222,8 +222,8 @@ const (
 	OpCloseUpvalueSpill16 OpCode = 178
 
 	// --- NEW: Global Variable Operations ---
-	OpGetGlobal     OpCode = 46 // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
-	OpSetGlobal     OpCode = 47 // GlobalIdx(16bit) Ry: Globals[GlobalIdx] = Ry (direct indexed access)
+	OpGetGlobal     OpCode = 46  // Rx GlobalIdx(16bit): Rx = Globals[GlobalIdx] (direct indexed access)
+	OpSetGlobal     OpCode = 47  // GlobalIdx(16bit) Ry: Globals[GlobalIdx] = Ry (direct indexed access)
 	OpSetGlobalInit OpCode = 145 // GlobalIdx(16bit) Ry: Globals[GlobalIdx] = Ry (init at declaration, bypasses TDZ check)
 	// --- END NEW ---
 
@@ -788,22 +788,29 @@ type ScopeDescriptor struct {
 
 // Chunk represents a sequence of bytecode instructions and associated data.
 type Chunk struct {
-	Code           []byte             // The bytecode instructions (OpCodes and operands)
-	Constants      []Value            // Constant pool (Now uses Value from vm package)
-	Lines          []int              // Line number for each byte in Code (parallel array)
+	Code      []byte  // The bytecode instructions (OpCodes and operands)
+	Constants []Value // Constant pool (Now uses Value from vm package)
+	Lines     []int   // Line number for each byte in Code (parallel array)
+	// Source is the file this chunk was compiled from, so a runtime error can
+	// name and quote the right file. Without it every VM-raised error's
+	// Position.Source stayed nil and errors.DisplayErrors fell back to whatever
+	// source the embedder passed - the entry script - printing a line of the
+	// wrong file underneath an otherwise-correct line number (#148). Nil for
+	// hand-assembled chunks and any compile path that has no source file.
+	Source         *source.SourceFile
 	ExceptionTable []ExceptionHandler // Exception handlers for try/catch blocks
 	// BuiltinGlobalNames and GlobalNames record the compiler's indexed global
 	// layout. InterpretChunk consumers use them to reject incompatible VMs before
 	// bytecode can read or overwrite a different binding at the same index.
 	// Empty metadata denotes a legacy chunk whose layout is unknown.
-	BuiltinGlobalNames []string
-	GlobalNames        []string
-	IsStrict              bool               // Whether this chunk runs in strict mode
-	HasSimpleParameterList bool              // True if all params are plain identifiers (no defaults, rest, or destructuring)
-	ScopeDesc             *ScopeDescriptor   // Scope info for direct eval (nil if not needed)
-	MaxRegs        int                // Maximum registers needed to execute this chunk
-	NumSpillSlots  int                // Number of spill slots needed (for register overflow)
-	currentLine    int                // Current line for operand bytes (internal use)
+	BuiltinGlobalNames     []string
+	GlobalNames            []string
+	IsStrict               bool             // Whether this chunk runs in strict mode
+	HasSimpleParameterList bool             // True if all params are plain identifiers (no defaults, rest, or destructuring)
+	ScopeDesc              *ScopeDescriptor // Scope info for direct eval (nil if not needed)
+	MaxRegs                int              // Maximum registers needed to execute this chunk
+	NumSpillSlots          int              // Number of spill slots needed (for register overflow)
+	currentLine            int              // Current line for operand bytes (internal use)
 	// Inline caches for property access sites within this chunk, indexed by bytecode offset
 	// (the IP where the opcode starts). This avoids a global map lookup per property access.
 	propInlineCaches []*PropInlineCache
@@ -811,9 +818,9 @@ type Chunk struct {
 	// These indices should have their heap slots marked as non-configurable (DontDelete)
 	VarGlobalIndices []uint16
 	// Constant deduplication caches for O(1) lookup (avoids O(n) linear search)
-	stringConstCache  map[string]uint16  // Cache for string constants
-	intConstCache     map[int64]uint16   // Cache for integer constants
-	floatConstCache   map[float64]uint16 // Cache for float constants
+	stringConstCache map[string]uint16  // Cache for string constants
+	intConstCache    map[int64]uint16   // Cache for integer constants
+	floatConstCache  map[float64]uint16 // Cache for float constants
 }
 
 // GetLine returns the source line number corresponding to a given bytecode offset.

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -648,3 +648,26 @@ func (vm *VM) prepareDirectCall(calleeVal Value, thisValue Value, args []Value, 
 
 	return shouldSwitch, err
 }
+
+// ExceptionValueFromError extracts the JS value a Go error is carrying, for
+// native code that needs to turn a Go error back into a JS value rather than
+// re-throw it (rejecting a promise with it, aggregating it into a
+// SuppressedError, ...).
+//
+// An ExceptionError already holds the real thrown value - a rich Error object
+// with .code/.errno/.name/whatever the thrower built - and that value must
+// survive. Only a Go error that never went through the exception machinery
+// (an I/O failure, an internal invariant) has nothing better to offer than its
+// message, and falls back to a plain string.
+//
+// Callers that want to *throw* rather than *inspect* should keep using the
+// throwException(ee.GetExceptionValue()) idiom instead: that path also has to
+// construct a real Error instance for the fallback case, which this helper
+// deliberately does not do (it would change the rejection value of every
+// existing caller at once).
+func (vm *VM) ExceptionValueFromError(err error) Value {
+	if ee, ok := err.(ExceptionError); ok {
+		return ee.GetExceptionValue()
+	}
+	return NewString(err.Error())
+}

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nooga/paserati/pkg/errors"
+	"github.com/nooga/paserati/pkg/source"
 )
 
 // --- Exception State ---
@@ -94,10 +95,17 @@ func (vm *VM) throwException(value Value) {
 		if vm.frameCount > 0 {
 			vm.lastThrowLine, vm.lastThrowFuncName = vm.getFrameLineInfo(&vm.frames[vm.frameCount-1])
 			vm.lastThrowColumn = 1 // Column tracking not implemented yet
+			// Capture the file too, not just the line. lastThrowLine is a line
+			// in the *throwing* frame's own source, which for a throw inside an
+			// imported module is not the entry script - reporting the one
+			// without the other made DisplayErrors quote that line number out
+			// of the wrong file (#148).
+			vm.lastThrowSource = frameSource(&vm.frames[vm.frameCount-1])
 		} else {
 			vm.lastThrowLine = 1
 			vm.lastThrowColumn = 1
 			vm.lastThrowFuncName = "<script>"
+			vm.lastThrowSource = nil
 		}
 	}
 	// If already unwinding, keep the flag and location (we're re-throwing after native propagation)
@@ -365,6 +373,15 @@ func (vm *VM) handleFinallyBlock(handler *ExceptionHandler) {
 	// check for pending actions and execute them appropriately.
 }
 
+// frameSource returns the source file the frame's bytecode was compiled from,
+// or nil when the chunk has none (hand-assembled chunks, host-built functions).
+func frameSource(frame *CallFrame) *source.SourceFile {
+	if frame == nil || frame.closure == nil || frame.closure.Fn == nil || frame.closure.Fn.Chunk == nil {
+		return nil
+	}
+	return frame.closure.Fn.Chunk.Source
+}
+
 // getFrameLineInfo extracts the line number from a frame at the current instruction position
 // Returns (line, functionName) where line is 1 if no info available
 func (vm *VM) getFrameLineInfo(frame *CallFrame) (int, string) {
@@ -478,11 +495,15 @@ func (vm *VM) handleUncaughtException() {
 	}
 
 	// Create runtime error with actual line and function information
+	fileName := "<script>"
+	if vm.lastThrowSource != nil {
+		fileName = vm.lastThrowSource.DisplayPath()
+	}
 	runtimeErr := &errors.RuntimeError{
-		Position:     errors.Position{Line: line, Column: column, StartPos: 0, EndPos: 0},
+		Position:     errors.Position{Line: line, Column: column, StartPos: 0, EndPos: 0, Source: vm.lastThrowSource},
 		Msg:          errorMsg,
 		FunctionName: funcName,
-		FileName:     "<script>", // TODO: Add actual filename tracking
+		FileName:     fileName,
 	}
 	vm.errors = append(vm.errors, runtimeErr)
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/nooga/paserati/pkg/errors"
 	"github.com/nooga/paserati/pkg/runtime"
+	"github.com/nooga/paserati/pkg/source"
 )
 
 const RegFileSize = 256 // Max registers per function call frame
@@ -320,11 +321,12 @@ type VM struct {
 	currentNewTarget  Value // newTarget for Reflect.construct cross-realm support
 
 	// Exception/call boundary diagnostics
-	lastThrownException       Value  // remembers the last thrown exception value
-	escapedDirectCallBoundary bool   // true if unwinding skipped a direct-call frame to reach outer handler
-	lastThrowLine             int    // line number where exception was thrown
-	lastThrowColumn           int    // column number where exception was thrown
-	lastThrowFuncName         string // function name where exception was thrown
+	lastThrownException       Value              // remembers the last thrown exception value
+	escapedDirectCallBoundary bool               // true if unwinding skipped a direct-call frame to reach outer handler
+	lastThrowLine             int                // line number where exception was thrown
+	lastThrowColumn           int                // column number where exception was thrown
+	lastThrowFuncName         string             // function name where exception was thrown
+	lastThrowSource           *source.SourceFile // source file the throwing frame came from (nil if unknown)
 
 	// TypedArray prototypes
 	TypedArrayConstructor      Value // Abstract %TypedArray% constructor - all typed arrays inherit from this
@@ -16877,6 +16879,46 @@ func (vm *VM) isUnscopable(withObj Value, propName string) (bool, bool) {
 	return excludeVal.IsTruthy(), false
 }
 
+// runtimeErrorAt is runtimeError with a real source position supplied by the
+// caller, for the cases where one is actually known.
+//
+// runtimeError below can only synthesize a position from the *currently
+// executing* frame, which is the right answer for an error raised by the code
+// in that frame and the wrong answer whenever the failure is really about some
+// other source entirely - a module that failed to compile, say, whose own
+// diagnostic already knows its exact line, column and file (#148). Passing
+// that position through means errors.DisplayErrors renders the caret and
+// snippet against the file that actually failed instead of falling back to
+// whatever source the embedder happened to hand it.
+//
+// FileName is re-pointed at the supplied position's own source when it has
+// one, so RuntimeError.Error()'s "file:line:column" triple stays internally
+// consistent rather than labelling another file's line with "<script>".
+// FunctionName is left at the synthesized frame's value: the executing
+// function genuinely is the frame's, it just isn't where the failure lives.
+func (vm *VM) runtimeErrorAt(pos errors.Position, format string, args ...interface{}) InterpretResult {
+	result := vm.runtimeError(format, args...)
+	if len(vm.errors) > 0 {
+		if re, ok := vm.errors[len(vm.errors)-1].(*errors.RuntimeError); ok {
+			re.Position = pos
+			if pos.Source != nil {
+				re.FileName = pos.Source.DisplayPath()
+			}
+		}
+	}
+	return result
+}
+
+// runtimeErrorFrom is runtimeErrorAt when the real position has to be dug out
+// of an opaque error first, falling back to runtimeError's frame synthesis when
+// the error carries no position at all.
+func (vm *VM) runtimeErrorFrom(cause error, format string, args ...interface{}) InterpretResult {
+	if pos, ok := errors.PositionOf(cause); ok {
+		return vm.runtimeErrorAt(pos, format, args...)
+	}
+	return vm.runtimeError(format, args...)
+}
+
 // runtimeError formats a runtime error message, appends it to the VM's error list,
 // and returns the InterpretRuntimeError status.
 func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
@@ -16931,16 +16973,29 @@ func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
 
 	msg := fmt.Sprintf(format, args...)
 
+	// Attach the executing frame's own source file. The line above came out of
+	// that frame's line table, so reporting it against any other file - which is
+	// what a nil Source does, since DisplayErrors then falls back to whatever
+	// the embedder passed, i.e. the entry script - underlines an unrelated line
+	// of an unrelated file (#148). Column stays 1: the bytecode line table has
+	// no column information to recover, and inventing one is worse than
+	// admitting the line is all we know.
+	src := frameSource(frame)
+	fileName := "<script>" // TODO: name host-built chunks better
+	if src != nil {
+		fileName = src.DisplayPath()
+	}
 	runtimeErr := &errors.RuntimeError{
 		Position: errors.Position{
 			Line:     line,
 			Column:   1, // Default to column 1
 			StartPos: 0,
 			EndPos:   0,
+			Source:   src,
 		},
 		Msg:          msg,
 		FunctionName: funcName,
-		FileName:     "<script>", // TODO: Add actual filename tracking
+		FileName:     fileName,
 	}
 	vm.errors = append(vm.errors, runtimeErr)
 
@@ -19420,13 +19475,13 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 		// resolve against the importing module, not cwd.
 		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
 		if err != nil {
-			return vm.runtimeError("Failed to load module '%s': %s", modulePath, err.Error()), Undefined
+			return vm.runtimeErrorFrom(err, "Failed to load module '%s': %s", modulePath, err.Error()), Undefined
 		}
 
 		// Check if the module had any errors during loading/compilation
 		if moduleErr := moduleRecord.GetError(); moduleErr != nil {
 			// fmt.Printf("// [VM] executeModule: Module '%s' has error: %v\n", modulePath, moduleErr)
-			return vm.runtimeError("Module '%s' failed to load: %s", modulePath, moduleErr.Error()), Undefined
+			return vm.runtimeErrorFrom(moduleErr, "Module '%s' failed to load: %s", modulePath, moduleErr.Error()), Undefined
 		}
 
 		// The module loader already dedupes *records* by resolved path (so this

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1416,22 +1416,83 @@ func (vm *VM) CallArgs4(fn, thisValue, a0, a1, a2, a3 Value) (Value, error) {
 	return r, err
 }
 
+// enterOrdinaryNativeCall establishes the state a native callee sees for an
+// ordinary [[Call]], and returns the function that restores it.
+//
+// The point is what it *clears*: currentNewTarget and inConstructorCall. A
+// [[Call]] has no new.target - only [[Construct]] carries one - but vm.Call
+// used to save and set only currentThis, so both of those leaked in from
+// whatever was on the Go stack above. Called from inside a native constructor
+// (which the interpreter runs with currentNewTarget set to the constructor and
+// inConstructorCall true), every nested vm.Call inherited them, and any native
+// callee reading GetNewTarget()/IsConstructorCall() silently behaved as though
+// it were being constructed by the *outer* constructor.
+//
+// That is how `new String(o)`, for an object with no callable toString/valueOf,
+// came to throw a String rather than a TypeError (#154): ToPrimitive's final
+// step calls vm.ThrowTypeError, which builds its instance with
+// vm.Call(TypeError, ...) - and that call resolved its prototype from
+// new.target, which was still the String constructor. The thrown object had
+// name "TypeError" and the right message, but String.prototype for its
+// [[Prototype]], so `e instanceof TypeError` was false.
+//
+// ConstructWithNewTarget is the deliberate counterpart: it saves the same three
+// fields and *sets* them, because it really is a [[Construct]].
+func (vm *VM) enterOrdinaryNativeCall(thisValue Value) func() {
+	prevThis := vm.currentThis
+	vm.currentThis = thisValue
+	restoreCallState := vm.enterOrdinaryCall()
+	return func() {
+		restoreCallState()
+		vm.currentThis = prevThis
+	}
+}
+
+// enterOrdinaryCall clears the construct context for the duration of an
+// ordinary [[Call]] and returns the function that restores it. See
+// enterOrdinaryNativeCall for why.
+//
+// Both of vm.Call's callee kinds need this, for different reasons. A native
+// callee reads these fields itself. A *user-JS* callee does not - new.target
+// inside a function is per-frame and was already correct - but the bytecode it
+// runs plain-calls natives through the interpreter, and the interpreter's
+// plain-call path does not touch these fields (only its four construct sites
+// do). So a native constructor that calls back into user JS used to leave its
+// construct context visible to every native that user JS called:
+//
+//	new String({ toString() { return typeof String("a"); } })
+//
+// reported "object" - the inner String("a"), an ordinary call, saw
+// inConstructorCall still true from the outer `new String` and returned a
+// wrapper object instead of a primitive.
+//
+// executeUserFunctionWithNewTarget is the construct counterpart and is
+// deliberately left alone: it sets up new.target rather than clearing it.
+func (vm *VM) enterOrdinaryCall() func() {
+	prevNewTarget := vm.currentNewTarget
+	prevInConstructorCall := vm.inConstructorCall
+	vm.currentNewTarget = Undefined
+	vm.inConstructorCall = false
+	return func() {
+		vm.currentNewTarget = prevNewTarget
+		vm.inConstructorCall = prevInConstructorCall
+	}
+}
+
 func (vm *VM) Call(fn Value, thisValue Value, args []Value) (Value, error) {
 	switch fn.Type() {
 	case TypeNativeFunction:
 		// For native functions, call directly with proper 'this' context
 		nativeFunc := AsNativeFunction(fn)
-		prevThis := vm.currentThis
-		vm.currentThis = thisValue
-		defer func() { vm.currentThis = prevThis }()
+		restore := vm.enterOrdinaryNativeCall(thisValue)
+		defer restore()
 		return nativeFunc.Fn(args)
 
 	case TypeNativeFunctionWithProps:
 		// Handle native function with properties
 		nativeFuncWithProps := fn.AsNativeFunctionWithProps()
-		prevThis := vm.currentThis
-		vm.currentThis = thisValue
-		defer func() { vm.currentThis = prevThis }()
+		restore := vm.enterOrdinaryNativeCall(thisValue)
+		defer restore()
 		return nativeFuncWithProps.Fn(args)
 
 	case TypeClosure, TypeFunction:
@@ -1850,6 +1911,10 @@ func (vm *VM) lastRecordedErrorMessage() string {
 // executeUserFunctionSafe executes a user function from a native function using sentinel frames
 // This allows proper nested calls without infinite recursion
 func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (Value, error) {
+	// This is an ordinary [[Call]], so nothing it reaches - including natives
+	// its bytecode calls - may see an enclosing construct context.
+	defer vm.enterOrdinaryCall()()
+
 	// If unwinding flags are set but currentException is Null, it means the exception was
 	// already handed off to native code as a Go error. Native code either:
 	// 1. Handled it and is making a new call (not re-throwing) - clear the flags

--- a/tests/scripts/array_fromasync_rejects_with_typeerror.ts
+++ b/tests/scripts/array_fromasync_rejects_with_typeerror.ts
@@ -1,0 +1,28 @@
+// expect: TypeError:true:true
+// Array.fromAsync's argument-validation rejections must carry a real TypeError
+// object, not its message flattened to a string (#147). The native side built a
+// proper TypeError and then threw away everything but .message on the way into
+// the rejected promise, so `e instanceof TypeError` was false and `e.message`
+// was undefined in the handler.
+let nullArg: any = null;
+let notCallable: any = 5;
+
+let first = "no-throw";
+let firstIsTypeError = false;
+try {
+  await Array.fromAsync(nullArg);
+} catch (e) {
+  first = e.name;
+  firstIsTypeError =
+    e instanceof TypeError &&
+    e.message === "Cannot convert undefined or null to object";
+}
+
+let secondIsTypeError = false;
+try {
+  await Array.fromAsync([1], notCallable);
+} catch (e) {
+  secondIsTypeError = e instanceof TypeError;
+}
+
+first + ":" + firstIsTypeError + ":" + secondIsTypeError;

--- a/tests/scripts/date_ctor_converts_objects.ts
+++ b/tests/scripts/date_ctor_converts_objects.ts
@@ -1,0 +1,19 @@
+// expect: 0:0:1234:true:true
+// new Date(x) with a single non-Date argument must go through ToPrimitive
+// before deciding whether to parse a string or run ToNumber (spec 21.4.2.1
+// step 3). It used to call x.ToString() directly for object arguments, so
+// new Date({valueOf: () => 0}) tried to parse "[object Object]" as a date, and
+// the unparseable case stored float64(0x7FF8000000000000) - the NaN bit pattern
+// converted as an *integer*, ~9.22e18 - instead of a NaN, reporting a huge
+// timestamp rather than an Invalid Date.
+const viaValueOf = new Date({ valueOf: () => 0 } as any).getTime();
+const viaWrapper = new Date(Object(0) as any).getTime();
+const viaDateCopy = new Date(new Date(1234)).getTime();
+
+// An object with no numeric conversion is an Invalid Date, not a huge number.
+const plainObjectIsInvalid = Number.isNaN(new Date({} as any).getTime());
+// ToNumber, not date-string parsing, for non-string primitives.
+const booleanIsOne = new Date(true as any).getTime() === 1;
+
+viaValueOf + ":" + viaWrapper + ":" + viaDateCopy + ":" +
+  plainObjectIsInvalid + ":" + booleanIsOne;

--- a/tests/scripts/date_ctor_converts_objects.ts
+++ b/tests/scripts/date_ctor_converts_objects.ts
@@ -1,4 +1,4 @@
-// expect: 0:0:1234:true:true
+// expect: 0:0:1234:true:true:true
 // new Date(x) with a single non-Date argument must go through ToPrimitive
 // before deciding whether to parse a string or run ToNumber (spec 21.4.2.1
 // step 3). It used to call x.ToString() directly for object arguments, so
@@ -15,5 +15,16 @@ const plainObjectIsInvalid = Number.isNaN(new Date({} as any).getTime());
 // ToNumber, not date-string parsing, for non-string primitives.
 const booleanIsOne = new Date(true as any).getTime() === 1;
 
+// new Date(string) and Date.parse must accept the same formats (spec 21.4.3.2).
+// The constructor used to carry a shorter ladder of its own, so these two were
+// Invalid Date through the constructor while Date.parse handled them.
+const parseAgrees = ["01/02/2006", "January 2, 2006", "2006-01-02T15:04:05Z", "2006", "nope"]
+  .every((s) => {
+    const viaParse = Date.parse(s);
+    const viaCtor = new Date(s).getTime();
+    return viaParse === viaCtor ||
+      (Number.isNaN(viaParse) && Number.isNaN(viaCtor));
+  });
+
 viaValueOf + ":" + viaWrapper + ":" + viaDateCopy + ":" +
-  plainObjectIsInvalid + ":" + booleanIsOne;
+  plainObjectIsInvalid + ":" + booleanIsOne + ":" + parseAgrees;

--- a/tests/scripts/native_call_clears_new_target.ts
+++ b/tests/scripts/native_call_clears_new_target.ts
@@ -1,0 +1,44 @@
+// expect: TypeError:true:TypeError:true:TypeError:true:string/number:object
+// An ordinary [[Call]] carries no new.target - only [[Construct]] does - but
+// vm.Call saved and set only `this`, so currentNewTarget and inConstructorCall
+// leaked in from whatever native constructor was running above it on the Go
+// stack. Every native callee reading them then behaved as though the *outer*
+// constructor were constructing it (#154).
+//
+// The visible consequence: ToPrimitive's "neither toString nor valueOf is
+// callable" step throws by constructing a TypeError through vm.Call, which
+// resolved its prototype from new.target - still `String` here. The thrown
+// object had name "TypeError" and the right message but String.prototype for
+// its [[Prototype]], so `e instanceof TypeError` was false and
+// e.constructor.name was "String".
+const unconvertible: any = { valueOf: null, toString: null };
+
+function classify(f: () => void): string {
+  try {
+    f();
+    return "no-throw:false";
+  } catch (e) {
+    return e.name + ":" + (e instanceof TypeError);
+  }
+}
+
+// The same leak reached natives called by *bytecode* running inside a native
+// constructor, not just by the constructor's own Go code: the interpreter's
+// plain-call path never touched these fields either, so the inner String("a")
+// and Number("5") below saw inConstructorCall still true from the enclosing
+// `new String` and returned wrapper objects instead of primitives.
+const innerTypes = String(
+  new String({
+    toString() {
+      return typeof String("a") + "/" + typeof Number("5");
+    },
+  } as any)
+);
+
+// ...while a genuine construct still constructs.
+const realConstructStillWraps = typeof new String("z");
+
+classify(() => new String(unconvertible)) + ":" +
+  classify(() => new Number(unconvertible)) + ":" +
+  classify(() => new Date(unconvertible)) + ":" +
+  innerTypes + ":" + realConstructStillWraps;

--- a/tests/scripts/number_ctor_converts_objects.ts
+++ b/tests/scripts/number_ctor_converts_objects.ts
@@ -1,0 +1,18 @@
+// expect: 7:5:0:0:7:NaN:true
+// Number(x) has to convert an object argument the way the spec does -
+// ToNumber(ToPrimitive(x, "number")). It used to reach into a wrapper's
+// [[PrimitiveValue]] slot and fall through to NaN for every other object, so
+// Number(obj) never converted an ordinary object at all, while unary + on the
+// same value was correct because that path goes through the VM's ToPrimitive.
+const viaValueOf = Number({ valueOf: () => 7 } as any);
+const viaArray = Number([5] as any);
+const viaEmptyArray = Number([] as any);
+const viaDate = Number(new Date(0) as any);
+const viaStringWrapper = Number(Object("7") as any);
+const plainObject = Number({} as any);
+
+// Both must agree, and both must go through the prototype method.
+const agreesWithUnaryPlus = Number({ valueOf: () => 7 } as any) === +({ valueOf: () => 7 } as any);
+
+viaValueOf + ":" + viaArray + ":" + viaEmptyArray + ":" + viaDate + ":" +
+  viaStringWrapper + ":" + plainObject + ":" + agreesWithUnaryPlus;

--- a/tests/scripts/object_wrapper_honors_prototype_valueof.ts
+++ b/tests/scripts/object_wrapper_honors_prototype_valueof.ts
@@ -1,0 +1,31 @@
+// expect: 2:2:true:true
+// Object(primitive) must produce a wrapper whose only own property is the
+// internal primitive slot, exactly like `new Number(x)` already did. It used to
+// install its own valueOf returning the boxed primitive, which shadowed the
+// prototype's - so a user-overridden Number.prototype.valueOf / BigInt.prototype
+// .valueOf was never consulted for a wrapper built by Object(), and ToPrimitive
+// silently used the shadowing copy instead (#115).
+let valueOfGets = 0;
+let valueOfCalls = 0;
+
+const NumberValueOf = Number.prototype.valueOf;
+Object.defineProperty(Number.prototype, "valueOf", {
+  get: () => {
+    valueOfGets++;
+    return function (this: any) {
+      valueOfCalls++;
+      return NumberValueOf.call(this) * 2;
+    };
+  },
+  configurable: true,
+});
+
+const eqUsesOverride = Object(1) == 2;
+const addUsesOverride = Object(3) + 0 === 6;
+
+// Own properties must match what `new Number(1)` has - no shadowing valueOf.
+const wrapperOwn = Object.getOwnPropertyNames(Object(1)).join(",");
+const constructedOwn = Object.getOwnPropertyNames(new Number(1)).join(",");
+
+valueOfGets + ":" + valueOfCalls + ":" + eqUsesOverride + ":" +
+  (addUsesOverride && wrapperOwn === constructedOwn);


### PR DESCRIPTION
Fixes #147, fixes #148, fixes #115, fixes #154. Six commits, each independently
revertible, each with a test that reproduces the reported symptom against the
unfixed code.

Two new issues filed from what turned up: #153 (residual column question) and
#156 (a pre-existing VM panic on the uncaught path, unrelated to any fix here).

## #147 — a native async function's rejection kept only the message string

`ModuleBuilder.AsyncFunction`'s wrapper flattened every Go error its inner
function returned to `vm.NewString(err.Error())`, so an error implementing
`vm.ExceptionError` — a host's real `Error` object with `.code`/`.errno`/
`.syscall` on it — reached `.catch()` as a bare JS string. The *synchronous*
`ModuleBuilder.Function` path does the right thing, which is what made this
visible in noderati: `fs.statSync`'s ENOENT arrived with `e.code === "ENOENT"`,
while `fs/promises.stat`'s, built the identical way, arrived as a string.

Generalized rather than patched at the one site, since "turn a Go error back
into a JS value" happens wherever native code absorbs an exception instead of
re-throwing it. `vm.ExceptionValueFromError` is that step, and the sweep found
two more live instances of the same bug:

- `Array.fromAsync`'s argument-validation rejections built a real `TypeError`
  and then rejected with only its message, so `e instanceof TypeError` was
  false and `e.message` undefined in the handler.
- `async_generator_init`'s `next()` had the check open-coded; it now shares the
  helper. `disposable_stack_init`'s local `exceptionValue()` *was* this helper
  and delegates to it.

The string fallback is kept deliberately — only a Go error that never went
through the exception machinery reaches it, and constructing an `Error` there
(as the interpreter's own throw path does) would change the observable
rejection value of every existing caller at once. `fetch_init`'s rejections are
left alone: those are Go I/O and JSON-parse failures, never `ExceptionError`, so
the helper would change nothing there.

## #148 — runtime errors reported the wrong file

Two independent causes, both of which made the reported location contradict the
message printed directly above it.

**A position discarded before it could be reported.** The module loader
stringified every diagnostic it stored on a `ModuleRecord`
(`fmt.Errorf("parsing failed: %s", errs[0].Error())` and friends, 7 sites). The
real `line:column` survived as *text*, but the structured position — the only
thing `DisplayErrors` can render a caret and snippet against — was gone, so
`vm.runtimeError` had no choice but to synthesize one from the importing frame:

```
PS4001 [ERROR]: Module './bad.ts' failed to load: parsing failed: Syntax Error at 4:11: Expression expected.
  1: import { ok } from "./bad.ts";     <- entry.ts line 1, not bad.ts line 4
     ^
    at line 1, column 1
```

`errors.PositionedError` now carries the diagnostic across the plain-`error`
boundary with its position intact — rendered message unchanged, so it is
invisible to anything that only reads `.Error()`. `vm.runtimeErrorFrom` digs the
position back out; `PositionOf` walks `Unwrap` chains, so future wrapping works
too.

**`Position.Source` never set at all — the general half.** Even with the right
line, no VM-raised error said which *file* the line was in, so `DisplayErrors`
always took its snippet from the embedder's `fallbackSource`, i.e. the entry
script. Generalized rather than fixed per call site, since `runtimeError` backs
a wide range of internal VM errors and every one of them had this: `vm.Chunk`
now records the source it was compiled from (the compiler sets it from
`Program.Source`; nested function compilers inherit it alongside `IsStrict`),
and both `runtimeError` and `handleUncaughtException` attach the
executing/throwing frame's source. A `TypeError` thrown inside an imported
module now quotes that module's line instead of an unrelated line of the entry
script.

`RunOptions.Filename` — already documented for error reporting, previously
honored only in Script mode — is now honored in module mode too, and the CLI
passes it, so the entry script names itself rather than `<eval>`. Callers with
no file (REPL, `-e`) set neither field and keep `<eval>`.

Column stays 1 in the frame-synthesized path: `emitOpCode` takes only a line, at
hundreds of call sites, so there is no column data in the bytecode to recover,
and a first-non-whitespace guess would invent a location rather than admit the
line is all we know. Real columns *do* come through where a wrapped diagnostic
knows its own. Filed as #153 with the design options written up.

## #115 — the issue's stated root cause was wrong

The report hypothesized "an internal fast path in `==` that unwraps the BigInt
value directly, bypassing ToPrimitive". `abstractEqual` and `toPrimitive` are
both correct and both were running. The bypass was in the wrapper:

```js
Object.getOwnPropertyNames(Object(5))      // [[PrimitiveValue]],valueOf
Object.getOwnPropertyNames(new Number(5))  // [[PrimitiveValue]]
```

`Object()`'s ToObject boxing installed an own `valueOf` closing over the boxed
primitive, on all five wrapper kinds. Being an own property it shadowed
`Number.prototype.valueOf` / `BigInt.prototype.valueOf` / etc, so a prototype
override was never reached and no getter ever fired. Not BigInt-specific.
`new Number(5)` never did this, which makes it the correctness oracle — the fix
is deleting the five installs so `Object()` reaches the same end state as `new`.
The own copy was pure redundancy: all five prototypes' `valueOf` already
implement the spec's `ThisNumberValue`/`ThisBigIntValue`/… unwrap.

## Not on any issue list, and the largest thing here

Pulling on what sat behind #115 (`built-ins/BigInt/wrapper-object-ordinary-toprimitive.js`
got 13 assertions further and stopped on `Number(obj)` / `new Date(obj)`) turned
up that **`Number()` never converted an object at all**:

```js
Number({valueOf: () => 7})   // NaN, want 7
Number([5])                  // NaN, want 5
Number(new Date(0))          // NaN, want 0
+{valueOf: () => 7}          // 7  — correct, different code path
```

Its switch had no object case, so everything that was not a wrapper fell through
to `default: NaN`. Unary `+` was right the whole time because that goes through
the VM's own ToPrimitive, which is exactly what made the two disagree.
`Number(x)` is now `ToNumber(ToPrimitive(x, "number"))`, fixing the general case
and the wrapper case together.

`new Date(x)` had the same shortcut plus a second bug: for an object argument it
called `arg.ToString()` with no ToPrimitive, and the unparseable branch stored
`float64(0x7FF8000000000000)` — the NaN *bit pattern* converted as an integer,
~9.22e18 — so the result read as a real timestamp instead of an Invalid Date. It
now follows 21.4.2.1 step 3: copy a Date's own `[[DateValue]]`, else
ToPrimitive, then parse only if the result is a String and ToNumber otherwise.

That surfaced one more divergence. `Date.parse` carried a strictly larger format
ladder than the constructor, so per spec 21.4.3.2 — where `Date.parse` is
*defined* in terms of the same abstract parse — the same string was accepted by
one and rejected by the other:

```js
Date.parse("01/02/2006")   // 1136160000000
new Date("01/02/2006")     // Invalid Date
```

Both now go through one `parseDateString`.

## #154 — an ordinary call inherited the enclosing construct context

Filed mid-PR as "not fixed", then fixed. **The diagnosis in that issue is wrong
and the final commit supersedes it**; both are left in the thread on purpose,
because the wrong turn is informative.

The issue concluded the mechanism was in the interpreter's construct path, on
the evidence that returning an explicit `ExceptionError` from the builtin didn't
help. That negative result was real. The conclusion was not — the exception was
never being *substituted*, it was being *built wrong*:

```js
const o = { valueOf: null, toString: null };
try { new String(o) } catch (e) {
  e.name                                        // "TypeError"  (right)
  e.message                                     // right
  Object.getPrototypeOf(e) === String.prototype // true         (wrong)
  e instanceof TypeError                        // false
}
```

An ordinary `[[Call]]` has no new.target — only `[[Construct]]` carries one —
but `vm.Call` saved and set only `currentThis`, leaving `currentNewTarget` and
`inConstructorCall` as whatever the Go stack above had set. `ToPrimitive`'s
"neither method is callable" step calls `vm.ThrowTypeError`, which builds its
instance via `vm.Call(TypeError, ...)` — and that resolved its prototype from
new.target, still the `String` constructor. Corroborating: `value.go`'s
`newErrorHelper` already clears `currentNewTarget` for exactly this reason;
`ThrowTypeError` simply doesn't route through it.

Fixed at the boundary rather than in `ThrowTypeError`, since the leak is a
property of `vm.Call`. Both callee kinds needed it, for different reasons — and
the second is a plainly-wrong result with no error object involved:

```js
new String({ toString() { return typeof String("a"); } })   // "object"
```

`new.target` inside a user function was already correct (it's per-frame), but
the bytecode that function runs plain-calls natives through the interpreter,
whose plain-call path doesn't touch these fields either — only its four
construct sites do. So a native constructor calling back into user JS left its
construct context visible to every native that user JS called, and the inner
`String("a")` — an ordinary call, which must be a primitive — returned a
wrapper.

`ConstructWithNewTarget` and `executeUserFunctionWithNewTarget` are untouched:
they *set* this state because they really are `[[Construct]]`. Verified
`new String("z")` still yields a wrapper.

This also closes the last open assertion in
`built-ins/BigInt/wrapper-object-ordinary-toprimitive.js`, which the two
preceding commits took from failing-at-assertion-1 to failing-only-here. That
test now passes end to end — so the #115 commit body is out of date where it
says the tests it unblocks "both stop at the second bug above".

## Filed, not fixed

**#156**: an *uncaught* TypeError from `ToPrimitive` inside a native call panics
the VM with `index out of range [-2]` (`frameCount` goes negative) and the
process still **exits 0**. `runtimeError` then panics again while reporting it.
Reproduces on `origin/main` at `119a49d1`, on both the call and construct forms,
with the plain-call `String({valueOf:null,toString:null})` as the smaller repro
— so it is pre-existing and unrelated to anything here. The issue separates the
three problems (negative `frameCount`, unsafe reporting path, exit 0); the last
two are worth fixing regardless of the first.

**#153**: the residual column question from #148, with the three options and
their costs.

## Verification

- `go test ./...`: green.
- `go test ./tests -run TestScripts`: green.
- Test262 `built-ins`: **+16** across the branch (+13 from the conversion work,
  +3 from #154), no new failures. `language`: net +0.
- Each fix has a test that reproduces the reported symptom against the unfixed
  code — verified by stashing the fix and re-running:
  - `TestHostAsyncFunctionRejectsWithRealExceptionValue` → `string:undefined`
  - `error_position_test.go` (×3) → "diagnostic has no Source"
  - `object_wrapper_honors_prototype_valueof.ts` → `0:0:false:false`
  - `number_ctor_converts_objects.ts` → `NaN:NaN:NaN:NaN:7:NaN:false`
  - `date_ctor_converts_objects.ts` → `9221120237041091000:...:false:false`
  - `native_call_clears_new_target.ts` → `TypeError:false:...:object/object:object`

Note for review: #148's `Chunk.Source` change makes VM error messages name real
files where they previously said `<script>`, and `<eval>` where the source is
genuinely anonymous. No smoke test asserted on those strings and the test262
diff is +0, but it is the one user-visible output change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
