### PR TITLE
Fix Object.assign enumerability and class-constructor error passthrough (#167, #168)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2783,7 +2783,11 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				// Set on target
 				if target.Type() == vm.TypeObject {
 					targetPlain := target.AsPlainObject()
-					targetPlain.SetOwnNonEnumerable(key, value)
+					// Object.assign copies as if by ordinary [[Set]] - the
+					// property must land enumerable on the target, not
+					// non-enumerable (paserati#168). SetOwnNonEnumerable
+					// exists for built-in method registration, not for this.
+					targetPlain.SetOwn(key, value)
 				} else if target.Type() == vm.TypeDictObject {
 					targetDict := target.AsDictObject()
 					targetDict.SetOwn(key, value)
@@ -2796,7 +2800,11 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				// Set on target
 				if target.Type() == vm.TypeObject {
 					targetPlain := target.AsPlainObject()
-					targetPlain.SetOwnNonEnumerable(key, value)
+					// Object.assign copies as if by ordinary [[Set]] - the
+					// property must land enumerable on the target, not
+					// non-enumerable (paserati#168). SetOwnNonEnumerable
+					// exists for built-in method registration, not for this.
+					targetPlain.SetOwn(key, value)
 				} else if target.Type() == vm.TypeDictObject {
 					targetDict := target.AsDictObject()
 					targetDict.SetOwn(key, value)
@@ -2811,7 +2819,11 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				// Set on target
 				if target.Type() == vm.TypeObject {
 					targetPlain := target.AsPlainObject()
-					targetPlain.SetOwnNonEnumerable(key, value)
+					// Object.assign copies as if by ordinary [[Set]] - the
+					// property must land enumerable on the target, not
+					// non-enumerable (paserati#168). SetOwnNonEnumerable
+					// exists for built-in method registration, not for this.
+					targetPlain.SetOwn(key, value)
 				} else if target.Type() == vm.TypeDictObject {
 					targetDict := target.AsDictObject()
 					targetDict.SetOwn(key, value)

--- a/pkg/driver/issue_167_test.go
+++ b/pkg/driver/issue_167_test.go
@@ -1,0 +1,73 @@
+package driver
+
+import (
+	"errors"
+	"testing"
+)
+
+type issue167Thing struct{ Value string }
+
+func newIssue167Thing(input string) (*issue167Thing, error) {
+	if input == "" {
+		return nil, errors.New("input required")
+	}
+	return &issue167Thing{Value: input}, nil
+}
+
+// TestClassConstructorErrorReturnThrows covers paserati#167:
+// ModuleBuilder.createClassConstructor only ever looked at results[0] from
+// a Go constructor call, silently discarding a second (error) return value.
+// A constructor with the idiomatic Go shape func(...) (*T, error) that
+// returned a non-nil error made `new X(...)` evaluate to undefined
+// instead of throwing - the same (value, error) handling goFunctionToVM
+// already had for plain functions was missing here.
+func TestClassConstructorErrorReturnThrows(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue167mod", func(m *ModuleBuilder) {
+		m.Class("Thing", &issue167Thing{}, newIssue167Thing)
+	})
+
+	res, errs := p.RunString(`
+		import { Thing } from "issue167mod";
+		let threw = false;
+		let message = "";
+		try {
+			new Thing("");
+		} catch (e) {
+			threw = true;
+			message = e.message;
+		}
+		JSON.stringify({ threw, message });
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := res.ToString()
+	want := `{"threw":true,"message":"input required"}`
+	if got != want {
+		t.Fatalf("expected constructor error to throw: got %s, want %s", got, want)
+	}
+}
+
+// TestClassConstructorErrorReturnSucceedsWithoutError guards against a
+// regression: the (value, error) success case - error is nil - must still
+// return a working instance, not treat every two-value constructor as an
+// error path.
+func TestClassConstructorErrorReturnSucceedsWithoutError(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue167mod2", func(m *ModuleBuilder) {
+		m.Class("Thing", &issue167Thing{}, newIssue167Thing)
+	})
+
+	res, errs := p.RunString(`
+		import { Thing } from "issue167mod2";
+		const t = new Thing("hello");
+		t.Value;
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if res.ToString() != "hello" {
+		t.Fatalf("expected instance field 'hello', got %s", res.ToString())
+	}
+}

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -353,6 +353,17 @@ func (m *ModuleBuilder) createClassConstructor(goStruct interface{}, constructor
 			return vm.Undefined, nil
 		}
 
+		// Handle the common (value, error) constructor shape (paserati#167):
+		// mirrors goFunctionToVM's own len(results) == 2 error check above -
+		// without this, a non-nil error here was silently discarded and
+		// `new X(...)` evaluated to undefined instead of throwing.
+		if len(results) == 2 && results[1].Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+			if !results[1].IsNil() {
+				errVal := results[1].Interface().(error)
+				return vm.Undefined, errVal
+			}
+		}
+
 		// Get the created Go instance
 		goInstance := results[0]
 		if !goInstance.IsValid() || goInstance.IsNil() {

--- a/tests/scripts/object_assign_enumerable.ts
+++ b/tests/scripts/object_assign_enumerable.ts
@@ -1,0 +1,34 @@
+// expect: true
+// paserati#168: Object.assign copied properties onto a PlainObject target as
+// non-enumerable (SetOwnNonEnumerable instead of SetOwn), making them
+// invisible to Object.keys/for-in/JSON.stringify/spread and to a second
+// Object.assign call reading the first result as its source.
+const merged = Object.assign({}, { a: 1 });
+
+const checks: boolean[] = [];
+checks.push(merged.a === 1);
+checks.push(JSON.stringify(Object.keys(merged)) === '["a"]');
+checks.push(JSON.stringify(merged) === '{"a":1}');
+checks.push(JSON.stringify({ ...merged }) === '{"a":1}');
+
+let seenInForIn = false;
+for (const k in merged) {
+  if (k === "a") seenInForIn = true;
+}
+checks.push(seenInForIn);
+
+const desc = Object.getOwnPropertyDescriptor(merged, "a");
+checks.push(desc!.enumerable === true);
+
+// A property already on the target before the copy must stay enumerable too.
+const o = Object.assign({ b: 2 }, { a: 1 });
+checks.push(JSON.stringify(Object.keys(o)) === '["b","a"]');
+
+// A value copied by one Object.assign must survive being the *source* of a
+// second Object.assign (this is what compounds the bug in practice).
+const step1 = Object.assign({}, { fn: () => "hi" });
+const step2 = Object.assign({}, step1);
+checks.push(typeof step2.fn === "function");
+checks.push(JSON.stringify(Object.keys(step2)) === '["fn"]');
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Fixes two independent bugs, each with a minimal repro and a regression test.

## paserati#168 — `Object.assign` copies properties as non-enumerable onto a `PlainObject` target

`objectAssignWithVM`'s `PlainObject`-target branch called `SetOwnNonEnumerable` instead of `SetOwn` at all three copy sites (source is a plain object, source is a dict object, source is an array's indexed elements) — the `DictObject`-target branch immediately alongside each already used the correct `SetOwn`. `SetOwnNonEnumerable` exists for built-in method registration, not for `Object.assign`'s copy-as-if-by-`[[Set]]` semantics, so every property `Object.assign` copied onto a plain-object target became invisible to anything that filters by enumerability: `Object.keys`, `for...in`, `JSON.stringify`, object spread — and, since `Object.assign`'s own source enumeration filters the same way, **a second `Object.assign` reading the first result as its source**. That compounds silently: a value survives one `assign` (direct access still works) and vanishes on the next, with nothing erroring anywhere. This is exactly what broke `hosted-git-info`'s two-`Object.assign`-deep merge pattern in the reporter's noderati host.

The array source's separately-copied `"length"` property is deliberately left on `SetOwnNonEnumerable`, not changed to match: per spec, an array's `length` is itself non-enumerable, so that line was already correct behavior for a real `length` property (whether `Object.assign` should copy it at all is a separate, narrower question this issue didn't raise).

Verified `SetOwn` only updates the value on a property that already exists, so this doesn't flip an existing non-enumerable property to enumerable when `Object.assign`'s source happens to share that key — matching `[[Set]]` semantics, not `[[DefineOwnProperty]]`.

## paserati#167 — class constructor's `(value, error)` Go return is silently discarded

`ModuleBuilder.createClassConstructor`'s wrapper only ever looked at `results[0]` from the reflected constructor call — a Go constructor with the idiomatic `func(...) (*T, error)` shape that returned a non-nil error had that error silently discarded, since `results[0]` (the value) is `nil` in that case and the wrapper's existing `goInstance.IsNil()` check just falls through to returning `vm.Undefined`. So `new X(...)` in JS evaluated to `undefined` instead of throwing, for any constructor using this common Go error-return convention.

Fix mirrors `goFunctionToVM`'s existing `len(results) == 2` error check: if the constructor returns two values and the second implements `error` and is non-nil, return that error from the wrapper so it propagates as a JS throw — the same way `ModuleBuilder.Function`'s plain functions already handle this shape correctly.

## Testing

- `go test ./...` — all packages pass
- `go test ./tests -run TestScripts` (smoke test) — green
- Test262: zero regressions on `language` and `built-ins` subpaths, diffed against `baseline.txt` (checked specifically that `Object/assign`'s existing test262 failures are unaffected — none of test262's own `Object.assign` tests happen to assert the copied property's enumerability directly, which is why the diff shows no movement there; the manual repros from the issue and the new smoke test are the direct evidence for this fix)
- New coverage: 1 smoke test for #168 (enumerability across `Object.keys`/`for-in`/`JSON.stringify`/spread/a second `Object.assign`, plus the existing-property-preserved case), 2 Go tests in `pkg/driver` for #167 (error throws, and the success path still returns a working instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
