### PR TITLE
Fix native vm.Value args, 'as' contextual keyword, re-exported imports, reentrant export collection (#162, #163, #164, #165)

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4756,6 +4756,27 @@ func (c *Compiler) compileExportNamedDeclaration(node *parser.ExportNamedDeclara
 							c.moduleBindings.DefineExport(localName, exportName, vm.Undefined, nil, globalIdx)
 						}
 						debugPrintf("// [Compiler] Exported: %s as %s\n", localName, exportName)
+					} else if c.IsModuleMode() && c.moduleBindings.IsImported(localName) &&
+						c.moduleBindings.ImportedNames[localName].ImportType != ImportNamespaceRef {
+						// The local name isn't a local declaration - it's an
+						// imported named/default binding (import { X } from
+						// "./mod"; export { X };, or the default-import
+						// equivalent). Imported names are deliberately never
+						// defined in the symbol table (see processImportBinding
+						// above), so treat this the same as a direct re-export
+						// clause: resolve it through the import's own source
+						// module/name rather than this module's own scope.
+						// See paserati#163.
+						//
+						// A namespace import (import * as NS) falls through to
+						// the "not found" error below instead: its "source
+						// name" is the sentinel "*", which nothing downstream
+						// (GetReExports/VM.GetModuleExport) can resolve as a
+						// real export name, so accepting it here would silently
+						// compile to an undefined re-export rather than erroring.
+						importRef := c.moduleBindings.ImportedNames[localName]
+						c.moduleBindings.DefineReExport(exportName, importRef.SourceModule, importRef.SourceName)
+						debugPrintf("// [Compiler] Re-exported (via import): %s as %s from %s\n", importRef.SourceName, exportName, importRef.SourceModule)
 					} else {
 						return BadRegister, NewCompileError(node, fmt.Sprintf("exported name '%s' not found in current scope", localName))
 					}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -975,6 +975,19 @@ func (p *Paserati) RunModule(filename string) bool {
 
 		// Store the compiled chunk in the module record for VM access
 		moduleRecord.CompiledChunk = chunk
+
+		// This compile (unlike the loader's own, in the common case above)
+		// happened on p.compiler right here, so its export indices/re-exports
+		// are trustworthy - record them on moduleRecord now, the same way the
+		// loader's applyCompilerExports does, so export collection below can
+		// rely solely on moduleRecord regardless of which branch ran.
+		exportGlobalIndices := p.compiler.GetExportGlobalIndices()
+		exportIndices := make(map[string]uint16, len(exportGlobalIndices))
+		for name, idx := range exportGlobalIndices {
+			exportIndices[name] = uint16(idx)
+		}
+		moduleRecord.ExportIndices = exportIndices
+		moduleRecord.ReExports = p.compiler.GetReExports()
 	}
 
 	// Set the module path in the VM so import.meta.url works correctly
@@ -991,21 +1004,13 @@ func (p *Paserati) RunModule(filename string) bool {
 		return p.DisplayResult(sourceCode, finalValue, runtimeErrs)
 	}
 
-	// After successful execution, collect exported values from the compiler
-	if p.compiler.IsModuleMode() {
-		exportedValues := p.collectExportedValues()
-		moduleRecord.ExportValues = exportedValues
-		// Also store the export indices mapping for dynamic import support
-		// Convert map[string]int to map[string]uint16
-		exportGlobalIndices := p.compiler.GetExportGlobalIndices()
-		exportIndices := make(map[string]uint16, len(exportGlobalIndices))
-		for name, idx := range exportGlobalIndices {
-			exportIndices[name] = uint16(idx)
-		}
-		moduleRecord.ExportIndices = exportIndices
-		moduleRecord.ReExports = p.compiler.GetReExports()
-		debugPrintf("// [Driver] Collected %d exported values from module\n", len(exportedValues))
-	}
+	// After successful execution, collect exported values using this
+	// module's own recorded export indices (see collectExportedValuesForModule -
+	// paserati#165: p.compiler's *current* IsModuleMode()/export indices are
+	// not reliable here, since this call may be reentrant).
+	exportedValues := p.collectExportedValuesForModule(moduleRecord)
+	moduleRecord.ExportValues = exportedValues
+	debugPrintf("// [Driver] Collected %d exported values from module\n", len(exportedValues))
 
 	// Get source code for error display
 	sourceCode := ""
@@ -1106,6 +1111,19 @@ func (p *Paserati) RunModuleWithValue(filename string) (vm.Value, []errors.Paser
 
 		// Store the compiled chunk in the module record for VM access
 		moduleRecord.CompiledChunk = chunk
+
+		// This compile (unlike the loader's own, in the common case above)
+		// happened on p.compiler right here, so its export indices/re-exports
+		// are trustworthy - record them on moduleRecord now, the same way the
+		// loader's applyCompilerExports does, so export collection below can
+		// rely solely on moduleRecord regardless of which branch ran.
+		exportGlobalIndices := p.compiler.GetExportGlobalIndices()
+		exportIndices := make(map[string]uint16, len(exportGlobalIndices))
+		for name, idx := range exportGlobalIndices {
+			exportIndices[name] = uint16(idx)
+		}
+		moduleRecord.ExportIndices = exportIndices
+		moduleRecord.ReExports = p.compiler.GetReExports()
 	}
 
 	// Set the module path in the VM so import.meta.url works correctly
@@ -1114,21 +1132,14 @@ func (p *Paserati) RunModuleWithValue(filename string) (vm.Value, []errors.Paser
 	// Execute the module and return the final value
 	finalValue, runtimeErrs := p.vmInstance.Interpret(chunk)
 
-	// After successful execution, collect exported values from the compiler
-	if p.compiler.IsModuleMode() {
-		exportedValues := p.collectExportedValues()
-		moduleRecord.ExportValues = exportedValues
-		// Also store the export indices mapping for dynamic import support
-		// Convert map[string]int to map[string]uint16
-		exportGlobalIndices := p.compiler.GetExportGlobalIndices()
-		exportIndices := make(map[string]uint16, len(exportGlobalIndices))
-		for name, idx := range exportGlobalIndices {
-			exportIndices[name] = uint16(idx)
-		}
-		moduleRecord.ExportIndices = exportIndices
-		moduleRecord.ReExports = p.compiler.GetReExports()
-		debugPrintf("// [Driver] Collected %d exported values from module\n", len(exportedValues))
-	}
+	// After successful execution, collect exported values using this
+	// module's own recorded export indices (see collectExportedValuesForModule -
+	// paserati#165: p.compiler's *current* IsModuleMode()/export indices are
+	// not reliable here, since this call may be reentrant, e.g. reached via a
+	// require() partway through executing an unrelated entry script).
+	exportedValues := p.collectExportedValuesForModule(moduleRecord)
+	moduleRecord.ExportValues = exportedValues
+	debugPrintf("// [Driver] Collected %d exported values from module\n", len(exportedValues))
 
 	return finalValue, []errors.PaseratiError{}, runtimeErrs
 }
@@ -1213,7 +1224,7 @@ func (p *Paserati) runAsModule(sourceCode string, program *parser.Program, modul
 	// mid-execution (and got Undefined for anything not yet initialized) is corrected
 	// for any subsequent read, and so a later, separate call resolves correctly too.
 	if p.compiler.IsModuleMode() {
-		p.vmInstance.FinishExecutingModule(moduleName, p.collectExportedValues())
+		p.vmInstance.FinishExecutingModule(moduleName, p.collectExportedValues(moduleName))
 	}
 
 	return finalValue, runtimeErrs
@@ -1665,9 +1676,17 @@ func (p *Paserati) InitializeRealmBuiltins(realm *vm.Realm, initializers []built
 	return nil
 }
 
-// collectExportedValues collects the runtime values of exported variables from the VM
-// This is called after successful module execution to populate the ModuleRecord.ExportValues
-func (p *Paserati) collectExportedValues() map[string]vm.Value {
+// collectExportedValues collects the runtime values of exported variables from the VM.
+// This is called after successful module execution to populate the ModuleRecord.ExportValues.
+//
+// Unlike collectExportedValuesForModule, this trusts p.compiler's *current*
+// module-mode state and export indices directly - safe only at a call site
+// that just finished compiling and running this exact chunk on p.compiler
+// itself (runAsModule, the sole remaining caller), so nothing reentrant can
+// have touched it in between. fromResolvedPath is that module's own
+// resolved path, needed to resolve any re-exports of an imported binding
+// (see paserati#163) via VM.GetModuleExport.
+func (p *Paserati) collectExportedValues(fromResolvedPath string) map[string]vm.Value {
 	exports := make(map[string]vm.Value)
 
 	// Debug disabled
@@ -1690,6 +1709,68 @@ func (p *Paserati) collectExportedValues() map[string]vm.Value {
 		}
 	}
 	// Debug disabled
+
+	// Re-exports (export { x } from "./mod", or export { X } where X was
+	// itself an imported binding - see paserati#163) never occupy a local
+	// global slot, so exportIndices above can't see them.
+	for exportName, re := range p.compiler.GetReExports() {
+		if _, already := exports[exportName]; already {
+			continue
+		}
+		exports[exportName] = p.vmInstance.GetModuleExport(fromResolvedPath, re.SourceModule, re.SourceName)
+	}
+
+	return exports
+}
+
+// collectExportedValuesForModule collects the runtime values of a specific
+// module's exports directly from moduleRecord.ExportIndices, rather than
+// asking the shared p.compiler what its *current* module-mode state and
+// export indices happen to be.
+//
+// p.compiler is a single stateful instance whose module-mode flag and export
+// indices reflect whichever compile last ran on it. RunModule/RunModuleWithValue
+// don't always do that compile themselves - most of the time moduleRecord
+// already arrives pre-compiled by the module loader's own per-module compiler
+// (see modules/loader.go's applyCompilerExports, which is what actually
+// populated moduleRecord.ExportIndices/ReExports at compile time). A call
+// reached reentrantly - e.g. a require() handled partway through executing
+// the entry script - can find p.compiler's mode flag flipped back to
+// non-module by whatever compiled in between, silently skipping export
+// collection with no error. See paserati#165.
+func (p *Paserati) collectExportedValuesForModule(moduleRecord *modules.ModuleRecord) map[string]vm.Value {
+	// A native module's real exports are populated directly by
+	// handleNativeModuleSource at load time, not by compiling/running a
+	// chunk - it has no ExportIndices/ReExports of its own to derive
+	// anything from (RunModule/RunModuleWithValue still compile+run its
+	// placeholder empty AST for such a module, since nothing short-circuits
+	// that path). Recomputing from those empty maps would produce an empty
+	// result and silently wipe out the real exports already on the record.
+	if moduleRecord.IsNativeModule() {
+		return moduleRecord.GetExportValues()
+	}
+
+	exports := make(map[string]vm.Value)
+	for exportName, globalIdx := range moduleRecord.ExportIndices {
+		if value, exists := p.vmInstance.GetGlobalByIndex(int(globalIdx)); exists {
+			exports[exportName] = value
+		} else {
+			exports[exportName] = vm.Undefined
+		}
+	}
+
+	// Re-exports (export { x } from "./mod", or export { X } where X was
+	// itself an imported binding rather than a local declaration - see
+	// paserati#163) never occupy a local global slot, so ExportIndices above
+	// can't see them. They resolve through the VM's own module-context
+	// machinery instead - see VM.GetModuleExport.
+	for exportName, re := range moduleRecord.GetReExports() {
+		if _, already := exports[exportName]; already {
+			continue
+		}
+		exports[exportName] = p.vmInstance.GetModuleExport(moduleRecord.ResolvedPath, re.SourceModule, re.SourceName)
+	}
+
 	return exports
 }
 

--- a/pkg/driver/issue_162_test.go
+++ b/pkg/driver/issue_162_test.go
@@ -1,0 +1,36 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestNativeFunctionVMValueParameterReceivesRealArgument covers paserati#162:
+// a Go native function declared through ModuleBuilder.Function with a
+// vm.Value-typed parameter used to always receive a zeroed vm.Value instead
+// of the real JS argument, because vmValueToReflectValue had no case for
+// reflect.TypeOf(vm.Value{}) itself and fell through to its default
+// reflect.Zero(targetType). This made it impossible to accept a raw JS
+// callback (or any other value) as a plain vm.Value parameter through the
+// declarative ModuleBuilder.Function path - cb.IsCallable() on the zeroed
+// value was silently false no matter what was actually passed.
+func TestNativeFunctionVMValueParameterReceivesRealArgument(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("probe162", func(m *ModuleBuilder) {
+		m.Function("check", func(cb vm.Value) bool {
+			return cb.IsCallable()
+		})
+	})
+
+	res, errs := p.RunString(`
+		import { check } from "probe162";
+		check(() => {});
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if res != vm.True {
+		t.Fatalf("expected the callback argument to reach the native function untouched (IsCallable() true), got %s", res.Inspect())
+	}
+}

--- a/pkg/driver/issue_163_165_test.go
+++ b/pkg/driver/issue_163_165_test.go
@@ -1,0 +1,129 @@
+package driver
+
+import (
+	"os"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+func writeIssueTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// TestRunModuleWithValueCollectsExportsWhenReentrant covers paserati#165:
+// RunModuleWithValue (and RunModule) used to gate export-value collection
+// on p.compiler.IsModuleMode() - the shared, stateful compiler instance's
+// *current* mode flag, which an unrelated compile in between (e.g. running
+// some other script on the same Paserati instance) can silently flip away
+// from what this specific module needs. The module still executed
+// correctly; only ExportValues came back empty, with no error anywhere.
+func TestRunModuleWithValueCollectsExportsWhenReentrant(t *testing.T) {
+	dir := t.TempDir()
+	writeIssueTestFile(t, dir+"/mod.mjs", `
+		export function greet() { return "hi"; }
+		export default { greet };
+	`)
+
+	p := NewPaseratiWithBaseDir(dir)
+
+	// Simulate reentrancy: compile+run something unrelated on the same
+	// shared p.compiler in between loading and running our target module,
+	// the way a require() reached partway through executing an entry
+	// script would.
+	if _, errs := p.RunString(`1 + 1`); len(errs) > 0 {
+		t.Fatalf("unexpected errors running unrelated script: %v", errs)
+	}
+
+	final, loadErrs, runErrs := p.RunModuleWithValue("./mod.mjs")
+	if len(loadErrs) > 0 || len(runErrs) > 0 {
+		t.Fatalf("unexpected errors: load=%v run=%v", loadErrs, runErrs)
+	}
+	if final.Type() == vm.TypeUndefined {
+		t.Fatalf("expected the module's own final expression value, got undefined")
+	}
+
+	rec, err := p.LoadModule("./mod.mjs", ".")
+	if err != nil {
+		t.Fatalf("LoadModule error: %v", err)
+	}
+	exportValues := rec.GetExportValues()
+	if len(exportValues) == 0 {
+		t.Fatalf("expected non-empty export values, got %v", exportValues)
+	}
+	if greet, ok := exportValues["greet"]; !ok || !greet.IsCallable() {
+		t.Fatalf("expected a callable 'greet' export, got %v (ok=%v)", exportValues["greet"], ok)
+	}
+	if _, ok := exportValues["default"]; !ok {
+		t.Fatalf("expected a 'default' export, got %v", exportValues)
+	}
+}
+
+// TestRunModuleWithValueBarrelReexportOfImport covers the specific gap
+// left after the first pass at paserati#165: a module whose export is
+// itself a re-export of an imported binding (the barrel/index.js pattern -
+// import { X } from "./base"; export { X };, see paserati#163) never
+// occupies a local global slot, so ModuleRecord.ExportIndices alone can't
+// see it. It only resolves through the VM's own module-context machinery
+// (VM.GetModuleExport).
+func TestRunModuleWithValueBarrelReexportOfImport(t *testing.T) {
+	dir := t.TempDir()
+	writeIssueTestFile(t, dir+"/base.mjs", `export default class Diff { kind() { return "diff"; } }`)
+	writeIssueTestFile(t, dir+"/index.mjs", `
+		import Diff from "./base.mjs";
+		export { Diff };
+	`)
+
+	p := NewPaseratiWithBaseDir(dir)
+
+	rec, err := p.LoadModule("./index.mjs", ".")
+	if err != nil {
+		t.Fatalf("LoadModule error: %v", err)
+	}
+
+	if _, loadErrs, runErrs := p.RunModuleWithValue("./index.mjs"); len(loadErrs) > 0 || len(runErrs) > 0 {
+		t.Fatalf("unexpected errors: load=%v run=%v", loadErrs, runErrs)
+	}
+
+	exportValues := rec.GetExportValues()
+	diffCtor, ok := exportValues["Diff"]
+	if !ok {
+		t.Fatalf("expected a 'Diff' export, got %v", exportValues)
+	}
+	if !diffCtor.IsCallable() {
+		t.Fatalf("expected 'Diff' export to be a callable constructor, got %v", diffCtor.Inspect())
+	}
+}
+
+// TestRunModuleWithValueNativeModuleExportsSurvive guards against a
+// regression introduced while fixing paserati#165: RunModule/RunModuleWithValue
+// still compile+run a native module's placeholder empty AST (it has no
+// ExportIndices/ReExports of its own to derive anything from), so blindly
+// recomputing ExportValues from those empty maps would silently wipe out
+// the real exports handleNativeModuleSource already populated at load time.
+func TestRunModuleWithValueNativeModuleExportsSurvive(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("probe165native", func(m *ModuleBuilder) {
+		m.Const("ANSWER", 42.0)
+	})
+
+	rec, err := p.LoadModule("probe165native", ".")
+	if err != nil {
+		t.Fatalf("LoadModule error: %v", err)
+	}
+	if len(rec.GetExportValues()) == 0 {
+		t.Fatalf("expected native module to already have exports right after loading")
+	}
+
+	if _, loadErrs, runErrs := p.RunModuleWithValue("probe165native"); len(loadErrs) > 0 || len(runErrs) > 0 {
+		t.Fatalf("unexpected errors: load=%v run=%v", loadErrs, runErrs)
+	}
+
+	exportValues := rec.GetExportValues()
+	if _, ok := exportValues["ANSWER"]; !ok {
+		t.Fatalf("expected native module's real exports to survive RunModuleWithValue, got %v", exportValues)
+	}
+}

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -720,6 +720,11 @@ func mapTypeToObjectType(t reflect.Type, valueType types.Type) types.Type {
 
 // vmValueToReflectValue converts a VM value to a reflect.Value for function calls
 func vmValueToReflectValue(vmVal vm.Value, targetType reflect.Type) reflect.Value {
+	// A Go parameter typed vm.Value itself wants the raw argument, untouched.
+	// Mirror reflectValueToVM's symmetric passthrough on the return side.
+	if targetType == reflect.TypeOf(vm.Value{}) {
+		return reflect.ValueOf(vmVal)
+	}
 	switch targetType.Kind() {
 	case reflect.String:
 		if vmVal.IsString() {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -3959,7 +3959,8 @@ func (p *Parser) isContextualKeywordAsIdent() bool {
 	switch p.curToken.Type {
 	case lexer.SET, lexer.GET, lexer.FROM, lexer.OF, lexer.AS,
 		lexer.ASYNC, lexer.STATIC, lexer.TYPE, lexer.READONLY,
-		lexer.OVERRIDE, lexer.ABSTRACT, lexer.UNDEFINED, lexer.IS:
+		lexer.OVERRIDE, lexer.ABSTRACT, lexer.UNDEFINED, lexer.IS,
+		lexer.SATISFIES:
 		return true
 	}
 	return false

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -268,6 +268,7 @@ func NewParser(l *lexer.Lexer) *Parser {
 	p.registerPrefix(lexer.ABSTRACT, p.parseIdentifier)  // ABSTRACT is a contextual keyword, can be used as identifier
 	p.registerPrefix(lexer.IS, p.parseIdentifier)        // IS is a contextual keyword (type predicates), can be used as identifier in JS
 	p.registerPrefix(lexer.SATISFIES, p.parseIdentifier) // SATISFIES is a TS operator, but also a valid binding name (e.g. semver)
+	p.registerPrefix(lexer.AS, p.parseIdentifier)        // AS is a TS operator (type assertions), but also a valid binding name
 	p.registerPrefix(lexer.FUNCTION, func() Expression { return p.parseFunctionLiteral(false) })
 	p.registerPrefix(lexer.ASYNC, p.parseAsyncExpression) // Added for async functions and async arrows
 	p.registerPrefix(lexer.CLASS, p.parseClassExpression)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -19940,6 +19940,34 @@ func (vm *VM) collectModuleExports(modulePath string, moduleCtx *ModuleContext) 
 	}
 }
 
+// GetModuleExport resolves a named export from a module by its module
+// specifier/path, executing it first if it hasn't run yet (idempotent -
+// safe to call on an already-executed module, mirroring how
+// collectModuleExports resolves a ModuleRecord's own re-exports above,
+// including its save/restore of currentModulePath around the same pair of
+// calls - a relative modulePath like "./base.ts" resolves against whatever
+// currentModulePath happens to be, via vm.moduleFromPath(), so this must
+// pin it to fromResolvedPath rather than leaving it at whatever the most
+// recent unrelated Interpret call left it as).
+//
+// This is the public entry point a driver needs to resolve a re-export
+// of an imported binding (export { X } where X came from an import, or
+// export { x } from "./mod") from outside module execution - such
+// re-exports live only in this VM's module-context machinery, never in a
+// ModuleRecord's own ExportValues/ExportIndices. fromResolvedPath is the
+// resolved path of the module that declared the re-export (i.e. the one
+// modulePath is relative to). See paserati#163, #165.
+func (vm *VM) GetModuleExport(fromResolvedPath, modulePath, exportName string) Value {
+	prevFrom := vm.currentModulePath
+	if fromResolvedPath != "" {
+		vm.currentModulePath = fromResolvedPath
+	}
+	defer func() { vm.currentModulePath = prevFrom }()
+
+	_, _ = vm.executeModule(modulePath)
+	return vm.getModuleExport(modulePath, exportName)
+}
+
 // getModuleExport retrieves an exported value from a module
 func (vm *VM) getModuleExport(modulePath string, exportName string) Value {
 	moduleCtx, exists := vm.moduleContexts[modulePath]

--- a/tests/scripts/contextual_keyword_as_identifier.ts
+++ b/tests/scripts/contextual_keyword_as_identifier.ts
@@ -1,0 +1,14 @@
+// expect: 4
+// paserati#164: `as` is a contextual keyword (type assertions), not a
+// fully reserved word - it must also parse as a plain identifier
+// reference, the way `satisfies`/`of`/`from`/`type` already do.
+const as = 1;
+function f(as: number): number {
+  return as;
+}
+let asserted = 2 as number;
+// The actual prefix-then-infix collision this fix creates: `as` parsed as
+// a plain identifier reference, immediately followed by the `as` type
+// assertion operator reusing the very same token.
+let collision = as as number;
+f(as) + asserted + collision;

--- a/tests/scripts/contextual_keyword_satisfies_parameter.ts
+++ b/tests/scripts/contextual_keyword_satisfies_parameter.ts
@@ -1,0 +1,17 @@
+// expect: 33
+// paserati#164 (follow-up): `satisfies` is a contextual keyword just like
+// `as`, but isContextualKeywordAsIdent - the check parseFunctionParameters/
+// parseParameterList use to accept a contextual keyword as a parameter
+// name - was missing it, so `satisfies` (unlike `as`) failed to parse as a
+// function or arrow parameter name specifically, in both declaration and
+// arrow-function form.
+function f(satisfies: number): number {
+  return satisfies;
+}
+const g = (satisfies: number) => satisfies;
+// Also cover satisfies as a non-first parameter, after a comma.
+function h(a: number, satisfies: number): number {
+  return a + satisfies;
+}
+const k = (a: number, satisfies: number) => a + satisfies;
+f(9) + g(7) + h(1, 9) + k(1, 6);

--- a/tests/scripts/reexport_of_aliased_import.ts
+++ b/tests/scripts/reexport_of_aliased_import.ts
@@ -1,0 +1,7 @@
+// expect: 99
+// paserati#163: re-exporting an aliased import (import { Foo as Bar };
+// export { Bar };) must resolve through the import's *source* name
+// ("Foo"), not the local alias ("Bar"), when looking it up in base.ts.
+import { Bar } from "./reexport_of_aliased_import_index.ts";
+
+Bar;

--- a/tests/scripts/reexport_of_aliased_import_base.ts
+++ b/tests/scripts/reexport_of_aliased_import_base.ts
@@ -1,0 +1,1 @@
+export const Foo = 99;

--- a/tests/scripts/reexport_of_aliased_import_index.ts
+++ b/tests/scripts/reexport_of_aliased_import_index.ts
@@ -1,0 +1,2 @@
+import { Foo as Bar } from "./reexport_of_aliased_import_base.ts";
+export { Bar };

--- a/tests/scripts/reexport_of_default_import.ts
+++ b/tests/scripts/reexport_of_default_import.ts
@@ -1,0 +1,7 @@
+// expect: diff
+// paserati#163: re-exporting a default import (barrel-file pattern),
+// consumed here through a namespace import.
+import * as NS from "./reexport_of_default_import_index.ts";
+
+const d = new NS.Diff();
+d.kind();

--- a/tests/scripts/reexport_of_default_import_base.ts
+++ b/tests/scripts/reexport_of_default_import_base.ts
@@ -1,0 +1,5 @@
+export default class Diff {
+  kind(): string {
+    return "diff";
+  }
+}

--- a/tests/scripts/reexport_of_default_import_index.ts
+++ b/tests/scripts/reexport_of_default_import_index.ts
@@ -1,0 +1,2 @@
+import Diff from "./reexport_of_default_import_base.ts";
+export { Diff };

--- a/tests/scripts/reexport_of_named_import.ts
+++ b/tests/scripts/reexport_of_named_import.ts
@@ -1,0 +1,6 @@
+// expect: 42
+// paserati#163: export { Foo } where Foo is an imported (not locally
+// declared) binding must resolve through the import's source module.
+import { Foo } from "./reexport_of_named_import_index.ts";
+
+Foo;

--- a/tests/scripts/reexport_of_named_import_base.ts
+++ b/tests/scripts/reexport_of_named_import_base.ts
@@ -1,0 +1,1 @@
+export const Foo = 42;

--- a/tests/scripts/reexport_of_named_import_index.ts
+++ b/tests/scripts/reexport_of_named_import_index.ts
@@ -1,0 +1,2 @@
+import { Foo } from "./reexport_of_named_import_base.ts";
+export { Foo };

--- a/tests/scripts/reexport_of_namespace_import.ts
+++ b/tests/scripts/reexport_of_namespace_import.ts
@@ -1,0 +1,8 @@
+// expect_compile_error: exported name 'NS' not found in current scope
+// paserati#163: re-exporting a *namespace* import (import * as NS; export
+// { NS };) has no established resolution path (there's no real "*" export
+// name to look up in the source module), so this must keep erroring
+// loudly rather than silently compiling to an undefined re-export.
+import { NS } from "./reexport_of_namespace_import_index.ts";
+
+NS;

--- a/tests/scripts/reexport_of_namespace_import_base.ts
+++ b/tests/scripts/reexport_of_namespace_import_base.ts
@@ -1,0 +1,1 @@
+export const Foo = 1;

--- a/tests/scripts/reexport_of_namespace_import_index.ts
+++ b/tests/scripts/reexport_of_namespace_import_index.ts
@@ -1,0 +1,2 @@
+import * as NS from "./reexport_of_namespace_import_base.ts";
+export { NS };


### PR DESCRIPTION
Fixes four independent bugs, each with a minimal repro and a regression test.

## paserati#162 — native function's `vm.Value` param always zeroed

`vmValueToReflectValue` had no case for `reflect.TypeOf(vm.Value{})` itself, so a Go native function declared through `ModuleBuilder.Function` with a parameter typed `vm.Value` always fell through to the default `reflect.Zero(targetType)` branch, silently discarding the real JS argument. For a callback parameter this was worse than a type error: `cb.IsCallable()` on the zeroed value was unconditionally `false`, nothing raised anywhere.

Fix mirrors `reflectValueToVM`'s existing passthrough on the return side: when the target type is `vm.Value` itself, pass the argument through untouched.

## paserati#164 — `as`/`satisfies` treated as fully reserved

`as` is a TypeScript contextual keyword, reserved only where it introduces a type assertion (`expr as Type`) — everywhere else it's an ordinary identifier. `satisfies`/`of`/`from`/`type`/etc. already get this treatment (registered as both infix operator and prefix identifier parser), but `as` was only ever registered as an infix operator, so referencing a variable/parameter/import named `as` as a *value* failed to parse.

Fix registers `AS` as a prefix parser too, mirroring `SATISFIES`. Verified against the actual glob-minified-bundle pattern from the issue (`n.replace(as,fe)`).

**Follow-up**: a narrower related gap was found and fixed in the same area — `satisfies` (unlike `as`) still failed to parse as a function or arrow *parameter name*, in both declaration and arrow-function form, because `isContextualKeywordAsIdent` (the check both parameter-list parsers use) had every other contextual keyword but was missing `SATISFIES`.

## paserati#163 — `export { X }` fails when X came from an import

`export { X }` failed to compile whenever `X` was a name introduced by an import declaration rather than a local `var`/`let`/`const`/`function`/`class` — `exported name 'X' not found in current scope` — because imported names are deliberately never defined in the compiler's symbol table (they resolve via `OpGetModuleExport` instead), so the existing scope lookup always missed them. This is the barrel/index-file re-export pattern (`import { X } from './a'; export { X };`, or the default-import equivalent) used constantly by real npm packages — this is literally how `diff@8.0.4`'s ESM entry point is structured.

Fix recognizes an unresolved export name that IS a known import binding and registers it as a re-export of that import's own source module/name, the same way `export { x } from "./mod"` already works. A namespace import (`import * as NS`) is deliberately excluded and still errors: its "source name" is the sentinel `"*"`, which nothing downstream can resolve as a real export, so accepting it would silently compile to an `undefined` re-export instead of erroring loudly.

## paserati#165 — `RunModuleWithValue` drops exports on reentrant calls

`RunModule`/`RunModuleWithValue` gated export-value collection on `p.compiler.IsModuleMode()` — the shared, stateful compiler instance's *current* mode flag — rather than on whether the specific module being run actually compiled in module mode. A reentrant call (e.g. a host's `require()` reached partway through executing an unrelated entry script) could find that flag flipped by whatever compiled in between, silently skipping export collection with no error anywhere.

Fix derives export indices from `moduleRecord` itself (populated at compile time by whichever compiler actually produced its chunk) instead of re-deriving compiler state at execution time. A native module's real exports (populated directly at load time, not by compiling/running a chunk) are passed through untouched rather than recomputed from empty indices — a regression this fix would otherwise have introduced, caught before shipping.

**These two interact**: a module's re-exported-import bindings (#163) never occupy a local global slot, so `ModuleRecord.ExportIndices` alone can't see them — they only resolve through the VM's own module-context machinery, which is what the new `VM.GetModuleExport` exposes publicly for driver-level export collection to call (pinning `currentModulePath` around it the same way the VM's own internal re-export resolution already does). That's why #163 and #165 land in one commit together, and why their driver.go plumbing is combined.

## Testing

- `go test ./...` — all packages pass
- `go test ./tests -run TestScripts` (smoke test) — green
- Test262: zero regressions on `language` and `built-ins` subpaths, diffed against `baseline.txt`
- New coverage: 4 Go tests in `pkg/driver` (native-arg passthrough, reentrancy, barrel re-export, native-module-exports-survive), 2 smoke tests for #164 (the prefix-then-infix `as as number` collision, and `satisfies` as a function/arrow parameter including a non-first-parameter case), 4 multi-file module smoke tests for #163 (named/default/aliased import re-export, plus the namespace-import negative case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

