### PR TITLE
fix(destructuring): a binding pattern works in every declarator position (#159, #160)

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3301,10 +3301,11 @@ func (c *Checker) checkArrayDestructuringDeclaration(node *parser.ArrayDestructu
 			c.addError(node, "const declaration must be initialized")
 		}
 		// For let/var without initializer, all variables get undefined type
+		env := c.declarationEnv(node.Token != nil && node.Token.Literal == "var")
 		for _, element := range node.Elements {
 			if element != nil && element.Target != nil {
 				if ident, ok := element.Target.(*parser.Identifier); ok {
-					if !c.env.Define(ident.Value, types.Undefined, node.IsConst) {
+					if !env.Define(ident.Value, types.Undefined, node.IsConst) {
 						c.addError(ident, fmt.Sprintf("identifier '%s' already declared", ident.Value))
 					}
 					ident.SetComputedType(types.Undefined)
@@ -3451,10 +3452,11 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 			c.addError(node, "const declaration must be initialized")
 		}
 		// For let/var without initializer, all variables get undefined type
+		env := c.declarationEnv(node.Token != nil && node.Token.Literal == "var")
 		for _, prop := range node.Properties {
 			if prop != nil && prop.Target != nil {
 				if ident, ok := prop.Target.(*parser.Identifier); ok {
-					if !c.env.Define(ident.Value, types.Undefined, node.IsConst) {
+					if !env.Define(ident.Value, types.Undefined, node.IsConst) {
 						c.addError(ident, fmt.Sprintf("identifier '%s' already declared", ident.Value))
 					}
 					ident.SetComputedType(types.Undefined)
@@ -3465,7 +3467,7 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 		// Handle rest property without initializer
 		if node.RestProperty != nil {
 			if ident, ok := node.RestProperty.Target.(*parser.Identifier); ok {
-				if !c.env.Define(ident.Value, types.Undefined, node.IsConst) {
+				if !env.Define(ident.Value, types.Undefined, node.IsConst) {
 					c.addError(ident, fmt.Sprintf("identifier '%s' already declared", ident.Value))
 				}
 				ident.SetComputedType(types.Undefined)

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -4327,49 +4327,26 @@ func (c *Checker) checkExportAllDeclaration(node *parser.ExportAllDeclaration) {
 // processExportDeclaration processes a declaration that's being exported directly
 func (c *Checker) processExportDeclaration(decl parser.Statement) {
 	switch node := decl.(type) {
-	case *parser.LetStatement:
-		if node.Name != nil {
-			localName := node.Name.Value
-			// Look up the type from the environment (the statement was already processed)
-			exportType, _, exists := c.env.Resolve(localName)
-			if !exists {
-				exportType = types.Any
-			}
-
-			if c.IsModuleMode() {
-				c.moduleEnv.DefineExport(localName, localName, exportType, decl)
-			}
-			debugPrintf("// [Checker] Exported let: %s (type: %s)\n", localName, exportType.String())
+	case *parser.LetStatement, *parser.ConstStatement, *parser.VarStatement,
+		*parser.ObjectDestructuringDeclaration, *parser.ArrayDestructuringDeclaration,
+		*parser.DeclarationGroup:
+		// Every name the declaration binds is exported, not just the first
+		// declarator - and a destructuring pattern binds several. This used to
+		// read the statement's legacy first-declarator Name field, which
+		// exported one name from a multi-declarator clause and nothing at all
+		// from a destructuring declaration (`export const {a} = obj`).
+		if !c.IsModuleMode() {
+			return
 		}
-
-	case *parser.ConstStatement:
-		if node.Name != nil {
-			localName := node.Name.Value
-			// Look up the type from the environment (the statement was already processed)
+		for _, localName := range parser.DeclaredNames(decl) {
+			// The declaration has already been checked, so its bindings are in
+			// the environment with their inferred or annotated types.
 			exportType, _, exists := c.env.Resolve(localName)
 			if !exists {
 				exportType = types.Any
 			}
-
-			if c.IsModuleMode() {
-				c.moduleEnv.DefineExport(localName, localName, exportType, decl)
-			}
-			debugPrintf("// [Checker] Exported const: %s (type: %s)\n", localName, exportType.String())
-		}
-
-	case *parser.VarStatement:
-		if node.Name != nil {
-			localName := node.Name.Value
-			// Look up the type from the environment (the statement was already processed)
-			exportType, _, exists := c.env.Resolve(localName)
-			if !exists {
-				exportType = types.Any
-			}
-
-			if c.IsModuleMode() {
-				c.moduleEnv.DefineExport(localName, localName, exportType, decl)
-			}
-			debugPrintf("// [Checker] Exported var: %s (type: %s)\n", localName, exportType.String())
+			c.moduleEnv.DefineExport(localName, localName, exportType, decl)
+			debugPrintf("// [Checker] Exported declaration binding: %s (type: %s)\n", localName, exportType.String())
 		}
 
 	case *parser.ExpressionStatement:

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3610,10 +3610,17 @@ func (c *Checker) checkObjectDestructuringDeclaration(node *parser.ObjectDestruc
 			restType = &types.ObjectType{Properties: make(map[string]types.Type)}
 		}
 
-		// Define the rest variable
+		// Define the rest variable. Like every other binding of the pattern, a
+		// `var` rest belongs in the function scope, not the current block - see
+		// declarationEnv.
 		if ident, ok := node.RestProperty.Target.(*parser.Identifier); ok {
-			if !c.env.Define(ident.Value, restType, node.IsConst) {
-				c.addError(ident, fmt.Sprintf("identifier '%s' already declared", ident.Value))
+			restEnv := c.declarationEnv(node.Token != nil && node.Token.Literal == "var")
+			if !restEnv.Define(ident.Value, restType, node.IsConst) {
+				if node.Token != nil && node.Token.Literal == "var" {
+					restEnv.Update(ident.Value, restType)
+				} else {
+					c.addError(ident, fmt.Sprintf("identifier '%s' already declared", ident.Value))
+				}
 			}
 			ident.SetComputedType(restType)
 		}

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -2118,6 +2118,14 @@ func (c *Checker) visit(node parser.Node) {
 	case *parser.ObjectDestructuringDeclaration:
 		c.checkObjectDestructuringDeclaration(node)
 
+	case *parser.DeclarationGroup:
+		// A single let/const/var clause mixing plain bindings with destructuring
+		// patterns. The group adds no scope of its own - visit its members in
+		// source order, exactly as if they were siblings.
+		for _, decl := range node.Declarations {
+			c.visit(decl)
+		}
+
 	case *parser.ReturnStatement:
 		if c.functionNestingDepth == 0 && !c.allowTopLevelReturn {
 			c.addError(node, "A 'return' statement can only be used within a function body.")

--- a/pkg/checker/destructuring_nested.go
+++ b/pkg/checker/destructuring_nested.go
@@ -214,8 +214,25 @@ func (c *Checker) checkNestedObjectTarget(objectTarget *parser.ObjectLiteral, ex
 	}
 }
 
+// declarationEnv returns the scope a declaration's bindings belong in. `var` is
+// function-scoped: its names go in the nearest function (or global) scope no
+// matter how many blocks deep the declaration sits, which is what the plain
+// VarStatement path already does via GetFunctionScope. let/const are
+// block-scoped and belong in the current scope.
+//
+// Defining a `var` pattern's bindings in the current scope instead is what made
+// them invisible after the enclosing block: `function f(){ { var {w} = o; }
+// return w; }` reported TS2304 even though the runtime binds w at function
+// scope.
+func (c *Checker) declarationEnv(isVar bool) *Environment {
+	if isVar {
+		return c.env.GetFunctionScope()
+	}
+	return c.env
+}
+
 // checkDestructuringTargetForDeclaration handles type checking and environment definition for destructuring targets in declarations
-func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expression, expectedType types.Type, isConst bool, allowRedeclare bool) {
+func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expression, expectedType types.Type, isConst bool, isVar bool) {
 	switch targetNode := target.(type) {
 	case *parser.Identifier:
 		// Simple identifier target - define in environment with refined type
@@ -232,9 +249,12 @@ func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expressio
 			}
 		}
 
-		if !c.env.Define(targetNode.Value, finalType, isConst) {
-			if allowRedeclare {
-				c.env.Update(targetNode.Value, finalType)
+		env := c.declarationEnv(isVar)
+		if !env.Define(targetNode.Value, finalType, isConst) {
+			if isVar {
+				// var redeclaration is legal; keep the plain-VarStatement path's
+				// behavior of updating the existing binding.
+				env.Update(targetNode.Value, finalType)
 			} else {
 				c.addError(targetNode, fmt.Sprintf("identifier '%s' already declared", targetNode.Value))
 			}
@@ -242,16 +262,16 @@ func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expressio
 		targetNode.SetComputedType(finalType)
 	case *parser.ArrayLiteral:
 		// Nested array destructuring declaration
-		c.checkNestedArrayTargetForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
+		c.checkNestedArrayTargetForDeclaration(targetNode, expectedType, isConst, isVar)
 	case *parser.ObjectLiteral:
 		// Nested object destructuring declaration
-		c.checkNestedObjectTargetForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
+		c.checkNestedObjectTargetForDeclaration(targetNode, expectedType, isConst, isVar)
 	case *parser.ArrayParameterPattern:
 		// Parameter patterns in declarations (shouldn't happen normally, but handle for consistency)
-		c.checkNestedArrayParameterPatternForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
+		c.checkNestedArrayParameterPatternForDeclaration(targetNode, expectedType, isConst, isVar)
 	case *parser.ObjectParameterPattern:
 		// Parameter patterns in declarations (shouldn't happen normally, but handle for consistency)
-		c.checkNestedObjectParameterPatternForDeclaration(targetNode, expectedType, isConst, allowRedeclare)
+		c.checkNestedObjectParameterPatternForDeclaration(targetNode, expectedType, isConst, isVar)
 	case *parser.UndefinedLiteral:
 		// Elision in destructuring - no type checking needed, just skip this element
 		return
@@ -269,7 +289,7 @@ func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expressio
 }
 
 // checkNestedArrayTargetForDeclaration handles type checking for nested array destructuring in declarations
-func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.ArrayLiteral, expectedType types.Type, isConst bool, allowRedeclare bool) {
+func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.ArrayLiteral, expectedType types.Type, isConst bool, isVar bool) {
 	// Validate that expectedType is array-like
 	widenedType := types.GetWidenedType(expectedType)
 	var elementType types.Type
@@ -285,7 +305,7 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 			} else {
 				elemType = types.Undefined
 			}
-			c.checkDestructuringTargetForDeclaration(element, elemType, isConst, allowRedeclare)
+			c.checkDestructuringTargetForDeclaration(element, elemType, isConst, isVar)
 		}
 		return
 	} else if unionType, ok := expectedType.(*types.UnionType); ok {
@@ -303,7 +323,7 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 
 		if arrayLikeType != nil {
 			// Recursively check with the array-like type from the union
-			c.checkNestedArrayTargetForDeclaration(arrayTarget, arrayLikeType, isConst, allowRedeclare)
+			c.checkNestedArrayTargetForDeclaration(arrayTarget, arrayLikeType, isConst, isVar)
 			return
 		}
 
@@ -318,12 +338,12 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 
 	// For regular array types, check each element with the same element type
 	for _, element := range arrayTarget.Elements {
-		c.checkDestructuringTargetForDeclaration(element, elementType, isConst, allowRedeclare)
+		c.checkDestructuringTargetForDeclaration(element, elementType, isConst, isVar)
 	}
 }
 
 // checkNestedObjectTargetForDeclaration handles type checking for nested object destructuring in declarations
-func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.ObjectLiteral, expectedType types.Type, isConst bool, allowRedeclare bool) {
+func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.ObjectLiteral, expectedType types.Type, isConst bool, isVar bool) {
 	// Validate that expectedType is object-like
 	widenedType := types.GetWidenedType(expectedType)
 
@@ -384,12 +404,12 @@ func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.Obj
 				}
 			}
 
-			c.checkDestructuringTargetForDeclaration(prop.Value, propType, isConst, allowRedeclare)
+			c.checkDestructuringTargetForDeclaration(prop.Value, propType, isConst, isVar)
 		}
 	} else {
 		// For Any type, all nested targets get Any type
 		for _, prop := range objectTarget.Properties {
-			c.checkDestructuringTargetForDeclaration(prop.Value, types.Any, isConst, allowRedeclare)
+			c.checkDestructuringTargetForDeclaration(prop.Value, types.Any, isConst, isVar)
 		}
 	}
 }
@@ -470,7 +490,7 @@ func (c *Checker) checkNestedObjectParameterPattern(pattern *parser.ObjectParame
 }
 
 // checkNestedArrayParameterPatternForDeclaration handles type checking for nested array parameter patterns in declarations
-func (c *Checker) checkNestedArrayParameterPatternForDeclaration(pattern *parser.ArrayParameterPattern, expectedType types.Type, isConst bool, allowRedeclare bool) {
+func (c *Checker) checkNestedArrayParameterPatternForDeclaration(pattern *parser.ArrayParameterPattern, expectedType types.Type, isConst bool, isVar bool) {
 	widenedType := types.GetWidenedType(expectedType)
 	var elementType types.Type
 
@@ -484,12 +504,12 @@ func (c *Checker) checkNestedArrayParameterPatternForDeclaration(pattern *parser
 		if elem == nil || elem.Target == nil {
 			continue
 		}
-		c.checkDestructuringTargetForDeclaration(elem.Target, elementType, isConst, allowRedeclare)
+		c.checkDestructuringTargetForDeclaration(elem.Target, elementType, isConst, isVar)
 	}
 }
 
 // checkNestedObjectParameterPatternForDeclaration handles type checking for nested object parameter patterns in declarations
-func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parser.ObjectParameterPattern, expectedType types.Type, isConst bool, allowRedeclare bool) {
+func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parser.ObjectParameterPattern, expectedType types.Type, isConst bool, isVar bool) {
 	widenedType := types.GetWidenedType(expectedType)
 
 	if widenedType != types.Any {
@@ -501,9 +521,9 @@ func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parse
 					continue
 				}
 				if prop.Target != nil {
-					c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst, allowRedeclare)
+					c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst, isVar)
 				} else {
-					c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst, allowRedeclare)
+					c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst, isVar)
 				}
 			}
 			return
@@ -525,9 +545,9 @@ func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parse
 			}
 
 			if prop.Target != nil {
-				c.checkDestructuringTargetForDeclaration(prop.Target, propType, isConst, allowRedeclare)
+				c.checkDestructuringTargetForDeclaration(prop.Target, propType, isConst, isVar)
 			} else {
-				c.checkDestructuringTargetForDeclaration(prop.Key, propType, isConst, allowRedeclare)
+				c.checkDestructuringTargetForDeclaration(prop.Key, propType, isConst, isVar)
 			}
 		}
 	} else {
@@ -537,9 +557,9 @@ func (c *Checker) checkNestedObjectParameterPatternForDeclaration(pattern *parse
 				continue
 			}
 			if prop.Target != nil {
-				c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst, allowRedeclare)
+				c.checkDestructuringTargetForDeclaration(prop.Target, types.Any, isConst, isVar)
 			} else {
-				c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst, allowRedeclare)
+				c.checkDestructuringTargetForDeclaration(prop.Key, types.Any, isConst, isVar)
 			}
 		}
 	}

--- a/pkg/checker/destructuring_nested.go
+++ b/pkg/checker/destructuring_nested.go
@@ -7,6 +7,43 @@ import (
 	"github.com/nooga/paserati/pkg/types"
 )
 
+// nestedObjectPatternRestType is the type a rest binding inside a nested object
+// pattern receives: an object of the source's properties minus the ones the
+// pattern extracted by name. Mirrors the top-level RestProperty case in
+// checkObjectDestructuringDeclaration.
+//
+// A nested pattern is a raw ObjectLiteral, so its rest arrives as a
+// SpreadElement in ObjectProperty.Key rather than in a RestProperty field -
+// which is why it reaches the key check rather than the target walk.
+func nestedObjectPatternRestType(source types.Type, pattern *parser.ObjectLiteral) types.Type {
+	if types.GetWidenedType(source) == types.Any {
+		return types.Any
+	}
+	objType, ok := source.(*types.ObjectType)
+	if !ok {
+		return &types.ObjectType{Properties: make(map[string]types.Type)}
+	}
+	extracted := make(map[string]struct{})
+	for _, prop := range pattern.Properties {
+		if prop == nil {
+			continue
+		}
+		if keyIdent, ok := prop.Key.(*parser.Identifier); ok {
+			extracted[keyIdent.Value] = struct{}{}
+		} else if numLit, ok := prop.Key.(*parser.NumberLiteral); ok {
+			extracted[numLit.Token.Literal] = struct{}{}
+		}
+		// Computed keys and the rest element itself contribute nothing.
+	}
+	remaining := make(map[string]types.Type)
+	for name, t := range objType.Properties {
+		if _, wasExtracted := extracted[name]; !wasExtracted {
+			remaining[name] = t
+		}
+	}
+	return &types.ObjectType{Properties: remaining}
+}
+
 // unwrapNestedPatternTarget peels the wrappers a *nested* destructuring target
 // can carry, and adjusts the type the binding inside should receive.
 //
@@ -260,13 +297,10 @@ func (c *Checker) checkNestedObjectTarget(objectTarget *parser.ObjectLiteral, ex
 			} else if numLit, ok := prop.Key.(*parser.NumberLiteral); ok {
 				propName = numLit.Token.Literal
 			} else {
-				if _, isRest := prop.Key.(*parser.SpreadElement); isRest {
+				if spread, isRest := prop.Key.(*parser.SpreadElement); isRest {
 					// A rest element nested inside an object pattern
-					// (`{a: {b, ...rr}}`). The parser stores it as a
-					// SpreadElement in Key, so it reaches this key check rather
-					// than the target walk. The compiler cannot emit it either,
-					// so name the limitation instead of blaming the key.
-					c.addError(prop.Key, "a rest element is not supported inside a nested object pattern")
+					// (`{a: {b, ...rr}}`) - see nestedObjectPatternRestType.
+					c.checkDestructuringTargetForProperty(spread.Argument, nestedObjectPatternRestType(expectedType, objectTarget), "")
 					continue
 				}
 				c.addError(prop.Key, "object destructuring key must be an identifier or number")
@@ -291,6 +325,10 @@ func (c *Checker) checkNestedObjectTarget(objectTarget *parser.ObjectLiteral, ex
 	} else {
 		// For Any type, all nested targets get Any type
 		for _, prop := range objectTarget.Properties {
+			if spread, isRest := prop.Key.(*parser.SpreadElement); isRest {
+				c.checkDestructuringTargetForProperty(spread.Argument, types.Any, "")
+				continue
+			}
 			c.checkDestructuringTargetForProperty(prop.Value, types.Any, "")
 		}
 	}
@@ -481,13 +519,11 @@ func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.Obj
 			} else if numLit, ok := prop.Key.(*parser.NumberLiteral); ok {
 				propName = numLit.Token.Literal
 			} else {
-				if _, isRest := prop.Key.(*parser.SpreadElement); isRest {
+				if spread, isRest := prop.Key.(*parser.SpreadElement); isRest {
 					// A rest element nested inside an object pattern
-					// (`{a: {b, ...rr}}`). The parser stores it as a
-					// SpreadElement in Key, so it reaches this key check rather
-					// than the target walk. The compiler cannot emit it either,
-					// so name the limitation instead of blaming the key.
-					c.addError(prop.Key, "a rest element is not supported inside a nested object pattern")
+					// (`{a: {b, ...rr}}`): it gets the source's remaining
+					// properties, like a top-level object rest.
+					c.checkDestructuringTargetForDeclaration(spread.Argument, nestedObjectPatternRestType(expectedType, objectTarget), isConst, isVar)
 					continue
 				}
 				c.addError(prop.Key, "object destructuring key must be an identifier or number")
@@ -512,6 +548,10 @@ func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.Obj
 	} else {
 		// For Any type, all nested targets get Any type
 		for _, prop := range objectTarget.Properties {
+			if spread, isRest := prop.Key.(*parser.SpreadElement); isRest {
+				c.checkDestructuringTargetForDeclaration(spread.Argument, types.Any, isConst, isVar)
+				continue
+			}
 			c.checkDestructuringTargetForDeclaration(prop.Value, types.Any, isConst, isVar)
 		}
 	}

--- a/pkg/checker/destructuring_nested.go
+++ b/pkg/checker/destructuring_nested.go
@@ -7,6 +7,71 @@ import (
 	"github.com/nooga/paserati/pkg/types"
 )
 
+// unwrapNestedPatternTarget peels the wrappers a *nested* destructuring target
+// can carry, and adjusts the type the binding inside should receive.
+//
+// A pattern is represented two ways depending on depth. At the top level of a
+// declaration a default lives in DestructuringProperty.Default /
+// DestructuringElement.Default and a rest in DestructuringElement.IsRest, with
+// Target holding the binding. Nested one level down, Target is a raw
+// ObjectLiteral/ArrayLiteral, so a default appears as an AssignmentExpression
+// and a rest as a SpreadElement, with the binding inside the wrapper. The
+// target walks knew Identifier/ObjectLiteral/ArrayLiteral but neither wrapper,
+// so `const {h: {i = 7}} = o` and `const [[j, ...k]] = o` were rejected with
+// "invalid destructuring target type: *parser.AssignmentExpression/SpreadElement"
+// even though the runtime binds them correctly.
+//
+// The type adjustments mirror the top-level cases: a default replaces an
+// Undefined/Unknown type with its own widened type, and a rest binding gets an
+// array of the element type. Returns the target unchanged when it carries
+// neither wrapper.
+func (c *Checker) unwrapNestedPatternTarget(target parser.Expression, expectedType types.Type) (parser.Expression, types.Type) {
+	switch t := target.(type) {
+	case *parser.AssignmentExpression:
+		// Nested default: `{h: {i = 7}}` / `[[m = 4]]`.
+		if t.Value != nil {
+			c.visit(t.Value)
+			defaultType := t.Value.GetComputedType()
+			if defaultType == nil {
+				defaultType = types.Any
+			}
+			if expectedType == types.Undefined || expectedType == types.Unknown {
+				expectedType = types.GetWidenedType(defaultType)
+			}
+		}
+		return t.Left, expectedType
+	case *parser.SpreadElement:
+		// Nested rest: `[[x, ...ys]]`. The caller passes the element type, so an
+		// array of it is right for a plain array or Any source. A tuple source
+		// needs the union of the *remaining* element types instead, which only
+		// the array walk knows the position for - it calls restElementType
+		// directly and bypasses this.
+		return t.Argument, &types.ArrayType{ElementType: expectedType}
+	}
+	return target, expectedType
+}
+
+// restElementType is the type a rest binding receives when destructuring source
+// at position index: an array of the remaining element types. Mirrors the
+// top-level IsRest case in checkArrayDestructuringDeclaration.
+func restElementType(source types.Type, index int) types.Type {
+	switch t := source.(type) {
+	case *types.ArrayType:
+		return &types.ArrayType{ElementType: t.ElementType}
+	case *types.TupleType:
+		if index >= len(t.ElementTypes) {
+			return &types.ArrayType{ElementType: types.Never}
+		}
+		remaining := t.ElementTypes[index:]
+		if len(remaining) == 1 {
+			return &types.ArrayType{ElementType: remaining[0]}
+		}
+		return &types.ArrayType{ElementType: &types.UnionType{Types: remaining}}
+	default:
+		return &types.ArrayType{ElementType: types.Any}
+	}
+}
+
 // checkDestructuringTarget handles recursive type checking for destructuring targets
 func (c *Checker) checkDestructuringTarget(target parser.Expression, expectedType types.Type, context interface{}) {
 	switch targetNode := target.(type) {
@@ -30,6 +95,10 @@ func (c *Checker) checkDestructuringTarget(target parser.Expression, expectedTyp
 		// Index access as target: [arr[0]] = [value]
 		// Type check the index expression and ensure it's assignable
 		c.visit(targetNode)
+	case *parser.AssignmentExpression, *parser.SpreadElement:
+		// Nested default or rest - see unwrapNestedPatternTarget.
+		inner, innerType := c.unwrapNestedPatternTarget(target, expectedType)
+		c.checkDestructuringTarget(inner, innerType, context)
 	case *parser.UndefinedLiteral:
 		// Elision in destructuring - no type checking needed, just skip this element
 		return
@@ -57,6 +126,10 @@ func (c *Checker) checkDestructuringTargetForProperty(target parser.Expression, 
 	case *parser.IndexExpression:
 		// Index access as target: {prop: arr[0]} = {prop: value}
 		c.visit(targetNode)
+	case *parser.AssignmentExpression, *parser.SpreadElement:
+		// Nested default or rest - see unwrapNestedPatternTarget.
+		inner, innerType := c.unwrapNestedPatternTarget(target, expectedType)
+		c.checkDestructuringTargetForProperty(inner, innerType, propName)
 	case *parser.UndefinedLiteral:
 		// Elision in destructuring - no type checking needed, just skip this element
 		return
@@ -187,6 +260,15 @@ func (c *Checker) checkNestedObjectTarget(objectTarget *parser.ObjectLiteral, ex
 			} else if numLit, ok := prop.Key.(*parser.NumberLiteral); ok {
 				propName = numLit.Token.Literal
 			} else {
+				if _, isRest := prop.Key.(*parser.SpreadElement); isRest {
+					// A rest element nested inside an object pattern
+					// (`{a: {b, ...rr}}`). The parser stores it as a
+					// SpreadElement in Key, so it reaches this key check rather
+					// than the target walk. The compiler cannot emit it either,
+					// so name the limitation instead of blaming the key.
+					c.addError(prop.Key, "a rest element is not supported inside a nested object pattern")
+					continue
+				}
 				c.addError(prop.Key, "object destructuring key must be an identifier or number")
 				continue
 			}
@@ -283,6 +365,10 @@ func (c *Checker) checkDestructuringTargetForDeclaration(target parser.Expressio
 		// Index access as target: const [arr[0]] = [value]
 		// This is valid in JavaScript (though less common in declarations)
 		c.visit(targetNode)
+	case *parser.AssignmentExpression, *parser.SpreadElement:
+		// Nested default or rest - see unwrapNestedPatternTarget.
+		inner, innerType := c.unwrapNestedPatternTarget(target, expectedType)
+		c.checkDestructuringTargetForDeclaration(inner, innerType, isConst, isVar)
 	default:
 		c.addError(target, fmt.Sprintf("invalid destructuring target type: %T", target))
 	}
@@ -299,6 +385,14 @@ func (c *Checker) checkNestedArrayTargetForDeclaration(arrayTarget *parser.Array
 	} else if tupleType, ok := widenedType.(*types.TupleType); ok {
 		// For tuple types, check each element with its specific type
 		for i, element := range arrayTarget.Elements {
+			// A rest element consumes the remaining tuple members, so it gets an
+			// array of their union - not element i's type, which would
+			// over-narrow and silently accept e.g. string[] for a
+			// (string|boolean)[] value.
+			if spread, ok := element.(*parser.SpreadElement); ok {
+				c.checkDestructuringTargetForDeclaration(spread.Argument, restElementType(tupleType, i), isConst, isVar)
+				continue
+			}
 			var elemType types.Type
 			if i < len(tupleType.ElementTypes) {
 				elemType = tupleType.ElementTypes[i]
@@ -387,6 +481,15 @@ func (c *Checker) checkNestedObjectTargetForDeclaration(objectTarget *parser.Obj
 			} else if numLit, ok := prop.Key.(*parser.NumberLiteral); ok {
 				propName = numLit.Token.Literal
 			} else {
+				if _, isRest := prop.Key.(*parser.SpreadElement); isRest {
+					// A rest element nested inside an object pattern
+					// (`{a: {b, ...rr}}`). The parser stores it as a
+					// SpreadElement in Key, so it reaches this key check rather
+					// than the target walk. The compiler cannot emit it either,
+					// so name the limitation instead of blaming the key.
+					c.addError(prop.Key, "a rest element is not supported inside a nested object pattern")
+					continue
+				}
 				c.addError(prop.Key, "object destructuring key must be an identifier or number")
 				continue
 			}

--- a/pkg/checker/function_common.go
+++ b/pkg/checker/function_common.go
@@ -378,8 +378,13 @@ func (c *Checker) resolveFunctionParametersWithContext(ctx *FunctionCheckContext
 func (c *Checker) setupFunctionEnvironment(ctx *FunctionCheckContext, paramTypes []types.Type, paramNames []*parser.Identifier, restParameterType types.Type, restParameterName *parser.Identifier, preliminarySignature *types.Signature, typeParamEnv *Environment) *Environment {
 	debugPrintf("// [Checker Function Common] Creating scope for '%s'. Current Env: %p\n", ctx.FunctionName, c.env)
 	originalEnv := c.env
-	// Use the type parameter environment as the base for the function body environment
-	funcEnv := NewEnclosedEnvironment(typeParamEnv)
+	// Use the type parameter environment as the base for the function body
+	// environment. NewFunctionEnvironment, not NewEnclosedEnvironment: this is a
+	// function scope, and GetFunctionScope (which is where every `var` binding
+	// lands) walks up until it finds one. A block-scoped env here let a `var` in
+	// any function body escape to the *enclosing* function or global scope -
+	// `function outer(){ function inner(){ var w = 1; } return w; }` resolved w.
+	funcEnv := NewFunctionEnvironment(typeParamEnv)
 	c.env = funcEnv
 
 	// Define regular parameters (skip 'this' parameters which have nil nameNode)

--- a/pkg/checker/namespace.go
+++ b/pkg/checker/namespace.go
@@ -215,20 +215,15 @@ func (c *Checker) checkNamespaceBodyStatement(stmt parser.Statement, nsType *typ
 		_ = n
 		return
 
-	case *parser.LetStatement:
-		c.visit(n)
+	case *parser.LetStatement, *parser.ConstStatement, *parser.VarStatement,
+		*parser.ObjectDestructuringDeclaration, *parser.ArrayDestructuringDeclaration:
+		c.visit(inner)
 		if exported {
-			c.copyVarBindings(n.Declarations, nsType)
-		}
-	case *parser.ConstStatement:
-		c.visit(n)
-		if exported {
-			c.copyVarBindings(n.Declarations, nsType)
-		}
-	case *parser.VarStatement:
-		c.visit(n)
-		if exported {
-			c.copyVarBindings(n.Declarations, nsType)
+			// Every declarator of the clause, and every name a destructuring
+			// pattern binds - `export const {a} = obj` had no case here at all,
+			// so a was missing from the namespace type (TS2339 on N.a) even
+			// though it existed as a binding inside the body.
+			c.copyBindingTypes(parser.DeclaredNames(inner), nsType)
 		}
 
 	case *parser.ExpressionStatement:
@@ -267,15 +262,12 @@ func (c *Checker) checkNamespaceBodyStatement(stmt parser.Statement, nsType *typ
 	}
 }
 
-// copyVarBindings copies the resolved types of var/let/const declarators from
-// the current body env into the namespace's ValueShape.
-func (c *Checker) copyVarBindings(decls []*parser.VarDeclarator, nsType *types.NamespaceType) {
-	for _, d := range decls {
-		if d == nil || d.Name == nil {
-			continue
-		}
-		if t, _, found := c.env.Resolve(d.Name.Value); found {
-			nsType.ValueShape.Properties[d.Name.Value] = t
+// copyBindingTypes copies the resolved types of the named bindings from the
+// current body env into the namespace's ValueShape.
+func (c *Checker) copyBindingTypes(names []string, nsType *types.NamespaceType) {
+	for _, name := range names {
+		if t, _, found := c.env.Resolve(name); found {
+			nsType.ValueShape.Properties[name] = t
 		}
 	}
 }

--- a/pkg/checker/statements.go
+++ b/pkg/checker/statements.go
@@ -1141,6 +1141,14 @@ func (c *Checker) defineDestructuringTarget(target parser.Expression, typ types.
 	case *parser.ObjectLiteral:
 		// Nested object destructuring - recursively handle
 		for _, prop := range t.Properties {
+			// A rest element nested inside the pattern (`{a: {b, ...rr}}`)
+			// arrives as a SpreadElement in Key, so the identifier check below
+			// would skip it silently and the later read would be "Cannot find
+			// name 'rr'".
+			if spread, isRest := prop.Key.(*parser.SpreadElement); isRest {
+				c.defineDestructuringTarget(spread.Argument, nestedObjectPatternRestType(typ, t), isConst, isVar)
+				continue
+			}
 			// Extract key name from the property
 			if ident, ok := prop.Key.(*parser.Identifier); ok {
 				var propType types.Type

--- a/pkg/checker/statements.go
+++ b/pkg/checker/statements.go
@@ -1112,10 +1112,13 @@ func (c *Checker) checkObjectDestructuringInForLoop(node *parser.ObjectDestructu
 //
 // Note this walker is shallower than checkDestructuringTargetForDeclaration: for
 // a nested object pattern it reads prop.Key only, so a nested *renamed* target
-// (`{f: {g: h}}`) binds g rather than h, and it has no AssignmentExpression
-// (nested default) or SpreadElement (nested rest) cases. Pre-existing, and not
-// about scope.
+// (`{f: {g: h}}`) binds g rather than h. Pre-existing, and not about scope.
 func (c *Checker) defineDestructuringTarget(target parser.Expression, typ types.Type, isConst bool, isVar bool) {
+	// A nested default or rest wraps the binding - see
+	// unwrapNestedPatternTarget. Without this, `for (const [[x, ...ys]] of xs)`
+	// and `for (const {a: [q = 5]} of xs)` silently bound nothing (this walk's
+	// default case skips quietly), so the later read was TS2304.
+	target, typ = c.unwrapNestedPatternTarget(target, typ)
 	env := c.declarationEnv(isVar)
 	switch t := target.(type) {
 	case *parser.Identifier:

--- a/pkg/checker/statements.go
+++ b/pkg/checker/statements.go
@@ -845,10 +845,14 @@ func (c *Checker) checkForOfStatement(node *parser.ForOfStatement) {
 	c.env = loopEnv
 	debugPrintf("// [Checker ForOfStmt] Created loop scope %p (outer: %p)\n", loopEnv, originalEnv)
 
-	// Hoist var declarations to the outer scope so they're visible in the iterable expression.
-	// e.g. `for (var of of of)` — the iterable `of` must find `var of` in scope.
+	// Hoist var declarations out of the loop scope so they're visible in the
+	// iterable expression - e.g. `for (var of of of)`, where the iterable `of`
+	// must find `var of` in scope - and, since var is function-scoped, after the
+	// loop as well. originalEnv is only the *immediately* enclosing scope, so
+	// defining there left `{ for (var q of xs) {} } q` unresolvable one block
+	// deeper; the function scope is the right home.
 	if varStmt, ok := node.Variable.(*parser.VarStatement); ok && varStmt.Name != nil {
-		originalEnv.Define(varStmt.Name.Value, types.Any, false)
+		c.declarationEnv(true).Define(varStmt.Name.Value, types.Any, false)
 	}
 
 	// Visit the iterable first to determine its type
@@ -974,9 +978,10 @@ func (c *Checker) checkForOfStatement(node *parser.ForOfStatement) {
 					constStmt.Name.SetComputedType(elementType)
 				}
 			} else if varStmt, ok := node.Variable.(*parser.VarStatement); ok {
-				// Define the loop variable with the element type
+				// Define the loop variable with the element type. var is
+				// function-scoped, so it does not belong in the loop scope.
 				if varStmt.Name != nil {
-					c.env.Define(varStmt.Name.Value, elementType, false)
+					c.declarationEnv(true).Define(varStmt.Name.Value, elementType, false)
 					varStmt.ComputedType = elementType
 					varStmt.Name.SetComputedType(elementType)
 				}
@@ -1022,6 +1027,7 @@ func (c *Checker) checkForOfStatement(node *parser.ForOfStatement) {
 
 // checkArrayDestructuringInForLoop type-checks array destructuring patterns in for-of/for-in loops
 func (c *Checker) checkArrayDestructuringInForLoop(node *parser.ArrayDestructuringDeclaration, sourceType types.Type) {
+	isVar := node.Token != nil && node.Token.Literal == "var"
 	// For each element in the destructuring pattern, extract its type and define it
 	for i, element := range node.Elements {
 		var elemType types.Type
@@ -1051,12 +1057,13 @@ func (c *Checker) checkArrayDestructuringInForLoop(node *parser.ArrayDestructuri
 		}
 
 		// Define the variable(s) from the target
-		c.defineDestructuringTarget(element.Target, elemType, node.IsConst)
+		c.defineDestructuringTarget(element.Target, elemType, node.IsConst, isVar)
 	}
 }
 
 // checkObjectDestructuringInForLoop type-checks object destructuring patterns in for-of/for-in loops
 func (c *Checker) checkObjectDestructuringInForLoop(node *parser.ObjectDestructuringDeclaration, sourceType types.Type) {
+	isVar := node.Token != nil && node.Token.Literal == "var"
 	// For each property in the destructuring pattern, extract its type and define it
 	for _, prop := range node.Properties {
 		var propType types.Type
@@ -1088,22 +1095,32 @@ func (c *Checker) checkObjectDestructuringInForLoop(node *parser.ObjectDestructu
 		}
 
 		// Define the variable from the target
-		c.defineDestructuringTarget(prop.Target, propType, node.IsConst)
+		c.defineDestructuringTarget(prop.Target, propType, node.IsConst, isVar)
 	}
 
 	// Handle rest property
 	if node.RestProperty != nil {
 		// Rest gets the remaining object type (simplified as the source type for now)
-		c.defineDestructuringTarget(node.RestProperty.Target, sourceType, node.IsConst)
+		c.defineDestructuringTarget(node.RestProperty.Target, sourceType, node.IsConst, isVar)
 	}
 }
 
 // defineDestructuringTarget defines variables from a destructuring target (handles nested patterns)
-func (c *Checker) defineDestructuringTarget(target parser.Expression, typ types.Type, isConst bool) {
+// defineDestructuringTarget defines the bindings of a for-of/for-in head's
+// destructuring pattern. isVar routes them to the function scope, since `var` is
+// function-scoped however deep the loop sits (see declarationEnv).
+//
+// Note this walker is shallower than checkDestructuringTargetForDeclaration: for
+// a nested object pattern it reads prop.Key only, so a nested *renamed* target
+// (`{f: {g: h}}`) binds g rather than h, and it has no AssignmentExpression
+// (nested default) or SpreadElement (nested rest) cases. Pre-existing, and not
+// about scope.
+func (c *Checker) defineDestructuringTarget(target parser.Expression, typ types.Type, isConst bool, isVar bool) {
+	env := c.declarationEnv(isVar)
 	switch t := target.(type) {
 	case *parser.Identifier:
 		// Simple identifier - define it
-		c.env.Define(t.Value, typ, isConst)
+		env.Define(t.Value, typ, isConst)
 		t.SetComputedType(typ)
 	case *parser.ArrayLiteral:
 		// Nested array destructuring - recursively handle
@@ -1116,7 +1133,7 @@ func (c *Checker) defineDestructuringTarget(target parser.Expression, typ types.
 			} else {
 				elemType = types.Any
 			}
-			c.defineDestructuringTarget(elem, elemType, isConst)
+			c.defineDestructuringTarget(elem, elemType, isConst, isVar)
 		}
 	case *parser.ObjectLiteral:
 		// Nested object destructuring - recursively handle
@@ -1133,7 +1150,7 @@ func (c *Checker) defineDestructuringTarget(target parser.Expression, typ types.
 				} else {
 					propType = types.Any
 				}
-				c.env.Define(ident.Value, propType, isConst)
+				env.Define(ident.Value, propType, isConst)
 				ident.SetComputedType(propType)
 			}
 		}
@@ -1160,9 +1177,11 @@ func (c *Checker) checkForInStatement(node *parser.ForInStatement) {
 	c.env = loopEnv
 	debugPrintf("// [Checker ForInStmt] Created loop scope %p (outer: %p)\n", loopEnv, originalEnv)
 
-	// Hoist var declarations to the outer scope so they're visible in the object expression.
+	// Hoist var declarations out of the loop scope so they're visible in the
+	// object expression, and - since var is function-scoped - after the loop as
+	// well. See the matching comment in checkForOfStatement.
 	if varStmt, ok := node.Variable.(*parser.VarStatement); ok && varStmt.Name != nil {
-		originalEnv.Define(varStmt.Name.Value, types.Any, false)
+		c.declarationEnv(true).Define(varStmt.Name.Value, types.Any, false)
 	}
 
 	// Visit the object first to determine its type
@@ -1197,14 +1216,12 @@ func (c *Checker) checkForInStatement(node *parser.ForInStatement) {
 					letStmt.Name.SetComputedType(elementType)
 				}
 			} else if varStmt, ok := node.Variable.(*parser.VarStatement); ok {
-				// Var in for-in header hoists to nearest function/global scope.
+				// Var in for-in header hoists to nearest function/global scope -
+				// which is what the comment always said, but originalEnv is only
+				// the immediately enclosing scope, not necessarily a function
+				// scope.
 				if varStmt.Name != nil {
-					// Define in the outer (original) environment, not the temporary loop block.
-					if originalEnv != nil {
-						originalEnv.Define(varStmt.Name.Value, elementType, false)
-					} else {
-						c.env.Define(varStmt.Name.Value, elementType, false)
-					}
+					c.declarationEnv(true).Define(varStmt.Name.Value, elementType, false)
 					varStmt.ComputedType = elementType
 					varStmt.Name.SetComputedType(elementType)
 				}

--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nooga/paserati/pkg/errors"
+	"github.com/nooga/paserati/pkg/lexer"
 	"github.com/nooga/paserati/pkg/parser"
 	"github.com/nooga/paserati/pkg/types"
 	"github.com/nooga/paserati/pkg/vm"
@@ -2276,19 +2277,26 @@ func (c *Compiler) compileNamedDefaultExpr(defaultExpr parser.Expression, destRe
 	return err
 }
 
+// isVarDeclToken reports whether a destructuring declaration's keyword token is
+// `var`. var is function-scoped; let/const are block-scoped. See
+// defineDestructuredVariableWithValue.
+func isVarDeclToken(tok *lexer.Token) bool {
+	return tok != nil && tok.Type == lexer.VAR
+}
+
 // defineIdentWithOptionalDefault initializes a destructuring declaration binding.
 // For const, the value must be computed first and then defined — assigning
 // after DefineConstTDZ throws "Assignment to constant variable".
-func (c *Compiler) defineIdentWithOptionalDefault(name string, isConst bool, valueReg Register, defaultExpr parser.Expression, line int) errors.PaseratiError {
+func (c *Compiler) defineIdentWithOptionalDefault(name string, isConst bool, isVar bool, valueReg Register, defaultExpr parser.Expression, line int) errors.PaseratiError {
 	if defaultExpr == nil {
-		return c.defineDestructuredVariableWithValue(name, isConst, valueReg, line)
+		return c.defineDestructuredVariableWithValue(name, isConst, isVar, valueReg, line)
 	}
 	resultReg := c.regAlloc.Alloc()
 	if err := c.emitSelectValueOrDefault(valueReg, resultReg, defaultExpr, name, line); err != nil {
 		c.regAlloc.Free(resultReg)
 		return err
 	}
-	err := c.defineDestructuredVariableWithValue(name, isConst, resultReg, line)
+	err := c.defineDestructuredVariableWithValue(name, isConst, isVar, resultReg, line)
 	c.regAlloc.Free(resultReg)
 	return err
 }
@@ -2469,7 +2477,7 @@ func (c *Compiler) compileObjectRestProperty(objReg Register, extractedProps []*
 }
 
 // compileObjectRestDeclaration compiles rest property declaration for object destructuring
-func (c *Compiler) compileObjectRestDeclaration(objReg Register, extractedProps []*parser.DestructuringProperty, varName string, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileObjectRestDeclaration(objReg Register, extractedProps []*parser.DestructuringProperty, varName string, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// Create array of property names to exclude
 	excludeArrayReg := c.regAlloc.Alloc()
 	defer c.regAlloc.Free(excludeArrayReg)
@@ -2541,7 +2549,7 @@ func (c *Compiler) compileObjectRestDeclaration(objReg Register, extractedProps 
 	c.emitByte(byte(excludeArrayReg)) // exclude array register
 
 	// Define the rest variable with the rest object
-	return c.defineDestructuredVariableWithValue(varName, isConst, restObjReg, line)
+	return c.defineDestructuredVariableWithValue(varName, isConst, isVar, restObjReg, line)
 }
 
 // compileArrayDestructuringDeclaration compiles let/const [a, b] = expr declarations
@@ -2561,7 +2569,7 @@ func (c *Compiler) compileArrayDestructuringDeclaration(node *parser.ArrayDestru
 
 			if ident, ok := element.Target.(*parser.Identifier); ok {
 				// Define variable with undefined value
-				err := c.defineDestructuredVariable(ident.Value, node.IsConst, types.Undefined, line)
+				err := c.defineDestructuredVariable(ident.Value, node.IsConst, isVarDeclToken(node.Token), types.Undefined, line)
 				if err != nil {
 					return BadRegister, err
 				}
@@ -2582,7 +2590,7 @@ func (c *Compiler) compileArrayDestructuringDeclaration(node *parser.ArrayDestru
 	// 2. Use iterator protocol for all destructuring
 	// This works for arrays (which have Symbol.iterator built-in) AND custom iterables
 	// Arrays' Symbol.iterator provides optimal performance by returning numeric indices
-	err = c.compileArrayDestructuringIteratorPath(node, valueReg, line)
+	err = c.compileArrayDestructuringIteratorPath(node, isVarDeclToken(node.Token), valueReg, line)
 	if err != nil {
 		return BadRegister, err
 	}
@@ -2591,7 +2599,7 @@ func (c *Compiler) compileArrayDestructuringDeclaration(node *parser.ArrayDestru
 }
 
 // compileArrayDestructuringFastPath compiles array destructuring using numeric indexing (fast path)
-func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructuringDeclaration, arrayReg Register, line int) errors.PaseratiError {
+func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructuringDeclaration, isVar bool, arrayReg Register, line int) errors.PaseratiError {
 	// For each element, compile: define target = array[index]
 	for i, element := range node.Elements {
 		if element.Target == nil {
@@ -2700,7 +2708,7 @@ func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructu
 				c.patchJump(jumpPastDefault)
 
 				// Now define the variable with the computed value
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, resultReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, resultReg, line)
 				if err != nil {
 					c.regAlloc.Free(resultReg)
 					c.regAlloc.Free(valueReg)
@@ -2710,7 +2718,7 @@ func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructu
 				c.regAlloc.Free(resultReg)
 			} else {
 				// Define variable with extracted value
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, valueReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, valueReg, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return err
@@ -2720,14 +2728,14 @@ func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructu
 			// Nested pattern target (ArrayLiteral or ObjectLiteral)
 			if element.Default != nil {
 				// Handle conditional assignment for nested patterns
-				err := c.compileConditionalAssignmentForDeclaration(element.Target, valueReg, element.Default, node.IsConst, line)
+				err := c.compileConditionalAssignmentForDeclaration(element.Target, valueReg, element.Default, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return err
 				}
 			} else {
 				// Direct nested pattern assignment using recursive compilation
-				err := c.compileNestedPatternDeclaration(element.Target, valueReg, node.IsConst, line)
+				err := c.compileNestedPatternDeclaration(element.Target, valueReg, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return err
@@ -2743,7 +2751,7 @@ func (c *Compiler) compileArrayDestructuringFastPath(node *parser.ArrayDestructu
 }
 
 // compileArrayDestructuringIteratorPath compiles array destructuring using iterator protocol
-func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestructuringDeclaration, iterableReg Register, line int) errors.PaseratiError {
+func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestructuringDeclaration, isVar bool, iterableReg Register, line int) errors.PaseratiError {
 	// fmt.Printf("// [COMPILE-ITER] Starting iterator path compilation, iterableReg=R%d\n", iterableReg)
 
 	// Set up the destructuring source. When the pattern has no rest element and
@@ -2779,14 +2787,14 @@ func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestr
 
 			// Bind rest array to target
 			if ident, ok := element.Target.(*parser.Identifier); ok {
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, restArrayReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, restArrayReg, line)
 				c.regAlloc.Free(restArrayReg)
 				if err != nil {
 					return err
 				}
 			} else {
 				// Nested pattern: [...[x, y]] - destructure the rest array into the pattern
-				err := c.compileNestedPatternDeclaration(element.Target, restArrayReg, node.IsConst, line)
+				err := c.compileNestedPatternDeclaration(element.Target, restArrayReg, node.IsConst, isVar, line)
 				c.regAlloc.Free(restArrayReg)
 				if err != nil {
 					return err
@@ -2881,7 +2889,7 @@ func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestr
 				c.patchJump(jumpPastDefault)
 
 				// 5. Now resultReg contains the correct value - define the variable with it
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, resultReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, resultReg, line)
 				c.regAlloc.Free(resultReg)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
@@ -2889,7 +2897,7 @@ func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestr
 				}
 			} else {
 				// Define variable with value
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, valueReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, valueReg, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return err
@@ -2898,13 +2906,13 @@ func (c *Compiler) compileArrayDestructuringIteratorPath(node *parser.ArrayDestr
 		} else {
 			// Nested pattern
 			if element.Default != nil {
-				err := c.compileConditionalAssignmentForDeclaration(element.Target, valueReg, element.Default, node.IsConst, line)
+				err := c.compileConditionalAssignmentForDeclaration(element.Target, valueReg, element.Default, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return err
 				}
 			} else {
-				err := c.compileNestedPatternDeclaration(element.Target, valueReg, node.IsConst, line)
+				err := c.compileNestedPatternDeclaration(element.Target, valueReg, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return err
@@ -2939,7 +2947,7 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 
 			if ident, ok := prop.Target.(*parser.Identifier); ok {
 				// Define variable with undefined value
-				err := c.defineDestructuredVariable(ident.Value, node.IsConst, types.Undefined, line)
+				err := c.defineDestructuredVariable(ident.Value, node.IsConst, isVarDeclToken(node.Token), types.Undefined, line)
 				if err != nil {
 					return BadRegister, err
 				}
@@ -2949,7 +2957,7 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 		// Handle rest property without initializer
 		if node.RestProperty != nil {
 			if ident, ok := node.RestProperty.Target.(*parser.Identifier); ok {
-				err := c.defineDestructuredVariable(ident.Value, node.IsConst, types.Undefined, line)
+				err := c.defineDestructuredVariable(ident.Value, node.IsConst, isVarDeclToken(node.Token), types.Undefined, line)
 				if err != nil {
 					return BadRegister, err
 				}
@@ -3222,14 +3230,14 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 				// and then assigning (compileConditionalAssignment) throws
 				// "Assignment to constant variable" inside functions, where
 				// the binding was already pre-declared via DefineConstTDZ.
-				err := c.defineIdentWithOptionalDefault(targetIdent.Value, node.IsConst, valueReg, prop.Default, line)
+				err := c.defineIdentWithOptionalDefault(targetIdent.Value, node.IsConst, isVarDeclToken(node.Token), valueReg, prop.Default, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return BadRegister, err
 				}
 			} else {
 				// Define variable with extracted value
-				err := c.defineDestructuredVariableWithValue(targetIdent.Value, node.IsConst, valueReg, line)
+				err := c.defineDestructuredVariableWithValue(targetIdent.Value, node.IsConst, isVarDeclToken(node.Token), valueReg, line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return BadRegister, err
@@ -3239,14 +3247,14 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 			// Nested pattern target (ArrayLiteral or ObjectLiteral)
 			if prop.Default != nil {
 				// Handle conditional assignment for nested patterns
-				err := c.compileConditionalAssignmentForDeclaration(prop.Target, valueReg, prop.Default, node.IsConst, line)
+				err := c.compileConditionalAssignmentForDeclaration(prop.Target, valueReg, prop.Default, node.IsConst, isVarDeclToken(node.Token), line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return BadRegister, err
 				}
 			} else {
 				// Direct nested pattern assignment using recursive compilation
-				err := c.compileNestedPatternDeclaration(prop.Target, valueReg, node.IsConst, line)
+				err := c.compileNestedPatternDeclaration(prop.Target, valueReg, node.IsConst, isVarDeclToken(node.Token), line)
 				if err != nil {
 					c.regAlloc.Free(valueReg)
 					return BadRegister, err
@@ -3262,7 +3270,7 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 	if node.RestProperty != nil {
 		if ident, ok := node.RestProperty.Target.(*parser.Identifier); ok {
 			// Create rest object with remaining properties
-			err := c.compileObjectRestDeclaration(tempReg, node.Properties, ident.Value, node.IsConst, line)
+			err := c.compileObjectRestDeclaration(tempReg, node.Properties, ident.Value, node.IsConst, isVarDeclToken(node.Token), line)
 			if err != nil {
 				return BadRegister, err
 			}
@@ -3273,11 +3281,11 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 }
 
 // defineDestructuredVariable defines a new variable from destructuring (without value)
-func (c *Compiler) defineDestructuredVariable(name string, isConst bool, valueType types.Type, line int) errors.PaseratiError {
+func (c *Compiler) defineDestructuredVariable(name string, isConst bool, isVar bool, valueType types.Type, line int) errors.PaseratiError {
 	undefReg := c.regAlloc.Alloc()
 	c.emitLoadUndefined(undefReg, line)
 
-	err := c.defineDestructuredVariableWithValue(name, isConst, undefReg, line)
+	err := c.defineDestructuredVariableWithValue(name, isConst, isVar, undefReg, line)
 	if err != nil {
 		c.regAlloc.Free(undefReg)
 		return err
@@ -3291,8 +3299,20 @@ func (c *Compiler) defineDestructuredVariable(name string, isConst bool, valueTy
 	return nil
 }
 
-// defineDestructuredVariableWithValue defines a new variable from destructuring with a specific value
-func (c *Compiler) defineDestructuredVariableWithValue(name string, isConst bool, valueReg Register, line int) errors.PaseratiError {
+// defineDestructuredVariableWithValue defines a new variable from destructuring with a specific value.
+//
+// isVar distinguishes a `var` pattern from let/const. `var` is function-scoped:
+// its name was already hoisted into this function's scope (or, at top level, to
+// a global) by collectVarDeclarations, and the destructuring must write *through*
+// to that binding. let/const are block-scoped and get a fresh binding here, which
+// is what makes them shadow an outer one.
+//
+// Without the distinction, `function f(){ { var {w} = {w: 2}; } return w; }`
+// defined a second, block-local `w` at the destructuring's temp register,
+// shadowing the hoisted one - so the value landed in the temp and `return w`
+// read the still-undefined hoisted register. The plain-var path writes through
+// correctly, which is why `{ var w = 2; }` worked and `{ var {w} = o; }` did not.
+func (c *Compiler) defineDestructuredVariableWithValue(name string, isConst bool, isVar bool, valueReg Register, line int) errors.PaseratiError {
 	// Check if we're truly at global scope: no enclosing function AND no enclosed symbol table
 	// For loops with let/const create an enclosed symbol table, so those variables should be local
 	isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
@@ -3301,6 +3321,32 @@ func (c *Compiler) defineDestructuredVariableWithValue(name string, isConst bool
 		globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
 		c.emitSetGlobalInit(globalIdx, valueReg, line)
 		c.currentSymbolTable.DefineGlobal(name, globalIdx)
+	} else if isVar {
+		// var: write through to the hoisted binding. findVarInFunctionScope walks
+		// out of enclosing *blocks* but stops at the enclosing compiler, so a var
+		// can never write into an outer function's binding.
+		if sym, funcTable := c.findVarInFunctionScope(name); funcTable != nil {
+			switch {
+			case sym.IsGlobal:
+				// Top-level var inside a block: the hoisted binding is a global.
+				c.emitSetGlobal(sym.GlobalIndex, valueReg, line)
+			case sym.IsSpilled:
+				c.emitStoreSpill(sym.SpillIndex, valueReg, line)
+			case sym.Register != nilRegister:
+				if valueReg != sym.Register {
+					c.emitMove(sym.Register, valueReg, line)
+				}
+			default:
+				// Symbol exists but has no storage yet - claim this register for it.
+				funcTable.Define(name, valueReg)
+				c.regAlloc.Pin(valueReg)
+			}
+		} else {
+			// No hoisted binding found (a var reached without collectVarDeclarations
+			// having seen it). Define it in this function's scope, not the block's.
+			c.currentSymbolTable.Define(name, valueReg)
+			c.regAlloc.Pin(valueReg)
+		}
 	} else {
 		// IMPORTANT: Check ONLY the CURRENT scope for existing bindings.
 		// This is critical for proper shadowing (e.g., catch parameters should shadow outer vars).

--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -3322,26 +3322,7 @@ func (c *Compiler) defineDestructuredVariableWithValue(name string, isConst bool
 		c.emitSetGlobalInit(globalIdx, valueReg, line)
 		c.currentSymbolTable.DefineGlobal(name, globalIdx)
 	} else if isVar {
-		// var: write through to the hoisted binding. findVarInFunctionScope walks
-		// out of enclosing *blocks* but stops at the enclosing compiler, so a var
-		// can never write into an outer function's binding.
-		if sym, funcTable := c.findVarInFunctionScope(name); funcTable != nil {
-			switch {
-			case sym.IsGlobal:
-				// Top-level var inside a block: the hoisted binding is a global.
-				c.emitSetGlobal(sym.GlobalIndex, valueReg, line)
-			case sym.IsSpilled:
-				c.emitStoreSpill(sym.SpillIndex, valueReg, line)
-			case sym.Register != nilRegister:
-				if valueReg != sym.Register {
-					c.emitMove(sym.Register, valueReg, line)
-				}
-			default:
-				// Symbol exists but has no storage yet - claim this register for it.
-				funcTable.Define(name, valueReg)
-				c.regAlloc.Pin(valueReg)
-			}
-		} else {
+		if !c.storeToHoistedVar(name, valueReg, line) {
 			// No hoisted binding found (a var reached without collectVarDeclarations
 			// having seen it). Define it in this function's scope, not the block's.
 			c.currentSymbolTable.Define(name, valueReg)

--- a/pkg/compiler/compile_exception.go
+++ b/pkg/compiler/compile_exception.go
@@ -140,7 +140,7 @@ func (c *Compiler) compileTryStatement(node *parser.TryStatement, hint Register)
 					}
 					// Use iterator protocol for array destructuring in catch parameters
 					// This is required for ECMAScript compliance - calling Symbol.iterator on the value
-					if err := c.compileArrayDestructuringIteratorPath(decl, catchReg, node.Token.Line); err != nil {
+					if err := c.compileArrayDestructuringIteratorPath(decl, false, catchReg, node.Token.Line); err != nil {
 						c.currentSymbolTable = previousSymbolTable
 						return BadRegister, err
 					}
@@ -153,7 +153,7 @@ func (c *Compiler) compileTryStatement(node *parser.TryStatement, hint Register)
 						RestProperty: param.RestProperty,
 						Value:        nil, // value already in catchReg
 					}
-					if err := c.compileObjectDestructuringDeclarationWithValueReg(decl, catchReg, node.Token.Line); err != nil {
+					if err := c.compileObjectDestructuringDeclarationWithValueReg(decl, false, catchReg, node.Token.Line); err != nil {
 						c.currentSymbolTable = previousSymbolTable
 						return BadRegister, err
 					}
@@ -363,7 +363,7 @@ func (c *Compiler) compileTryStatement(node *parser.TryStatement, hint Register)
 					}
 					// Use iterator protocol for array destructuring in catch parameters
 					// This is required for ECMAScript compliance - calling Symbol.iterator on the value
-					if err := c.compileArrayDestructuringIteratorPath(decl, catchReg, node.Token.Line); err != nil {
+					if err := c.compileArrayDestructuringIteratorPath(decl, false, catchReg, node.Token.Line); err != nil {
 						c.currentSymbolTable = previousSymbolTable
 						return BadRegister, err
 					}
@@ -376,7 +376,7 @@ func (c *Compiler) compileTryStatement(node *parser.TryStatement, hint Register)
 						RestProperty: param.RestProperty,
 						Value:        nil, // value already in catchReg
 					}
-					if err := c.compileObjectDestructuringDeclarationWithValueReg(decl, catchReg, node.Token.Line); err != nil {
+					if err := c.compileObjectDestructuringDeclarationWithValueReg(decl, false, catchReg, node.Token.Line); err != nil {
 						c.currentSymbolTable = previousSymbolTable
 						return BadRegister, err
 					}

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -254,6 +254,7 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	iteratorCleanupTryStart := len(c.chunk.Code)
 
 	var perIterationRegs []Register
+	var perIterationSpills []uint16
 	if letStmt, ok := node.Variable.(*parser.LetStatement); ok {
 		symbol := c.currentSymbolTable.Define(letStmt.Name.Value, c.regAlloc.Alloc())
 		c.regAlloc.Pin(symbol.Register)
@@ -284,6 +285,12 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		err := c.compileForOfArrayDestructuring(arrayDestr, valueReg, isConst, isVarDeclToken(arrayDestr.Token), node.Token.Line)
 		if err != nil {
 			return BadRegister, err
+		}
+		// let/const get a fresh binding per iteration; var is one binding.
+		if !isVarDeclToken(arrayDestr.Token) {
+			regs, spills := c.headPerIterationBindings(arrayDestr)
+			perIterationRegs = append(perIterationRegs, regs...)
+			perIterationSpills = append(perIterationSpills, spills...)
 		}
 	} else if objDestr, ok := node.Variable.(*parser.ObjectDestructuringDeclaration); ok {
 		// Object destructuring: for(const {x, y} of arr)
@@ -349,6 +356,12 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 					return BadRegister, err
 				}
 			}
+		}
+		// let/const get a fresh binding per iteration; var is one binding.
+		if !headIsVar {
+			regs, spills := c.headPerIterationBindings(objDestr)
+			perIterationRegs = append(perIterationRegs, regs...)
+			perIterationSpills = append(perIterationSpills, spills...)
 		}
 	} else if exprStmt, ok := node.Variable.(*parser.ExpressionStatement); ok {
 		// This is an existing variable/pattern being assigned to
@@ -430,6 +443,9 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 	// capture the value at this iteration, not the final value.
 	for _, reg := range perIterationRegs {
 		c.emitCloseUpvalue(reg, node.Token.Line)
+	}
+	for _, spillIdx := range perIterationSpills {
+		c.emitCloseUpvalueSpill(spillIdx, node.Token.Line)
 	}
 	// #132: same treatment for let/const/class declared directly in the loop's
 	// own body (as opposed to the header binding above).

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -334,13 +334,13 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 
 				if prop.Default != nil {
 					// Handle conditional assignment for nested patterns
-					err := c.compileConditionalAssignmentForDeclaration(prop.Target, extractedReg, prop.Default, isConst, node.Token.Line)
+					err := c.compileConditionalAssignmentForDeclaration(prop.Target, extractedReg, prop.Default, isConst, false, node.Token.Line)
 					if err != nil {
 						return BadRegister, err
 					}
 				} else {
 					// Direct nested pattern assignment
-					err := c.compileNestedPatternDeclaration(prop.Target, extractedReg, isConst, node.Token.Line)
+					err := c.compileNestedPatternDeclaration(prop.Target, extractedReg, isConst, false, node.Token.Line)
 					if err != nil {
 						return BadRegister, err
 					}
@@ -352,7 +352,8 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		if objDestr.RestProperty != nil {
 			if ident, ok := objDestr.RestProperty.Target.(*parser.Identifier); ok {
 				// Create rest object with remaining properties
-				err := c.compileObjectRestDeclaration(valueReg, objDestr.Properties, ident.Value, true, node.Token.Line)
+				// A for-of head binding is per-iteration, never a write-through var.
+				err := c.compileObjectRestDeclaration(valueReg, objDestr.Properties, ident.Value, true, false, node.Token.Line)
 				if err != nil {
 					return BadRegister, err
 				}
@@ -478,8 +479,8 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		HandlerPC:         iteratorCleanupHandlerPC,
 		CatchReg:          -1,
 		IsCatch:           false,
-		IsFinally:         false,             // NOT a regular finally - shouldn't intercept returns
-		IsIteratorCleanup: true,              // Special handler for iterator cleanup on exception
+		IsFinally:         false, // NOT a regular finally - shouldn't intercept returns
+		IsIteratorCleanup: true,  // Special handler for iterator cleanup on exception
 		FinallyReg:        -1,
 	}
 	c.chunk.ExceptionTable = append(c.chunk.ExceptionTable, iteratorCleanupHandler)
@@ -638,8 +639,8 @@ func (c *Compiler) compileForOfArrayAssignmentWithIterator(arrayLit *parser.Arra
 		HandlerPC:         iteratorCleanupHandlerPC,
 		CatchReg:          -1,
 		IsCatch:           false,
-		IsFinally:         false,             // NOT a regular finally - shouldn't intercept normal returns
-		IsIteratorCleanup: true,              // Special handler for iterator cleanup on exception
+		IsFinally:         false, // NOT a regular finally - shouldn't intercept normal returns
+		IsIteratorCleanup: true,  // Special handler for iterator cleanup on exception
 		FinallyReg:        -1,
 	}
 	c.chunk.ExceptionTable = append(c.chunk.ExceptionTable, iteratorCleanupHandler)
@@ -689,7 +690,7 @@ func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestru
 				c.regAlloc.Free(restArrayReg)
 			} else {
 				// Nested pattern: [...[x, y]]
-				err := c.compileNestedPatternDeclaration(element.Target, restArrayReg, isConst, line)
+				err := c.compileNestedPatternDeclaration(element.Target, restArrayReg, isConst, false, line)
 				c.regAlloc.Free(restArrayReg)
 				if err != nil {
 					return err
@@ -726,13 +727,13 @@ func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestru
 		} else {
 			// Nested pattern
 			if element.Default != nil {
-				err := c.compileConditionalAssignmentForDeclaration(element.Target, extractedReg, element.Default, isConst, line)
+				err := c.compileConditionalAssignmentForDeclaration(element.Target, extractedReg, element.Default, isConst, false, line)
 				c.regAlloc.Free(extractedReg)
 				if err != nil {
 					return err
 				}
 			} else {
-				err := c.compileNestedPatternDeclaration(element.Target, extractedReg, isConst, line)
+				err := c.compileNestedPatternDeclaration(element.Target, extractedReg, isConst, false, line)
 				c.regAlloc.Free(extractedReg)
 				if err != nil {
 					return err
@@ -772,8 +773,8 @@ func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestru
 		HandlerPC:         iteratorCleanupHandlerPC,
 		CatchReg:          -1,
 		IsCatch:           false,
-		IsFinally:         false,             // NOT a regular finally - shouldn't intercept normal returns
-		IsIteratorCleanup: true,              // Special handler for iterator cleanup on exception
+		IsFinally:         false, // NOT a regular finally - shouldn't intercept normal returns
+		IsIteratorCleanup: true,  // Special handler for iterator cleanup on exception
 		FinallyReg:        -1,
 	}
 	c.chunk.ExceptionTable = append(c.chunk.ExceptionTable, iteratorCleanupHandler)

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -266,23 +266,29 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		perIterationRegs = append(perIterationRegs, symbol.Register)
 		c.emitMove(symbol.Register, valueReg, node.Token.Line)
 	} else if varStmt, ok := node.Variable.(*parser.VarStatement); ok {
-		symbol := c.currentSymbolTable.Define(varStmt.Name.Value, c.regAlloc.Alloc())
-		c.regAlloc.Pin(symbol.Register)
-		// Note: var is function-scoped, so no per-iteration binding needed
-		c.emitMove(symbol.Register, valueReg, node.Token.Line)
+		// var is function-scoped: one binding, reassigned each iteration, so it
+		// gets no per-iteration register. Write through to the binding
+		// collectVarDeclarations hoisted - defining a fresh one here shadowed it,
+		// so a read after the loop saw the still-undefined hoisted register.
+		if !c.storeToHoistedVar(varStmt.Name.Value, valueReg, node.Token.Line) {
+			symbol := c.currentSymbolTable.Define(varStmt.Name.Value, c.regAlloc.Alloc())
+			c.regAlloc.Pin(symbol.Register)
+			c.emitMove(symbol.Register, valueReg, node.Token.Line)
+		}
 	} else if arrayDestr, ok := node.Variable.(*parser.ArrayDestructuringDeclaration); ok {
 		// Array destructuring: for(const [x, y] of arr)
 		// Check for null/undefined before destructuring (ECMAScript requirement)
 		c.emitDestructuringNullCheck(valueReg, node.Token.Line)
 		// Use iterator protocol to destructure the value
 		isConst := arrayDestr.IsConst
-		err := c.compileForOfArrayDestructuring(arrayDestr, valueReg, isConst, node.Token.Line)
+		err := c.compileForOfArrayDestructuring(arrayDestr, valueReg, isConst, isVarDeclToken(arrayDestr.Token), node.Token.Line)
 		if err != nil {
 			return BadRegister, err
 		}
 	} else if objDestr, ok := node.Variable.(*parser.ObjectDestructuringDeclaration); ok {
 		// Object destructuring: for(const {x, y} of arr)
 		// Check for null/undefined before destructuring (ECMAScript requirement)
+		headIsVar := isVarDeclToken(objDestr.Token)
 		c.emitDestructuringNullCheck(valueReg, node.Token.Line)
 		for _, prop := range objDestr.Properties {
 			if prop.Target == nil {
@@ -309,38 +315,24 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 
 			// Handle assignment with potential default value
 			if ident, ok := prop.Target.(*parser.Identifier); ok {
-				// Simple identifier target
-				symbol := c.currentSymbolTable.Define(ident.Value, c.regAlloc.Alloc())
-				c.regAlloc.Pin(symbol.Register)
-
-				if prop.Default != nil {
-					// Use conditional assignment: target = extractedReg !== undefined ? extractedReg : default
-					targetIdent := &parser.Identifier{Token: ident.Token, Value: ident.Value}
-					err := c.compileConditionalAssignment(targetIdent, extractedReg, prop.Default, node.Token.Line)
-					if err != nil {
-						return BadRegister, err
-					}
-				} else {
-					c.emitMove(symbol.Register, extractedReg, node.Token.Line)
+				if err := c.bindForOfHeadTarget(ident, extractedReg, prop.Default, headIsVar, node.Token.Line); err != nil {
+					return BadRegister, err
 				}
 			} else {
-				// Nested pattern target (ArrayLiteral or ObjectLiteral)
-				isConst := true // default for const
-				if _, ok := node.Variable.(*parser.VarStatement); ok {
-					isConst = false
-				} else if _, ok := node.Variable.(*parser.LetStatement); ok {
-					isConst = false
-				}
-
+				// Nested pattern target (ArrayLiteral or ObjectLiteral).
+				// isConst/isVar come from the destructuring declaration's own
+				// keyword token - node.Variable IS that declaration for a pattern
+				// head, never a Let/Var/ConstStatement, so the old type switch
+				// here always fell through and left isConst true.
 				if prop.Default != nil {
 					// Handle conditional assignment for nested patterns
-					err := c.compileConditionalAssignmentForDeclaration(prop.Target, extractedReg, prop.Default, isConst, false, node.Token.Line)
+					err := c.compileConditionalAssignmentForDeclaration(prop.Target, extractedReg, prop.Default, objDestr.IsConst, headIsVar, node.Token.Line)
 					if err != nil {
 						return BadRegister, err
 					}
 				} else {
 					// Direct nested pattern assignment
-					err := c.compileNestedPatternDeclaration(prop.Target, extractedReg, isConst, false, node.Token.Line)
+					err := c.compileNestedPatternDeclaration(prop.Target, extractedReg, objDestr.IsConst, headIsVar, node.Token.Line)
 					if err != nil {
 						return BadRegister, err
 					}
@@ -352,8 +344,7 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 		if objDestr.RestProperty != nil {
 			if ident, ok := objDestr.RestProperty.Target.(*parser.Identifier); ok {
 				// Create rest object with remaining properties
-				// A for-of head binding is per-iteration, never a write-through var.
-				err := c.compileObjectRestDeclaration(valueReg, objDestr.Properties, ident.Value, true, false, node.Token.Line)
+				err := c.compileObjectRestDeclaration(valueReg, objDestr.Properties, ident.Value, objDestr.IsConst, headIsVar, node.Token.Line)
 				if err != nil {
 					return BadRegister, err
 				}
@@ -649,7 +640,30 @@ func (c *Compiler) compileForOfArrayAssignmentWithIterator(arrayLit *parser.Arra
 }
 
 // compileForOfArrayDestructuring uses iterator protocol to destructure array patterns in for-of loops
-func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestructuringDeclaration, valueReg Register, isConst bool, line int) errors.PaseratiError {
+// bindForOfHeadTarget binds one identifier target of a for-of head's
+// destructuring pattern.
+//
+// `var` is function-scoped: one binding, reassigned each iteration, so it writes
+// through to the binding collectVarDeclarations hoisted (see storeToHoistedVar).
+// Defining a fresh register in the loop's own scope instead left the name
+// unresolvable once the loop scope was popped, so `for (var {w} of xs)` followed
+// by a read of w threw ReferenceError. let/const keep their per-iteration
+// register.
+func (c *Compiler) bindForOfHeadTarget(ident *parser.Identifier, valueReg Register, defaultExpr parser.Expression, isVar bool, line int) errors.PaseratiError {
+	if isVar {
+		return c.defineIdentWithOptionalDefault(ident.Value, false, true, valueReg, defaultExpr, line)
+	}
+	symbol := c.currentSymbolTable.Define(ident.Value, c.regAlloc.Alloc())
+	c.regAlloc.Pin(symbol.Register)
+	if defaultExpr != nil {
+		targetIdent := &parser.Identifier{Token: ident.Token, Value: ident.Value}
+		return c.compileConditionalAssignment(targetIdent, valueReg, defaultExpr, line)
+	}
+	c.emitMove(symbol.Register, valueReg, line)
+	return nil
+}
+
+func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestructuringDeclaration, valueReg Register, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// Set up the destructuring source. Without a rest element and over a pristine
 	// array at runtime, elements are read by index and the iterator protocol is
 	// skipped (see beginArrayDestruct).
@@ -684,13 +698,14 @@ func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestru
 
 			// Bind rest array to target
 			if ident, ok := element.Target.(*parser.Identifier); ok {
-				symbol := c.currentSymbolTable.Define(ident.Value, c.regAlloc.Alloc())
-				c.regAlloc.Pin(symbol.Register)
-				c.emitMove(symbol.Register, restArrayReg, line)
+				err := c.bindForOfHeadTarget(ident, restArrayReg, nil, isVar, line)
 				c.regAlloc.Free(restArrayReg)
+				if err != nil {
+					return err
+				}
 			} else {
 				// Nested pattern: [...[x, y]]
-				err := c.compileNestedPatternDeclaration(element.Target, restArrayReg, isConst, false, line)
+				err := c.compileNestedPatternDeclaration(element.Target, restArrayReg, isConst, isVar, line)
 				c.regAlloc.Free(restArrayReg)
 				if err != nil {
 					return err
@@ -707,33 +722,21 @@ func (c *Compiler) compileForOfArrayDestructuring(arrayDestr *parser.ArrayDestru
 
 		// Handle assignment based on target type
 		if ident, ok := element.Target.(*parser.Identifier); ok {
-			// Simple identifier target
-			symbol := c.currentSymbolTable.Define(ident.Value, c.regAlloc.Alloc())
-			c.regAlloc.Pin(symbol.Register)
-
-			if element.Default != nil {
-				// Conditional assignment with default
-				targetIdent := &parser.Identifier{Token: ident.Token, Value: ident.Value}
-				err := c.compileConditionalAssignment(targetIdent, extractedReg, element.Default, line)
-				c.regAlloc.Free(extractedReg)
-				if err != nil {
-					return err
-				}
-			} else {
-				// Simple move
-				c.emitMove(symbol.Register, extractedReg, line)
-				c.regAlloc.Free(extractedReg)
+			err := c.bindForOfHeadTarget(ident, extractedReg, element.Default, isVar, line)
+			c.regAlloc.Free(extractedReg)
+			if err != nil {
+				return err
 			}
 		} else {
 			// Nested pattern
 			if element.Default != nil {
-				err := c.compileConditionalAssignmentForDeclaration(element.Target, extractedReg, element.Default, isConst, false, line)
+				err := c.compileConditionalAssignmentForDeclaration(element.Target, extractedReg, element.Default, isConst, isVar, line)
 				c.regAlloc.Free(extractedReg)
 				if err != nil {
 					return err
 				}
 			} else {
-				err := c.compileNestedPatternDeclaration(element.Target, extractedReg, isConst, false, line)
+				err := c.compileNestedPatternDeclaration(element.Target, extractedReg, isConst, isVar, line)
 				c.regAlloc.Free(extractedReg)
 				if err != nil {
 					return err

--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -1444,12 +1444,12 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 		// The destructuring will extract values from paramReg and bind them to local variables
 		switch pattern := param.Pattern.(type) {
 		case *parser.ArrayParameterPattern:
-			err := functionCompiler.compileNestedArrayParameterPattern(pattern, paramReg, false, param.Token.Line)
+			err := functionCompiler.compileNestedArrayParameterPattern(pattern, paramReg, false, false, param.Token.Line)
 			if err != nil {
 				functionCompiler.addError(param, fmt.Sprintf("error compiling parameter destructuring: %v", err))
 			}
 		case *parser.ObjectParameterPattern:
-			err := functionCompiler.compileNestedObjectParameterPattern(pattern, paramReg, false, param.Token.Line)
+			err := functionCompiler.compileNestedObjectParameterPattern(pattern, paramReg, false, false, param.Token.Line)
 			if err != nil {
 				functionCompiler.addError(param, fmt.Sprintf("error compiling parameter destructuring: %v", err))
 			}
@@ -1513,13 +1513,13 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 		switch pattern := restParamPattern.(type) {
 		case *parser.ArrayParameterPattern:
 			// Convert to destructuring and compile it
-			err := functionCompiler.compileNestedArrayParameterPattern(pattern, restParamReg, false, node.Token.Line)
+			err := functionCompiler.compileNestedArrayParameterPattern(pattern, restParamReg, false, false, node.Token.Line)
 			if err != nil {
 				functionCompiler.addError(node.RestParameter, fmt.Sprintf("error compiling rest parameter destructuring: %v", err))
 			}
 		case *parser.ObjectParameterPattern:
 			// Convert to destructuring and compile it
-			err := functionCompiler.compileNestedObjectParameterPattern(pattern, restParamReg, false, node.Token.Line)
+			err := functionCompiler.compileNestedObjectParameterPattern(pattern, restParamReg, false, false, node.Token.Line)
 			if err != nil {
 				functionCompiler.addError(node.RestParameter, fmt.Sprintf("error compiling rest parameter destructuring: %v", err))
 			}

--- a/pkg/compiler/compile_namespace.go
+++ b/pkg/compiler/compile_namespace.go
@@ -164,23 +164,12 @@ func (c *Compiler) predeclareNamespaceExports(body *parser.BlockStatement, acces
 			continue
 		}
 		switch d := exp.Declaration.(type) {
-		case *parser.LetStatement:
-			for _, decl := range d.Declarations {
-				if decl != nil && decl.Name != nil {
-					c.currentSymbolTable.DefineNamespaceProperty(decl.Name.Value, accessExpr)
-				}
-			}
-		case *parser.ConstStatement:
-			for _, decl := range d.Declarations {
-				if decl != nil && decl.Name != nil {
-					c.currentSymbolTable.DefineNamespaceProperty(decl.Name.Value, accessExpr)
-				}
-			}
-		case *parser.VarStatement:
-			for _, decl := range d.Declarations {
-				if decl != nil && decl.Name != nil {
-					c.currentSymbolTable.DefineNamespaceProperty(decl.Name.Value, accessExpr)
-				}
+		case *parser.LetStatement, *parser.ConstStatement, *parser.VarStatement,
+			*parser.ObjectDestructuringDeclaration, *parser.ArrayDestructuringDeclaration:
+			// Every declarator of the clause, and every name a destructuring
+			// pattern binds.
+			for _, name := range parser.DeclaredNames(exp.Declaration) {
+				c.currentSymbolTable.DefineNamespaceProperty(name, accessExpr)
 			}
 		case *parser.ClassDeclaration:
 			if d.Name != nil {
@@ -235,6 +224,11 @@ func (c *Compiler) compileNamespaceBodyStatement(stmt parser.Statement, accessEx
 	case *parser.VarStatement:
 		return c.compileNamespaceVarLikeExports(d.Declarations, accessExpr)
 
+	case *parser.ObjectDestructuringDeclaration:
+		return c.compileNamespaceDestructuringExport(d, accessExpr)
+	case *parser.ArrayDestructuringDeclaration:
+		return c.compileNamespaceDestructuringExport(d, accessExpr)
+
 	case *parser.ClassDeclaration:
 		return c.compileNamespaceClassExport(d, accessExpr)
 
@@ -273,7 +267,7 @@ func (c *Compiler) compileNamespaceVarLikeExports(decls []*parser.VarDeclarator,
 			continue
 		}
 		assign := &parser.AssignmentExpression{
-			Token: decl.Name.Token,
+			Token:    decl.Name.Token,
 			Operator: "=",
 			Left: &parser.MemberExpression{
 				Token:    decl.Name.Token,
@@ -364,4 +358,210 @@ func (c *Compiler) compileNamespaceEnumExport(en *parser.EnumDeclaration, access
 	}
 	c.emitSetProp(objReg, enumReg, uint16(nameIdx), en.Token.Line)
 	return nil
+}
+
+// compileNamespaceDestructuringExport compiles an exported destructuring
+// declaration inside a namespace body, e.g.
+//
+//	namespace N { export const {a, b: c} = obj; }
+//
+// as the equivalent destructuring *assignment* onto the namespace object:
+//
+//	({a: N.a, b: N.c} = obj)
+//
+// This is the same rewrite compileNamespaceVarLikeExports performs for a plain
+// declarator (`export const x = v` becomes `<ns>.x = v`), and it is what keeps
+// the invariant documented on compileNamespaceDeclaration: an exported
+// namespace binding *is* the namespace property, so internal reads/writes and
+// external observation cannot drift apart. (Compiling the declaration as
+// ordinary locals and then copying each name onto the namespace object would
+// export the right values once, but `N.x = 5` would no longer be visible to
+// code inside the namespace.)
+//
+// The names have already been bound as NamespaceProperty symbols by
+// predeclareNamespaceExports, so references to them inside the body resolve to
+// property accesses on the namespace object.
+func (c *Compiler) compileNamespaceDestructuringExport(decl parser.Statement, accessExpr parser.Expression) errors.PaseratiError {
+	var assign parser.Expression
+
+	switch d := decl.(type) {
+	case *parser.ObjectDestructuringDeclaration:
+		props, err := c.retargetDestructuringProperties(d.Properties, accessExpr)
+		if err != nil {
+			return err
+		}
+		rest, err := c.retargetDestructuringElement(d.RestProperty, accessExpr)
+		if err != nil {
+			return err
+		}
+		assign = &parser.ObjectDestructuringAssignment{
+			Token:        d.Token,
+			Properties:   props,
+			RestProperty: rest,
+			Value:        d.Value,
+		}
+
+	case *parser.ArrayDestructuringDeclaration:
+		elements, err := c.retargetDestructuringElements(d.Elements, accessExpr)
+		if err != nil {
+			return err
+		}
+		assign = &parser.ArrayDestructuringAssignment{
+			Token:    d.Token,
+			Elements: elements,
+			Value:    d.Value,
+		}
+
+	default:
+		return NewCompileError(decl, "unsupported destructuring export in namespace body")
+	}
+
+	hint := c.regAlloc.Alloc()
+	_, err := c.compileNode(assign, hint)
+	c.regAlloc.Free(hint)
+	return err
+}
+
+// retargetDestructuringProperties copies pattern properties with every binding
+// target redirected onto the namespace object. Copies rather than mutating: the
+// checker has already annotated these nodes, and predeclareNamespaceExports
+// walks the same statements this pass does.
+func (c *Compiler) retargetDestructuringProperties(props []*parser.DestructuringProperty, accessExpr parser.Expression) ([]*parser.DestructuringProperty, errors.PaseratiError) {
+	if props == nil {
+		return nil, nil
+	}
+	out := make([]*parser.DestructuringProperty, 0, len(props))
+	for _, prop := range props {
+		if prop == nil {
+			out = append(out, nil)
+			continue
+		}
+		target, err := c.retargetPattern(prop.Target, accessExpr)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, &parser.DestructuringProperty{
+			Key:     prop.Key,
+			Target:  target,
+			Default: prop.Default,
+		})
+	}
+	return out, nil
+}
+
+// retargetDestructuringElements is retargetDestructuringProperties for array
+// pattern elements. A nil element is an elision (`[, a]`) and stays nil.
+func (c *Compiler) retargetDestructuringElements(elements []*parser.DestructuringElement, accessExpr parser.Expression) ([]*parser.DestructuringElement, errors.PaseratiError) {
+	if elements == nil {
+		return nil, nil
+	}
+	out := make([]*parser.DestructuringElement, 0, len(elements))
+	for _, elem := range elements {
+		retargeted, err := c.retargetDestructuringElement(elem, accessExpr)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, retargeted)
+	}
+	return out, nil
+}
+
+func (c *Compiler) retargetDestructuringElement(elem *parser.DestructuringElement, accessExpr parser.Expression) (*parser.DestructuringElement, errors.PaseratiError) {
+	if elem == nil {
+		return nil, nil
+	}
+	target, err := c.retargetPattern(elem.Target, accessExpr)
+	if err != nil {
+		return nil, err
+	}
+	return &parser.DestructuringElement{
+		Target:  target,
+		Default: elem.Default,
+		IsRest:  elem.IsRest,
+	}, nil
+}
+
+// retargetPattern rewrites a pattern target so each name it binds writes to
+// `<ns>.<name>` instead of declaring a local.
+//
+// It must recognize every shape parser.CollectPatternNames does, because a
+// shape it fails to rewrite would bind a local that never reaches the namespace
+// object - silently, since the name has already been predeclared as a
+// NamespaceProperty and would just read back undefined. Anything unrecognized
+// is therefore a compile error, not a fall-through.
+func (c *Compiler) retargetPattern(target parser.Expression, accessExpr parser.Expression) (parser.Expression, errors.PaseratiError) {
+	if target == nil {
+		return nil, nil
+	}
+	switch t := target.(type) {
+	case *parser.Identifier:
+		return &parser.MemberExpression{
+			Token:    t.Token,
+			Object:   accessExpr,
+			Property: &parser.Identifier{Token: t.Token, Value: t.Value},
+		}, nil
+
+	case *parser.AssignmentExpression:
+		// A nested default: `{a: {b = 1}}`. The binding is the left-hand side.
+		left, err := c.retargetPattern(t.Left, accessExpr)
+		if err != nil {
+			return nil, err
+		}
+		return &parser.AssignmentExpression{
+			Token:    t.Token,
+			Operator: t.Operator,
+			Left:     left,
+			Value:    t.Value,
+		}, nil
+
+	case *parser.SpreadElement:
+		// A nested rest element: `[[x, ...ys]]`.
+		arg, err := c.retargetPattern(t.Argument, accessExpr)
+		if err != nil {
+			return nil, err
+		}
+		return &parser.SpreadElement{Token: t.Token, Argument: arg}, nil
+
+	case *parser.ObjectLiteral:
+		// Nested object pattern: `{f: {g}}` / `{f: {g: h}}`.
+		props := make([]*parser.ObjectProperty, 0, len(t.Properties))
+		for _, prop := range t.Properties {
+			if prop == nil {
+				props = append(props, nil)
+				continue
+			}
+			if prop.Value != nil {
+				// `g: h` - the target is the value.
+				value, err := c.retargetPattern(prop.Value, accessExpr)
+				if err != nil {
+					return nil, err
+				}
+				props = append(props, &parser.ObjectProperty{Key: prop.Key, Value: value})
+				continue
+			}
+			// Shorthand `{g}`, where Key is both the source property name and
+			// the target. Retargeting Key in place would lose the property name,
+			// so expand it to the explicit `g: <ns>.g` form.
+			target, err := c.retargetPattern(prop.Key, accessExpr)
+			if err != nil {
+				return nil, err
+			}
+			props = append(props, &parser.ObjectProperty{Key: prop.Key, Value: target})
+		}
+		return &parser.ObjectLiteral{Token: t.Token, Properties: props}, nil
+
+	case *parser.ArrayLiteral:
+		// Nested array pattern: `[a, [b, c]]`.
+		elements := make([]parser.Expression, 0, len(t.Elements))
+		for _, elem := range t.Elements {
+			retargeted, err := c.retargetPattern(elem, accessExpr)
+			if err != nil {
+				return nil, err
+			}
+			elements = append(elements, retargeted)
+		}
+		return &parser.ArrayLiteral{Token: t.Token, Elements: elements}, nil
+	}
+
+	return nil, NewCompileError(target, "unsupported destructuring target in an exported namespace declaration")
 }

--- a/pkg/compiler/compile_namespace.go
+++ b/pkg/compiler/compile_namespace.go
@@ -530,6 +530,21 @@ func (c *Compiler) retargetPattern(target parser.Expression, accessExpr parser.E
 				props = append(props, nil)
 				continue
 			}
+			if spread, isRest := prop.Key.(*parser.SpreadElement); isRest {
+				// A rest element inside the nested pattern (`{f: {g, ...rr}}`),
+				// which the parser stores as a SpreadElement in Key with a nil
+				// Value. Retarget its argument and keep it in Key - the
+				// shorthand branch below would otherwise treat the SpreadElement
+				// itself as the property name and bind nothing.
+				arg, err := c.retargetPattern(spread.Argument, accessExpr)
+				if err != nil {
+					return nil, err
+				}
+				props = append(props, &parser.ObjectProperty{
+					Key: &parser.SpreadElement{Token: spread.Token, Argument: arg},
+				})
+				continue
+			}
 			if prop.Value != nil {
 				// `g: h` - the target is the value.
 				value, err := c.retargetPattern(prop.Value, accessExpr)

--- a/pkg/compiler/compile_nested_declarations.go
+++ b/pkg/compiler/compile_nested_declarations.go
@@ -90,6 +90,20 @@ func (c *Compiler) compileNestedObjectDeclaration(objectTarget *parser.ObjectLit
 
 	// Convert properties to destructuring properties
 	for _, prop := range objectTarget.Properties {
+		// A rest element inside a nested object pattern (`{a: {b, ...rr}}`).
+		// The parser stores it as a SpreadElement in Key with a nil Value - the
+		// nested pattern is a raw ObjectLiteral, so it has no RestProperty field
+		// of its own the way a top-level ObjectDestructuringDeclaration does.
+		// Route it to the synthesized declaration's RestProperty, where the
+		// existing top-level rest lowering picks it up.
+		if spread, ok := prop.Key.(*parser.SpreadElement); ok {
+			declaration.RestProperty = &parser.DestructuringElement{
+				Target: spread.Argument,
+				IsRest: true,
+			}
+			continue
+		}
+
 		// Key can be identifier, number, or bigint (for array destructuring as object)
 		var keyIdent *parser.Identifier
 		if ident, ok := prop.Key.(*parser.Identifier); ok {

--- a/pkg/compiler/compile_nested_declarations.go
+++ b/pkg/compiler/compile_nested_declarations.go
@@ -9,20 +9,20 @@ import (
 )
 
 // compileNestedPatternDeclaration handles nested pattern variable declarations
-func (c *Compiler) compileNestedPatternDeclaration(target parser.Expression, valueReg Register, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileNestedPatternDeclaration(target parser.Expression, valueReg Register, isConst bool, isVar bool, line int) errors.PaseratiError {
 	switch targetNode := target.(type) {
 	case *parser.ArrayLiteral:
 		// Convert to ArrayDestructuringDeclaration and compile
-		return c.compileNestedArrayDeclaration(targetNode, valueReg, isConst, line)
+		return c.compileNestedArrayDeclaration(targetNode, valueReg, isConst, isVar, line)
 	case *parser.ObjectLiteral:
 		// Convert to ObjectDestructuringDeclaration and compile
-		return c.compileNestedObjectDeclaration(targetNode, valueReg, isConst, line)
+		return c.compileNestedObjectDeclaration(targetNode, valueReg, isConst, isVar, line)
 	case *parser.ArrayParameterPattern:
 		// Handle ArrayParameterPattern from transformed function parameters
-		return c.compileNestedArrayParameterPattern(targetNode, valueReg, isConst, line)
+		return c.compileNestedArrayParameterPattern(targetNode, valueReg, isConst, isVar, line)
 	case *parser.ObjectParameterPattern:
 		// Handle ObjectParameterPattern from transformed function parameters
-		return c.compileNestedObjectParameterPattern(targetNode, valueReg, isConst, line)
+		return c.compileNestedObjectParameterPattern(targetNode, valueReg, isConst, isVar, line)
 	case *parser.UndefinedLiteral:
 		// Elision in destructuring - no code to generate, just skip this element
 		return nil
@@ -32,7 +32,7 @@ func (c *Compiler) compileNestedPatternDeclaration(target parser.Expression, val
 }
 
 // compileNestedArrayDeclaration handles nested array pattern declarations
-func (c *Compiler) compileNestedArrayDeclaration(arrayTarget *parser.ArrayLiteral, valueReg Register, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileNestedArrayDeclaration(arrayTarget *parser.ArrayLiteral, valueReg Register, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// Convert ArrayLiteral to ArrayDestructuringDeclaration format
 	declaration := &parser.ArrayDestructuringDeclaration{
 		Token:   arrayTarget.Token,
@@ -76,11 +76,11 @@ func (c *Compiler) compileNestedArrayDeclaration(arrayTarget *parser.ArrayLitera
 	}
 
 	// Use iterator protocol for nested destructuring (handles arrays and iterables)
-	return c.compileArrayDestructuringIteratorPath(declaration, valueReg, line)
+	return c.compileArrayDestructuringIteratorPath(declaration, isVar, valueReg, line)
 }
 
 // compileNestedObjectDeclaration handles nested object pattern declarations
-func (c *Compiler) compileNestedObjectDeclaration(objectTarget *parser.ObjectLiteral, valueReg Register, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileNestedObjectDeclaration(objectTarget *parser.ObjectLiteral, valueReg Register, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// Convert ObjectLiteral to ObjectDestructuringDeclaration format
 	declaration := &parser.ObjectDestructuringDeclaration{
 		Token:   objectTarget.Token,
@@ -146,11 +146,11 @@ func (c *Compiler) compileNestedObjectDeclaration(objectTarget *parser.ObjectLit
 	}
 
 	// Reuse existing compilation logic but with direct value register
-	return c.compileObjectDestructuringDeclarationWithValueReg(declaration, valueReg, line)
+	return c.compileObjectDestructuringDeclarationWithValueReg(declaration, isVar, valueReg, line)
 }
 
 // compileArrayDestructuringDeclarationWithValueReg compiles array destructuring declarations using an existing value register
-func (c *Compiler) compileArrayDestructuringDeclarationWithValueReg(node *parser.ArrayDestructuringDeclaration, valueReg Register, line int) errors.PaseratiError {
+func (c *Compiler) compileArrayDestructuringDeclarationWithValueReg(node *parser.ArrayDestructuringDeclaration, isVar bool, valueReg Register, line int) errors.PaseratiError {
 	// ECMAScript compliance: Throw TypeError if destructuring null or undefined
 	// This is required at runtime even if type checker catches it at compile time
 	c.emitDestructuringNullCheck(valueReg, line)
@@ -264,7 +264,7 @@ func (c *Compiler) compileArrayDestructuringDeclarationWithValueReg(node *parser
 				c.patchJump(jumpPastDefault)
 
 				// Now define the variable with the computed value
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, resultReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, resultReg, line)
 				if err != nil {
 					c.regAlloc.Free(resultReg)
 					c.regAlloc.Free(extractedReg)
@@ -274,7 +274,7 @@ func (c *Compiler) compileArrayDestructuringDeclarationWithValueReg(node *parser
 				c.regAlloc.Free(resultReg)
 			} else {
 				// Define variable with extracted value
-				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, extractedReg, line)
+				err := c.defineDestructuredVariableWithValue(ident.Value, node.IsConst, isVar, extractedReg, line)
 				if err != nil {
 					c.regAlloc.Free(extractedReg)
 					return err
@@ -284,14 +284,14 @@ func (c *Compiler) compileArrayDestructuringDeclarationWithValueReg(node *parser
 			// Nested pattern target (ArrayLiteral or ObjectLiteral)
 			if element.Default != nil {
 				// Handle conditional assignment for nested patterns
-				err := c.compileConditionalAssignmentForDeclaration(element.Target, extractedReg, element.Default, node.IsConst, line)
+				err := c.compileConditionalAssignmentForDeclaration(element.Target, extractedReg, element.Default, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(extractedReg)
 					return err
 				}
 			} else {
 				// Direct nested pattern assignment using recursive compilation
-				err := c.compileNestedPatternDeclaration(element.Target, extractedReg, node.IsConst, line)
+				err := c.compileNestedPatternDeclaration(element.Target, extractedReg, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(extractedReg)
 					return err
@@ -307,7 +307,7 @@ func (c *Compiler) compileArrayDestructuringDeclarationWithValueReg(node *parser
 }
 
 // compileObjectDestructuringDeclarationWithValueReg compiles object destructuring declarations using an existing value register
-func (c *Compiler) compileObjectDestructuringDeclarationWithValueReg(node *parser.ObjectDestructuringDeclaration, valueReg Register, line int) errors.PaseratiError {
+func (c *Compiler) compileObjectDestructuringDeclarationWithValueReg(node *parser.ObjectDestructuringDeclaration, isVar bool, valueReg Register, line int) errors.PaseratiError {
 	// ECMAScript compliance: Throw TypeError if destructuring null or undefined
 	// This is required at runtime even if type checker catches it at compile time
 	c.emitDestructuringNullCheck(valueReg, line)
@@ -384,7 +384,7 @@ func (c *Compiler) compileObjectDestructuringDeclarationWithValueReg(node *parse
 			// Simple identifier target. Compute default first so const
 			// bindings (pre-declared via DefineConstTDZ) are initialized
 			// rather than assigned after the fact.
-			err := c.defineIdentWithOptionalDefault(ident.Value, node.IsConst, extractedReg, prop.Default, line)
+			err := c.defineIdentWithOptionalDefault(ident.Value, node.IsConst, isVar, extractedReg, prop.Default, line)
 			if err != nil {
 				c.regAlloc.Free(extractedReg)
 				return err
@@ -393,14 +393,14 @@ func (c *Compiler) compileObjectDestructuringDeclarationWithValueReg(node *parse
 			// Nested pattern target (ArrayLiteral or ObjectLiteral)
 			if prop.Default != nil {
 				// Handle conditional assignment for nested patterns
-				err := c.compileConditionalAssignmentForDeclaration(prop.Target, extractedReg, prop.Default, node.IsConst, line)
+				err := c.compileConditionalAssignmentForDeclaration(prop.Target, extractedReg, prop.Default, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(extractedReg)
 					return err
 				}
 			} else {
 				// Direct nested pattern assignment using recursive compilation
-				err := c.compileNestedPatternDeclaration(prop.Target, extractedReg, node.IsConst, line)
+				err := c.compileNestedPatternDeclaration(prop.Target, extractedReg, node.IsConst, isVar, line)
 				if err != nil {
 					c.regAlloc.Free(extractedReg)
 					return err
@@ -416,7 +416,7 @@ func (c *Compiler) compileObjectDestructuringDeclarationWithValueReg(node *parse
 	if node.RestProperty != nil {
 		if ident, ok := node.RestProperty.Target.(*parser.Identifier); ok {
 			// Create rest object with remaining properties
-			err := c.compileObjectRestDeclaration(valueReg, node.Properties, ident.Value, node.IsConst, line)
+			err := c.compileObjectRestDeclaration(valueReg, node.Properties, ident.Value, node.IsConst, isVar, line)
 			if err != nil {
 				return err
 			}
@@ -427,7 +427,7 @@ func (c *Compiler) compileObjectDestructuringDeclarationWithValueReg(node *parse
 }
 
 // compileConditionalAssignmentForDeclaration handles conditional assignment for nested patterns in declarations
-func (c *Compiler) compileConditionalAssignmentForDeclaration(target parser.Expression, valueReg Register, defaultExpr parser.Expression, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileConditionalAssignmentForDeclaration(target parser.Expression, valueReg Register, defaultExpr parser.Expression, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// This implements: target = (valueReg !== undefined) ? valueReg : defaultExpr
 	// IMPORTANT: We must only declare variables ONCE, not in both branches!
 	// Solution: Select the value at runtime, store in a single register, then declare once
@@ -459,7 +459,7 @@ func (c *Compiler) compileConditionalAssignmentForDeclaration(target parser.Expr
 
 	// 5. Now resultReg contains the correct value (either from valueReg or default)
 	// Declare variables once using resultReg
-	err = c.compileNestedPatternDeclaration(target, resultReg, isConst, line)
+	err = c.compileNestedPatternDeclaration(target, resultReg, isConst, isVar, line)
 	if err != nil {
 		return err
 	}
@@ -468,7 +468,7 @@ func (c *Compiler) compileConditionalAssignmentForDeclaration(target parser.Expr
 }
 
 // compileNestedArrayParameterPattern handles nested array parameter patterns from function parameters
-func (c *Compiler) compileNestedArrayParameterPattern(pattern *parser.ArrayParameterPattern, valueReg Register, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileNestedArrayParameterPattern(pattern *parser.ArrayParameterPattern, valueReg Register, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// ArrayParameterPattern already has Elements as []*DestructuringElement
 	// Create a declaration and compile it
 	declaration := &parser.ArrayDestructuringDeclaration{
@@ -478,11 +478,11 @@ func (c *Compiler) compileNestedArrayParameterPattern(pattern *parser.ArrayParam
 		Value:    nil, // We already have the value in valueReg
 	}
 
-	return c.compileArrayDestructuringIteratorPath(declaration, valueReg, line)
+	return c.compileArrayDestructuringIteratorPath(declaration, isVar, valueReg, line)
 }
 
 // compileNestedObjectParameterPattern handles nested object parameter patterns from function parameters
-func (c *Compiler) compileNestedObjectParameterPattern(pattern *parser.ObjectParameterPattern, valueReg Register, isConst bool, line int) errors.PaseratiError {
+func (c *Compiler) compileNestedObjectParameterPattern(pattern *parser.ObjectParameterPattern, valueReg Register, isConst bool, isVar bool, line int) errors.PaseratiError {
 	// ObjectParameterPattern already has Properties as []*DestructuringProperty
 	// Create a declaration and compile it
 	declaration := &parser.ObjectDestructuringDeclaration{
@@ -493,5 +493,5 @@ func (c *Compiler) compileNestedObjectParameterPattern(pattern *parser.ObjectPar
 		Value:        nil, // We already have the value in valueReg
 	}
 
-	return c.compileObjectDestructuringDeclarationWithValueReg(declaration, valueReg, line)
+	return c.compileObjectDestructuringDeclarationWithValueReg(declaration, isVar, valueReg, line)
 }

--- a/pkg/compiler/compile_statement.go
+++ b/pkg/compiler/compile_statement.go
@@ -1165,6 +1165,7 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 	// ECMAScript spec: each iteration gets fresh bindings, so closures capture
 	// different values per iteration. We close upvalues at end of each iteration.
 	var perIterationRegs []Register
+	var perIterationSpills []uint16
 	if hasLexicalDecl {
 		prevSymbolTable = c.currentSymbolTable
 		c.currentSymbolTable = NewEnclosedSymbolTable(c.currentSymbolTable)
@@ -1281,6 +1282,25 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 		if _, err := c.compileNode(node.Initializer, initReg); err != nil {
 			return BadRegister, err
 		}
+		// A let/const *pattern* initializer (`for (let {w} = obj; ...)`) binds its
+		// names inside the destructuring helpers, so unlike the plain-declarator
+		// branches above there is no single register to record at declare time.
+		// Collect them once the pattern is bound - they are per-iteration
+		// bindings like any other let/const loop variable.
+		switch init := node.Initializer.(type) {
+		case *parser.ObjectDestructuringDeclaration:
+			if !isVarDeclToken(init.Token) {
+				regs, spills := c.headPerIterationBindings(init)
+				perIterationRegs = append(perIterationRegs, regs...)
+				perIterationSpills = append(perIterationSpills, spills...)
+			}
+		case *parser.ArrayDestructuringDeclaration:
+			if !isVarDeclToken(init.Token) {
+				regs, spills := c.headPerIterationBindings(init)
+				perIterationRegs = append(perIterationRegs, regs...)
+				perIterationSpills = append(perIterationSpills, spills...)
+			}
+		}
 	}
 
 	// *** Per-iteration bindings: close upvalues AFTER init but BEFORE first iteration ***
@@ -1290,6 +1310,9 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 	// the initial values, separate from closures created in test/body/update.
 	for _, reg := range perIterationRegs {
 		c.emitCloseUpvalue(reg, node.Token.Line)
+	}
+	for _, spillIdx := range perIterationSpills {
+		c.emitCloseUpvalueSpill(spillIdx, node.Token.Line)
 	}
 
 	// Per ECMAScript spec, initialize completion value V = undefined
@@ -1346,6 +1369,9 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 	// the value at this iteration. The register keeps its value for the update.
 	for _, reg := range perIterationRegs {
 		c.emitCloseUpvalue(reg, node.Token.Line)
+	}
+	for _, spillIdx := range perIterationSpills {
+		c.emitCloseUpvalueSpill(spillIdx, node.Token.Line)
 	}
 	// #132: same treatment for let/const/class declared directly in the loop's
 	// own body (as opposed to the header above) - see BodyPerIterationRegs'

--- a/pkg/compiler/compile_statement.go
+++ b/pkg/compiler/compile_statement.go
@@ -1091,6 +1091,34 @@ func (c *Compiler) compileWhileStatementLabeled(node *parser.WhileStatement, lab
 	return hint, nil
 }
 
+// predefineForHeadVar pre-declares a `var` bound in a for/for-in/for-of head so
+// the name resolves while the condition, update and body are compiled.
+//
+// It deliberately declares NOTHING when the name already has a hoisted binding
+// in this function's scope: `var` is function-scoped, and collectVarDeclarations
+// recurses into loop heads, so that binding is what the head must write to. The
+// two sites this replaces defined a fresh nilRegister binding in the *current*
+// table instead, which shadowed the hoisted one - the store then landed in the
+// shadow and a read after the loop saw the still-undefined hoisted register
+// (`function f(){ { for (var q of [5]) {} } return q; }` gave undefined). Only
+// the true-global branch was right, which is why the same loops worked at script
+// top level.
+func (c *Compiler) predefineForHeadVar(name string) {
+	if _, funcTable := c.findVarInFunctionScope(name); funcTable != nil {
+		// Already hoisted - leave it alone so Resolve() finds the hoisted binding.
+		return
+	}
+	if c.enclosing == nil && c.currentSymbolTable.Outer == nil {
+		// True global scope: predefine as global so the identifier resolves as a
+		// global in the condition/update.
+		globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
+		c.currentSymbolTable.DefineGlobal(name, globalIdx)
+		return
+	}
+	// Nothing hoisted: declare it in this function's scope, not the block's.
+	c.varHoistTable().Define(name, nilRegister)
+}
+
 func (c *Compiler) compileForStatement(node *parser.ForStatement, hint Register) (Register, errors.PaseratiError) {
 	return c.compileForStatementLabeled(node, "", hint)
 }
@@ -1155,25 +1183,10 @@ func (c *Compiler) compileForStatementLabeled(node *parser.ForStatement, label s
 			// Prefer explicit declarations if present; otherwise fall back to legacy Name field
 			if len(vs.Declarations) > 0 {
 				for _, d := range vs.Declarations {
-					isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
-					if isGlobalScope {
-						// True global scope: predefine as global so identifier resolves as global in condition/update
-						globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(d.Name.Value))
-						c.currentSymbolTable.DefineGlobal(d.Name.Value, globalIdx)
-					} else {
-						// Local scope: predefine local binding; register will be set by compileVarStatement
-						c.currentSymbolTable.Define(d.Name.Value, nilRegister)
-					}
+					c.predefineForHeadVar(d.Name.Value)
 				}
 			} else if vs.Name != nil {
-				name := vs.Name.Value
-				isGlobalScope := c.enclosing == nil && c.currentSymbolTable.Outer == nil
-				if isGlobalScope {
-					globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
-					c.currentSymbolTable.DefineGlobal(name, globalIdx)
-				} else {
-					c.currentSymbolTable.Define(name, nilRegister)
-				}
+				c.predefineForHeadVar(vs.Name.Value)
 			}
 		} else if ls, ok := node.Initializer.(*parser.LetStatement); ok {
 			// Handle let declarations in for loop
@@ -2036,27 +2049,10 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 	if vs, ok := node.Variable.(*parser.VarStatement); ok {
 		if len(vs.Declarations) > 0 {
 			for _, d := range vs.Declarations {
-				if c.enclosing == nil {
-					idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(d.Name.Value))
-					c.currentSymbolTable.DefineGlobal(d.Name.Value, idx)
-					// fmt.Printf("// [ForInPredefine] var %s as global idx=%d\n", d.Name.Value, idx)
-				} else {
-					c.currentSymbolTable.Define(d.Name.Value, nilRegister)
-					// fmt.Printf("// [ForInPredefine] var %s as local (nil reg)\n", d.Name.Value)
-				}
+				c.predefineForHeadVar(d.Name.Value)
 			}
 		} else if vs.Name != nil {
-			name := vs.Name.Value
-			if c.enclosing == nil {
-				idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(name))
-				c.currentSymbolTable.DefineGlobal(name, idx)
-				// fmt.Printf("// [ForInPredefine] var %s as global idx=%d\n", name, idx)
-			} else {
-				c.currentSymbolTable.Define(name, nilRegister)
-				// fmt.Printf("// [ForInPredefine] var %s as local (nil reg)\n", name)
-			}
-		} else {
-			// fmt.Printf("// [ForInPredefine] VarStatement without Name/Declarations\n")
+			c.predefineForHeadVar(vs.Name.Value)
 		}
 	} else if hasLexicalDecl {
 		// Define TDZ bindings for let/const variables BEFORE compiling object expression

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -60,78 +60,29 @@ func getExportSpecName(expr parser.Expression) string {
 	return ""
 }
 
+// The pattern-name enumeration below lives in pkg/parser
+// (parser.CollectPatternNames and friends) - it is a pure AST query, and the
+// checker needs the same answer for module export registration. These are thin
+// aliases kept so the existing call sites read unchanged.
+
 // collectDestructuringNames extracts variable names from object destructuring properties
 func collectDestructuringNames(props []*parser.DestructuringProperty, rest *parser.DestructuringElement, seen map[string]bool, names *[]string) {
-	for _, prop := range props {
-		if prop == nil || prop.Target == nil {
-			continue
-		}
-		collectPatternNames(prop.Target, seen, names)
-	}
-	if rest != nil && rest.Target != nil {
-		collectPatternNames(rest.Target, seen, names)
-	}
+	parser.CollectObjectPatternNames(props, rest, seen, names)
 }
 
 // collectArrayDestructuringNames extracts variable names from array destructuring elements
 func collectArrayDestructuringNames(elements []*parser.DestructuringElement, seen map[string]bool, names *[]string) {
-	for _, elem := range elements {
-		if elem == nil || elem.Target == nil {
-			continue
-		}
-		collectPatternNames(elem.Target, seen, names)
-	}
-}
-
-// collectPatternNames recursively extracts variable names from a destructuring pattern target
-func collectPatternNames(target parser.Expression, seen map[string]bool, names *[]string) {
-	if target == nil {
-		return
-	}
-	switch t := target.(type) {
-	case *parser.Identifier:
-		if !seen[t.Value] {
-			*names = append(*names, t.Value)
-			seen[t.Value] = true
-		}
-	case *parser.ObjectLiteral:
-		// Nested object pattern: { a: { b, c } }
-		for _, prop := range t.Properties {
-			if prop == nil {
-				continue
-			}
-			if prop.Value != nil {
-				// Key: Value pattern - the target is in Value
-				collectPatternNames(prop.Value, seen, names)
-			} else if prop.Key != nil {
-				// Shorthand pattern { a } - Key is both the source and target
-				collectPatternNames(prop.Key, seen, names)
-			}
-		}
-	case *parser.ArrayLiteral:
-		// Nested array pattern: [a, [b, c]]
-		for _, elem := range t.Elements {
-			collectPatternNames(elem, seen, names)
-		}
-	}
+	parser.CollectArrayPatternNames(elements, seen, names)
 }
 
 // extractDestructuringVarNames extracts all variable names from an ObjectDestructuringDeclaration
-// This is a wrapper that creates a new seen map for use in block predefine pass
 func extractDestructuringVarNames(decl *parser.ObjectDestructuringDeclaration) []string {
-	var names []string
-	seen := make(map[string]bool)
-	collectDestructuringNames(decl.Properties, decl.RestProperty, seen, &names)
-	return names
+	return parser.DeclaredNames(decl)
 }
 
 // extractArrayDestructuringVarNames extracts all variable names from an ArrayDestructuringDeclaration
-// This is a wrapper that creates a new seen map for use in block predefine pass
 func extractArrayDestructuringVarNames(decl *parser.ArrayDestructuringDeclaration) []string {
-	var names []string
-	seen := make(map[string]bool)
-	collectArrayDestructuringNames(decl.Elements, seen, &names)
-	return names
+	return parser.DeclaredNames(decl)
 }
 
 // collectVarDeclarations recursively collects all var declaration names from statements.

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1614,13 +1614,43 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 						}
 					}
 				case *parser.ObjectDestructuringDeclaration:
-					// Pre-define all variables from object destructuring pattern
-					// This is needed so closures can capture them before the destructuring is executed
-					// Use TDZ for let/const, regular Define for var
+					// Pre-define all variables from the pattern so closures can
+					// capture them before the destructuring executes.
+					//
+					// A `var` pattern is function-scoped and its names were already
+					// hoisted into the function (or module) scope by
+					// collectVarDeclarations. Pre-defining them again HERE, in the
+					// block's own table, created a second binding at a fresh
+					// register that shadowed the hoisted one - so the destructuring
+					// wrote to the shadow and a read after the block saw the
+					// still-undefined hoisted register. Route var to the function
+					// table, exactly as the VarStatement case below does.
 					useTDZ := s.Token.Type == lexer.LET || s.Token.Type == lexer.CONST
 					isConst := s.Token.Type == lexer.CONST
+					isVar := s.Token.Type == lexer.VAR
 					varNames := extractDestructuringVarNames(s)
 					for _, name := range varNames {
+						if isVar {
+							funcTable := c.varHoistTable()
+							if sym, _, found := funcTable.Resolve(name); found && (sym.Register != nilRegister || sym.IsSpilled || sym.IsGlobal) {
+								debugPrintf("// [BlockPredefine] var destructured '%s' already hoisted in function scope, skipping\n", name)
+								continue
+							}
+							reg, ok := c.regAlloc.TryAllocForVariable()
+							if ok {
+								funcTable.Define(name, reg)
+								c.emitLoadUndefined(reg, s.Token.Line)
+								debugPrintf("// [BlockPredefine] Pre-defined var destructured '%s' in register R%d in function scope\n", name, reg)
+							} else {
+								spillIdx := c.AllocSpillSlot()
+								funcTable.DefineSpilled(name, spillIdx)
+								spillTempUsed = true
+								c.emitLoadUndefined(spillTempReg, s.Token.Line)
+								c.emitStoreSpill(spillIdx, spillTempReg, s.Token.Line)
+								debugPrintf("// [BlockPredefine] Pre-defined var destructured '%s' in SPILL SLOT %d in function scope\n", name, spillIdx)
+							}
+							continue
+						}
 						if _, alreadyInCurrentScope := c.currentSymbolTable.store[name]; !alreadyInCurrentScope {
 							reg, ok := c.regAlloc.TryAllocForVariable()
 							if ok {
@@ -1659,12 +1689,43 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 						}
 					}
 				case *parser.ArrayDestructuringDeclaration:
-					// Pre-define all variables from array destructuring pattern
-					// Use TDZ for let/const, regular Define for var
+					// Pre-define all variables from the pattern so closures can
+					// capture them before the destructuring executes.
+					//
+					// A `var` pattern is function-scoped and its names were already
+					// hoisted into the function (or module) scope by
+					// collectVarDeclarations. Pre-defining them again HERE, in the
+					// block's own table, created a second binding at a fresh
+					// register that shadowed the hoisted one - so the destructuring
+					// wrote to the shadow and a read after the block saw the
+					// still-undefined hoisted register. Route var to the function
+					// table, exactly as the VarStatement case below does.
 					useTDZ := s.Token.Type == lexer.LET || s.Token.Type == lexer.CONST
 					isConst := s.Token.Type == lexer.CONST
+					isVar := s.Token.Type == lexer.VAR
 					varNames := extractArrayDestructuringVarNames(s)
 					for _, name := range varNames {
+						if isVar {
+							funcTable := c.varHoistTable()
+							if sym, _, found := funcTable.Resolve(name); found && (sym.Register != nilRegister || sym.IsSpilled || sym.IsGlobal) {
+								debugPrintf("// [BlockPredefine] var array destructured '%s' already hoisted in function scope, skipping\n", name)
+								continue
+							}
+							reg, ok := c.regAlloc.TryAllocForVariable()
+							if ok {
+								funcTable.Define(name, reg)
+								c.emitLoadUndefined(reg, s.Token.Line)
+								debugPrintf("// [BlockPredefine] Pre-defined var array destructured '%s' in register R%d in function scope\n", name, reg)
+							} else {
+								spillIdx := c.AllocSpillSlot()
+								funcTable.DefineSpilled(name, spillIdx)
+								spillTempUsed = true
+								c.emitLoadUndefined(spillTempReg, s.Token.Line)
+								c.emitStoreSpill(spillIdx, spillTempReg, s.Token.Line)
+								debugPrintf("// [BlockPredefine] Pre-defined var array destructured '%s' in SPILL SLOT %d in function scope\n", name, spillIdx)
+							}
+							continue
+						}
 						if _, alreadyInCurrentScope := c.currentSymbolTable.store[name]; !alreadyInCurrentScope {
 							reg, ok := c.regAlloc.TryAllocForVariable()
 							if ok {
@@ -1708,15 +1769,7 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 					// walk up to find the function-level symbol table
 					for _, declarator := range s.Declarations {
 						if declarator.Name != nil {
-							// Find the function-level symbol table (the one with Outer == nil OR whose Outer is from enclosing compiler)
-							funcTable := c.currentSymbolTable
-							for funcTable.Outer != nil {
-								// Stop if the outer scope belongs to an enclosing compiler (for nested functions)
-								if c.enclosing != nil && c.isDefinedInEnclosingCompiler(funcTable.Outer) {
-									break
-								}
-								funcTable = funcTable.Outer
-							}
+							funcTable := c.varHoistTable()
 
 							// Check if var already defined in function scope
 							if sym, _, found := funcTable.Resolve(declarator.Name.Value); !found || sym.Register == nilRegister {
@@ -3154,6 +3207,21 @@ func (c *Compiler) ShouldUseHeapForEvalBinding(name string) bool {
 // Unlike Resolve(), this stops at function boundaries (doesn't cross into enclosing compilers).
 // This is used to check if a var was pre-defined during block hoisting in the SAME function.
 // Returns the symbol and the function-level table if found, otherwise returns zero Symbol and nil.
+// varHoistTable returns the symbol table a `var` binding belongs in: this
+// compiler's function-level table, found by walking out of any enclosing block
+// scopes but stopping at the enclosing compiler (a var never lands in an outer
+// function's scope).
+func (c *Compiler) varHoistTable() *SymbolTable {
+	funcTable := c.currentSymbolTable
+	for funcTable.Outer != nil {
+		if c.enclosing != nil && c.isDefinedInEnclosingCompiler(funcTable.Outer) {
+			break
+		}
+		funcTable = funcTable.Outer
+	}
+	return funcTable
+}
+
 func (c *Compiler) findVarInFunctionScope(name string) (Symbol, *SymbolTable) {
 	// Walk up the scope chain within this compiler's function
 	funcTable := c.currentSymbolTable

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4917,42 +4917,29 @@ func (c *Compiler) extractExportNamesFromAST(program *parser.Program) []string {
 // Parallels type checker's processExportDeclaration
 func (c *Compiler) processExportDeclaration(decl parser.Statement) {
 	switch d := decl.(type) {
-	case *parser.LetStatement:
-		if c.IsModuleMode() {
-			if d.Name != nil {
-				// Let/const declarations also get stored as globals at top-level.
-				// Prefer the symbol table's own record over a fresh by-name heap
-				// lookup: a top-level let's heap slot may be keyed by something
-				// other than its plain name (see moduleGlobalKey, #103/#106),
-				// which GetGlobalIndex(plainName) would miss entirely.
-				globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
-				c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
-				debugPrintf("// [Compiler] Exported let: %s at global[%d]\n", d.Name.Value, globalIdx)
-			}
+	case *parser.LetStatement, *parser.ConstStatement, *parser.VarStatement,
+		*parser.ObjectDestructuringDeclaration, *parser.ArrayDestructuringDeclaration,
+		*parser.DeclarationGroup:
+		// Every name the declaration binds is exported, not just the first
+		// declarator - and a destructuring pattern binds several. Reading the
+		// statement's legacy first-declarator Name field exported exactly one
+		// name (and, for a multi-declarator clause, the *last* one, because
+		// compileLetStatement aliases node.Name to each declarator as it goes
+		// and the declaration is compiled before we get here); a destructuring
+		// declaration had no case at all, so `export const {a} = obj` exported
+		// nothing.
+		if !c.IsModuleMode() {
+			return
 		}
-
-	case *parser.VarStatement:
-		if c.IsModuleMode() {
-			if d.Name != nil {
-				// Var declarations also get stored as globals at top-level.
-				// See the LetStatement case above for why resolveExportGlobalIndex
-				// (not a fresh plain-name lookup) is required here.
-				globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
-				c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
-				debugPrintf("// [Compiler] Exported var: %s at global[%d]\n", d.Name.Value, globalIdx)
-			}
-		}
-
-	case *parser.ConstStatement:
-		if c.IsModuleMode() {
-			if d.Name != nil {
-				// Let/const declarations also get stored as globals at top-level.
-				// See the LetStatement case above for why resolveExportGlobalIndex
-				// (not a fresh plain-name lookup) is required here.
-				globalIdx := c.resolveExportGlobalIndex(d.Name.Value)
-				c.moduleBindings.DefineExport(d.Name.Value, d.Name.Value, vm.Undefined, d, globalIdx)
-				debugPrintf("// [Compiler] Exported const: %s at global[%d]\n", d.Name.Value, globalIdx)
-			}
+		for _, name := range parser.DeclaredNames(decl) {
+			// Top-level let/const/var and pattern bindings are all stored as
+			// globals. Prefer the symbol table's own record over a fresh by-name
+			// heap lookup: a top-level binding's heap slot may be keyed by
+			// something other than its plain name (see moduleGlobalKey,
+			// #103/#106), which GetGlobalIndex(plainName) would miss entirely.
+			globalIdx := c.resolveExportGlobalIndex(name)
+			c.moduleBindings.DefineExport(name, name, vm.Undefined, decl, globalIdx)
+			debugPrintf("// [Compiler] Exported declaration binding: %s at global[%d]\n", name, globalIdx)
 		}
 
 	case *parser.ExpressionStatement:

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -3705,6 +3705,34 @@ func (c *Compiler) trackIfLoopBodyLocal(name string) {
 	}
 }
 
+// headPerIterationBindings returns the storage of the bindings a let/const loop
+// *head* pattern introduced, so the loop can give each iteration a fresh one.
+// It is the header counterpart of trackIfLoopBodyLocal (#132), and exists
+// because a pattern head's bindings are created deep inside the destructuring
+// helpers - nested targets, defaults and rest elements all land in the symbol
+// table through different paths - so collecting registers at each binding site
+// would mean threading a sink through all of them. Looking the names up once
+// the pattern is bound gets every shape.
+//
+// Only the CURRENT scope is consulted, deliberately: unlike a body declaration,
+// whose binding is certainly in the current table by the time it is tracked, a
+// head pattern name may coincide with an outer binding. Resolving outward and
+// closing that register would clobber an enclosing scope's variable.
+func (c *Compiler) headPerIterationBindings(decl parser.Statement) (regs []Register, spills []uint16) {
+	for _, name := range parser.DeclaredNames(decl) {
+		sym, ok := c.currentSymbolTable.store[name]
+		if !ok || sym.IsGlobal {
+			continue
+		}
+		if sym.IsSpilled {
+			spills = append(spills, sym.SpillIndex)
+		} else if sym.Register != nilRegister {
+			regs = append(regs, sym.Register)
+		}
+	}
+	return regs, spills
+}
+
 // closeLoopBodyPerIterationBindings emits OpCloseUpvalue(Spill) for every
 // body-declared per-iteration binding tracked on lc (#132). Called at the
 // same point in each loop's compile where its own header per-iteration

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -167,6 +167,10 @@ func collectVarDeclarations(stmts []parser.Statement) []string {
 			if s.Token.Literal == "var" {
 				collectArrayDestructuringNames(s.Elements, seen, &names)
 			}
+		case *parser.DeclarationGroup:
+			for _, inner := range s.Declarations {
+				collect(inner)
+			}
 		case *parser.BlockStatement:
 			if s != nil && s.Statements != nil {
 				for _, inner := range s.Statements {
@@ -286,6 +290,10 @@ func collectLetConstDeclarations(stmts []parser.Statement) []string {
 			// let/const destructuring
 			if s.Token.Literal == "let" || s.Token.Literal == "const" {
 				collectArrayDestructuringNames(s.Elements, seen, &names)
+			}
+		case *parser.DeclarationGroup:
+			for _, inner := range s.Declarations {
+				visit(inner)
 			}
 		case *parser.ExportNamedDeclaration:
 			// `export const X = ...` / `export let X = ...` wrap the actual
@@ -2151,6 +2159,20 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 
 	case *parser.ObjectDestructuringDeclaration:
 		return c.compileObjectDestructuringDeclaration(node, hint)
+
+	case *parser.DeclarationGroup:
+		// A single let/const/var clause mixing plain bindings with destructuring
+		// patterns. The group adds no scope of its own - compile its members in
+		// source order, exactly as if they were siblings.
+		var lastReg Register = BadRegister
+		for _, decl := range node.Declarations {
+			reg, err := c.compileNode(decl, hint)
+			if err != nil {
+				return BadRegister, err
+			}
+			lastReg = reg
+		}
+		return lastReg, nil
 
 	case *parser.ReturnStatement: // Although less relevant for top-level script return
 		return c.compileReturnStatement(node, hint) // TODO: Fix this

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -224,14 +224,17 @@ func collectLetConstDeclarations(stmts []parser.Statement) []string {
 		}
 		switch s := stmt.(type) {
 		case *parser.LetStatement:
-			if !s.Declare && s.Name != nil && !seen[s.Name.Value] {
-				names = append(names, s.Name.Value)
-				seen[s.Name.Value] = true
+			// EVERY declarator, not just the first. s.Name is the legacy
+			// first-declaration alias, so `let a = 1, b = 2` used to pre-register
+			// only a - leaving b with no TDZ marker, which made a
+			// before-declaration read of b report "b is not defined" instead of
+			// "Cannot access 'b' before initialization".
+			if !s.Declare {
+				parser.CollectDeclaredNames(s, seen, &names)
 			}
 		case *parser.ConstStatement:
-			if !s.Declare && s.Name != nil && !seen[s.Name.Value] {
-				names = append(names, s.Name.Value)
-				seen[s.Name.Value] = true
+			if !s.Declare {
+				parser.CollectDeclaredNames(s, seen, &names)
 			}
 		case *parser.ObjectDestructuringDeclaration:
 			// let/const destructuring
@@ -1256,49 +1259,22 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 			for _, stmt := range program.Statements {
 				switch s := stmt.(type) {
 				case *parser.LetStatement:
-					if s.Name == nil {
-						continue
-					}
 					// A caller-local of the same name must be *shadowed*, not
 					// deferred to: the eval's own let/const always introduces a
 					// fresh binding in its own lexical environment. Only skip
 					// when this scope already has a real (non-caller-local)
 					// definition for the name (e.g. already hoisted above).
-					if existing, ok := c.currentSymbolTable.store[s.Name.Value]; ok && !existing.IsCallerLocal {
-						continue
-					}
-					if reg, ok := c.regAlloc.TryAllocForVariable(); ok {
-						c.currentSymbolTable.DefineTDZ(s.Name.Value, reg)
-						c.regAlloc.Pin(reg)
-						c.emitLoadUninitialized(reg, s.Token.Line)
-					} else {
-						spillIdx := c.AllocSpillSlot()
-						c.currentSymbolTable.DefineTDZSpilled(s.Name.Value, spillIdx)
-						tempReg := c.regAlloc.Alloc()
-						c.emitLoadUninitialized(tempReg, s.Token.Line)
-						c.emitStoreSpill(spillIdx, tempReg, s.Token.Line)
-						c.regAlloc.Free(tempReg)
+					//
+					// Every declarator, not just s.Name (the legacy
+					// first-declaration alias): `eval("let a = 1, b = 2")` gave
+					// b no TDZ marker.
+					for _, name := range parser.DeclaredNames(s) {
+						c.predefineEvalLexicalName(name, false, s.Token.Line)
 					}
 				case *parser.ConstStatement:
-					if s.Name == nil {
-						continue
-					}
-					// See the LetStatement case above: shadow caller-locals,
-					// only skip a real existing definition in this scope.
-					if existing, ok := c.currentSymbolTable.store[s.Name.Value]; ok && !existing.IsCallerLocal {
-						continue
-					}
-					if reg, ok := c.regAlloc.TryAllocForVariable(); ok {
-						c.currentSymbolTable.DefineConstTDZ(s.Name.Value, reg)
-						c.regAlloc.Pin(reg)
-						c.emitLoadUninitialized(reg, s.Token.Line)
-					} else {
-						spillIdx := c.AllocSpillSlot()
-						c.currentSymbolTable.DefineConstTDZSpilled(s.Name.Value, spillIdx)
-						tempReg := c.regAlloc.Alloc()
-						c.emitLoadUninitialized(tempReg, s.Token.Line)
-						c.emitStoreSpill(spillIdx, tempReg, s.Token.Line)
-						c.regAlloc.Free(tempReg)
+					// See the LetStatement case above.
+					for _, name := range parser.DeclaredNames(s) {
+						c.predefineEvalLexicalName(name, true, s.Token.Line)
 					}
 				}
 			}
@@ -1565,54 +1541,14 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 			for _, stmt := range node.Statements {
 				switch s := stmt.(type) {
 				case *parser.LetStatement:
-					if s.Name != nil {
-						// Check if variable exists in CURRENT scope only (not outer scopes)
-						// to allow shadowing in enclosed block scopes
-						if _, alreadyInCurrentScope := c.currentSymbolTable.store[s.Name.Value]; !alreadyInCurrentScope {
-							reg, ok := c.regAlloc.TryAllocForVariable()
-							if ok {
-								c.currentSymbolTable.DefineTDZ(s.Name.Value, reg)
-								c.regAlloc.Pin(reg)
-								// Emit TDZ marker (Uninitialized value) into the register
-								c.emitLoadUninitialized(reg, s.Token.Line)
-								debugPrintf("// [BlockPredefine] Pre-defined let '%s' in register R%d (symbolTable=%p)\n", s.Name.Value, reg, c.currentSymbolTable)
-							} else {
-								// Variable register threshold reached, use spilling
-								spillIdx := c.AllocSpillSlot()
-								c.currentSymbolTable.DefineTDZSpilled(s.Name.Value, spillIdx)
-								// Emit TDZ marker to temp register, then store to spill slot
-								tempReg := c.regAlloc.Alloc()
-								c.emitLoadUninitialized(tempReg, s.Token.Line)
-								c.emitStoreSpill(spillIdx, tempReg, s.Token.Line)
-								c.regAlloc.Free(tempReg)
-								debugPrintf("// [BlockPredefine] Pre-defined let '%s' in SPILL SLOT %d (symbolTable=%p)\n", s.Name.Value, spillIdx, c.currentSymbolTable)
-							}
-						}
+					// Every declarator, not just s.Name (the legacy
+					// first-declaration alias) - see predefineLexicalName.
+					for _, name := range parser.DeclaredNames(s) {
+						c.predefineLexicalName(name, false, s.Token.Line)
 					}
 				case *parser.ConstStatement:
-					if s.Name != nil {
-						// Check if variable exists in CURRENT scope only (not outer scopes)
-						// to allow shadowing in enclosed block scopes
-						if _, alreadyInCurrentScope := c.currentSymbolTable.store[s.Name.Value]; !alreadyInCurrentScope {
-							reg, ok := c.regAlloc.TryAllocForVariable()
-							if ok {
-								c.currentSymbolTable.DefineConstTDZ(s.Name.Value, reg)
-								c.regAlloc.Pin(reg)
-								// Emit TDZ marker (Uninitialized value) into the register
-								c.emitLoadUninitialized(reg, s.Token.Line)
-								debugPrintf("// [BlockPredefine] Pre-defined const '%s' in register R%d (symbolTable=%p)\n", s.Name.Value, reg, c.currentSymbolTable)
-							} else {
-								// Variable register threshold reached, use spilling
-								spillIdx := c.AllocSpillSlot()
-								c.currentSymbolTable.DefineConstTDZSpilled(s.Name.Value, spillIdx)
-								// Emit TDZ marker to temp register, then store to spill slot
-								tempReg := c.regAlloc.Alloc()
-								c.emitLoadUninitialized(tempReg, s.Token.Line)
-								c.emitStoreSpill(spillIdx, tempReg, s.Token.Line)
-								c.regAlloc.Free(tempReg)
-								debugPrintf("// [BlockPredefine] Pre-defined const '%s' in SPILL SLOT %d (symbolTable=%p)\n", s.Name.Value, spillIdx, c.currentSymbolTable)
-							}
-						}
+					for _, name := range parser.DeclaredNames(s) {
+						c.predefineLexicalName(name, true, s.Token.Line)
 					}
 				case *parser.ObjectDestructuringDeclaration:
 					// Pre-define all variables from the pattern so closures can
@@ -3240,6 +3176,77 @@ func (c *Compiler) storeToHoistedVar(name string, valueReg Register, line int) b
 		c.regAlloc.Pin(valueReg)
 	}
 	return true
+}
+
+// predefineLexicalName gives one let/const binding its TDZ marker in the current
+// block scope, so a read before the declaration line throws
+// "Cannot access '<name>' before initialization" rather than falling through to
+// an outer binding or reporting the name as undefined.
+//
+// A no-op when the name is already defined in the CURRENT scope only (not outer
+// scopes), which is what lets an inner block shadow an outer binding.
+//
+// Callers must invoke this once per declarator. The three sites that used to
+// inline this body all read the statement's legacy first-declaration alias
+// (s.Name), so `let a = 1, b = 2` marked only a.
+func (c *Compiler) predefineLexicalName(name string, isConst bool, line int) {
+	if _, alreadyInCurrentScope := c.currentSymbolTable.store[name]; alreadyInCurrentScope {
+		return
+	}
+	if reg, ok := c.regAlloc.TryAllocForVariable(); ok {
+		if isConst {
+			c.currentSymbolTable.DefineConstTDZ(name, reg)
+		} else {
+			c.currentSymbolTable.DefineTDZ(name, reg)
+		}
+		c.regAlloc.Pin(reg)
+		c.emitLoadUninitialized(reg, line)
+		debugPrintf("// [BlockPredefine] Pre-defined lexical '%s' in register R%d (symbolTable=%p)\n", name, reg, c.currentSymbolTable)
+		return
+	}
+	// Variable register threshold reached, use spilling.
+	spillIdx := c.AllocSpillSlot()
+	if isConst {
+		c.currentSymbolTable.DefineConstTDZSpilled(name, spillIdx)
+	} else {
+		c.currentSymbolTable.DefineTDZSpilled(name, spillIdx)
+	}
+	tempReg := c.regAlloc.Alloc()
+	c.emitLoadUninitialized(tempReg, line)
+	c.emitStoreSpill(spillIdx, tempReg, line)
+	c.regAlloc.Free(tempReg)
+	debugPrintf("// [BlockPredefine] Pre-defined lexical '%s' in SPILL SLOT %d (symbolTable=%p)\n", name, spillIdx, c.currentSymbolTable)
+}
+
+// predefineEvalLexicalName is predefineLexicalName for direct-eval code, where a
+// caller-local of the same name must be *shadowed* rather than deferred to: the
+// eval's own let/const always introduces a fresh binding in its own lexical
+// environment, so only a real (non-caller-local) definition already in this
+// scope suppresses the marker.
+func (c *Compiler) predefineEvalLexicalName(name string, isConst bool, line int) {
+	if existing, ok := c.currentSymbolTable.store[name]; ok && !existing.IsCallerLocal {
+		return
+	}
+	if reg, ok := c.regAlloc.TryAllocForVariable(); ok {
+		if isConst {
+			c.currentSymbolTable.DefineConstTDZ(name, reg)
+		} else {
+			c.currentSymbolTable.DefineTDZ(name, reg)
+		}
+		c.regAlloc.Pin(reg)
+		c.emitLoadUninitialized(reg, line)
+		return
+	}
+	spillIdx := c.AllocSpillSlot()
+	if isConst {
+		c.currentSymbolTable.DefineConstTDZSpilled(name, spillIdx)
+	} else {
+		c.currentSymbolTable.DefineTDZSpilled(name, spillIdx)
+	}
+	tempReg := c.regAlloc.Alloc()
+	c.emitLoadUninitialized(tempReg, line)
+	c.emitStoreSpill(spillIdx, tempReg, line)
+	c.regAlloc.Free(tempReg)
 }
 
 // varHoistTable returns the symbol table a `var` binding belongs in: this

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -151,21 +151,22 @@ func collectVarDeclarations(stmts []parser.Statement) []string {
 				collect(s.Body)
 			}
 		case *parser.ForInStatement:
-			// For-in initializer can be a var declaration
+			// For-in head can be a var declaration - including a destructuring
+			// pattern (`for (var {w} in o)`), which the VarStatement-only check
+			// this replaces missed entirely, leaving w unhoisted and its later
+			// read a ReferenceError. collect ignores head shapes that declare
+			// nothing (an assignment to an existing binding).
 			if s.Variable != nil {
-				if varStmt, ok := s.Variable.(*parser.VarStatement); ok {
-					collect(varStmt)
-				}
+				collect(s.Variable)
 			}
 			if s.Body != nil {
 				collect(s.Body)
 			}
 		case *parser.ForOfStatement:
-			// For-of initializer can be a var declaration
+			// For-of head can be a var declaration, pattern included - see the
+			// ForInStatement case above.
 			if s.Variable != nil {
-				if varStmt, ok := s.Variable.(*parser.VarStatement); ok {
-					collect(varStmt)
-				}
+				collect(s.Variable)
 			}
 			if s.Body != nil {
 				collect(s.Body)
@@ -3207,6 +3208,40 @@ func (c *Compiler) ShouldUseHeapForEvalBinding(name string) bool {
 // Unlike Resolve(), this stops at function boundaries (doesn't cross into enclosing compilers).
 // This is used to check if a var was pre-defined during block hoisting in the SAME function.
 // Returns the symbol and the function-level table if found, otherwise returns zero Symbol and nil.
+// storeToHoistedVar emits the store for a `var` binding whose name was already
+// hoisted into this function's scope (or, at top level, to a global) by
+// collectVarDeclarations, and reports whether such a binding was found.
+//
+// `var` is function-scoped, so a declaration or loop head nested inside a block
+// must write *through* to the hoisted binding rather than define a new one -
+// defining one in the current scope shadows the hoisted register, so the value
+// lands in the shadow and a read after the block sees the still-undefined
+// hoisted binding. findVarInFunctionScope walks out of enclosing blocks but
+// stops at the enclosing compiler, so a var can never write into an outer
+// function's binding.
+func (c *Compiler) storeToHoistedVar(name string, valueReg Register, line int) bool {
+	sym, funcTable := c.findVarInFunctionScope(name)
+	if funcTable == nil {
+		return false
+	}
+	switch {
+	case sym.IsGlobal:
+		// Top-level var inside a block: the hoisted binding is a global.
+		c.emitSetGlobal(sym.GlobalIndex, valueReg, line)
+	case sym.IsSpilled:
+		c.emitStoreSpill(sym.SpillIndex, valueReg, line)
+	case sym.Register != nilRegister:
+		if valueReg != sym.Register {
+			c.emitMove(sym.Register, valueReg, line)
+		}
+	default:
+		// Symbol exists but has no storage yet - claim this register for it.
+		funcTable.Define(name, valueReg)
+		c.regAlloc.Pin(valueReg)
+	}
+	return true
+}
+
 // varHoistTable returns the symbol table a `var` binding belongs in: this
 // compiler's function-level table, found by walking out of any enclosing block
 // scopes but stopping at the enclosing compiler (a var never lands in an outer

--- a/pkg/driver/export_destructuring_test.go
+++ b/pkg/driver/export_destructuring_test.go
@@ -72,13 +72,19 @@ func TestExportDeclarationExportsEveryBinding(t *testing.T) {
 			want:  "1,2,3,4",
 		},
 		{
+			// The nested default and nested rest shapes were left out when this
+			// test was written: the checker rejected them ("invalid destructuring
+			// target type: *parser.AssignmentExpression / *parser.SpreadElement")
+			// independently of exports. They are included now that it doesn't.
 			name: "renamed, elided, defaulted and nested pattern targets",
 			lib: "export const {x: a, y: b} = {x: 1, y: 2};\n" +
 				"export const [c, , d] = [3, 99, 4];\n" +
 				"export const {e = 5} = {};\n" +
-				"export const {f: {g}} = {f: {g: 6}};\n",
-			names: []string{"a", "b", "c", "d", "e", "g"},
-			want:  "1,2,3,4,5,6",
+				"export const {f: {g}} = {f: {g: 6}};\n" +
+				"export const {h: {i = 7}} = {h: {}};\n" +
+				"export const {l: [m = 11]} = {l: []};\n",
+			names: []string{"a", "b", "c", "d", "e", "g", "i", "m"},
+			want:  "1,2,3,4,5,6,7,11",
 		},
 	}
 
@@ -104,6 +110,21 @@ func TestExportDeclarationExportsEveryBinding(t *testing.T) {
 				t.Errorf("namespace import = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestExportedNestedRestBinding covers a rest element nested inside a pattern.
+// It gets its own test rather than joining the table above, because a rest
+// binding is an array and Array.prototype.join flattens it - which would make
+// the assertion pass whether k held [9, 10] or two separate scalar exports.
+func TestExportedNestedRestBinding(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "lib.ts"), "export const [[j, ...k]] = [[8, 9, 10]];\n")
+	mustWrite(t, filepath.Join(dir, "entry.ts"),
+		"import { j, k } from \"./lib.ts\";\n"+
+			"j + \"|\" + JSON.stringify(k);\n")
+	if got := runFileForValue(t, dir, "entry.ts"); got != "8|[9,10]" {
+		t.Errorf("nested rest export = %q, want %q", got, "8|[9,10]")
 	}
 }
 

--- a/pkg/driver/export_destructuring_test.go
+++ b/pkg/driver/export_destructuring_test.go
@@ -1,0 +1,170 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runFileForValue runs name as the entry module in dir and returns the final
+// value's string form, failing the test on any diagnostic.
+func runFileForValue(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	p := NewPaseratiWithBaseDir(dir)
+	val, errs := p.RunCode(string(src), RunOptions{ModuleName: name, Filename: path})
+	if len(errs) > 0 {
+		t.Fatalf("running %s: %v", name, errs[0])
+	}
+	return val.ToString()
+}
+
+// TestExportDeclarationExportsEveryBinding covers the two ways
+// processExportDeclaration (in both the checker and the compiler) used to miss
+// exported names, because it read the declaration statement's legacy
+// first-declarator Name field instead of the bindings the declaration actually
+// introduces:
+//
+//   - A destructuring declaration had no case at all, so `export const {a} = o`
+//     declared a locally but exported nothing. Importers saw undefined, and a
+//     namespace import omitted the name entirely - so it was the export
+//     registration that was missing, not the value.
+//   - A multi-declarator clause exported exactly one name, and it was the
+//     *last* one, not the first: compileLetStatement aliases node.Name to each
+//     declarator as it compiles it, and the declaration is compiled before
+//     processExportDeclaration reads that field.
+func TestExportDeclarationExportsEveryBinding(t *testing.T) {
+	tests := []struct {
+		name  string
+		lib   string
+		names []string // the bindings lib exports, in the order want lists them
+		want  string
+	}{
+		{
+			name: "object and array patterns beside a plain binding",
+			lib: "export const {a} = {a: 1};\n" +
+				"export const [b] = [2];\n" +
+				"export const c = 3;\n",
+			names: []string{"a", "b", "c"},
+			want:  "1,2,3",
+		},
+		{
+			// Every declarator of a multi-declarator clause, for each keyword.
+			name: "multi-declarator let and var",
+			lib: "export let a = 1, b = 2;\n" +
+				"export var c = 3, d = 4;\n",
+			names: []string{"a", "b", "c", "d"},
+			want:  "1,2,3,4",
+		},
+		{
+			// The shape paserati#159 made parseable: a pattern as a non-first
+			// declarator. It desugars to two ExportNamedDeclarations, so both
+			// halves have to register.
+			name: "pattern mixed into a declarator list",
+			lib: "export let a = 1, {b} = {b: 2};\n" +
+				"export const {c} = {c: 3}, d = 4;\n",
+			names: []string{"a", "b", "c", "d"},
+			want:  "1,2,3,4",
+		},
+		{
+			name: "renamed, elided, defaulted and nested pattern targets",
+			lib: "export const {x: a, y: b} = {x: 1, y: 2};\n" +
+				"export const [c, , d] = [3, 99, 4];\n" +
+				"export const {e = 5} = {};\n" +
+				"export const {f: {g}} = {f: {g: 6}};\n",
+			names: []string{"a", "b", "c", "d", "e", "g"},
+			want:  "1,2,3,4,5,6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWrite(t, filepath.Join(dir, "lib.ts"), tt.lib)
+
+			// Named imports.
+			entry := "import { " + strings.Join(tt.names, ", ") + " } from \"./lib.ts\";\n" +
+				"[" + strings.Join(tt.names, ", ") + "].join(\",\");\n"
+			mustWrite(t, filepath.Join(dir, "entry.ts"), entry)
+			if got := runFileForValue(t, dir, "entry.ts"); got != tt.want {
+				t.Errorf("named imports = %q, want %q", got, tt.want)
+			}
+
+			// A namespace import must carry the same names - this is what showed
+			// them missing rather than merely undefined.
+			nsEntry := "import * as m from \"./lib.ts\";\n" +
+				"[" + nsReads(tt.names) + "].join(\",\");\n"
+			mustWrite(t, filepath.Join(dir, "ns.ts"), nsEntry)
+			if got := runFileForValue(t, dir, "ns.ts"); got != tt.want {
+				t.Errorf("namespace import = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExportedPatternBindingKeepsItsType checks the checker half: the export has
+// to be registered with the binding's real type, not skipped (which surfaces as
+// `any` at the import site and silently accepts everything).
+func TestExportedPatternBindingKeepsItsType(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "lib.ts"),
+		"export const {num, str} = {num: 1, str: \"s\"};\n"+
+			"export let a = 1, {flag} = {flag: true};\n")
+
+	// The well-typed reads must pass...
+	mustWrite(t, filepath.Join(dir, "ok.ts"),
+		"import { num, str, flag } from \"./lib.ts\";\n"+
+			"const n: number = num;\n"+
+			"const s: string = str;\n"+
+			"const b: boolean = flag;\n"+
+			"[n, s, b].join(\",\");\n")
+	if got := runFileForValue(t, dir, "ok.ts"); got != "1,s,true" {
+		t.Errorf("typed reads = %q, want %q", got, "1,s,true")
+	}
+
+	// ...and a mistyped one must be caught, which it can't be if the export was
+	// never registered or was registered as any.
+	mustWrite(t, filepath.Join(dir, "bad.ts"),
+		"import { str } from \"./lib.ts\";\n"+
+			"const n: number = str;\n"+
+			"n;\n")
+	errs := runFileForErrors(t, dir, "bad.ts")
+	if len(errs) == 0 {
+		t.Fatal("assigning an exported string binding to a number was accepted")
+	}
+	if !strings.Contains(errs[0].Error(), "not assignable to type 'number'") {
+		t.Errorf("unexpected diagnostic: %v", errs[0])
+	}
+}
+
+// TestExportStarForwardsPatternBindings checks that `export * from` picks up
+// pattern-bound names too: it expands via the source module's export list, so it
+// only ever saw whatever processExportDeclaration had registered.
+func TestExportStarForwardsPatternBindings(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "lib.ts"),
+		"export const {a} = {a: 1};\n"+
+			"export const [b] = [2];\n"+
+			"export let c = 3, d = 4;\n")
+	mustWrite(t, filepath.Join(dir, "reexport.ts"), "export * from \"./lib.ts\";\n")
+	mustWrite(t, filepath.Join(dir, "entry.ts"),
+		"import { a, b, c, d } from \"./reexport.ts\";\n"+
+			"[a, b, c, d].join(\",\");\n")
+
+	if got := runFileForValue(t, dir, "entry.ts"); got != "1,2,3,4" {
+		t.Errorf("re-exported bindings = %q, want %q", got, "1,2,3,4")
+	}
+}
+
+func nsReads(names []string) string {
+	reads := make([]string, len(names))
+	for i, n := range names {
+		reads[i] = "m." + n
+	}
+	return strings.Join(reads, ", ")
+}

--- a/pkg/driver/export_destructuring_test.go
+++ b/pkg/driver/export_destructuring_test.go
@@ -128,6 +128,21 @@ func TestExportedNestedRestBinding(t *testing.T) {
 	}
 }
 
+// TestExportedNestedObjectRestBinding covers a rest element nested inside an
+// object pattern. Like the nested array rest above it is an array-free value but
+// still gets its own test rather than joining the table's join(","), because
+// JSON.stringify is the only way to assert an object's shape.
+func TestExportedNestedObjectRestBinding(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "lib.ts"), "export const {a: {b, ...rr}} = {a: {b: 1, c: 2, d: 3}};\n")
+	mustWrite(t, filepath.Join(dir, "entry.ts"),
+		"import { b, rr } from \"./lib.ts\";\n"+
+			"b + \"|\" + JSON.stringify(rr);\n")
+	if got := runFileForValue(t, dir, "entry.ts"); got != "1|{\"c\":2,\"d\":3}" {
+		t.Errorf("nested object rest export = %q, want %q", got, "1|{\"c\":2,\"d\":3}")
+	}
+}
+
 // TestExportedPatternBindingKeepsItsType checks the checker half: the export has
 // to be registered with the binding's real type, not skipped (which surfaces as
 // `any` at the import site and silently accepts everything).

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -3065,6 +3065,36 @@ func (add *ArrayDestructuringDeclaration) String() string {
 	return out.String()
 }
 
+// DeclarationGroup represents a single let/const/var clause whose declarator
+// list mixes plain bindings with destructuring patterns, e.g.
+// `let r = 1, {a} = obj, b = 2`. There is no single AST node that can hold both
+// kinds of declarator (VarDeclarator.Name is an *Identifier, and the
+// destructuring declarations are statements in their own right), so the parser
+// desugars such a clause into one declaration statement per declarator and
+// groups them here, in source order.
+//
+// A DeclarationGroup introduces no scope of its own: its members must be
+// checked/compiled exactly as if they were siblings in the enclosing statement
+// list. In statement position the parser splices the members straight into that
+// list, so a group normally only survives where a single Statement is required -
+// most notably a `for` initializer (`for (let i = 0, {a} = obj; ...)`).
+type DeclarationGroup struct {
+	Token        *lexer.Token // The 'let', 'const', or 'var' token
+	Declarations []Statement  // One declaration statement per declarator, in source order
+}
+
+func (dg *DeclarationGroup) statementNode()       {}
+func (dg *DeclarationGroup) TokenLiteral() string { return dg.Token.Literal }
+func (dg *DeclarationGroup) String() string {
+	parts := []string{}
+	for _, d := range dg.Declarations {
+		if d != nil {
+			parts = append(parts, d.String())
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
 // ObjectDestructuringDeclaration represents let/const/var {a, b} = expr
 type ObjectDestructuringDeclaration struct {
 	Token          *lexer.Token             // The 'let', 'const', or 'var' token

--- a/pkg/parser/bound_names.go
+++ b/pkg/parser/bound_names.go
@@ -1,0 +1,146 @@
+package parser
+
+// Binding-name enumeration for declarations.
+//
+// Several passes need "what names does this declaration introduce?": var
+// hoisting, let/const TDZ pre-registration, and module export registration.
+// A destructuring pattern makes that a recursive question, and the recursion
+// has two shapes to cover, because a pattern is represented differently at its
+// top level than when nested:
+//
+//   - At the top level of a declaration, a default lives in
+//     DestructuringProperty.Default / DestructuringElement.Default and a rest
+//     element in DestructuringElement.IsRest, with Target holding the binding.
+//   - Nested one level down, Target is a raw ObjectLiteral/ArrayLiteral
+//     expression, so a default appears as an AssignmentExpression and a rest as
+//     a SpreadElement, and the binding is inside those wrappers.
+//
+// Missing the wrapped forms is what made a name behind a nested default or rest
+// invisible to var hoisting: `function f(){ { var {a: {b = 1}} = o; } return b; }`
+// threw ReferenceError even though the same declaration outside a block bound b
+// correctly.
+
+// CollectPatternNames appends the binding names in a destructuring pattern
+// target to *names, in source order, skipping any name already in seen.
+func CollectPatternNames(target Expression, seen map[string]bool, names *[]string) {
+	if target == nil {
+		return
+	}
+	switch t := target.(type) {
+	case *Identifier:
+		if !seen[t.Value] {
+			*names = append(*names, t.Value)
+			seen[t.Value] = true
+		}
+	case *AssignmentExpression:
+		// A nested default: `{a: {b = 1}}` / `[[m = 4]]`. The binding is the
+		// assignment's left-hand side.
+		CollectPatternNames(t.Left, seen, names)
+	case *SpreadElement:
+		// A nested rest element: `[[x, ...ys]]`.
+		CollectPatternNames(t.Argument, seen, names)
+	case *ObjectLiteral:
+		// Nested object pattern: `{a: {b, c}}`
+		for _, prop := range t.Properties {
+			if prop == nil {
+				continue
+			}
+			if prop.Value != nil {
+				// Key: Value pattern - the target is in Value.
+				CollectPatternNames(prop.Value, seen, names)
+			} else if prop.Key != nil {
+				// Shorthand `{a}`, or a rest `{...r}`, which the parser stores as
+				// a SpreadElement in Key. Either way the Key is the target.
+				CollectPatternNames(prop.Key, seen, names)
+			}
+		}
+	case *ArrayLiteral:
+		// Nested array pattern: `[a, [b, c]]`
+		for _, elem := range t.Elements {
+			CollectPatternNames(elem, seen, names)
+		}
+	}
+}
+
+// CollectObjectPatternNames appends the binding names of an object pattern's
+// properties and rest property to *names.
+func CollectObjectPatternNames(props []*DestructuringProperty, rest *DestructuringElement, seen map[string]bool, names *[]string) {
+	for _, prop := range props {
+		if prop == nil {
+			continue
+		}
+		CollectPatternNames(prop.Target, seen, names)
+	}
+	if rest != nil {
+		CollectPatternNames(rest.Target, seen, names)
+	}
+}
+
+// CollectArrayPatternNames appends the binding names of an array pattern's
+// elements to *names.
+func CollectArrayPatternNames(elements []*DestructuringElement, seen map[string]bool, names *[]string) {
+	for _, elem := range elements {
+		if elem == nil {
+			continue
+		}
+		CollectPatternNames(elem.Target, seen, names)
+	}
+}
+
+// CollectDeclaredNames appends the binding names a single declaration statement
+// introduces to *names, in source order. It covers a let/const/var declarator
+// list (every declarator, not just the first) and a destructuring declaration;
+// anything else contributes nothing.
+//
+// This looks at one statement only - it does not recurse into nested statement
+// lists, and it does not filter by declaration keyword. Callers that need
+// either (var hoisting walks bodies and wants only `var`; TDZ registration
+// wants only let/const) do that themselves.
+func CollectDeclaredNames(stmt Statement, seen map[string]bool, names *[]string) {
+	switch s := stmt.(type) {
+	case *LetStatement:
+		collectDeclaratorNames(s.Declarations, s.Name, seen, names)
+	case *ConstStatement:
+		collectDeclaratorNames(s.Declarations, s.Name, seen, names)
+	case *VarStatement:
+		collectDeclaratorNames(s.Declarations, s.Name, seen, names)
+	case *ObjectDestructuringDeclaration:
+		CollectObjectPatternNames(s.Properties, s.RestProperty, seen, names)
+	case *ArrayDestructuringDeclaration:
+		CollectArrayPatternNames(s.Elements, seen, names)
+	case *DeclarationGroup:
+		for _, d := range s.Declarations {
+			CollectDeclaredNames(d, seen, names)
+		}
+	}
+}
+
+// DeclaredNames is CollectDeclaredNames with its own seen map, for a one-off
+// query about a single statement.
+func DeclaredNames(stmt Statement) []string {
+	var names []string
+	seen := make(map[string]bool)
+	CollectDeclaredNames(stmt, seen, &names)
+	return names
+}
+
+// collectDeclaratorNames reads the declarator list, falling back to the
+// legacy first-declarator Name field for the parser paths that only set that.
+func collectDeclaratorNames(declarators []*VarDeclarator, legacyName *Identifier, seen map[string]bool, names *[]string) {
+	if len(declarators) == 0 {
+		if legacyName != nil && !seen[legacyName.Value] {
+			*names = append(*names, legacyName.Value)
+			seen[legacyName.Value] = true
+		}
+		return
+	}
+	for _, d := range declarators {
+		if d == nil || d.Name == nil {
+			continue
+		}
+		if !seen[d.Name.Value] {
+			*names = append(*names, d.Name.Value)
+			seen[d.Name.Value] = true
+		}
+	}
+}

--- a/pkg/parser/parse_var_declaration.go
+++ b/pkg/parser/parse_var_declaration.go
@@ -1,0 +1,348 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/nooga/paserati/pkg/lexer"
+)
+
+// varDeclKind names the three variable-declaration keywords, so the single
+// declarator-list parser below can serve all of them.
+type varDeclKind int
+
+const (
+	varDeclLet varDeclKind = iota
+	varDeclConst
+	varDeclVar
+)
+
+func (k varDeclKind) keyword() string {
+	switch k {
+	case varDeclConst:
+		return "const"
+	case varDeclVar:
+		return "var"
+	default:
+		return "let"
+	}
+}
+
+// declListItem is one parsed declarator: either a plain binding
+// (`x`, `x: T = e`) or a destructuring pattern (`{a} = e`, `[a] = e`), which is
+// its own statement node.
+type declListItem struct {
+	declarator *VarDeclarator // set for a plain binding
+	pattern    Statement      // set for a destructuring pattern
+}
+
+// parseVariableDeclarationList parses the declarator list of a let/const/var
+// clause and returns the statement(s) it declares.
+//
+// Every declarator position accepts either an identifier or a binding pattern -
+// ECMAScript's LexicalBinding/VariableDeclaration allows both in *any* position,
+// not just the first (paserati#159). The three keyword-specific parsers used to
+// each carry their own copy of this loop, and every copy only understood
+// identifiers after a comma, so `let r = 1, {a} = obj` failed to parse while
+// `let {a} = obj, r = 1` parsed as a *single* destructuring declaration whose
+// initializer had swallowed `, r = 1` as a comma operator (paserati#160).
+//
+// Precondition: curToken is the first token of the first declarator (the
+// keyword has already been consumed). On return curToken is the clause's last
+// token, with an optional trailing semicolon consumed.
+func (p *Parser) parseVariableDeclarationList(declToken *lexer.Token, kind varDeclKind) Statement {
+	first, ok := p.parseDeclListItem(declToken, kind, kind.keyword())
+	if !ok {
+		return nil
+	}
+
+	items, ok := p.parseMoreDeclListItems([]declListItem{first}, declToken, kind)
+	if !ok {
+		return nil
+	}
+
+	// Optional semicolon terminating the whole clause. The destructuring
+	// declaration parsers deliberately leave this to us so that a pattern in
+	// the last declarator position doesn't consume the statement terminator
+	// out from under this loop.
+	if p.peekTokenIs(lexer.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return p.buildDeclarationStatements(declToken, kind, items)
+}
+
+// parseMoreDeclListItems parses the `, declarator` tail of a declarator list,
+// appending to items. Precondition: curToken is the last token of the preceding
+// declarator.
+func (p *Parser) parseMoreDeclListItems(items []declListItem, declToken *lexer.Token, kind varDeclKind) ([]declListItem, bool) {
+	for p.peekTokenIs(lexer.COMMA) {
+		commaToken := p.peekToken
+		p.nextToken() // Consume ','
+
+		// TS1009: a trailing comma before end-of-statement or a statement keyword
+		if p.peekTokenIs(lexer.RETURN) || p.peekTokenIs(lexer.BREAK) ||
+			p.peekTokenIs(lexer.CONTINUE) || p.peekTokenIs(lexer.THROW) ||
+			p.peekTokenIs(lexer.SEMICOLON) || p.peekTokenIs(lexer.EOF) ||
+			p.peekTokenIs(lexer.RBRACE) {
+			p.addError(commaToken, "Trailing comma not allowed.")
+			break
+		}
+
+		p.nextToken() // Move to the first token of the next declarator
+
+		item, ok := p.parseDeclListItem(declToken, kind, ",")
+		if !ok {
+			return nil, false
+		}
+		items = append(items, item)
+	}
+	return items, true
+}
+
+// parseDeclListItem parses a single declarator. Returns ok=false if the
+// declarator could not be parsed (an error has been reported).
+func (p *Parser) parseDeclListItem(declToken *lexer.Token, kind varDeclKind, precededBy string) (declListItem, bool) {
+	switch {
+	case p.curTokenIs(lexer.LBRACKET):
+		decl := p.parseArrayDestructuringDeclaration(declToken, kind == varDeclConst, true)
+		if decl == nil {
+			return declListItem{}, false
+		}
+		return declListItem{pattern: decl}, true
+
+	case p.curTokenIs(lexer.LBRACE):
+		decl := p.parseObjectDestructuringDeclaration(declToken, kind == varDeclConst, true)
+		if decl == nil {
+			return declListItem{}, false
+		}
+		return declListItem{pattern: decl}, true
+
+	case p.curTokenIsIdentLike():
+		declarator := &VarDeclarator{}
+		declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
+
+		if !p.parseDeclaratorAnnotation(declarator) {
+			return declListItem{}, false
+		}
+
+		if kind == varDeclConst {
+			// const requires an initializer.
+			if !p.expectPeek(lexer.ASSIGN) {
+				return declListItem{}, false
+			}
+			p.nextToken() // Move to the first token of the initializer
+			declarator.Value = p.parseExpression(COMMA)
+		} else if p.peekTokenIs(lexer.ASSIGN) {
+			p.nextToken() // Consume '='
+			p.nextToken() // Move to the first token of the initializer
+			// COMMA precedence: an Initializer is an AssignmentExpression, so it
+			// must never swallow the comma separating declarators.
+			declarator.Value = p.parseExpression(COMMA)
+		}
+		return declListItem{declarator: declarator}, true
+
+	default:
+		p.addError(p.curToken, fmt.Sprintf(
+			"expected identifier or destructuring pattern after '%s', got %s",
+			precededBy, p.curToken.Type))
+		return declListItem{}, false
+	}
+}
+
+// buildDeclarationStatements turns the parsed declarators into AST statements,
+// preserving the pre-existing single-statement shapes wherever it can: an
+// all-identifier list stays one Let/Const/VarStatement, and a lone destructuring
+// declarator stays a bare Array/ObjectDestructuringDeclaration. Only a genuinely
+// mixed (or multi-pattern) list needs a DeclarationGroup.
+func (p *Parser) buildDeclarationStatements(declToken *lexer.Token, kind varDeclKind, items []declListItem) Statement {
+	if len(items) == 0 {
+		return nil
+	}
+
+	patterns := 0
+	for _, it := range items {
+		if it.pattern != nil {
+			patterns++
+		}
+	}
+
+	if patterns == 0 {
+		declarators := make([]*VarDeclarator, 0, len(items))
+		for _, it := range items {
+			declarators = append(declarators, it.declarator)
+		}
+		return newVarLikeStatement(declToken, kind, declarators)
+	}
+
+	if len(items) == 1 {
+		return items[0].pattern
+	}
+
+	group := &DeclarationGroup{Token: declToken}
+	for _, it := range items {
+		if it.pattern != nil {
+			group.Declarations = append(group.Declarations, it.pattern)
+			continue
+		}
+		// One statement per plain binding: the compiler's Let/Const/Var paths
+		// alias the statement's legacy Name/Value fields to the declarator being
+		// compiled, so a single declarator per statement keeps those consistent.
+		group.Declarations = append(group.Declarations,
+			newVarLikeStatement(declToken, kind, []*VarDeclarator{it.declarator}))
+	}
+	return group
+}
+
+// newVarLikeStatement builds the Let/Const/VarStatement for a declarator list,
+// including the legacy first-declarator fields the checker and compiler still
+// read.
+func newVarLikeStatement(declToken *lexer.Token, kind varDeclKind, declarators []*VarDeclarator) Statement {
+	first := declarators[0]
+	switch kind {
+	case varDeclConst:
+		return &ConstStatement{
+			Token:          declToken,
+			Declarations:   declarators,
+			Name:           first.Name,
+			TypeAnnotation: first.TypeAnnotation,
+			Value:          first.Value,
+			ComputedType:   first.ComputedType,
+		}
+	case varDeclVar:
+		return &VarStatement{
+			Token:          declToken,
+			Declarations:   declarators,
+			Name:           first.Name,
+			TypeAnnotation: first.TypeAnnotation,
+			Value:          first.Value,
+			ComputedType:   first.ComputedType,
+		}
+	default:
+		return &LetStatement{
+			Token:          declToken,
+			Declarations:   declarators,
+			Name:           first.Name,
+			TypeAnnotation: first.TypeAnnotation,
+			Value:          first.Value,
+			ComputedType:   first.ComputedType,
+		}
+	}
+}
+
+// forInitDeclKind reports the declaration keyword and keyword token of an
+// already-parsed for-loop head binding, and whether it is a variable
+// declaration at all (a for initializer can also be a plain expression).
+func forInitDeclKind(stmt Statement) (varDeclKind, *lexer.Token, bool) {
+	kindOf := func(isConst bool, tok *lexer.Token) varDeclKind {
+		if isConst {
+			return varDeclConst
+		}
+		if tok != nil && tok.Literal == "var" {
+			return varDeclVar
+		}
+		return varDeclLet
+	}
+	// A failed sub-parse can leave a typed-nil pointer in the interface, which
+	// is not == nil; treat that as "not a declaration" rather than dereferencing.
+	switch s := stmt.(type) {
+	case *LetStatement:
+		if s == nil {
+			return varDeclLet, nil, false
+		}
+		return varDeclLet, s.Token, true
+	case *ConstStatement:
+		if s == nil {
+			return varDeclLet, nil, false
+		}
+		return varDeclConst, s.Token, true
+	case *VarStatement:
+		if s == nil {
+			return varDeclLet, nil, false
+		}
+		return varDeclVar, s.Token, true
+	case *ArrayDestructuringDeclaration:
+		if s == nil {
+			return varDeclLet, nil, false
+		}
+		return kindOf(s.IsConst, s.Token), s.Token, true
+	case *ObjectDestructuringDeclaration:
+		if s == nil {
+			return varDeclLet, nil, false
+		}
+		return kindOf(s.IsConst, s.Token), s.Token, true
+	}
+	return varDeclLet, nil, false
+}
+
+// continueForInitDeclarators parses the `, declarator` tail of a `for` loop
+// initializer, given the already-parsed first declaration. Like statement
+// position, any declarator here may be a binding pattern -
+// `for (let i = 0, {a} = obj; ...)` is legal (paserati#159).
+//
+// Returns the statement to use as the loop's initializer: `first` itself,
+// extended in place when every extra declarator is a plain binding (which
+// preserves flags such as LetStatement.IsUsing), or a DeclarationGroup when a
+// pattern is involved.
+func (p *Parser) continueForInitDeclarators(first Statement, declToken *lexer.Token, kind varDeclKind) Statement {
+	if !p.peekTokenIs(lexer.COMMA) {
+		return first
+	}
+
+	extra, ok := p.parseMoreDeclListItems(nil, declToken, kind)
+	if !ok {
+		return nil
+	}
+	if len(extra) == 0 {
+		return first
+	}
+
+	patterns := 0
+	for _, it := range extra {
+		if it.pattern != nil {
+			patterns++
+		}
+	}
+
+	if patterns == 0 {
+		// All plain bindings: append them to the existing declaration so its
+		// identity and flags survive.
+		declarators := make([]*VarDeclarator, 0, len(extra))
+		for _, it := range extra {
+			declarators = append(declarators, it.declarator)
+		}
+		switch s := first.(type) {
+		case *LetStatement:
+			s.Declarations = append(s.Declarations, declarators...)
+			return s
+		case *ConstStatement:
+			s.Declarations = append(s.Declarations, declarators...)
+			return s
+		case *VarStatement:
+			s.Declarations = append(s.Declarations, declarators...)
+			return s
+		}
+	}
+
+	group := &DeclarationGroup{Token: declToken, Declarations: []Statement{first}}
+	for _, it := range extra {
+		if it.pattern != nil {
+			group.Declarations = append(group.Declarations, it.pattern)
+			continue
+		}
+		group.Declarations = append(group.Declarations,
+			newVarLikeStatement(declToken, kind, []*VarDeclarator{it.declarator}))
+	}
+	return group
+}
+
+// appendFlatteningGroups appends stmt to a statement list, splicing a
+// DeclarationGroup's members in as siblings. A group introduces no scope, and
+// the hoisting/pre-registration passes in the checker and compiler walk
+// statement lists looking for declaration statements by type - so wherever the
+// grammar allows a statement list, the members belong directly in it.
+func appendFlatteningGroups(list []Statement, stmt Statement) []Statement {
+	if group, ok := stmt.(*DeclarationGroup); ok {
+		return append(list, group.Declarations...)
+	}
+	return append(list, stmt)
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9337,89 +9337,21 @@ func (p *Parser) parseRegularForStatement(forToken *lexer.Token) *ForStatement {
 		}
 	}
 
-	// Now parse initializer if curToken is not SEMICOLON
+	// Now parse initializer if curToken is not SEMICOLON.
+	//
+	// This is only ever an *expression* initializer. A let/const/var for-head is
+	// routed to parseForStatementOrForOf by parseForStatement (which checks for
+	// the keyword in peek position before it can get here), because deciding
+	// between for-of/for-in and a regular for needs the head binding parsed
+	// first. This function is only reached with an empty initializer, or with a
+	// non-declaration one - so the three keyword branches that used to live here
+	// were dead, and were a fourth stale copy of the declarator loop that
+	// parseVariableDeclarationList now owns. Verified dead against the whole Go
+	// test suite and all 23,523 test262 language/ tests before removal.
 	if !p.curTokenIs(lexer.SEMICOLON) {
-		// IMPORTANT: 'let' is only a declaration keyword if followed by '[', '{', or an identifier
-		// Otherwise, 'let' can be used as an identifier in non-strict mode
-		isLetDeclaration := p.curTokenIs(lexer.LET) &&
-			(p.peekTokenIs(lexer.LBRACKET) || p.peekTokenIs(lexer.LBRACE) ||
-				p.peekTokenIs(lexer.IDENT) || p.isKeywordThatCanBeIdentifier(p.peekToken.Type))
-		if isLetDeclaration {
-			letStmt := &LetStatement{Token: p.curToken}
-			if !p.expectPeek(lexer.IDENT) {
-				return nil
-			}
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			if p.peekTokenIs(lexer.COLON) {
-				p.nextToken()
-				p.nextToken()
-				declarator.TypeAnnotation = p.parseTypeExpression()
-			}
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken()
-				p.nextToken()
-				// Use COMMA precedence to allow assignment expressions but stop at commas
-				declarator.Value = p.parseExpression(COMMA)
-			}
-			letStmt.Declarations = []*VarDeclarator{declarator}
-			// Set legacy fields for backward compatibility
-			letStmt.Name = declarator.Name
-			letStmt.TypeAnnotation = declarator.TypeAnnotation
-			letStmt.Value = declarator.Value
-			stmt.Initializer = letStmt
-		} else if p.curTokenIs(lexer.CONST) {
-			constStmt := &ConstStatement{Token: p.curToken}
-			if !p.expectPeek(lexer.IDENT) {
-				return nil
-			}
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			if p.peekTokenIs(lexer.COLON) {
-				p.nextToken()
-				p.nextToken()
-				declarator.TypeAnnotation = p.parseTypeExpression()
-			}
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken()
-				p.nextToken()
-				// Use COMMA precedence to allow assignment expressions but stop at commas
-				declarator.Value = p.parseExpression(COMMA)
-			}
-			constStmt.Declarations = []*VarDeclarator{declarator}
-			constStmt.Name = declarator.Name
-			constStmt.TypeAnnotation = declarator.TypeAnnotation
-			constStmt.Value = declarator.Value
-			stmt.Initializer = constStmt
-		} else if p.curTokenIs(lexer.VAR) {
-			varStmt := &VarStatement{Token: p.curToken}
-			if !p.expectPeek(lexer.IDENT) {
-				return nil
-			}
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			if p.peekTokenIs(lexer.COLON) {
-				p.nextToken()
-				p.nextToken()
-				declarator.TypeAnnotation = p.parseTypeExpression()
-			}
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken()
-				p.nextToken()
-				// Use COMMA precedence to allow assignment expressions but stop at commas
-				declarator.Value = p.parseExpression(COMMA)
-			}
-			varStmt.Declarations = []*VarDeclarator{declarator}
-			varStmt.Name = declarator.Name
-			varStmt.TypeAnnotation = declarator.TypeAnnotation
-			varStmt.Value = declarator.Value
-			stmt.Initializer = varStmt
-		} else {
-			// Expression initializer (handles any expression including function calls)
-			exprStmt := &ExpressionStatement{Token: p.curToken}
-			exprStmt.Expression = p.parseExpression(LOWEST)
-			stmt.Initializer = exprStmt
-		}
+		exprStmt := &ExpressionStatement{Token: p.curToken}
+		exprStmt.Expression = p.parseExpression(LOWEST)
+		stmt.Initializer = exprStmt
 		if !p.expectPeek(lexer.SEMICOLON) {
 			return nil
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -260,13 +260,13 @@ func NewParser(l *lexer.Lexer) *Parser {
 	p.registerPrefix(lexer.PRIVATE, p.parseIdentifier)
 	p.registerPrefix(lexer.PROTECTED, p.parseIdentifier)
 	p.registerPrefix(lexer.PUBLIC, p.parseIdentifier)
-	p.registerPrefix(lexer.OF, p.parseIdentifier)       // OF is a contextual keyword, can be used as identifier
-	p.registerPrefix(lexer.FROM, p.parseIdentifier)     // FROM is a contextual keyword (import/export), can be used as identifier
-	p.registerPrefix(lexer.TYPE, p.parseIdentifier)     // TYPE is a contextual keyword (TypeScript), can be used as identifier in JS
-	p.registerPrefix(lexer.READONLY, p.parseIdentifier) // READONLY is a contextual keyword, can be used as identifier
-	p.registerPrefix(lexer.OVERRIDE, p.parseIdentifier) // OVERRIDE is a contextual keyword, can be used as identifier
-	p.registerPrefix(lexer.ABSTRACT, p.parseIdentifier) // ABSTRACT is a contextual keyword, can be used as identifier
-	p.registerPrefix(lexer.IS, p.parseIdentifier)         // IS is a contextual keyword (type predicates), can be used as identifier in JS
+	p.registerPrefix(lexer.OF, p.parseIdentifier)        // OF is a contextual keyword, can be used as identifier
+	p.registerPrefix(lexer.FROM, p.parseIdentifier)      // FROM is a contextual keyword (import/export), can be used as identifier
+	p.registerPrefix(lexer.TYPE, p.parseIdentifier)      // TYPE is a contextual keyword (TypeScript), can be used as identifier in JS
+	p.registerPrefix(lexer.READONLY, p.parseIdentifier)  // READONLY is a contextual keyword, can be used as identifier
+	p.registerPrefix(lexer.OVERRIDE, p.parseIdentifier)  // OVERRIDE is a contextual keyword, can be used as identifier
+	p.registerPrefix(lexer.ABSTRACT, p.parseIdentifier)  // ABSTRACT is a contextual keyword, can be used as identifier
+	p.registerPrefix(lexer.IS, p.parseIdentifier)        // IS is a contextual keyword (type predicates), can be used as identifier in JS
 	p.registerPrefix(lexer.SATISFIES, p.parseIdentifier) // SATISFIES is a TS operator, but also a valid binding name (e.g. semver)
 	p.registerPrefix(lexer.FUNCTION, func() Expression { return p.parseFunctionLiteral(false) })
 	p.registerPrefix(lexer.ASYNC, p.parseAsyncExpression) // Added for async functions and async arrows
@@ -520,7 +520,7 @@ func (p *Parser) ParseProgram() (*Program, []errors.PaseratiError) {
 		}
 		stmt := p.parseStatement()
 		if stmt != nil {
-			program.Statements = append(program.Statements, stmt)
+			program.Statements = appendFlatteningGroups(program.Statements, stmt)
 
 			// --- Directive Prologue Check for "use strict" ---
 			if inDirectivePrologue {
@@ -1788,91 +1788,14 @@ func (p *Parser) isTupleElementLabelStart() bool {
 func (p *Parser) parseLetStatement() Statement {
 	letToken := p.curToken // Save the 'let' token
 
-	// Peek at the next token to determine if it's a destructuring pattern
 	p.nextToken() // Move to what comes after 'let'
 
-	switch p.curToken.Type {
-	case lexer.LBRACKET:
-		// Array destructuring: let [a, b] = ...
-		return p.parseArrayDestructuringDeclaration(letToken, false, true)
-	case lexer.LBRACE:
-		// Object destructuring: let {a, b} = ...
-		return p.parseObjectDestructuringDeclaration(letToken, false, true)
-	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
-		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
-		// Regular identifier: let x = ... or let x = ..., y = ... (including contextual keywords and FutureReservedWords)
-		stmt := &LetStatement{Token: letToken}
-		firstDeclarator := &VarDeclarator{}
-		firstDeclarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-		// Optional definite-assignment assertion and type annotation
-		if !p.parseDeclaratorAnnotation(firstDeclarator) {
-			return nil
-		}
-
-		// Allow omitting = value, defaulting to undefined
-		if p.peekTokenIs(lexer.ASSIGN) {
-			p.nextToken() // Consume '='
-			p.nextToken() // Consume token starting the expression
-			// Use COMMA precedence to allow assignment expressions but stop at commas
-			// This enables: var result = [x, y] = [1, 2] while stopping at: var a = 1, b = 2
-			firstDeclarator.Value = p.parseExpression(COMMA)
-		}
-
-		stmt.Declarations = []*VarDeclarator{firstDeclarator}
-
-		// Parse additional declarations separated by commas
-		for p.peekTokenIs(lexer.COMMA) {
-			commaToken := p.peekToken
-			p.nextToken() // Consume ','
-
-			// TS1009: detect trailing comma before statement keywords or end-of-statement
-			if p.peekTokenIs(lexer.RETURN) || p.peekTokenIs(lexer.BREAK) ||
-				p.peekTokenIs(lexer.CONTINUE) || p.peekTokenIs(lexer.THROW) ||
-				p.peekTokenIs(lexer.SEMICOLON) || p.peekTokenIs(lexer.EOF) ||
-				p.peekTokenIs(lexer.RBRACE) {
-				p.addError(commaToken, "Trailing comma not allowed.")
-				break
-			}
-
-			if !p.expectPeekIdentifierOrKeyword() {
-				return nil
-			}
-
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-			// Optional definite-assignment assertion and type annotation
-			if !p.parseDeclaratorAnnotation(declarator) {
-				return nil
-			}
-
-			// Allow omitting = value, defaulting to undefined
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken() // Consume '='
-				p.nextToken() // Consume token starting the expression
-				// Use COMMA precedence to allow assignment expressions but stop at commas
-				declarator.Value = p.parseExpression(COMMA)
-			}
-
-			stmt.Declarations = append(stmt.Declarations, declarator)
-		}
-
-		// Set legacy fields for backward compatibility (first declaration)
-		if len(stmt.Declarations) > 0 {
-			stmt.Name = stmt.Declarations[0].Name
-			stmt.TypeAnnotation = stmt.Declarations[0].TypeAnnotation
-			stmt.Value = stmt.Declarations[0].Value
-			stmt.ComputedType = stmt.Declarations[0].ComputedType
-		}
-
-		// Optional semicolon
-		if p.peekTokenIs(lexer.SEMICOLON) {
-			p.nextToken()
-		}
-
-		return stmt
+	// Any declarator position may hold an identifier or a binding pattern, so
+	// the whole clause is parsed by one shared declarator-list parser - see
+	// parseVariableDeclarationList (paserati#159, #160).
+	switch {
+	case p.curTokenIs(lexer.LBRACKET), p.curTokenIs(lexer.LBRACE), p.curTokenIsIdentLike():
+		return p.parseVariableDeclarationList(letToken, varDeclLet)
 	default:
 		p.addError(p.curToken, fmt.Sprintf("expected identifier or destructuring pattern after 'let', got %s", p.curToken.Type))
 		return nil
@@ -1882,83 +1805,14 @@ func (p *Parser) parseLetStatement() Statement {
 func (p *Parser) parseConstStatement() Statement {
 	constToken := p.curToken // Save the 'const' token
 
-	// Peek at the next token to determine if it's a destructuring pattern
 	p.nextToken() // Move to what comes after 'const'
 
-	switch p.curToken.Type {
-	case lexer.ENUM:
+	switch {
+	case p.curTokenIs(lexer.ENUM):
 		// Const enum: const enum Name { ... }
 		return p.parseConstEnumDeclarationStatement(constToken)
-	case lexer.LBRACKET:
-		// Array destructuring: const [a, b] = ...
-		return p.parseArrayDestructuringDeclaration(constToken, true, true)
-	case lexer.LBRACE:
-		// Object destructuring: const {a, b} = ...
-		return p.parseObjectDestructuringDeclaration(constToken, true, true)
-	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
-		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF, lexer.FROM,
-		lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.UNDEFINED, lexer.NULL, lexer.READONLY, lexer.OVERRIDE, lexer.ABSTRACT, lexer.IS:
-		// Regular identifier: const x = ... or const x = ..., y = ... (including contextual keywords and FutureReservedWords)
-		stmt := &ConstStatement{Token: constToken}
-		firstDeclarator := &VarDeclarator{}
-		firstDeclarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-		// Optional definite-assignment assertion and type annotation
-		if !p.parseDeclaratorAnnotation(firstDeclarator) {
-			return nil
-		}
-
-		// const requires initializer
-		if !p.expectPeek(lexer.ASSIGN) {
-			return nil
-		}
-
-		p.nextToken()                                    // Consume token starting the expression
-		firstDeclarator.Value = p.parseExpression(COMMA) // Use COMMA precedence to allow chained assignments but stop at comma
-
-		stmt.Declarations = []*VarDeclarator{firstDeclarator}
-
-		// Parse additional declarations separated by commas
-		for p.peekTokenIs(lexer.COMMA) {
-			p.nextToken() // Consume ','
-
-			if !p.expectPeekIdentifierOrKeyword() {
-				return nil
-			}
-
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-			// Optional definite-assignment assertion and type annotation
-			if !p.parseDeclaratorAnnotation(declarator) {
-				return nil
-			}
-
-			// const requires initializer for each declarator
-			if !p.expectPeek(lexer.ASSIGN) {
-				return nil
-			}
-
-			p.nextToken()                               // Consume token starting the expression
-			declarator.Value = p.parseExpression(COMMA) // Use COMMA precedence to allow chained assignments but stop at comma
-
-			stmt.Declarations = append(stmt.Declarations, declarator)
-		}
-
-		// Set legacy fields for backward compatibility (first declaration)
-		if len(stmt.Declarations) > 0 {
-			stmt.Name = stmt.Declarations[0].Name
-			stmt.TypeAnnotation = stmt.Declarations[0].TypeAnnotation
-			stmt.Value = stmt.Declarations[0].Value
-			stmt.ComputedType = stmt.Declarations[0].ComputedType
-		}
-
-		// Optional semicolon
-		if p.peekTokenIs(lexer.SEMICOLON) {
-			p.nextToken()
-		}
-
-		return stmt
+	case p.curTokenIs(lexer.LBRACKET), p.curTokenIs(lexer.LBRACE), p.curTokenIsIdentLike():
+		return p.parseVariableDeclarationList(constToken, varDeclConst)
 	default:
 		p.addError(p.curToken, fmt.Sprintf("expected identifier or destructuring pattern after 'const', got %s", p.curToken.Type))
 		return nil
@@ -1968,94 +1822,11 @@ func (p *Parser) parseConstStatement() Statement {
 func (p *Parser) parseVarStatement() Statement {
 	varToken := p.curToken // Save the 'var' token
 
-	// Peek at the next token to determine if it's a destructuring pattern
 	p.nextToken() // Move to what comes after 'var'
 
-	switch p.curToken.Type {
-	case lexer.LBRACKET:
-		// Array destructuring: var [a, b] = ...
-		return p.parseArrayDestructuringDeclaration(varToken, false, true)
-	case lexer.LBRACE:
-		// Object destructuring: var {a, b} = ...
-		debugPrint("// [PARSER DEBUG] parseVarStatement: detected LBRACE, calling parseObjectDestructuringDeclaration\n")
-		return p.parseObjectDestructuringDeclaration(varToken, false, true)
-	case lexer.IDENT, lexer.YIELD, lexer.GET, lexer.SET, lexer.THROW, lexer.RETURN, lexer.LET, lexer.AWAIT,
-		lexer.STATIC, lexer.IMPLEMENTS, lexer.INTERFACE, lexer.PRIVATE, lexer.PROTECTED, lexer.PUBLIC, lexer.OF,
-		lexer.UNDEFINED, lexer.NULL, lexer.FROM, lexer.TYPE, lexer.AS, lexer.ASYNC, lexer.ABSTRACT:
-		// Regular identifier case (including contextual keywords, FutureReservedWords in non-strict mode,
-		// and global property names like undefined/null which are not reserved words)
-		// Note: 'abstract' was removed from the future reserved words list in ES5
-		stmt := &VarStatement{Token: varToken}
-		firstDeclarator := &VarDeclarator{}
-		firstDeclarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-		// Optional definite-assignment assertion and type annotation
-		if !p.parseDeclaratorAnnotation(firstDeclarator) {
-			return nil
-		}
-
-		// Allow omitting = value, defaulting to undefined
-		if p.peekTokenIs(lexer.ASSIGN) {
-			p.nextToken() // Consume '='
-			p.nextToken() // Consume token starting the expression
-			// Use COMMA precedence to allow assignment expressions but stop at commas
-			// This enables: var result = [x, y] = [1, 2] while stopping at: var a = 1, b = 2
-			firstDeclarator.Value = p.parseExpression(COMMA)
-		}
-
-		stmt.Declarations = []*VarDeclarator{firstDeclarator}
-
-		// Parse additional declarations separated by commas
-		for p.peekTokenIs(lexer.COMMA) {
-			commaToken := p.peekToken
-			p.nextToken() // Consume ','
-
-			// TS1009: detect trailing comma before statement keywords or end-of-statement
-			if p.peekTokenIs(lexer.RETURN) || p.peekTokenIs(lexer.BREAK) ||
-				p.peekTokenIs(lexer.CONTINUE) || p.peekTokenIs(lexer.THROW) ||
-				p.peekTokenIs(lexer.SEMICOLON) || p.peekTokenIs(lexer.EOF) ||
-				p.peekTokenIs(lexer.RBRACE) {
-				p.addError(commaToken, "Trailing comma not allowed.")
-				break
-			}
-
-			if !p.expectPeekIdentifierOrKeyword() {
-				return nil
-			}
-
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-
-			// Optional definite-assignment assertion and type annotation
-			if !p.parseDeclaratorAnnotation(declarator) {
-				return nil
-			}
-
-			// Allow omitting = value, defaulting to undefined
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken() // Consume '='
-				p.nextToken() // Consume token starting the expression
-				// Use COMMA precedence to allow assignment expressions but stop at commas
-				declarator.Value = p.parseExpression(COMMA)
-			}
-
-			stmt.Declarations = append(stmt.Declarations, declarator)
-		}
-
-		// Set legacy fields for backward compatibility (first declaration)
-		if len(stmt.Declarations) > 0 {
-			stmt.Name = stmt.Declarations[0].Name
-			stmt.TypeAnnotation = stmt.Declarations[0].TypeAnnotation
-			stmt.Value = stmt.Declarations[0].Value
-			stmt.ComputedType = stmt.Declarations[0].ComputedType
-		}
-
-		// Optional semicolon - Consume it here
-		if p.peekTokenIs(lexer.SEMICOLON) {
-			p.nextToken()
-		}
-
-		return stmt
+	switch {
+	case p.curTokenIs(lexer.LBRACKET), p.curTokenIs(lexer.LBRACE), p.curTokenIsIdentLike():
+		return p.parseVariableDeclarationList(varToken, varDeclVar)
 	default:
 		p.addError(p.curToken, fmt.Sprintf("expected identifier or destructuring pattern after 'var', got %s", p.curToken.Type))
 		return nil
@@ -4056,7 +3827,7 @@ func (p *Parser) parseBlockStatement() *BlockStatement {
 	for !p.curTokenIs(lexer.RBRACE) && !p.curTokenIs(lexer.EOF) {
 		stmt := p.parseStatement()
 		if stmt != nil {
-			block.Statements = append(block.Statements, stmt)
+			block.Statements = appendFlatteningGroups(block.Statements, stmt)
 
 			// --- Hoisting Check ---
 			// Check if the statement IS an ExpressionStatement containing a FunctionLiteral
@@ -4115,7 +3886,7 @@ func (p *Parser) parseFunctionBodyWithDirectives() *BlockStatement {
 	for !p.curTokenIs(lexer.RBRACE) && !p.curTokenIs(lexer.EOF) {
 		stmt := p.parseStatement()
 		if stmt != nil {
-			block.Statements = append(block.Statements, stmt)
+			block.Statements = appendFlatteningGroups(block.Statements, stmt)
 
 			// Check for directive prologue ("use strict")
 			if inDirectivePrologue {
@@ -5964,15 +5735,18 @@ func (p *Parser) parseArrayDestructuringDeclaration(declToken *lexer.Token, isCo
 		}
 
 		p.nextToken() // Move to RHS expression
-		decl.Value = p.parseExpression(LOWEST)
+		// COMMA precedence: an Initializer is an AssignmentExpression, so it must
+		// stop at the comma separating declarators. At LOWEST,
+		// `let {a} = obj, b = 2` parsed as one destructuring declaration whose
+		// source was the comma expression `(obj, b = 2)` - i.e. `b`'s own value -
+		// which is what made #160 silently destructure the wrong thing.
+		decl.Value = p.parseExpression(COMMA)
 		if decl.Value == nil {
 			return nil
 		}
-
-		// Optional semicolon
-		if p.peekTokenIs(lexer.SEMICOLON) {
-			p.nextToken()
-		}
+		// The statement terminator belongs to whoever owns the declarator list
+		// (parseVariableDeclarationList); consuming it here would eat the ';'
+		// before that loop could see the clause had ended.
 	}
 
 	return decl
@@ -6195,15 +5969,18 @@ func (p *Parser) parseObjectDestructuringDeclaration(declToken *lexer.Token, isC
 		}
 
 		p.nextToken() // Move to RHS expression
-		decl.Value = p.parseExpression(LOWEST)
+		// COMMA precedence: an Initializer is an AssignmentExpression, so it must
+		// stop at the comma separating declarators. At LOWEST,
+		// `let {a} = obj, b = 2` parsed as one destructuring declaration whose
+		// source was the comma expression `(obj, b = 2)` - i.e. `b`'s own value -
+		// which is what made #160 silently destructure the wrong thing.
+		decl.Value = p.parseExpression(COMMA)
 		if decl.Value == nil {
 			return nil
 		}
-
-		// Optional semicolon
-		if p.peekTokenIs(lexer.SEMICOLON) {
-			p.nextToken()
-		}
+		// The statement terminator belongs to whoever owns the declarator list
+		// (parseVariableDeclarationList); consuming it here would eat the ';'
+		// before that loop could see the clause had ended.
 	}
 
 	return decl
@@ -6911,7 +6688,7 @@ func (p *Parser) parseSwitchCase() *SwitchCase {
 	for !p.curTokenIs(lexer.CASE) && !p.curTokenIs(lexer.DEFAULT) && !p.curTokenIs(lexer.RBRACE) && !p.curTokenIs(lexer.EOF) {
 		stmt := p.parseStatement() // parseStatement consumes tokens including optional semicolon
 		if stmt != nil {
-			caseClause.Body.Statements = append(caseClause.Body.Statements, stmt)
+			caseClause.Body.Statements = appendFlatteningGroups(caseClause.Body.Statements, stmt)
 
 			// --- Hoisting Check (same as parseBlockStatement) ---
 			// Check if the statement IS an ExpressionStatement containing a FunctionLiteral
@@ -9237,7 +9014,7 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 					p.nextToken() // consume '='
 					p.nextToken() // move to RHS
 					if arrayDecl, ok := varStmt.(*ArrayDestructuringDeclaration); ok {
-						arrayDecl.Value = p.parseExpression(LOWEST)
+						arrayDecl.Value = p.parseExpression(COMMA) // COMMA: an initializer stops at the declarator comma
 					}
 				}
 			} else if p.curTokenIs(lexer.LBRACE) {
@@ -9257,7 +9034,7 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 					p.nextToken() // consume '='
 					p.nextToken() // move to RHS
 					if objDecl, ok := varStmt.(*ObjectDestructuringDeclaration); ok {
-						objDecl.Value = p.parseExpression(LOWEST)
+						objDecl.Value = p.parseExpression(COMMA) // COMMA: an initializer stops at the declarator comma
 					}
 				}
 			} else if p.curTokenIs(lexer.IDENT) || p.isContextualKeywordAsIdent() {
@@ -9333,7 +9110,7 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 				p.nextToken() // consume '='
 				p.nextToken() // move to RHS
 				if arrayDecl, ok := varStmt.(*ArrayDestructuringDeclaration); ok {
-					arrayDecl.Value = p.parseExpression(LOWEST)
+					arrayDecl.Value = p.parseExpression(COMMA) // COMMA: an initializer stops at the declarator comma
 				}
 			}
 		} else if p.curTokenIs(lexer.LBRACE) {
@@ -9353,7 +9130,7 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 				p.nextToken() // consume '='
 				p.nextToken() // move to RHS
 				if objDecl, ok := varStmt.(*ObjectDestructuringDeclaration); ok {
-					objDecl.Value = p.parseExpression(LOWEST)
+					objDecl.Value = p.parseExpression(COMMA) // COMMA: an initializer stops at the declarator comma
 				}
 			}
 		} else if p.curTokenIs(lexer.IDENT) || p.isContextualKeywordAsIdent() {
@@ -9376,7 +9153,11 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 		// Check for destructuring patterns
 		if p.curTokenIs(lexer.LBRACKET) {
 			// Array destructuring: for(var [a, b] ...)
-			varStmt = p.parseArrayDestructuringDeclaration(varToken, false, false)
+			arrayDecl := p.parseArrayDestructuringDeclaration(varToken, false, false)
+			if arrayDecl == nil {
+				return nil // Error already reported (e.g. a rest element with an initializer)
+			}
+			varStmt = arrayDecl
 			varName = "" // Destructuring doesn't have a single name
 
 			// Check if there's an initializer for regular for loops
@@ -9384,12 +9165,18 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 				p.nextToken() // consume '='
 				p.nextToken() // move to RHS
 				if arrayDecl, ok := varStmt.(*ArrayDestructuringDeclaration); ok && arrayDecl != nil {
-					arrayDecl.Value = p.parseExpression(LOWEST)
+					// COMMA, not LOWEST: a declarator initializer must stop at the
+					// comma separating it from the next declarator.
+					arrayDecl.Value = p.parseExpression(COMMA)
 				}
 			}
 		} else if p.curTokenIs(lexer.LBRACE) {
 			// Object destructuring: for(var {a, b} ...)
-			varStmt = p.parseObjectDestructuringDeclaration(varToken, false, false)
+			objectDecl := p.parseObjectDestructuringDeclaration(varToken, false, false)
+			if objectDecl == nil {
+				return nil // Error already reported
+			}
+			varStmt = objectDecl
 			varName = "" // Destructuring doesn't have a single name
 
 			// Check if there's an initializer for regular for loops
@@ -9397,7 +9184,8 @@ func (p *Parser) parseForStatementOrForOf(forToken *lexer.Token, isAsync bool) S
 				p.nextToken() // consume '='
 				p.nextToken() // move to RHS
 				if objDecl, ok := varStmt.(*ObjectDestructuringDeclaration); ok && objDecl != nil {
-					objDecl.Value = p.parseExpression(LOWEST)
+					// COMMA, not LOWEST: see the ArrayDestructuringDeclaration case.
+					objDecl.Value = p.parseExpression(COMMA)
 				}
 			}
 		} else if p.curTokenIs(lexer.IDENT) || p.curTokenIs(lexer.LET) || p.isContextualKeywordAsIdent() {
@@ -9716,87 +9504,32 @@ func (p *Parser) parseRegularForStatementWithVar(forToken *lexer.Token, varStmt 
 	}
 
 	// Sync Declarations with legacy fields for all statement types
-	if vs, ok := varStmt.(*VarStatement); ok {
-		if len(vs.Declarations) > 0 {
-			vs.Declarations[0].Value = vs.Value
-			vs.Declarations[0].TypeAnnotation = vs.TypeAnnotation
+	switch s := varStmt.(type) {
+	case *VarStatement:
+		if len(s.Declarations) > 0 {
+			s.Declarations[0].Value = s.Value
+			s.Declarations[0].TypeAnnotation = s.TypeAnnotation
 		}
-		// Parse additional comma-separated declarations: for (var x = 1, y = 2; ...)
-		for p.peekTokenIs(lexer.COMMA) {
-			p.nextToken() // Consume ','
-			if !p.expectPeekIdentifierOrKeyword() {
-				return nil
-			}
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			// Optional Type Annotation
-			if p.peekTokenIs(lexer.COLON) {
-				p.nextToken() // Consume ':'
-				p.nextToken() // Consume token starting the type expression
-				declarator.TypeAnnotation = p.parseTypeExpression()
-			}
-			// Optional assignment
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken() // Consume '='
-				p.nextToken() // Consume token starting the expression
-				declarator.Value = p.parseExpression(COMMA)
-			}
-			vs.Declarations = append(vs.Declarations, declarator)
+	case *LetStatement:
+		if len(s.Declarations) > 0 {
+			s.Declarations[0].Value = s.Value
+			s.Declarations[0].TypeAnnotation = s.TypeAnnotation
 		}
-	} else if letStmt, ok := varStmt.(*LetStatement); ok {
-		if len(letStmt.Declarations) > 0 {
-			letStmt.Declarations[0].Value = letStmt.Value
-			letStmt.Declarations[0].TypeAnnotation = letStmt.TypeAnnotation
+	case *ConstStatement:
+		if len(s.Declarations) > 0 {
+			s.Declarations[0].Value = s.Value
+			s.Declarations[0].TypeAnnotation = s.TypeAnnotation
 		}
-		// Parse additional comma-separated declarations: for (let x = 1, y = 2; ...)
-		for p.peekTokenIs(lexer.COMMA) {
-			p.nextToken() // Consume ','
-			if !p.expectPeekIdentifierOrKeyword() {
-				return nil
-			}
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			// Optional Type Annotation
-			if p.peekTokenIs(lexer.COLON) {
-				p.nextToken() // Consume ':'
-				p.nextToken() // Consume token starting the type expression
-				declarator.TypeAnnotation = p.parseTypeExpression()
-			}
-			// Optional assignment
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken() // Consume '='
-				p.nextToken() // Consume token starting the expression
-				declarator.Value = p.parseExpression(COMMA)
-			}
-			letStmt.Declarations = append(letStmt.Declarations, declarator)
+	}
+
+	// Parse any additional comma-separated declarators:
+	// for (let x = 1, y = 2; ...) and for (let i = 0, {a} = obj; ...).
+	if kind, declToken, isDecl := forInitDeclKind(varStmt); isDecl {
+		initializer := p.continueForInitDeclarators(varStmt, declToken, kind)
+		if initializer == nil {
+			return nil
 		}
-	} else if constStmt, ok := varStmt.(*ConstStatement); ok {
-		if len(constStmt.Declarations) > 0 {
-			constStmt.Declarations[0].Value = constStmt.Value
-			constStmt.Declarations[0].TypeAnnotation = constStmt.TypeAnnotation
-		}
-		// Parse additional comma-separated declarations: for (const x = 1, y = 2; ...)
-		for p.peekTokenIs(lexer.COMMA) {
-			p.nextToken() // Consume ','
-			if !p.expectPeekIdentifierOrKeyword() {
-				return nil
-			}
-			declarator := &VarDeclarator{}
-			declarator.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
-			// Optional Type Annotation
-			if p.peekTokenIs(lexer.COLON) {
-				p.nextToken() // Consume ':'
-				p.nextToken() // Consume token starting the type expression
-				declarator.TypeAnnotation = p.parseTypeExpression()
-			}
-			// Optional assignment (const requires it, but parser doesn't enforce)
-			if p.peekTokenIs(lexer.ASSIGN) {
-				p.nextToken() // Consume '='
-				p.nextToken() // Consume token starting the expression
-				declarator.Value = p.parseExpression(COMMA)
-			}
-			constStmt.Declarations = append(constStmt.Declarations, declarator)
-		}
+		stmt.Initializer = initializer
 	}
 
 	// Expect semicolon after initializer
@@ -11799,17 +11532,27 @@ func (p *Parser) parseExportNamedDeclarationWithSpecifiers(exportToken *lexer.To
 }
 
 // parseExportNamedDeclarationWithDeclaration parses: export const x = 1; export function foo() {}
-func (p *Parser) parseExportNamedDeclarationWithDeclaration(exportToken *lexer.Token) *ExportNamedDeclaration {
-	stmt := &ExportNamedDeclaration{Token: exportToken}
-
+func (p *Parser) parseExportNamedDeclarationWithDeclaration(exportToken *lexer.Token) Statement {
 	// Parse the declaration statement
 	declaration := p.parseStatement()
 	if declaration == nil {
 		return nil
 	}
 
-	stmt.Declaration = declaration
-	return stmt
+	// `export let a = 1, {b} = obj` desugars to several declaration statements
+	// (see DeclarationGroup); each is exported in its own right, and the group
+	// is spliced back into the enclosing statement list by
+	// appendFlatteningGroups - export only ever appears in a statement list.
+	if group, ok := declaration.(*DeclarationGroup); ok {
+		exported := &DeclarationGroup{Token: group.Token}
+		for _, d := range group.Declarations {
+			exported.Declarations = append(exported.Declarations,
+				&ExportNamedDeclaration{Token: exportToken, Declaration: d})
+		}
+		return exported
+	}
+
+	return &ExportNamedDeclaration{Token: exportToken, Declaration: declaration}
 }
 
 // parseLeadingPipeUnionType handles union types that start with | like:

--- a/pkg/parser/var_declaration_list_test.go
+++ b/pkg/parser/var_declaration_list_test.go
@@ -1,0 +1,199 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/lexer"
+	"github.com/nooga/paserati/pkg/source"
+)
+
+func parseStatementsForTest(t *testing.T, input string) []Statement {
+	t.Helper()
+	sourceFile := source.NewEvalSource(input)
+	p := NewParser(lexer.NewLexerWithSource(sourceFile))
+	program, parseErrs := p.ParseProgram()
+	if len(parseErrs) != 0 {
+		for _, err := range parseErrs {
+			t.Errorf("  %s", err.Error())
+		}
+		t.Fatalf("parsing %q produced %d errors", input, len(parseErrs))
+	}
+	return program.Statements
+}
+
+// stmtShape names a statement by kind and, for declarations, the bindings it
+// introduces - enough to pin the desugaring without asserting on register
+// allocation or bytecode.
+func stmtShape(stmt Statement) string {
+	switch s := stmt.(type) {
+	case *LetStatement:
+		return "let " + declaratorNames(s.Declarations)
+	case *ConstStatement:
+		return "const " + declaratorNames(s.Declarations)
+	case *VarStatement:
+		return "var " + declaratorNames(s.Declarations)
+	case *ObjectDestructuringDeclaration:
+		return s.Token.Literal + " {…}"
+	case *ArrayDestructuringDeclaration:
+		return s.Token.Literal + " […]"
+	case *ExportNamedDeclaration:
+		return "export " + stmtShape(s.Declaration)
+	case *DeclarationGroup:
+		out := "group("
+		for i, d := range s.Declarations {
+			if i > 0 {
+				out += ", "
+			}
+			out += stmtShape(d)
+		}
+		return out + ")"
+	default:
+		return fmt.Sprintf("%T", stmt)
+	}
+}
+
+func declaratorNames(decls []*VarDeclarator) string {
+	out := ""
+	for i, d := range decls {
+		if i > 0 {
+			out += ","
+		}
+		if d == nil || d.Name == nil {
+			out += "<nil>"
+			continue
+		}
+		out += d.Name.Value
+	}
+	return out
+}
+
+// TestDeclaratorListShapes pins how a let/const/var declarator list desugars.
+// A pattern is legal in any declarator position (paserati#159, #160); the
+// pre-existing single-statement shapes must survive unchanged, and only a
+// genuinely mixed clause becomes a DeclarationGroup - spliced into the
+// enclosing statement list, so a mixed clause in statement position yields
+// several sibling statements rather than a group.
+func TestDeclaratorListShapes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		// Unchanged shapes: no pattern, or a pattern on its own.
+		{"let a = 1;", []string{"let a"}},
+		{"let a = 1, b = 2, c = 3;", []string{"let a,b,c"}},
+		{"const a = 1, b = 2;", []string{"const a,b"}},
+		{"var a = 1, b;", []string{"var a,b"}},
+		{"let {a} = o;", []string{"let {…}"}},
+		{"let [a] = o;", []string{"let […]"}},
+		{"const {a} = o;", []string{"const {…}"}},
+
+		// #159: pattern after a comma. Spliced into the statement list.
+		{"let a = 1, {b} = o;", []string{"let a", "let {…}"}},
+		{"let a = 1, [b] = o;", []string{"let a", "let […]"}},
+		{"const a = 1, {b} = o;", []string{"const a", "const {…}"}},
+		{"var a = 1, {b} = o;", []string{"var a", "var {…}"}},
+		{"let a, {b} = o;", []string{"let a", "let {…}"}},
+
+		// #160: pattern first, plain bindings after.
+		{"let {a} = o, b = 2;", []string{"let {…}", "let b"}},
+		{"let {a} = o, b;", []string{"let {…}", "let b"}},
+		{"const {a} = o, b = 2;", []string{"const {…}", "const b"}},
+
+		// Several patterns, and a pattern in the middle. One statement per
+		// declarator, in source order.
+		{"let {a} = o, {b} = o;", []string{"let {…}", "let {…}"}},
+		{"let a = 1, {b} = o, c = 3;", []string{"let a", "let {…}", "let c"}},
+
+		// Statements after the clause are unaffected by the splice.
+		{"let a = 1, {b} = o; let c = 2;", []string{"let a", "let {…}", "let c"}},
+
+		// Each desugared declaration is exported in its own right.
+		{"export let a = 1, {b} = o;", []string{"export let a", "export let {…}"}},
+		{"export let {a} = o, b = 2;", []string{"export let {…}", "export let b"}},
+	}
+
+	for _, tt := range tests {
+		stmts := parseStatementsForTest(t, tt.input)
+		got := make([]string, 0, len(stmts))
+		for _, s := range stmts {
+			got = append(got, stmtShape(s))
+		}
+		if fmt.Sprint(got) != fmt.Sprint(tt.want) {
+			t.Errorf("%q\n got: %v\nwant: %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestForInitDeclaratorListShapes pins the same desugaring in a `for`
+// initializer. A for initializer must be a single Statement, so this is the one
+// position where a DeclarationGroup survives rather than being spliced.
+func TestForInitDeclaratorListShapes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"for (let i = 0; ; ) {}", "let i"},
+		{"for (let i = 0, j = 1; ; ) {}", "let i,j"},
+		{"for (var i = 0, j = 1; ; ) {}", "var i,j"},
+		{"for (const i = 0, j = 1; ; ) {}", "const i,j"},
+		{"for (let {a} = o; ; ) {}", "let {…}"},
+		{"for (let i = 0, {a} = o; ; ) {}", "group(let i, let {…})"},
+		{"for (let {a} = o, i = 0; ; ) {}", "group(let {…}, let i)"},
+		{"for (var i = 0, [a] = o; ; ) {}", "group(var i, var […])"},
+		{"for (const {a} = o, i = 0; ; ) {}", "group(const {…}, const i)"},
+	}
+
+	for _, tt := range tests {
+		stmts := parseStatementsForTest(t, tt.input)
+		if len(stmts) != 1 {
+			t.Errorf("%q: expected 1 statement, got %d", tt.input, len(stmts))
+			continue
+		}
+		forStmt, ok := stmts[0].(*ForStatement)
+		if !ok {
+			t.Errorf("%q: expected *ForStatement, got %T", tt.input, stmts[0])
+			continue
+		}
+		if got := stmtShape(forStmt.Initializer); got != tt.want {
+			t.Errorf("%q initializer\n got: %s\nwant: %s", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestForOfInDeclaratorHeadUnaffected guards the lookahead that distinguishes a
+// for-of/for-in head (exactly one binding, no initializer) from a regular for
+// initializer, which the shared declarator-list parser must not disturb.
+func TestForOfInDeclaratorHeadUnaffected(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"for (let x of xs) {}", "let x"},
+		{"for (const {a} of xs) {}", "const {…}"},
+		{"for (const [a, b] of xs) {}", "const […]"},
+		{"for (var k in obj) {}", "var k"},
+		{"for (let {a} in obj) {}", "let {…}"},
+	}
+
+	for _, tt := range tests {
+		stmts := parseStatementsForTest(t, tt.input)
+		if len(stmts) != 1 {
+			t.Errorf("%q: expected 1 statement, got %d", tt.input, len(stmts))
+			continue
+		}
+		var variable Statement
+		switch s := stmts[0].(type) {
+		case *ForOfStatement:
+			variable = s.Variable
+		case *ForInStatement:
+			variable = s.Variable
+		default:
+			t.Errorf("%q: expected a for-of/for-in statement, got %T", tt.input, stmts[0])
+			continue
+		}
+		if got := stmtShape(variable); got != tt.want {
+			t.Errorf("%q head\n got: %s\nwant: %s", tt.input, got, tt.want)
+		}
+	}
+}

--- a/tests/scripts/destructuring_declarator_list.ts
+++ b/tests/scripts/destructuring_declarator_list.ts
@@ -1,0 +1,103 @@
+// expect: 1,2|1,2,3|1,2|1,2|10,20|10,undefined|10,20|10,20|10,20|1,2|1,2|1,2,3|1,[2,3],9|1,{"b":2},9|5,1|7,1
+// A binding pattern is legal in ANY declarator position, not just the first.
+// Both halves of that were broken:
+//
+//   #159  `let r = 1, {a} = obj` failed to parse outright. Each of
+//         parseLetStatement/parseConstStatement/parseVarStatement carried its
+//         own copy of the declarator loop, and every copy only accepted an
+//         identifier after a comma.
+//
+//   #160  `let {a} = obj, b = 2` parsed but silently destructured the wrong
+//         value. The destructuring declaration's initializer was parsed at
+//         LOWEST, so it swallowed `, b = 2` as a comma operator: the pattern's
+//         source became `(obj, b = 2)`, i.e. b's own value. Reported as a
+//         register-lifetime bug; the register was fine, the parse wasn't.
+//         An Initializer is an AssignmentExpression, so it must never consume
+//         the comma separating declarators - COMMA precedence, as the
+//         identifier path already used.
+//
+// All three keywords now share one declarator-list parser
+// (parseVariableDeclarationList). A clause that mixes plain bindings with
+// patterns desugars to one declaration statement per declarator, grouped in a
+// DeclarationGroup that introduces no scope of its own.
+
+let out: string[] = [];
+function rec(...vals: any[]) {
+  out.push(vals.map((v) => JSON.stringify(v)).join(","));
+}
+
+// --- #159: pattern as a non-first declarator ---
+let r1 = 1,
+  { a: h1 } = { a: 2 };
+rec(r1, h1);
+
+let r2 = 1,
+  [a2, b2] = [2, 3];
+rec(r2, a2, b2);
+
+const r3 = 1,
+  { a: h3 } = { a: 2 };
+rec(r3, h3);
+
+var r4 = 1,
+  { a: h4 } = { a: 2 };
+rec(r4, h4);
+
+// --- #160: pattern as the first of several declarators ---
+let { a: a5 } = { a: 10 },
+  b5 = 20;
+rec(a5, b5);
+
+// The no-initializer form threw "ReferenceError: b is not defined", because the
+// swallowed `, b` was parsed as a *read* of an undeclared global.
+let { a: a6 } = { a: 10 },
+  b6;
+rec(a6, b6);
+
+const { a: a7 } = { a: 10 },
+  b7 = 20;
+rec(a7, b7);
+
+var { a: a8 } = { a: 10 },
+  b8 = 20;
+rec(a8, b8);
+
+let [a9] = [10],
+  b9 = 20;
+rec(a9, b9);
+
+// --- several patterns in one clause ---
+let { a: a10 } = { a: 1 },
+  { b: b10 } = { b: 2 };
+rec(a10, b10);
+
+let [p11] = [1],
+  [q11] = [2];
+rec(p11, q11);
+
+// A pattern in the middle, with plain bindings on both sides.
+let a12 = 1,
+  { b: b12 } = { b: 2 },
+  c12 = 3;
+rec(a12, b12, c12);
+
+// --- pattern features still work in a list: rest, nesting, defaults ---
+let [a13, ...rest13] = [1, 2, 3],
+  z13 = 9;
+rec(a13, rest13, z13);
+
+let { a: a14, ...rest14 } = { a: 1, b: 2 },
+  z14 = 9;
+rec(a14, rest14, z14);
+
+let {
+    a: { b: b15 },
+  } = { a: { b: 5 } },
+  z15 = 1;
+rec(b15, z15);
+
+let { a: a16 = 7 } = {},
+  z16 = 1;
+rec(a16, z16);
+
+out.join("|");

--- a/tests/scripts/destructuring_declarator_list_for.ts
+++ b/tests/scripts/destructuring_declarator_list_for.ts
@@ -1,0 +1,57 @@
+// expect: 0,1,2|0,1,2|0,1|ok|3,2,1|undefined,1
+// A `for` initializer is a declarator list too, so a binding pattern is legal
+// in any of its positions: `for (let i = 0, {a} = obj; ...)`. It shared the
+// same defects as statement position (#159, #160) and the same fix - see
+// destructuring_declarator_list.ts.
+//
+// A for initializer must be a single Statement, so unlike statement position
+// (where the desugared declarations are spliced into the enclosing statement
+// list) the DeclarationGroup survives here, and the checker and compiler
+// process its members in order without opening a scope. `var` hoisting has to
+// see through the group as well.
+
+let out: string[] = [];
+
+// #159 order: plain binding first, pattern second.
+let acc1: number[] = [];
+for (let i = 0, { a } = { a: 3 }; i < a; i++) acc1.push(i);
+out.push(acc1.join(","));
+
+// #160 order: pattern first. Previously `a` was undefined, so `i < a` was false
+// and the loop body never ran.
+let acc2: number[] = [];
+for (let { a } = { a: 3 }, i = 0; i < a; i++) acc2.push(i);
+out.push(acc2.join(","));
+
+// var, and an array pattern.
+let acc3: number[] = [];
+for (var i3 = 0, [x3] = [2]; i3 < x3; i3++) acc3.push(i3);
+out.push(acc3.join(","));
+
+// const in a for head needs an initializer on every declarator.
+for (const { a: a4 } = { a: 1 }, b4 = 2; false; ) {
+}
+out.push("ok");
+
+// A lone pattern in the head still works (it always did).
+let acc5: number[] = [];
+for (let { a: a5 } = { a: 3 }; a5 > 0; a5--) acc5.push(a5);
+out.push(acc5.join(","));
+
+// var declarations in the head hoist to the top of the function, through the
+// group: v6 already exists (as undefined) before the loop runs.
+//
+// Only the plain binding is asserted here. `var` with a *pattern* doesn't hoist
+// its names past an enclosing block or loop head for the type checker at all -
+// `function f(){ { var {w} = o; } return w; }` and
+// `for (var {w} of xs)` both report TS2304 too - a pre-existing checker gap
+// unrelated to the declarator-list fix. The runtime binds them correctly.
+function hoisted(): string {
+  const before = typeof v6 === "undefined" ? "undefined" : "defined";
+  for (var v6 = 1, { w: w6 } = { w: 2 }; false; ) {
+  }
+  return [before, v6].join(",");
+}
+out.push(hoisted());
+
+out.join("|");

--- a/tests/scripts/destructuring_declarator_list_for.ts
+++ b/tests/scripts/destructuring_declarator_list_for.ts
@@ -1,4 +1,4 @@
-// expect: 0,1,2|0,1,2|0,1|ok|3,2,1|undefined,1
+// expect: 0,1,2|0,1,2|0,1|ok|3,2,1|undefined,undefined,1,2
 // A `for` initializer is a declarator list too, so a binding pattern is legal
 // in any of its positions: `for (let i = 0, {a} = obj; ...)`. It shared the
 // same defects as statement position (#159, #160) and the same fix - see
@@ -39,18 +39,18 @@ for (let { a: a5 } = { a: 3 }; a5 > 0; a5--) acc5.push(a5);
 out.push(acc5.join(","));
 
 // var declarations in the head hoist to the top of the function, through the
-// group: v6 already exists (as undefined) before the loop runs.
-//
-// Only the plain binding is asserted here. `var` with a *pattern* doesn't hoist
-// its names past an enclosing block or loop head for the type checker at all -
-// `function f(){ { var {w} = o; } return w; }` and
-// `for (var {w} of xs)` both report TS2304 too - a pre-existing checker gap
-// unrelated to the declarator-list fix. The runtime binds them correctly.
+// group: v6 and w6 both exist (as undefined) before the loop runs, and both are
+// readable after it. The pattern half used to report TS2304 - the checker
+// defined a var pattern's bindings in the current scope rather than the
+// function scope - which is why this assertion originally covered only v6.
 function hoisted(): string {
-  const before = typeof v6 === "undefined" ? "undefined" : "defined";
+  const before = [
+    typeof v6 === "undefined" ? "undefined" : "defined",
+    typeof w6 === "undefined" ? "undefined" : "defined",
+  ];
   for (var v6 = 1, { w: w6 } = { w: 2 }; false; ) {
   }
-  return [before, v6].join(",");
+  return [before[0], before[1], v6, w6].join(",");
 }
 out.push(hoisted());
 

--- a/tests/scripts/namespace_export_destructuring.ts
+++ b/tests/scripts/namespace_export_destructuring.ts
@@ -1,0 +1,163 @@
+// expect: 1,2|3|4|5|6,7|8|9|10|11|12,13|14,15|16,[17,18]|19,{"m":20}|21|22|23,23|25,25|27|57|57
+// A namespace member exported via a destructuring pattern never landed on the
+// namespace object: `namespace N { export const {a} = obj; }` left N.a
+// undefined at runtime, and absent from N's type (TS2339).
+//
+// This was the third of three export-registration paths with the same gap. The
+// module-level ones just needed the bindings enumerated, because those
+// bindings already exist as globals. The namespace path instead *rewrites* the
+// declaration - compileNamespaceVarLikeExports turns `export const x = v` into
+// `<ns>.x = v` - and a pattern has no single Name/Value to rewrite that way, so
+// it had no case at all.
+//
+// The fix rewrites an exported destructuring declaration into the equivalent
+// destructuring *assignment* onto the namespace object:
+//
+//   export const {a, b: c} = obj    ->    ({a: N.a, b: N.c} = obj)
+//
+// which keeps the invariant that an exported namespace binding *is* the
+// namespace property, so internal reads/writes and external observation can't
+// drift apart (asserted below).
+
+let out: string[] = [];
+
+// --- the repro, and each keyword ---
+namespace A {
+  export const { a } = { a: 1 };
+  export const b = 2;
+}
+out.push([A.a, A.b].join(","));
+
+namespace B {
+  export const [a] = [3];
+}
+out.push(String(B.a));
+
+namespace C {
+  export let { a } = { a: 4 };
+}
+out.push(String(C.a));
+
+namespace D {
+  export var { a } = { a: 5 };
+}
+out.push(String(D.a));
+
+// --- a pattern mixed into a declarator list (paserati#159's shape). The clause
+// desugars to a DeclarationGroup, which parseBlockStatement splices into the
+// namespace body as two separate ExportNamedDeclarations - so the namespace
+// code never sees a group, and needs no branch for one.
+namespace E {
+  export const a = 6,
+    { b } = { b: 7 };
+}
+out.push([E.a, E.b].join(","));
+
+namespace F {
+  export const { b } = { b: 8 },
+    a = 9;
+}
+out.push(String(F.b));
+out.push(String(F.a));
+
+// --- renamed target ---
+namespace G {
+  export const { x: a } = { x: 10 };
+}
+out.push(String(G.a));
+
+// --- nested patterns. The shorthand form is the one that discriminates: the
+// inner ObjectProperty has Key=g and Value=nil, so retargeting Key in place
+// would lose the source property name - it has to expand to `g: <ns>.g`.
+namespace H {
+  export const {
+    f: { g },
+  } = { f: { g: 11 } };
+}
+out.push(String(H.g));
+
+namespace I {
+  export const {
+    f: { g: h, k },
+  } = { f: { g: 12, k: 13 } };
+}
+out.push([I.h, I.k].join(","));
+
+namespace J {
+  export const { f: [h] } = { f: [14] };
+  export const [[i]] = [[15]];
+}
+out.push([J.h, J.i].join(","));
+
+// --- defaults, rest and elision ---
+namespace K {
+  export const [a, ...r] = [16, 17, 18];
+}
+out.push([K.a, JSON.stringify(K.r)].join(","));
+
+namespace L {
+  export const { a, ...r } = { a: 19, m: 20 };
+}
+out.push([L.a, JSON.stringify(L.r)].join(","));
+
+namespace M {
+  export const { a = 21 } = {};
+}
+out.push(String(M.a));
+
+namespace N {
+  export const [, a] = [99, 22];
+}
+out.push(String(N.a));
+
+// --- the exported binding IS the namespace property, both directions.
+// A write from inside the namespace is visible on the namespace object...
+namespace O {
+  export let { a } = { a: 22 };
+  export function bump(): number {
+    a = a + 1;
+    return a;
+  }
+}
+out.push([O.bump(), O.a].join(","));
+
+// ...and a write to the namespace object is visible inside.
+namespace P {
+  export let { a } = { a: 0 };
+  export function read(): number {
+    return a;
+  }
+}
+P.a = 25;
+out.push([P.a, P.read()].join(","));
+
+// --- nested namespaces, and the type is the real one (not any): assigning
+// Q.I.a to a number is only legal because the checker recorded its type.
+namespace Q {
+  export namespace I {
+    export const { a } = { a: 27 };
+  }
+}
+const typed: number = Q.I.a;
+out.push(String(typed));
+
+// --- a namespace whose object is a local rather than a global slot: the
+// retargeted MemberExpression is compiled at a different point than the
+// original declaration, so it has to resolve the same accessExpr either way.
+function scoped(): number {
+  namespace R {
+    export const { a } = { a: 28 };
+    export const [b] = [29];
+  }
+  return R.a + R.b;
+}
+out.push(String(scoped()));
+
+{
+  namespace S {
+    export const { a } = { a: 57 };
+  }
+  out.push(String(S.a));
+}
+
+out.join("|");

--- a/tests/scripts/namespace_export_destructuring.ts
+++ b/tests/scripts/namespace_export_destructuring.ts
@@ -1,4 +1,4 @@
-// expect: 1,2|3|4|5|6,7|8|9|10|11|12,13|14,15|56,57,[58,59]|16,[17,18]|19,{"m":20}|21|22|23,23|25,25|27|57|57
+// expect: 1,2|3|4|5|6,7|8|9|10|11|12,13|14,15|56,57,[58,59]|60,{"h":61,"i":62}|16,[17,18]|19,{"m":20}|21|22|23,23|25,25|27|57|57
 // A namespace member exported via a destructuring pattern never landed on the
 // namespace object: `namespace N { export const {a} = obj; }` left N.a
 // undefined at runtime, and absent from N's type (TS2339).
@@ -101,6 +101,20 @@ namespace JD {
   export const [[x, ...ys]] = [[57, 58, 59]];
 }
 out.push([JD.g, JD.x, JSON.stringify(JD.ys)].join(","));
+
+// A rest element nested inside an object pattern. retargetPattern reaches it
+// through ObjectProperty.Key rather than as a target, so the shorthand branch
+// used to treat the SpreadElement itself as the property name and bind nothing -
+// N.rr came back undefined while its sibling was correct.
+namespace JR {
+  export const {
+    f: { g: jrg, ...jrRest },
+  } = { f: { g: 60, h: 61, i: 62 } };
+}
+out.push(jrJoin());
+function jrJoin(): string {
+  return JR.jrg + "," + JSON.stringify(JR.jrRest);
+}
 
 // --- defaults, rest and elision ---
 namespace K {

--- a/tests/scripts/namespace_export_destructuring.ts
+++ b/tests/scripts/namespace_export_destructuring.ts
@@ -1,4 +1,4 @@
-// expect: 1,2|3|4|5|6,7|8|9|10|11|12,13|14,15|16,[17,18]|19,{"m":20}|21|22|23,23|25,25|27|57|57
+// expect: 1,2|3|4|5|6,7|8|9|10|11|12,13|14,15|56,57,[58,59]|16,[17,18]|19,{"m":20}|21|22|23,23|25,25|27|57|57
 // A namespace member exported via a destructuring pattern never landed on the
 // namespace object: `namespace N { export const {a} = obj; }` left N.a
 // undefined at runtime, and absent from N's type (TS2339).
@@ -88,6 +88,19 @@ namespace J {
   export const [[i]] = [[15]];
 }
 out.push([J.h, J.i].join(","));
+
+// A nested default and a nested rest. These were verified only with
+// --no-typecheck when this test was written, because the checker rejected them
+// ("invalid destructuring target type: *parser.AssignmentExpression /
+// *parser.SpreadElement") independently of namespaces - so retargetPattern's
+// two wrapper branches had no typed coverage. They do now.
+namespace JD {
+  export const {
+    f: { g = 56 },
+  } = { f: {} };
+  export const [[x, ...ys]] = [[57, 58, 59]];
+}
+out.push([JD.g, JD.x, JSON.stringify(JD.ys)].join(","));
 
 // --- defaults, rest and elision ---
 namespace K {

--- a/tests/scripts/nested_pattern_default_and_rest.ts
+++ b/tests/scripts/nested_pattern_default_and_rest.ts
@@ -1,4 +1,4 @@
-// expect: 7|1|3|5|4|9|8,[9,10]|1,[2,3]|s,[true]|2|1,5|1,2,3|4|6|11|12|13,[14,15]
+// expect: 7|1|3|5|4|9|8,[9,10]|1,[2,3]|s,[true]|1,{"c":2,"d":3}|1,{"c":"s"}|1,{"f":2},{"c":3}|1,9,x,{"c":2}|1,{"c":2}|1,{"c":2}|1,{"c":2}|1,{"c":2}|2|1,5|1,2,3|4|6|11|12|13,[14,15]
 // A default value or rest element *nested inside* a destructuring pattern was
 // rejected by the type checker, though the runtime bound both correctly:
 //
@@ -60,6 +60,60 @@ const tup: [[string, boolean]] = [["s", true]];
 const [[t1, ...trest]] = tup;
 const trestOk: boolean[] = trest;
 out.push(t1 + "," + JSON.stringify(trestOk));
+
+// --- a rest element nested inside an OBJECT pattern. Unlike the array case
+// above, this one is not a wrapper around the target: the parser stores it as a
+// SpreadElement in ObjectProperty.Key with a nil Value, because a nested pattern
+// is a raw ObjectLiteral and has no RestProperty field of its own. So it reached
+// the key check in three checker walks and the key conversion in the compiler's
+// nested-object lowering, none of which recognised it.
+const {
+  or1: { b: orb, ...orRest },
+} = { or1: { b: 1, c: 2, d: 3 } };
+out.push(orb + "," + JSON.stringify(orRest));
+
+// Its type is the source's remaining properties, so a wrong shape is rejected.
+const {
+  or2: { b: orb2, ...orRest2 },
+} = { or2: { b: 1, c: "s" } };
+const orTyped: { c: string } = orRest2;
+out.push(orb2 + "," + JSON.stringify(orTyped));
+
+// Two levels deep, each rest taking its own level's remainder.
+const {
+  or3: { inner: { e: ore, ...orInner }, ...orOuter },
+} = { or3: { inner: { e: 1, f: 2 }, c: 3 } };
+out.push([ore, JSON.stringify(orInner), JSON.stringify(orOuter)].join(","));
+
+// Beside a renamed, a defaulted and a numeric-key sibling.
+const {
+  or4: { b: orRenamed, z = 9, 0: orNum, ...orRest4 },
+} = { or4: { b: 1, 0: "x", c: 2 } };
+out.push([orRenamed, z, orNum, JSON.stringify(orRest4)].join(","));
+
+// Nested inside an array pattern, in a destructuring assignment, and in a
+// function parameter - three further target walks.
+const [{ b: orArr, ...orArrRest }] = [{ b: 1, c: 2 }];
+out.push(orArr + "," + JSON.stringify(orArrRest));
+
+let orAsgB = 0;
+let orAsgRest: any = null;
+({ x: { b: orAsgB, ...orAsgRest } } = { x: { b: 1, c: 2 } });
+out.push(orAsgB + "," + JSON.stringify(orAsgRest));
+
+function orParam({ p: { b, ...rest } }: { p: { b: number; c: number } }): string {
+  return b + "," + JSON.stringify(rest);
+}
+out.push(orParam({ p: { b: 1, c: 2 } }));
+
+// And in a for-of head, whose walk defines names without validating them.
+let orForOf = "";
+for (const {
+  q: { b, ...rest },
+} of [{ q: { b: 1, c: 2 } }]) {
+  orForOf = b + "," + JSON.stringify(rest);
+}
+out.push(orForOf);
 
 // --- nested defaults and rest in a for-of head. This walk defines names
 // without validating them, so the missing wrapper cases made it bind nothing

--- a/tests/scripts/nested_pattern_default_and_rest.ts
+++ b/tests/scripts/nested_pattern_default_and_rest.ts
@@ -1,0 +1,115 @@
+// expect: 7|1|3|5|4|9|8,[9,10]|1,[2,3]|s,[true]|2|1,5|1,2,3|4|6|11|12|13,[14,15]
+// A default value or rest element *nested inside* a destructuring pattern was
+// rejected by the type checker, though the runtime bound both correctly:
+//
+//   const {h: {i = 7}} = {h: {}};      // invalid destructuring target type: *parser.AssignmentExpression
+//   const [[j, ...k]] = [[8, 9, 10]];  // invalid destructuring target type: *parser.SpreadElement
+//
+// while a top-level default (`{e = 5}`) and a top-level rest (`[j, ...k]`) both
+// checked fine, as did nested patterns with neither.
+//
+// A pattern is represented two ways depending on depth. At the top level of a
+// declaration a default lives in DestructuringProperty.Default /
+// DestructuringElement.Default and a rest in DestructuringElement.IsRest, with
+// Target holding the binding. Nested one level down, Target is a raw
+// ObjectLiteral/ArrayLiteral, so a default appears as an AssignmentExpression
+// and a rest as a SpreadElement, with the binding inside the wrapper. The four
+// destructuring-target walks knew Identifier/ObjectLiteral/ArrayLiteral but
+// neither wrapper.
+
+let out: string[] = [];
+
+// --- nested defaults, taken and not taken ---
+const {
+  h: { i = 7 },
+} = { h: {} };
+out.push(String(i));
+
+const {
+  h2: { i2 = 7 },
+} = { h2: { i2: 1 } };
+out.push(String(i2));
+
+const {
+  a: { b: { c = 3 } },
+} = { a: { b: {} } };
+out.push(String(c));
+
+const { a2: [q = 5] } = { a2: [] };
+out.push(String(q));
+
+const [[m = 4]] = [[]];
+out.push(String(m));
+
+const [[m2 = 4]] = [[9]];
+out.push(String(m2));
+
+// --- nested rest elements ---
+const [[j, ...k]] = [[8, 9, 10]];
+out.push(j + "," + JSON.stringify(k));
+
+const {
+  r: [r1, ...rrest],
+} = { r: [1, 2, 3] };
+out.push(r1 + "," + JSON.stringify(rrest));
+
+// A rest binding over a nested TUPLE gets the union of the remaining member
+// types, not just the type at its own position - otherwise `string[]` would be
+// silently accepted for a value holding a boolean. Matches the top-level case.
+const tup: [[string, boolean]] = [["s", true]];
+const [[t1, ...trest]] = tup;
+const trestOk: boolean[] = trest;
+out.push(t1 + "," + JSON.stringify(trestOk));
+
+// --- nested defaults and rest in a for-of head. This walk defines names
+// without validating them, so the missing wrapper cases made it bind nothing
+// and the later read was "Cannot find name" rather than a target-type error.
+let forOfOut = 0;
+for (const {
+  f: { g = 2 },
+} of [{ f: {} }]) {
+  forOfOut = g;
+}
+out.push(String(forOfOut));
+
+let forOfRest = "";
+for (const [[x, ...ys]] of [[[1, 5]]]) {
+  forOfRest = x + "," + ys[0];
+}
+out.push(forOfRest);
+
+let forOfDeep = "";
+for (const { p: [a1 = 1, ...rest1] } of [{ p: [] as number[] }]) {
+  forOfDeep = [a1, 2, 3].join(",");
+  void rest1;
+}
+out.push(forOfDeep);
+
+// --- the same nested shapes in a for INITIALIZER ---
+let forInitOut = 0;
+for (const [[fi = 4]] = [[]]; forInitOut === 0; ) {
+  forInitOut = fi;
+}
+out.push(String(forInitOut));
+
+// --- and in a destructuring ASSIGNMENT, which uses two further target walks ---
+let asgA = 0;
+({
+  z: { asgA = 6 },
+} = { z: {} });
+out.push(String(asgA));
+
+let asgB = 0;
+({ y: [asgB = 11] } = { y: [] });
+out.push(String(asgB));
+
+let asgC = 0;
+[[asgC = 12]] = [[]];
+out.push(String(asgC));
+
+let asgD = 0;
+let asgRest: number[] = [];
+[[asgD, ...asgRest]] = [[13, 14, 15]];
+out.push(asgD + "," + JSON.stringify(asgRest));
+
+out.join("|");

--- a/tests/scripts/tdz_every_declarator.ts
+++ b/tests/scripts/tdz_every_declarator.ts
@@ -1,0 +1,52 @@
+// expect: TDZ 'a'|TDZ 'b'|TDZ 'c'
+// Every declarator of a let/const clause needs its Temporal Dead Zone marker,
+// not just the first. Four pre-registration sites read the statement's legacy
+// first-declaration alias (s.Name) instead of its declarator list, so for
+// `let a = 1, b = 2` only `a` was marked. Reading `b` before the declaration
+// then fell through to an unbound global and reported
+//
+//   ReferenceError: b is not defined
+//
+// where node reports "Cannot access 'b' before initialization".
+//
+// This file covers the top-level script path, whose TDZ error names the
+// variable. The block, function-body and direct-eval paths are in
+// tdz_every_declarator_nested.ts, which has to skip type checking: the checker
+// rejects a use-before-declaration inside a block or function outright with
+// TS2304 rather than tsc's TS2448, a separate pre-existing gap that is the same
+// for every declarator.
+
+let out: string[] = [];
+
+// Classifies the failure so a "not defined" regression is unmistakable.
+function classify(e: any, name: string): string {
+  const msg = String(e.message);
+  if (msg.indexOf("before initialization") < 0) return "NOT-TDZ: " + msg;
+  if (msg.indexOf("'" + name + "'") >= 0) return "TDZ '" + name + "'";
+  return "TDZ (unnamed)";
+}
+
+try {
+  a;
+} catch (e) {
+  out.push(classify(e, "a"));
+}
+try {
+  b;
+} catch (e) {
+  out.push(classify(e, "b"));
+}
+try {
+  c;
+} catch (e) {
+  out.push(classify(e, "c"));
+}
+
+let a = 1,
+  b = 2,
+  c = 3;
+void a;
+void b;
+void c;
+
+out.join("|");

--- a/tests/scripts/tdz_every_declarator_nested.ts
+++ b/tests/scripts/tdz_every_declarator_nested.ts
@@ -1,0 +1,87 @@
+// expect: TDZ|TDZ|TDZ|TDZ|TDZ|TDZ|TDZ|TDZ
+// skip-typecheck
+// The block, function-body and direct-eval halves of the non-first-declarator
+// TDZ fix - see tdz_every_declarator.ts for the top-level half and the full
+// explanation. `let a = 1, b = 2` used to mark only `a`, so reading `b` before
+// the declaration reported "b is not defined" instead of a TDZ error.
+//
+// Type checking is skipped because the checker rejects a use-before-declaration
+// inside a block or function outright ("Cannot find name 'b'", where tsc reports
+// TS2448 and compiles it). That gap is pre-existing and identical for the first
+// and non-first declarator, so it is not what this test is about - but it does
+// mean these shapes cannot be expressed in a type-checked script.
+//
+// These paths give the unnamed message form ("Cannot access variable before
+// initialization"), so the assertion is the error *kind*: a TDZ error rather
+// than "not defined".
+
+let out = [];
+
+function classify(e) {
+  const msg = String(e.message);
+  if (msg.indexOf("before initialization") < 0) return "NOT-TDZ: " + msg;
+  return "TDZ";
+}
+
+// --- function body ---
+function fnBody(which) {
+  try {
+    if (which === 0) d;
+    else e2;
+  } catch (err) {
+    return classify(err);
+  }
+  let d = 1,
+    e2 = 2;
+  return "NO-THROW";
+}
+out.push(fnBody(0));
+out.push(fnBody(1));
+
+// --- nested block ---
+function inBlock(which) {
+  {
+    try {
+      if (which === 0) f;
+      else g;
+    } catch (err) {
+      return classify(err);
+    }
+    let f = 1,
+      g = 2;
+  }
+  return "NO-THROW";
+}
+out.push(inBlock(0));
+out.push(inBlock(1));
+
+// --- const, through the same sites ---
+function constInBlock(which) {
+  {
+    try {
+      if (which === 0) h;
+      else i;
+    } catch (err) {
+      return classify(err);
+    }
+    const h = 1,
+      i = 2;
+  }
+  return "NO-THROW";
+}
+out.push(constInBlock(0));
+out.push(constInBlock(1));
+
+// --- direct eval, which hoists its own lexical bindings ---
+function inEval(src) {
+  try {
+    eval(src);
+  } catch (err) {
+    return classify(err);
+  }
+  return "NO-THROW";
+}
+out.push(inEval("j; let j = 1, k = 2;"));
+out.push(inEval("k; let j = 1, k = 2;"));
+
+out.join("|");

--- a/tests/scripts/var_iife_not_global.ts
+++ b/tests/scripts/var_iife_not_global.ts
@@ -1,7 +1,12 @@
-// Test that var in IIFE doesn't leak to global scope
-// expect_runtime_error: is not defined
+// expect_compile_error: Cannot find name 'x'
+// `var` is function-scoped, so a var inside an IIFE must not be visible outside
+// it. This used to be caught only at runtime ("ReferenceError: x is not
+// defined") because the checker gave a function body a *block*-scoped
+// environment: GetFunctionScope, where every var binding lands, walked straight
+// past the function body up to the enclosing function or global scope. The
+// checker now rejects it, which is what this test's original comment asked for.
 
-(function() {
+(function () {
   var x = 42;
 })();
 

--- a/tests/scripts/var_pattern_function_scope.ts
+++ b/tests/scripts/var_pattern_function_scope.ts
@@ -1,0 +1,147 @@
+// expect: 1|2|3|4|5|6|7|8|9|10|11|12|13
+// `var` is function-scoped, so its bindings belong in the nearest function (or
+// global) scope no matter how many blocks deep the declaration sits. The checker
+// has no var-hoisting pre-pass - it defines a binding when it visits the
+// declaration - and the plain VarStatement path routes that through
+// GetFunctionScope, but the two *destructuring* target walkers defined into
+// c.env, the current scope. So a var pattern one level deeper than the function
+// body vanished at the end of its block:
+//
+//   function f(){ { var {w} = {w: 2}; } return w; }   // TS2304: Cannot find name 'w'.
+//
+// while both `var {w} = ...` directly in the body and `{ var w = 2; }` resolved
+// fine. Same for a pattern in a for-of or for-init head, in a switch case, a try
+// block, a while body, or a labeled block.
+//
+// WHAT THIS TEST ASSERTS: that the *name resolves*. It deliberately does not
+// assert the destructured value for the cases below that go through an
+// enclosing block, because a separate open codegen bug makes `var` with a
+// pattern inside a block write a block-local binding instead of the hoisted one,
+// so those read back as undefined at function scope - identically with
+// --no-typecheck, i.e. nothing to do with the checker. Those cases just
+// reference the name (`void w`), which is what fails to compile when the name
+// does not resolve. The for-of and for-init heads are the shapes whose runtime
+// is already correct, so those assert real values.
+
+let out: string[] = [];
+
+// --- a pattern in a for-of head: name resolves AND the value is right ---
+function forOfHead(): number {
+  for (var { w } of [{ w: 1 }]) {
+  }
+  return w;
+}
+out.push(String(forOfHead()));
+
+function forOfHeadArray(): number {
+  for (var [w] of [[2]]) {
+  }
+  return w;
+}
+out.push(String(forOfHeadArray()));
+
+// --- a pattern in a for-init head, alone and mixed with a plain declarator ---
+function forInitHead(): number {
+  for (var { w } = { w: 3 }; false; ) {
+  }
+  return w;
+}
+out.push(String(forInitHead()));
+
+function forInitHeadMixed(): number {
+  for (var v = 9, { w } = { w: 4 }; false; ) {
+  }
+  return w;
+}
+out.push(String(forInitHeadMixed()));
+
+// --- a plain var in a for-of/for-in head nested one block deeper. The head
+// hoisted its name to the *immediately* enclosing scope, which is the block, not
+// the function - so this reported TS2304 for a plain binding too.
+function forOfInBlock(): string {
+  {
+    for (var q of [1]) {
+    }
+  }
+  void q;
+  return "5";
+}
+out.push(forOfInBlock());
+
+function forInInBlock(): string {
+  {
+    for (var k in { a: 1 }) {
+    }
+  }
+  void k;
+  return "6";
+}
+out.push(forInInBlock());
+
+// --- the shapes that reach the function scope through an enclosing statement.
+// Reading `w` after the enclosing statement IS the assertion: before the fix
+// each of these was TS2304, a compile error that failed the whole file. The
+// value is deliberately not asserted - see the header note - so `void w` records
+// the reference without depending on what it holds.
+function inBlock(): string {
+  {
+    var { w } = { w: 99 };
+  }
+  void w;
+  return "7";
+}
+out.push(inBlock());
+
+function inIf(): string {
+  if (true) {
+    var { w } = { w: 99 };
+  }
+  void w;
+  return "8";
+}
+out.push(inIf());
+
+function inSwitch(): string {
+  switch (1) {
+    case 1:
+      var { w } = { w: 99 };
+  }
+  void w;
+  return "9";
+}
+out.push(inSwitch());
+
+function inTry(): string {
+  try {
+    var { w } = { w: 99 };
+  } catch (e) {}
+  void w;
+  return "10";
+}
+out.push(inTry());
+
+function inWhile(): string {
+  while (false) {
+    var { w } = { w: 99 };
+  }
+  void w;
+  return "11";
+}
+out.push(inWhile());
+
+function inLabeled(): string {
+  lbl: {
+    var { w } = { w: 99 };
+  }
+  void w;
+  return "12";
+}
+out.push(inLabeled());
+
+// --- the same at script top level, where the "function scope" is the global
+// env. The for-of head's runtime is correct here, so assert the value.
+for (var { top } of [{ top: 13 }]) {
+}
+out.push(String(top));
+
+out.join("|");

--- a/tests/scripts/var_pattern_function_scope.ts
+++ b/tests/scripts/var_pattern_function_scope.ts
@@ -1,4 +1,4 @@
-// expect: 1|2|3|4|5|6|99|99|99|99|99|99|13
+// expect: 1|2|3|4|5|six|51|52,53|3,3,3|1,2,3|99|99|99|99|99|99|13
 // `var` is function-scoped, so its bindings belong in the nearest function (or
 // global) scope no matter how many blocks deep the declaration sits. The checker
 // has no var-hoisting pre-pass - it defines a binding when it visits the
@@ -13,11 +13,11 @@
 // fine. Same for a pattern in a for-of or for-init head, in a switch case, a try
 // block, a while body, or a labeled block.
 //
-// Every case below asserts the destructured *value*, which also proves the name
-// resolves. The block-family cases originally asserted only resolution: a
-// companion codegen bug made a `var` pattern inside a block write a block-local
-// binding instead of the hoisted one, so they read back as undefined. Both
-// halves are fixed - see the commit that repaired the write-through.
+// Every case below asserts the *value*, which also proves the name resolves.
+// This test grew in three passes, each one converting deferred assertions into
+// real ones as the matching half landed: the checker scope fix, the declaration
+// write-through fix, and the loop-head write-through fix. Nothing is deferred
+// now.
 
 let out: string[] = [];
 
@@ -51,36 +51,74 @@ function forInitHeadMixed(): number {
 }
 out.push(String(forInitHeadMixed()));
 
-// --- a plain var in a for-of/for-in head nested one block deeper. The head
-// hoisted its name to the *immediately* enclosing scope, which is the block, not
-// the function - so this reported TS2304 for a plain binding too.
-//
-// These two assert resolution only. A `var` declared in a `for` *head* inside a
-// nested block still writes a block-local rather than the hoisted binding - a
-// separate open bug in the loop-head path, broken identically for a plain
-// binding (`{ for (var q of [5]) {} } q` reads undefined) and worse for a
-// pattern (`{ for (var {w} of xs) {} } w` throws ReferenceError). Unrelated to
-// the declaration path this test covers; asserting the value here would bake in
-// the wrong number.
-function forOfInBlock(): string {
+// --- a var declared in a `for` HEAD nested one block deeper. The head
+// pre-declared its name in the *immediately* enclosing scope - the block, not
+// the function - so it reported TS2304 before the scope fix, and then wrote to
+// that shadow rather than the hoisted binding: a plain binding read back
+// undefined and a pattern threw ReferenceError, because the loop scope holding
+// the shadow was popped before the read.
+function forOfInBlock(): number {
   {
     for (var q of [5]) {
     }
   }
-  void q;
-  return "5";
+  return q;
 }
-out.push(forOfInBlock());
+out.push(String(forOfInBlock()));
 
 function forInInBlock(): string {
   {
     for (var k in { six: 1 }) {
     }
   }
-  void k;
-  return "6";
+  return k;
 }
 out.push(forInInBlock());
+
+function forInitInBlock(): number {
+  {
+    for (var fi = 51; false; ) {
+    }
+  }
+  return fi;
+}
+out.push(String(forInitInBlock()));
+
+// A pattern in a for-of head inside a block threw ReferenceError: its names were
+// never hoisted at all - collectVarDeclarations only recognised a plain
+// VarStatement in a loop head, not a destructuring declaration.
+function forOfPatternInBlock(): string {
+  {
+    for (var { w } of [{ w: 52 }]) {
+    }
+  }
+  {
+    for (var [z] of [[53]]) {
+    }
+  }
+  return [w, z].join(",");
+}
+out.push(forOfPatternInBlock());
+
+// var in a loop head is ONE binding, reassigned each iteration, so closures over
+// it all see the last value - unlike a let head, which is per-iteration.
+function varHeadIsOneBinding(): string {
+  const fs: (() => number)[] = [];
+  for (var vh of [1, 2, 3]) {
+    fs.push(() => vh);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(varHeadIsOneBinding());
+
+function letHeadIsPerIteration(): string {
+  const fs: (() => number)[] = [];
+  for (let lh of [1, 2, 3]) {
+    fs.push(() => lh);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(letHeadIsPerIteration());
 
 // --- the shapes that reach the function scope through an enclosing statement.
 // Each was TS2304 (a compile error failing the whole file) before the scope fix,

--- a/tests/scripts/var_pattern_function_scope.ts
+++ b/tests/scripts/var_pattern_function_scope.ts
@@ -1,4 +1,4 @@
-// expect: 1|2|3|4|5|6|7|8|9|10|11|12|13
+// expect: 1|2|3|4|5|6|99|99|99|99|99|99|13
 // `var` is function-scoped, so its bindings belong in the nearest function (or
 // global) scope no matter how many blocks deep the declaration sits. The checker
 // has no var-hoisting pre-pass - it defines a binding when it visits the
@@ -13,15 +13,11 @@
 // fine. Same for a pattern in a for-of or for-init head, in a switch case, a try
 // block, a while body, or a labeled block.
 //
-// WHAT THIS TEST ASSERTS: that the *name resolves*. It deliberately does not
-// assert the destructured value for the cases below that go through an
-// enclosing block, because a separate open codegen bug makes `var` with a
-// pattern inside a block write a block-local binding instead of the hoisted one,
-// so those read back as undefined at function scope - identically with
-// --no-typecheck, i.e. nothing to do with the checker. Those cases just
-// reference the name (`void w`), which is what fails to compile when the name
-// does not resolve. The for-of and for-init heads are the shapes whose runtime
-// is already correct, so those assert real values.
+// Every case below asserts the destructured *value*, which also proves the name
+// resolves. The block-family cases originally asserted only resolution: a
+// companion codegen bug made a `var` pattern inside a block write a block-local
+// binding instead of the hoisted one, so they read back as undefined. Both
+// halves are fixed - see the commit that repaired the write-through.
 
 let out: string[] = [];
 
@@ -58,9 +54,17 @@ out.push(String(forInitHeadMixed()));
 // --- a plain var in a for-of/for-in head nested one block deeper. The head
 // hoisted its name to the *immediately* enclosing scope, which is the block, not
 // the function - so this reported TS2304 for a plain binding too.
+//
+// These two assert resolution only. A `var` declared in a `for` *head* inside a
+// nested block still writes a block-local rather than the hoisted binding - a
+// separate open bug in the loop-head path, broken identically for a plain
+// binding (`{ for (var q of [5]) {} } q` reads undefined) and worse for a
+// pattern (`{ for (var {w} of xs) {} } w` throws ReferenceError). Unrelated to
+// the declaration path this test covers; asserting the value here would bake in
+// the wrong number.
 function forOfInBlock(): string {
   {
-    for (var q of [1]) {
+    for (var q of [5]) {
     }
   }
   void q;
@@ -70,7 +74,7 @@ out.push(forOfInBlock());
 
 function forInInBlock(): string {
   {
-    for (var k in { a: 1 }) {
+    for (var k in { six: 1 }) {
     }
   }
   void k;
@@ -79,64 +83,57 @@ function forInInBlock(): string {
 out.push(forInInBlock());
 
 // --- the shapes that reach the function scope through an enclosing statement.
-// Reading `w` after the enclosing statement IS the assertion: before the fix
-// each of these was TS2304, a compile error that failed the whole file. The
-// value is deliberately not asserted - see the header note - so `void w` records
-// the reference without depending on what it holds.
-function inBlock(): string {
+// Each was TS2304 (a compile error failing the whole file) before the scope fix,
+// and read back undefined before the write-through fix.
+function inBlock(): number {
   {
     var { w } = { w: 99 };
   }
-  void w;
-  return "7";
+  return w;
 }
-out.push(inBlock());
+out.push(String(inBlock()));
 
-function inIf(): string {
+function inIf(): number {
   if (true) {
     var { w } = { w: 99 };
   }
-  void w;
-  return "8";
+  return w;
 }
-out.push(inIf());
+out.push(String(inIf()));
 
-function inSwitch(): string {
+function inSwitch(): number {
   switch (1) {
     case 1:
       var { w } = { w: 99 };
   }
-  void w;
-  return "9";
+  return w;
 }
-out.push(inSwitch());
+out.push(String(inSwitch()));
 
-function inTry(): string {
+function inTry(): number {
   try {
     var { w } = { w: 99 };
   } catch (e) {}
-  void w;
-  return "10";
+  return w;
 }
-out.push(inTry());
+out.push(String(inTry()));
 
-function inWhile(): string {
-  while (false) {
+function inWhile(): number {
+  while (true) {
     var { w } = { w: 99 };
+    break;
   }
-  void w;
-  return "11";
+  return w;
 }
-out.push(inWhile());
+out.push(String(inWhile()));
 
-function inLabeled(): string {
+function inLabeled(): number {
   lbl: {
     var { w } = { w: 99 };
   }
-  void w;
-  return "12";
+  return w;
 }
-out.push(inLabeled());
+out.push(String(inLabeled()));
 
 // --- the same at script top level, where the "function scope" is the global
 // env. The for-of head's runtime is correct here, so assert the value.

--- a/tests/scripts/var_pattern_function_scope.ts
+++ b/tests/scripts/var_pattern_function_scope.ts
@@ -1,4 +1,4 @@
-// expect: 1|2|3|4|5|six|51|52,53|3,3,3|1,2,3|99|99|99|99|99|99|13
+// expect: 1|2|3|4|5|six|51|52,53|3,3,3|1,2,3|1,2,3|1,2,3|1,2,3|5,2,5|1/[9],2/[8]|1,2,3|1,2|1,3|1/10 1/20 2/10 2/20|99|99|99|99|99|99|13
 // `var` is function-scoped, so its bindings belong in the nearest function (or
 // global) scope no matter how many blocks deep the declaration sits. The checker
 // has no var-hoisting pre-pass - it defines a binding when it visits the
@@ -119,6 +119,109 @@ function letHeadIsPerIteration(): string {
   return fs.map((g) => g()).join(",");
 }
 out.push(letHeadIsPerIteration());
+
+// The same, for a let/const *pattern* head. These used to give the last value
+// for every closure: only the plain-identifier branches of the head dispatch
+// recorded their register as a per-iteration binding, so the pattern branches -
+// whose names are bound deep inside the destructuring helpers - were never
+// closed at the loop's back edge.
+function letPatternHeadIsPerIteration(): string {
+  const fs: (() => number)[] = [];
+  for (let { w } of [{ w: 1 }, { w: 2 }, { w: 3 }]) {
+    fs.push(() => w);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(letPatternHeadIsPerIteration());
+
+function constPatternHeadIsPerIteration(): string {
+  const fs: (() => number)[] = [];
+  for (const [w] of [[1], [2], [3]]) {
+    fs.push(() => w);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(constPatternHeadIsPerIteration());
+
+// A NESTED target is the discriminating shape: it is bound through
+// compileNestedPatternDeclaration rather than the head's own binding code, so it
+// only works if the per-iteration collection looks names up after the whole
+// pattern is bound.
+function nestedPatternHeadIsPerIteration(): string {
+  const fs: (() => number)[] = [];
+  for (let {
+    a: { b },
+  } of [{ a: { b: 1 } }, { a: { b: 2 } }, { a: { b: 3 } }]) {
+    fs.push(() => b);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(nestedPatternHeadIsPerIteration());
+
+// Defaults and rest elements reach their bindings through yet other paths.
+function defaultAndRestHeadsArePerIteration(): string {
+  const withDefault: (() => number)[] = [];
+  for (let { a = 5 } of [{}, { a: 2 }, {}]) {
+    withDefault.push(() => a);
+  }
+  const withRest: (() => string)[] = [];
+  for (let [a, ...r] of [
+    [1, 9],
+    [2, 8],
+  ]) {
+    withRest.push(() => a + "/" + JSON.stringify(r));
+  }
+  return (
+    withDefault.map((g) => g()).join(",") +
+    "|" +
+    withRest.map((g) => g()).join(",")
+  );
+}
+out.push(defaultAndRestHeadsArePerIteration());
+
+// A let/const pattern in a C-style for INITIALIZER is a per-iteration binding
+// too: the spec copies the bindings before the first test and after each update.
+function letPatternForInitIsPerIteration(): string {
+  const fs: (() => number)[] = [];
+  for (let { w } = { w: 1 }; w < 4; w++) {
+    fs.push(() => w);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(letPatternForInitIsPerIteration());
+
+// break and continue must not disturb the captures.
+function patternHeadWithBreak(): string {
+  const fs: (() => number)[] = [];
+  for (let { w } of [{ w: 1 }, { w: 2 }, { w: 3 }]) {
+    fs.push(() => w);
+    if (w === 2) break;
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(patternHeadWithBreak());
+
+function patternHeadWithContinue(): string {
+  const fs: (() => number)[] = [];
+  for (let { w } of [{ w: 1 }, { w: 2 }, { w: 3 }]) {
+    if (w === 2) continue;
+    fs.push(() => w);
+  }
+  return fs.map((g) => g()).join(",");
+}
+out.push(patternHeadWithContinue());
+
+// Nested loops each get their own per-iteration bindings.
+function nestedPatternLoops(): string {
+  const fs: (() => string)[] = [];
+  for (let { w } of [{ w: 1 }, { w: 2 }]) {
+    for (let { v } of [{ v: 10 }, { v: 20 }]) {
+      fs.push(() => w + "/" + v);
+    }
+  }
+  return fs.map((g) => g()).join(" ");
+}
+out.push(nestedPatternLoops());
 
 // --- the shapes that reach the function scope through an enclosing statement.
 // Each was TS2304 (a compile error failing the whole file) before the scope fix,


### PR DESCRIPTION
Fixes #159. Fixes #160.

Started on the two filed destructuring-declarator bugs. Both turned out to be
one parser defect, and fixing it exposed a chain of related gaps in the same
area — each one found by probing the shape next door rather than by the issue
tracker. 13 commits, each independently verified against `main`.

## The two filed issues

**#159** (`let r = 1, {a} = obj` fails to parse) and **#160** (`let {a} = obj, b = 2`
silently destructures the wrong value) are the same root cause: each of
`parseLetStatement`/`parseConstStatement`/`parseVarStatement` carried its own copy
of the declarator loop, and every copy accepted only an identifier after a comma.
Three more copies lived in the for-initializer path.

#160's issue text diagnoses it from the bytecode as a register-lifetime bug. It
isn't — a destructuring declaration's initializer was parsed at `LOWEST`, so it
swallowed `, b = 2` as a comma operator and the pattern's source became
`(obj, b = 2)`, i.e. `b`'s own value. An Initializer is an `AssignmentExpression`,
so it must stop at the comma; the identifier path already did.

All three keywords now share one declarator-list parser where every position
accepts an identifier or a pattern. A mixed clause desugars to one declaration
statement per declarator, grouped in a new `DeclarationGroup` that introduces no
scope; in statement position (including `export let a = 1, {b} = obj`) the members
are spliced into the enclosing statement list, so the existing hoisting and TDZ
passes see ordinary siblings. Clauses with no pattern, and lone patterns, keep
their exact previous AST shape.

## What that exposed

Nine further defects, all pre-existing on `main`, each verified against Node:

| Area | Defect |
|---|---|
| parser | binding names behind a *nested* default or rest were never enumerated, so `{ var {a: {b = 1}} = o; }` threw ReferenceError |
| modules | `export const {a} = obj` exported **nothing**; a multi-declarator clause exported only the **last** name |
| namespaces | `export const {a} = obj` inside a namespace left the member undefined and absent from the namespace's type |
| checker | a `var` pattern's bindings landed in the current block, not the function scope (false TS2304) |
| checker | function bodies got a *block*-scoped env, so any `var` in a function body leaked its name outward |
| compiler | a `var` pattern in a nested block wrote a block-local instead of the hoisted binding |
| compiler | a `var` in a `for` **head** inside a block did the same (plain bindings too) |
| compiler | a `let`/`const` **pattern** loop head got one shared binding instead of one per iteration |
| checker | a default or rest **nested inside** a pattern was rejected outright |
| compiler+checker | a rest nested inside an **object** pattern was unimplemented |
| compiler | only the **first** declarator of `let a = 1, b = 2` got its TDZ marker |

Two of these were worth the extra digging:

- The **function-scope marker** bug (`49509616`) was found only because routing
  `var` patterns to `GetFunctionScope()` made them inherit an existing leak. The
  discriminator was that the plain-`var` path leaked identically — so the parent's
  TS2304 on the pattern cases had been an accident of the name resolving nowhere,
  not correct scoping. `tests/scripts/var_iife_not_global.ts` had already noticed
  the symptom: its comment reads "Should be compile error" while its expectation
  settled for a runtime ReferenceError. It now expects the compile error.
- The **namespace** half of the nested-object-rest work (`476d34a5`) failed
  *silently* — correct sibling, undefined rest, no error. Only running the
  namespace shape found it; the other four sites announce themselves.

## Also

- Deleted a **fourth, dead** copy of the declarator loop in
  `parseRegularForStatement`, confirmed unreachable by panicking in each branch
  and running the whole Go suite plus all 23,523 test262 `language/` tests: zero
  hits.
- Fixed a pre-existing bug in the for-of object-pattern head that derived
  `isConst` by type-switching `node.Variable` for `Let`/`Var`/`ConstStatement` —
  but for a pattern head `node.Variable` *is* the destructuring declaration, so
  the switch always fell through and compiled a nested target as const.

## Verification

- `go test ./...` clean.
- **test262: language +3 / −0, built-ins +0 / −0** (vs `main`).
- **TypeScript conformance** (`paserati-testtsc -strict-errors`, 4460 tests):
  **+9 / −0**, stable across three runs.

The testtsc negatives reported in individual runs come from a pool of three tests
that flip on an **unchanged** build — `typeArgumentInferenceWithObjectLiteral.ts`,
`genericCallWithObjectTypeArgsAndConstraints2.ts` and
`dependentDestructuredVariablesFromNestedPatterns.ts`. Each was checked rather
than assumed: none contains a shape any commit here can reach, all three produce
byte-identical diagnostics on both builds, and the last one visibly varies
run-to-run in the property order of a printed type (Go map iteration order).

Where a suite didn't move, I checked whether that was real: test262 has **no** test
that nests a rest inside an object pattern, and its per-iteration-binding tests
(`head-{let,const}-fresh-binding-per-iteration.js`) use plain-identifier heads
only — so those `+0`s are absent coverage, not masked regressions.

## Tests

7 new smoke tests plus 3 tightened, and 2 new Go test files (parser AST-shape
tests, driver module-export tests). Every one fails on its parent commit.

Two carry deliberate caveats where a *separate* bug still blocks a stronger
assertion, each explaining why in-file:
- `var_pattern_function_scope.ts` — two cases assert name resolution only,
  because a `var` in a `for` head inside a block is a different open bug.
  (Later fixed in this branch; the file now asserts values there too.)
- `tdz_every_declarator_nested.ts` — skips type checking, because the checker
  rejects a block-level use-before-declaration outright (`TS2304`, where tsc
  reports `TS2448` and compiles it). That divergence is pre-existing, identical
  for every declarator, and left alone.

## Not fixed (checked, left alone)

- **#72** (direct eval's `var` doesn't reach the caller's scope) and **#85**
  (compiler panic on a generator closure-binding name collision) both still
  reproduce — I touched eval's *lexical* hoist, not its `var` handling.
- A `const` destructuring binding doesn't reject assignment at runtime — but
  `const {z} = o; z = 9` is equally allowed, so it isn't loop- or
  pattern-position-specific, and the checker catches all of these.
- `for-in`'s pattern branch doesn't collect nested per-iteration targets;
  patterns there are checker-rejected (TS2491), matching tsc.
