### PR TITLE
Fix: variadic function no longer requires a minimum argument count (#170)

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -265,17 +265,15 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			return false, nil // Don't switch frames - async execution happens via microtasks
 		}
 
-		// Arity checking
-		if calleeFunc.Variadic {
-			if argCount < calleeFunc.Arity {
-				currentFrame.ip = callerIP
-				return false, fmt.Errorf("Expected at least %d arguments but got %d", calleeFunc.Arity, argCount)
-			}
-		} else {
-			// Allow fewer arguments for functions with optional parameters
-			// The compiler handles padding with undefined for missing optional parameters
-			// Allow extra arguments (JavaScript behavior) - they are ignored or available via arguments object
-		}
+		// Arity checking: real JS never enforces a minimum argument count on an
+		// ordinary call, variadic or not - a parameter with no argument supplied
+		// is simply bound to undefined. The variadic branch used to throw here
+		// when called with fewer arguments than the non-rest parameter count
+		// (calleeFunc.Arity), treating it as a hard minimum; it isn't one, any
+		// more than it is for a non-variadic function's optional parameters.
+		// Missing named parameters are padded with undefined below regardless
+		// of variadic-ness, and the rest parameter itself already correctly
+		// ends up [] when there's nothing left to collect. See paserati#170.
 
 		// Check frame limit
 		if vm.frameCount >= len(vm.frames) {
@@ -410,7 +408,14 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			extraArgCount := argCount - calleeFunc.Arity
 			var restArray Value
 
-			if extraArgCount == 0 {
+			// extraArgCount is negative when called with fewer arguments than
+			// the non-rest parameter count (now legal - see the arity-checking
+			// comment above, paserati#170) - treat that the same as exactly
+			// zero extra arguments: an empty rest array, reusing the shared
+			// one rather than falling into the loop below with a negative
+			// bound (which happens to still produce an empty array, just via
+			// an unnecessary fresh allocation).
+			if extraArgCount <= 0 {
 				restArray = vm.emptyRestArray
 			} else {
 				restArray = NewArray()

--- a/tests/scripts/variadic_fewer_than_arity.ts
+++ b/tests/scripts/variadic_fewer_than_arity.ts
@@ -1,0 +1,33 @@
+// expect: true
+// paserati#170: a variadic function's non-rest parameters are not a hard
+// minimum argument count - real JS pads any missing one with undefined,
+// the same as any non-variadic function's optional parameters, and the
+// rest parameter itself ends up []. The VM used to throw "Expected at
+// least N arguments but got M" instead, for every variadic function
+// call site, unconditionally.
+//
+// Both calls below go through a value the checker can't statically
+// resolve (`getFoo(): any`), so they exercise the VM's own runtime arity
+// check directly - not the separate, intentionally out-of-scope
+// compile-time diagnostic (pkg/checker/call.go:704) that still fires for
+// a literal, statically-resolved call like `bar()` in a plain .ts file.
+class Foo {
+  browse(path, ...args) {
+    return [path, args];
+  }
+  browseTwo(a, b, ...rest) {
+    return [a, b, rest];
+  }
+}
+function getFoo(): any {
+  return new Foo();
+}
+
+const oneNamed = getFoo().browse();
+const twoNamed = getFoo().browseTwo(1);
+
+oneNamed[0] === undefined &&
+  oneNamed[1].length === 0 &&
+  twoNamed[0] === 1 &&
+  twoNamed[1] === undefined &&
+  twoNamed[2].length === 0;


### PR DESCRIPTION
Fixes [paserati#170](https://github.com/nooga/paserati/issues/170).

## What's broken

Real JS never enforces a minimum argument count on an ordinary function call — a parameter with no argument supplied for it is simply bound to `undefined`, always, regardless of how many parameters are declared or whether the trailing one is a rest parameter.

`prepareCall`'s arity check (`pkg/vm/call.go`) treated `calleeFunc.Arity` (the count of parameters before the rest parameter) as a hard minimum for variadic functions specifically, throwing `"Expected at least N arguments but got M"` — a genuine runtime throw, not a suppressable diagnostic, unconditionally at every call site regardless of `SkipTypeCheck`.

This surfaces independently of the separate, intentionally out-of-scope compile-time diagnostic in `pkg/checker/call.go:704` (same message, different code, static analysis only) — any call the checker can't statically resolve (a dynamically-typed receiver, a value returned as `any`, etc.) hits this VM-level throw directly with no way to opt out, even though `(firstArg, ...rest)` called with `firstArg` omitted is an extremely common, perfectly legal real-world shape (`hosted-git-info`'s `GitHost.prototype.browse` is exactly this).

## Fix

Deleted the throw. Missing named parameters are already padded with `undefined` regardless of variadic-ness (the non-variadic branch's own comment already describes this behavior), and the rest parameter itself already correctly ends up `[]` when there's nothing left to collect — confirmed by also making the adjacent `extraArgCount` computation treat "negative" (now reachable at this call site for the first time) the same as "exactly zero", matching how the other three call sites with this same rest-array computation already handle it.

## Testing

- Verified against all three repros in the issue (bare `bar()`, the dynamic-dispatch method call, and the two-named-parameter scaling case)
- `go test ./...` — all packages pass
- Test262: zero regressions on `language` and `built-ins` subpaths (also confirmed `"Expected at least"` doesn't appear anywhere in either the before or after full test262 output — this specific behavior genuinely isn't exercised by test262, not masked by unrelated failures)
- New coverage: [`tests/scripts/variadic_fewer_than_arity.ts`](tests/scripts/variadic_fewer_than_arity.ts) — uses a call site the checker can't statically resolve (`getFoo(): any`) so it exercises the VM-level check directly rather than the separate, still-intentionally-firing compile-time diagnostic; confirmed red→green against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
