### PR TITLE
Fix: new RegExp(...) supports lookahead/lookbehind via regexp2 fallback (#172)

### DIFF
--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -64,15 +64,38 @@ func NewRegExp(pattern, flags string) (Value, error) {
 		return Undefined, err
 	}
 
-	// Deliberately NO regexp2 fallback here. RE2 rejecting a pattern is how
-	// this path reports the SyntaxError that ECMAScript requires for the
-	// modifier and named-group early errors; routing those to regexp2, which
-	// accepts them, silently loses 27 test262 cases. Constructs RE2 cannot
-	// express (lookahead, backreferences) therefore still throw from the
-	// constructor while working in a literal — see the ticket.
 	compiledRegex, err := regexp.Compile(goPattern)
+	var compiledRegex2 *regexp2.Regexp
 	if err != nil {
-		return Undefined, err
+		// A regexp2 fallback here is deliberately narrow, not the unconditional
+		// one compileRegexEngines uses for regex literals (paserati#172).
+		// Measured against built-ins/RegExp at -timeout 2s (that suite is too
+		// flaky at the usual 0.2s to resolve a change this size - see
+		// 02454018's own note):
+		//   - unconditional fallback (whenever RE2 fails, regardless of why):
+		//     -27/+11. RE2 refusing a pattern is also how this path reports
+		//     the SyntaxError ECMAScript requires for a cluster of early
+		//     errors regexp2 doesn't itself enforce - contradictory/invalid
+		//     regexp-modifier arithmetic, invalid named-group identifiers,
+		//     and Annex B's restricted-escape/quantifiable-assertion rules
+		//     under the `u` flag.
+		//   - gated on the pattern containing one of the four lookaround
+		//     openers RE2 can't express at all: -1/+3. The one loss is
+		//     built-ins/RegExp/unicode_restricted_quantifiable_assertion.js:
+		//     a quantified lookaround under the `u` flag (`(?=.)*`) is itself
+		//     one of those Annex-B early errors, uses lookaround syntax, and
+		//     regexp2 (no notion of that restriction) happily accepts it.
+		// That one known, narrow regression is the cost of unblocking every
+		// other real use of lookaround - the thing this fallback exists for.
+		// (At -timeout 0.2s the net reads as -1/+0: the +3 property-escape
+		// gains, unrelated to lookaround, don't resolve inside that window.)
+		if needsRegexp2Fallback(pattern) {
+			opts := regexp2ECMAScriptOptions(flags)
+			compiledRegex2, err = regexp2.Compile(pattern, opts)
+		}
+		if compiledRegex2 == nil {
+			return Undefined, err
+		}
 	}
 
 	// Parse individual flags
@@ -83,28 +106,52 @@ func NewRegExp(pattern, flags string) (Value, error) {
 	sticky := strings.Contains(flags, "y")
 
 	regexObj := &RegExpObject{
-		Object:        Object{}, // Initialize base object
-		compiledRegex: compiledRegex,
-		source:        pattern,
-		flags:         flags,
-		global:        global,
-		ignoreCase:    ignoreCase,
-		multiline:     multiline,
-		dotAll:        dotAll,
-		sticky:        sticky,
-		lastIndex:     0,
+		Object:         Object{}, // Initialize base object
+		compiledRegex:  compiledRegex,
+		compiledRegex2: compiledRegex2,
+		source:         pattern,
+		flags:          flags,
+		global:         global,
+		ignoreCase:     ignoreCase,
+		multiline:      multiline,
+		dotAll:         dotAll,
+		sticky:         sticky,
+		lastIndex:      0,
 	}
 
 	return RegExpValue(regexObj), nil
 }
 
+// regexp2ECMAScriptOptions builds regexp2's option set for the given
+// JavaScript flags, shared by every call site that compiles with it.
+func regexp2ECMAScriptOptions(flags string) regexp2.RegexOptions {
+	opts := regexp2.RegexOptions(regexp2.ECMAScript)
+	if strings.Contains(flags, "i") {
+		opts |= regexp2.RegexOptions(regexp2.IgnoreCase)
+	}
+	if strings.Contains(flags, "m") {
+		opts |= regexp2.RegexOptions(regexp2.Multiline)
+	}
+	if strings.Contains(flags, "s") {
+		opts |= regexp2.RegexOptions(regexp2.Singleline) // In regexp2, Singleline makes . match \n
+	}
+	return opts
+}
+
+// needsRegexp2Fallback reports whether pattern uses a lookaround construct -
+// (?=, (?!, (?<= or (?<! - the only ECMAScript-valid syntax RE2 cannot
+// express at all. See the fallback's own comment in NewRegExp for why this
+// check exists and what it deliberately doesn't cover.
+func needsRegexp2Fallback(pattern string) bool {
+	return strings.Contains(pattern, "(?=") ||
+		strings.Contains(pattern, "(?!") ||
+		strings.Contains(pattern, "(?<=") ||
+		strings.Contains(pattern, "(?<!")
+}
+
 // compileRegexEngines compiles the regex pattern with both engines and returns a cached result.
 // This is called once per unique (pattern, flags) combination.
 func compileRegexEngines(pattern, flags string) *cachedCompiledRegex {
-	ignoreCase := strings.Contains(flags, "i")
-	multiline := strings.Contains(flags, "m")
-	dotAll := strings.Contains(flags, "s")
-
 	var compiledRegex *regexp.Regexp
 	var compiledRegex2 *regexp2.Regexp
 	var compileError string
@@ -115,21 +162,12 @@ func compileRegexEngines(pattern, flags string) *cachedCompiledRegex {
 		compiledRegex, _ = regexp.Compile(goPattern)
 	}
 
-	// If RE2 failed, try regexp2 (full ECMAScript support)
+	// If RE2 failed, try regexp2 (full ECMAScript support). Regex literals
+	// have always fallen back unconditionally here (unlike NewRegExp's own,
+	// deliberately narrower fallback for the RegExp constructor - see its
+	// comment) - this function's own behavior is unchanged by paserati#172.
 	if compiledRegex == nil {
-		// Build regexp2 options
-		opts := regexp2.RegexOptions(regexp2.ECMAScript)
-		if ignoreCase {
-			opts |= regexp2.RegexOptions(regexp2.IgnoreCase)
-		}
-		if multiline {
-			opts |= regexp2.RegexOptions(regexp2.Multiline)
-		}
-		if dotAll {
-			opts |= regexp2.RegexOptions(regexp2.Singleline) // In regexp2, Singleline makes . match \n
-		}
-
-		compiledRegex2, err = regexp2.Compile(pattern, opts)
+		compiledRegex2, err = regexp2.Compile(pattern, regexp2ECMAScriptOptions(flags))
 		if err != nil {
 			compileError = err.Error()
 		}

--- a/tests/scripts/regexp_constructor_lookaround.ts
+++ b/tests/scripts/regexp_constructor_lookaround.ts
@@ -1,0 +1,23 @@
+// expect: true
+// paserati#172: RegExp's constructor form (new RegExp("...")) used to
+// reject every lookaround construct - (?=, (?!, (?<=, (?<! - even though
+// the identical pattern written as a literal (/.../) already worked via
+// regexp2's fallback. Real JS never enforces this asymmetry: a dynamically
+// built pattern (the common case for pattern-matching libraries like
+// minimatch, which is what this blocked) must behave the same as a
+// literal with the same source.
+const negLookahead = new RegExp("a(?!b)");
+const posLookahead = new RegExp("a(?=b)");
+const posLookbehind = new RegExp("(?<=a)b");
+const negLookbehind = new RegExp("(?<!a)b");
+
+negLookahead.test("ac") &&
+  !negLookahead.test("ab") &&
+  posLookahead.test("ab") &&
+  !posLookahead.test("ac") &&
+  posLookbehind.test("ab") &&
+  !posLookbehind.test("cb") &&
+  negLookbehind.test("cb") &&
+  !negLookbehind.test("ab") &&
+  // Constructor and literal must agree for the same source.
+  new RegExp("a(?!b)").test("ac") === /a(?!b)/.test("ac");


### PR DESCRIPTION
Fixes [paserati#172](https://github.com/nooga/paserati/issues/172).

## What's broken

`new RegExp("a(?!b)")` threw Go's internal RE2 parse error instead of compiling, even though the identical pattern written as a literal (`/a(?!b)/`) already worked. `NewRegExpDeferred` (regex literals) has always fallen back from RE2 to `regexp2` — a full-ECMAScript, backtracking engine already a project dependency (`github.com/dlclark/regexp2`) — when RE2 can't express a construct, but `NewRegExp` (the `RegExp` constructor) had that fallback deliberately disabled entirely.

Any pattern built from a string at runtime rather than written as a literal — the normal shape for a pattern-matching library — hit this asymmetry:
- **`minimatch`** (glob's dependency) compiles a negative lookahead into essentially every pattern it translates, blocking `glob` wholesale.
- **`highlight.js`**'s bundled `latex` language definition hit the same wall in one of its 191 bundled languages.

## Why the fallback was disabled, and why a blanket fix doesn't work

RE2 refusing a pattern is also how the constructor path reports the `SyntaxError` ECMAScript requires for a cluster of early errors `regexp2` doesn't itself enforce — contradictory/invalid regexp-modifier arithmetic, invalid named-group identifiers, Annex B's restricted-escape/quantifiable-assertion rules under the `u` flag. I measured a blanket "always fall back to regexp2 when RE2 fails" version against `built-ins/RegExp` at `-timeout 2s` (that suite is too flaky at the usual 0.2s to resolve a change this size — same caveat as `02454018`'s own note): **-27/+11**. That confirms the exact "27 test262 cases" number in the code's own historical comment, empirically.

## Fix

None of those 27 early-error constructs use lookaround syntax. Gate the fallback on the pattern actually containing one of the four lookaround openers RE2 cannot express at all — `(?=`, `(?!`, `(?<=`, `(?<!` — rather than falling back unconditionally whenever RE2 fails. Measured at the same timeout: **-1/+3**.

The one loss, `built-ins/RegExp/unicode_restricted_quantifiable_assertion.js`, is a quantified lookaround under the `u` flag (`(?=.)*`) — itself one of the Annex-B early errors, but one that *does* use lookaround syntax, so the gate can't distinguish it; `regexp2` has no notion of that specific restriction and accepts it. That one known, narrow regression is the cost of unblocking every other real use of lookaround.

(At the default `-timeout 0.2s`, the net reads as `-1/+0` — the `+3` property-escape gains are unrelated to lookaround and don't resolve inside that shorter window.)

## Not fixed here — noted for visibility, not fixed in this PR

- `new RegExp("(?s-s:a)")` and `new RegExp("(?<x>a)(?<x>b)")` are silently **accepted** when they should throw a `SyntaxError` — RE2 itself accepts both (no fallback involved at all), so these are pre-existing early-error gaps, unrelated to lookaround or this fix.
- The constructor path also still can't express `\cA`-style control escapes or an empty `[]` class the way `regexp2` (or a literal) can — a separate, narrower constructor-path gap this fix doesn't touch, since neither uses lookaround syntax.

Happy to file these as their own issues if useful — flagging here since I found them while measuring this fix's blast radius, not because they're in scope.

## Testing

- Verified all four lookaround forms via the exact repro shape from the issue, plus the actual `minimatch`-style dynamic-pattern case (`new RegExp("^(?!\\.).*$")`)
- `go test ./...` — all packages pass
- Test262: `-27/+11` (blanket fallback, rejected) vs `-1/+3` (gated fallback, shipped) at `-timeout 2s` on `built-ins/RegExp`; `-1/+0` at the default `-timeout 0.2s`; zero unexpected regressions beyond the one documented, accepted case
- New coverage: [`tests/scripts/regexp_constructor_lookaround.ts`](tests/scripts/regexp_constructor_lookaround.ts) — all four lookaround forms via the constructor, plus an assertion that the constructor and literal forms agree for the same source; confirmed red→green against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
