### PR TITLE
fix: comma expression in an if condition (#157), and an uncaught native throw panicking the VM (#156)

### DIFF
--- a/pkg/driver/uncaught_native_throw_test.go
+++ b/pkg/driver/uncaught_native_throw_test.go
@@ -1,0 +1,65 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUncaughtToPrimitiveErrorDoesNotPanic covers #156: an *uncaught* TypeError
+// raised by ToPrimitive from inside a native call panicked the VM with
+// "index out of range [-2]".
+//
+// handleUncaughtException reports the exception and zeroes frameCount to stop
+// execution, but the interpreter's post-unwind paths did `continue` - which does
+// not exit the dispatch loop, it re-enters the body with frame/code/ip still
+// cached from the frame that was just discarded. The loop then decoded the dead
+// frame's bytecode and ran its OpReturn, taking frameCount to -1, and the next
+// read of vm.frames[frameCount-1] panicked.
+//
+// This has to be a Go test rather than a tests/scripts case: the bug only
+// appears when the exception goes *uncaught* to the top, and the script harness
+// can only assert on a value or a matched error, not on "the VM did not crash on
+// the way to reporting this".
+func TestUncaughtToPrimitiveErrorDoesNotPanic(t *testing.T) {
+	// An object ToPrimitive cannot convert: neither method is callable, so
+	// OrdinaryToPrimitive's final step throws via vm.ThrowTypeError - the native
+	// then returns normally with the VM unwinding, which is the path that broke.
+	const unconvertible = `const o = { valueOf: null, toString: null };`
+
+	cases := map[string]string{
+		"call":            `String(o);`,
+		"construct":       `new String(o);`,
+		"constructNumber": `new Number(o);`,
+		"constructDate":   `new Date(o);`,
+		// Getter form: the methods exist as accessors returning undefined.
+		"accessors": `const g = { get valueOf() { return undefined; }, get toString() { return undefined; } }; String(g);`,
+	}
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := NewPaserati()
+			p.SetSkipTypeCheck(true)
+			_, errs := p.RunCode(unconvertible+"\n"+body, RunOptions{})
+
+			if len(errs) == 0 {
+				t.Fatal("expected an uncaught-exception diagnostic, got none")
+			}
+
+			var reported []string
+			for _, e := range errs {
+				reported = append(reported, e.Error())
+			}
+			all := strings.Join(reported, "\n")
+
+			// The panic surfaced as an extra "Internal VM Error" diagnostic,
+			// and (because runtimeError itself then panicked on the negative
+			// frameCount) buried the real one.
+			if strings.Contains(all, "Internal VM Error") {
+				t.Errorf("VM panicked while reporting an uncaught exception:\n%s", all)
+			}
+			if !strings.Contains(all, "Cannot convert object to primitive value") {
+				t.Errorf("real TypeError diagnostic missing:\n%s", all)
+			}
+		})
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2111,7 +2111,15 @@ func (p *Parser) parseIfStatement() *IfStatement {
 	}
 
 	p.nextToken() // Consume '(', move to condition
-	stmt.Condition = p.parseExpression(COMMA)
+	// LOWEST, not COMMA: an if condition sits inside its own parentheses, which
+	// is exactly the context where a raw comma operator is unambiguous and
+	// legal - `if (a, b)`. COMMA means "stop before consuming a comma", which is
+	// right for a genuinely comma-delimited context (declarator initializers,
+	// parameter defaults) and wrong here: parseExpression stopped after `a`,
+	// leaving the `,` for expectPeek(RPAREN) to reject with "')' expected"
+	// (#157). while/do-while/switch all already parse their parenthesized
+	// condition at LOWEST; if was the sole outlier.
+	stmt.Condition = p.parseExpression(LOWEST)
 	if stmt.Condition == nil {
 		return nil
 	}

--- a/pkg/vm/runtime_error_report_test.go
+++ b/pkg/vm/runtime_error_report_test.go
@@ -1,0 +1,44 @@
+package vm
+
+import "testing"
+
+// TestRuntimeErrorSurvivesBrokenFrameCount covers the second half of #156.
+//
+// runtimeError is the *reporting* path: run()'s panic recovery calls it to turn
+// a panic into a diagnostic. It therefore has to stay safe when frame
+// bookkeeping is already broken, which is exactly when it gets called. Its
+// guard used to be `frameCount == 0`, so a negative count fell straight through
+// to vm.frames[frameCount-1] and panicked a second time - printing
+// "runtimeError itself panicked while reporting the above" and burying the real
+// diagnostic under an internal error.
+//
+// The first half of #156 (what let frameCount go negative in the first place)
+// is fixed separately, in the interpreter's post-unwind paths. This test is
+// deliberately independent of that: it asserts the reporter is robust, not that
+// the condition never happens.
+func TestRuntimeErrorSurvivesBrokenFrameCount(t *testing.T) {
+	for _, frameCount := range []int{0, -1, -2} {
+		vm := NewVM()
+		vm.frameCount = frameCount
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("runtimeError panicked with frameCount=%d: %v", frameCount, r)
+				}
+			}()
+			if got := vm.runtimeError("probe %d", frameCount); got != InterpretRuntimeError {
+				t.Errorf("frameCount=%d: got status %v, want InterpretRuntimeError", frameCount, got)
+			}
+		}()
+
+		// The diagnostic must still be recorded, not swallowed.
+		if len(vm.errors) != 1 {
+			t.Errorf("frameCount=%d: recorded %d errors, want 1", frameCount, len(vm.errors))
+			continue
+		}
+		if msg := vm.errors[0].Message(); msg == "" {
+			t.Errorf("frameCount=%d: recorded an empty message", frameCount)
+		}
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4168,6 +4168,20 @@ startExecution:
 				// Our frame was popped - we need to exit this VM loop immediately
 				// The exception should be handled by the caller (executeUserFunctionSafe)
 				// Don't update frame variables, just continue to let the main loop handle unwinding
+				//
+				// ...except that `continue` does not exit the loop, it re-enters
+				// the body with frame/code/ip still cached from the frame that
+				// was just popped. With frames left below, the loop's own
+				// unwinding machinery picks it up. With NO frames left - an
+				// uncaught exception, where handleUncaughtException has already
+				// reported it and set frameCount to 0 to stop execution - there
+				// is nothing to pick it up, so the loop decoded the dead frame's
+				// bytecode and eventually ran its OpReturn, taking frameCount to
+				// -1 and panicking on vm.frames[-2] (#156). Return the way the
+				// other post-unwind sites in this loop already do.
+				if vm.frameCount == 0 {
+					return InterpretRuntimeError, vm.currentException
+				}
 				continue
 			}
 
@@ -11328,6 +11342,15 @@ startExecution:
 				// Check if VM started unwinding during the native function call
 				// (e.g., ToPrimitive threw an exception but returned nil error)
 				if vm.unwinding {
+					// A native that raised through vm.ThrowTypeError (rather than
+					// returning an ExceptionError) reports "unwinding" by returning
+					// normally. If nothing caught it, handleUncaughtException has
+					// already reported it and zeroed frameCount to stop execution,
+					// so there is no frame for the loop to resume into and
+					// `continue` would decode the dead frame's bytecode (#156).
+					if vm.frameCount == 0 {
+						return InterpretRuntimeError, vm.currentException
+					}
 					continue // Let exception handling take over
 				}
 
@@ -11476,6 +11499,15 @@ startExecution:
 				// Check if VM started unwinding during the native function call
 				// (e.g., ToPrimitive threw an exception but returned nil error)
 				if vm.unwinding {
+					// A native that raised through vm.ThrowTypeError (rather than
+					// returning an ExceptionError) reports "unwinding" by returning
+					// normally. If nothing caught it, handleUncaughtException has
+					// already reported it and zeroed frameCount to stop execution,
+					// so there is no frame for the loop to resume into and
+					// `continue` would decode the dead frame's bytecode (#156).
+					if vm.frameCount == 0 {
+						return InterpretRuntimeError, vm.currentException
+					}
 					continue // Let exception handling take over
 				}
 
@@ -11740,6 +11772,12 @@ startExecution:
 						continue
 					}
 					if vm.unwinding {
+						// See #156: with no frames left there is nothing to
+						// resume into, and `continue` would run the dead frame's
+						// bytecode.
+						if vm.frameCount == 0 {
+							return InterpretRuntimeError, vm.currentException
+						}
 						continue
 					}
 					if inheritNewTarget && !newTargetForNative.Is(originalConstructor) {
@@ -11820,6 +11858,12 @@ startExecution:
 						continue
 					}
 					if vm.unwinding {
+						// See #156: with no frames left there is nothing to
+						// resume into, and `continue` would run the dead frame's
+						// bytecode.
+						if vm.frameCount == 0 {
+							return InterpretRuntimeError, vm.currentException
+						}
 						continue
 					}
 					if inheritNewTarget && !newTargetForNative.Is(originalConstructor) {
@@ -16923,8 +16967,15 @@ func (vm *VM) runtimeErrorFrom(cause error, format string, args ...interface{}) 
 // and returns the InterpretRuntimeError status.
 func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
 
-	// Get the current frame to access chunk and IP
-	if vm.frameCount == 0 {
+	// Get the current frame to access chunk and IP.
+	//
+	// `< 1`, not `== 0`: this is the *reporting* path, reached from the panic
+	// recovery in run(), so it must stay safe even when frame bookkeeping is
+	// already broken. With `== 0` a negative frameCount fell through to
+	// vm.frames[frameCount-1] and panicked a second time, which is how #156
+	// printed "runtimeError itself panicked while reporting the above" and
+	// buried the original diagnostic.
+	if vm.frameCount < 1 {
 		// Should not happen if called during run()
 		// Create a generic error if no frame context
 		runtimeErr := &errors.RuntimeError{

--- a/tests/scripts/if_condition_comma_operator.ts
+++ b/tests/scripts/if_condition_comma_operator.ts
@@ -1,0 +1,42 @@
+// expect: 2:5:else:elseif:42
+// A comma expression directly inside an if condition failed to parse with
+// "')' expected" (#157). parseIfStatement parsed its condition at COMMA
+// precedence - "stop before consuming a comma", correct for a comma-delimited
+// context like a declarator initializer, wrong inside the condition's own
+// parentheses, where a raw comma operator is unambiguous. while, do-while and
+// switch all already used LOWEST; if was the sole outlier.
+//
+// Every left operand here has a side effect on purpose: TypeScript reports
+// TS2695 ("Left side of comma operator is unused and has no side effects") for
+// the pure form, so `if (x, x > 0)` is a parse test that only runs untyped.
+let x = 1;
+let out = "";
+
+if ((x = 2), x > 0) out += String(x);
+
+// The real-world idiom - assign, then test - parenthesized or not.
+if ((x = 5), x > 0) out += ":" + x;
+
+if ((x = 6), 0) out += ":BAD";
+else out += ":else";
+
+if ((x = 7), false) out += ":BAD2";
+else if ((x = 8), true) out += ":elseif";
+
+// The shape this was found on: lru-cache's minified constructor, reduced.
+function isNum(v: any): boolean {
+  return typeof v === "number";
+}
+const defaults = { perf: 42 };
+class Cache {
+  #perf: number = 0;
+  ok: number = 0;
+  constructor(p?: number, e?: any) {
+    if (((this.#perf = p ?? defaults.perf), e !== 0 && !isNum(e)))
+      throw new TypeError("bad e");
+    this.ok = this.#perf;
+  }
+}
+out += ":" + new Cache(undefined, 0).ok;
+
+out;


### PR DESCRIPTION
Fixes #157, fixes #156. Two unrelated bugs, one commit each, each with a test
that reproduces the reported symptom against the unfixed code.

## #157 — a comma expression in an `if` condition failed to parse

```js
let x = 1;
if (x, x > 0) console.log("yes");   // TS1005: ')' expected
```

`parseIfStatement` parsed its condition at `COMMA` precedence, which in this
parser means "stop before consuming a comma token" — so `parseExpression`
returned after `x`, left the `,` unconsumed, and the `expectPeek(RPAREN)`
immediately after rejected it.

`COMMA` is right for a genuinely comma-delimited context, where a top-level
comma means "next declarator" or "next parameter" rather than the comma
operator. An `if` condition is not one of those: it sits inside its own
parentheses, which is exactly where a raw comma operator is unambiguous and
legal. `while`, `do`-`while` and `switch` all already parse their parenthesized
condition at `LOWEST`.

**Swept before changing anything**, since a one-line precedence fix invites the
question of how many siblings share it. Every comma-legal context checked by
hand — `while`, `do`-`while`, `switch`, all three `for` clauses, `for`-`in`,
`for`-`of`, `throw`, `return`, arrow body, parenthesized expression, `with` —
and `if` was the only failure. The other ~45 `COMMA` call sites are declarator
initializers, parameter and destructuring defaults, computed keys, object
values, the arrow body and the ternary alternative, all of which are
`AssignmentExpression` positions per spec where stopping at a comma is correct.
So this is a single-site outlier, not the first of a family.

Found via noderati on the real, unmodified `lru-cache` package, whose minified
constructor uses the assign-then-test idiom
`if(this.#S=D??N.defaultPerf,e!==0&&!T(e))throw ...`. Worth noting that **#148
is what made it findable**: the position reported before that fix (`2:2510`)
pointed at nothing in the file; the accurate one (`1:2846`) pointed straight at
it.

Every left operand in the regression test has a side effect on purpose —
TypeScript reports TS2695 for the pure `if (x, x > 0)` form, and so do we,
correctly.

## #156 — an uncaught exception from a native call panicked the VM

```
$ paserati --no-typecheck -e 'const o={valueOf:null,toString:null}; String(o);'
[VM PANIC] recovered: runtime error: index out of range [-2]
[VM PANIC] runtimeError itself panicked while reporting the above: ...
PS4001 [ERROR]: Uncaught exception: TypeError: Cannot convert object to primitive value
PS4001 [ERROR]: Internal VM Error: panic during execution: ...
```

Two independent defects. **The issue's third claim — "exits 0" — was my own
measurement error**: I read `$?` at the end of a shell pipeline, so it was
`head`'s status. The exit code is 70 and always was. The issue body is corrected
in place rather than quietly dropped.

**1. `frameCount` goes negative.** A probe at the `OpReturn` frame-pop showed
the mechanism directly rather than by inference:
`OpReturn entered with frameCount=0 unwinding=true`.

A native that raises through `vm.ThrowTypeError` (rather than surfacing an
`ExceptionError`) reports the throw by returning *normally* with `vm.unwinding`
set. When nothing catches it, `handleUncaughtException` has by then already
reported it and zeroed `frameCount` to stop execution. The interpreter's
post-unwind sites then did `continue` — which does not exit the dispatch loop;
it re-enters the body with `frame`/`code`/`ip` still cached from the frame that
no longer exists. The loop decoded that dead frame's bytecode, ran its
`OpReturn`, took `frameCount` to -1, and the next `vm.frames[frameCount-1]` read
indexed -2.

The `OpCall` site's own comment already said "we need to exit this VM loop
immediately" while doing `continue`, so this mostly makes the code do what it
claimed. Fixed at all five reachable sites with the guard the sibling
post-unwind sites already use: with no frames left there is nothing to resume
into, so return `InterpretRuntimeError` with the exception.

Deliberately **not** a guard at the top of the dispatch loop: that is the VM's
hottest path, and it would cost a compare per instruction — and re-lay out
`(*VM).run`, cf. #52 — to check a condition that only arises on this cold path.

Note the discriminator, which is the same one #154 turned on: a *user function*
throwing (surfaced as an `ExceptionError` through `vm.Call`) was always fine;
only a *native* raising via `vm.ThrowTypeError` and returning normally hit this.
Same two-routes-out-of-a-native shape as #154, different consequence — a
reviewer who just merged #155 will recognise the pattern.

**2. The reporting path was not robust against the broken state it exists to
report.** `runtimeError` is what `run()`'s panic recovery calls to turn a panic
into a diagnostic, so it is called precisely when frame bookkeeping is already
wrong — but it guarded on `frameCount == 0`, letting a negative count fall
through to `vm.frames[frameCount-1]` and panic a second time. That is the
"runtimeError itself panicked while reporting the above" line, which buried the
real `TypeError` under an `Internal VM Error`. Guard is now `< 1`.

`getFrameLineInfo` and `frameSource` were checked and deliberately left alone:
their only frame-indexing callers already sit behind a `frameCount > 0` test,
and `runtimeError`'s own call uses the local it obtained after the guard above.

## Verification

- `go test ./...`: green. `go test ./tests -run TestScripts`: green.
- Test262 `built-ins`: net +0. `language`: net +0.
- Each fix has a test that reproduces the symptom against the unfixed code:
  - `if_condition_comma_operator.ts` → `SyntaxError: ')' expected`
  - `pkg/driver/uncaught_native_throw_test.go` → `VM panicked while reporting an
    uncaught exception` (five call and construct forms). This one cannot be a
    `tests/scripts` case: the bug only appears when the exception goes
    **uncaught** to the top, and the script harness can only assert on a value
    or a matched error, not on "the VM did not crash on the way to reporting
    this".
  - `pkg/vm/runtime_error_report_test.go` → `runtimeError panicked with
    frameCount=-1`. Asserts the reporter stays safe at `frameCount` 0, -1 and -2
    independently of defect (1) ever recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
