### PR TITLE
fix(builtins): Object.assign handles an array target

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2730,6 +2730,55 @@ func reflectOwnKeysImpl(args []vm.Value) (vm.Value, error) {
 	return out, nil
 }
 
+// setObjectAssignTargetProperty copies one property onto Object.assign's
+// target, dispatching on the target's concrete type. The three call sites in
+// objectAssignWithVM's copy loop below used to each inline this same
+// two-branch (TypeObject/TypeDictObject) dispatch directly; a TypeArray
+// target matched neither, so Object.assign(arr, ...) silently did nothing at
+// all when the target was an array (paserati#174) - a common pattern for
+// tagging metadata onto a results array without a wrapper object.
+//
+// A numeric-index key gets a real indexed element - extending the array if
+// needed, the same way arr[idx] = value already does (see the identical
+// dispatch in op_setprop.go's TypeArray branch) - and anything else becomes
+// a plain named property, exactly like the `.provisional` case that
+// motivated this fix.
+func setObjectAssignTargetProperty(target vm.Value, key string, value vm.Value) {
+	switch target.Type() {
+	case vm.TypeObject:
+		// Object.assign copies as if by ordinary [[Set]] - the property must
+		// land enumerable on the target, not non-enumerable (paserati#168).
+		// SetOwnNonEnumerable exists for built-in method registration, not
+		// for this.
+		target.AsPlainObject().SetOwn(key, value)
+	case vm.TypeDictObject:
+		target.AsDictObject().SetOwn(key, value)
+	case vm.TypeArray:
+		arr := target.AsArray()
+		if idx, isIndex := vm.ParseArrayIndex(key); isIndex {
+			// ArrayObject.Set is O(idx): it fills every slot up to idx with
+			// Hole before writing. ParseArrayIndex accepts anything up to
+			// 2^32-2, so an object source key like "4294967294" would try
+			// to allocate/loop over four billion slots and hang - the same
+			// hazard maxDenseArraySetIndex already guards against for
+			// arrayLikeSet (array_generic.go) and maxDenseArrayDefineIndex
+			// guards for ArrayDefineOwnProperty (package vm). Past the
+			// bound, track it as a named/sparse property instead, same
+			// tradeoff those two call sites make.
+			if idx <= maxDenseArraySetIndex {
+				arr.Set(idx, value)
+			} else {
+				arr.DefineOwnProperty(key, value, true, true, true)
+				if idx+1 > arr.Length() {
+					arr.SetLength(idx + 1)
+				}
+			}
+		} else {
+			arr.SetOwn(key, value)
+		}
+	}
+}
+
 func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
@@ -2780,35 +2829,13 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			plainObj := source.AsPlainObject()
 			for _, key := range plainObj.OwnKeys() {
 				value, _ := plainObj.GetOwn(key)
-				// Set on target
-				if target.Type() == vm.TypeObject {
-					targetPlain := target.AsPlainObject()
-					// Object.assign copies as if by ordinary [[Set]] - the
-					// property must land enumerable on the target, not
-					// non-enumerable (paserati#168). SetOwnNonEnumerable
-					// exists for built-in method registration, not for this.
-					targetPlain.SetOwn(key, value)
-				} else if target.Type() == vm.TypeDictObject {
-					targetDict := target.AsDictObject()
-					targetDict.SetOwn(key, value)
-				}
+				setObjectAssignTargetProperty(target, key, value)
 			}
 		} else if source.Type() == vm.TypeDictObject {
 			dictObj := source.AsDictObject()
 			for _, key := range dictObj.OwnKeys() {
 				value, _ := dictObj.GetOwn(key)
-				// Set on target
-				if target.Type() == vm.TypeObject {
-					targetPlain := target.AsPlainObject()
-					// Object.assign copies as if by ordinary [[Set]] - the
-					// property must land enumerable on the target, not
-					// non-enumerable (paserati#168). SetOwnNonEnumerable
-					// exists for built-in method registration, not for this.
-					targetPlain.SetOwn(key, value)
-				} else if target.Type() == vm.TypeDictObject {
-					targetDict := target.AsDictObject()
-					targetDict.SetOwn(key, value)
-				}
+				setObjectAssignTargetProperty(target, key, value)
 			}
 		} else if source.Type() == vm.TypeArray {
 			arrObj := source.AsArray()
@@ -2816,20 +2843,17 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			for i := 0; i < arrObj.Length(); i++ {
 				key := strconv.Itoa(i)
 				value := arrObj.Get(i)
-				// Set on target
-				if target.Type() == vm.TypeObject {
-					targetPlain := target.AsPlainObject()
-					// Object.assign copies as if by ordinary [[Set]] - the
-					// property must land enumerable on the target, not
-					// non-enumerable (paserati#168). SetOwnNonEnumerable
-					// exists for built-in method registration, not for this.
-					targetPlain.SetOwn(key, value)
-				} else if target.Type() == vm.TypeDictObject {
-					targetDict := target.AsDictObject()
-					targetDict.SetOwn(key, value)
-				}
+				setObjectAssignTargetProperty(target, key, value)
 			}
-			// Also copy length property
+			// Also copy length property. Deliberately no vm.TypeArray case
+			// here (unlike setObjectAssignTargetProperty above, which now
+			// handles all three target types uniformly): an array's own
+			// "length" isn't enumerable, so real Object.assign wouldn't
+			// copy it at all - copying it here for object/dict targets is
+			// itself a pre-existing spec deviation (see paserati#168), and
+			// extending it to array targets would overwrite (truncate or
+			// grow) the target's own length instead of adding a property,
+			// which is worse than the existing deviation, not a fix for it.
 			if target.Type() == vm.TypeObject {
 				targetPlain := target.AsPlainObject()
 				targetPlain.SetOwnNonEnumerable("length", vm.NumberValue(float64(arrObj.Length())))

--- a/tests/scripts/object_assign_array_target.ts
+++ b/tests/scripts/object_assign_array_target.ts
@@ -1,0 +1,44 @@
+// expect: true
+// paserati#174: objectAssignWithVM's copy loop had no branch at all for a
+// vm.TypeArray target - only TypeObject/TypeDictObject - so Object.assign
+// silently did nothing when the target was an array, as if the call had
+// been a no-op. Distinct from paserati#168 (a wrong enumerable flag on
+// object targets, already fixed); this is array targets never being
+// handled in the first place.
+const checks: boolean[] = [];
+
+// The exact repro shape: tagging metadata onto a results array.
+const arr = Object.assign([], { provisional: 0 });
+checks.push(arr.provisional === 0);
+arr.provisional++;
+checks.push(arr.provisional === 1);
+
+// Existing elements must survive, and a non-numeric key becomes a plain
+// named property alongside them.
+const arr2 = Object.assign([1, 2, 3], { extra: "hi" });
+checks.push(JSON.stringify(arr2) === "[1,2,3]");
+checks.push(arr2.extra === "hi");
+
+// A numeric-string key becomes a real indexed element (extending the
+// array, with holes for anything skipped), matching arr[idx] = value -
+// not a named property literally called "0".
+const arr3 = Object.assign([], { 0: "x", 3: "y" });
+checks.push(arr3.length === 4);
+checks.push(JSON.stringify(arr3) === '["x",null,null,"y"]');
+
+// A huge numeric-index key (just under the 2^32-1 array length cap) must
+// be stored as a sparse property, not by growing a dense elements slice -
+// ArrayObject.Set is O(idx), so doing that naively hangs/OOMs on an index
+// this large. Must resolve instantly, matching arr[idx] = value's own
+// sparse-index guard (op_setprop.go / array_props.go). This asserts via
+// length + hasOwnProperty rather than arr4[4294967294] itself: reading a
+// defineProperty-stored sparse index below .length is a separate,
+// pre-existing gap in the array bracket-read fast path (both op_getprop.go
+// and OpGetIndex only ever consult .elements for a numeric index, never
+// falling back to the named-property store), not something this fix
+// touches or needs to fix.
+const arr4 = Object.assign([], { 4294967294: "x" });
+checks.push(arr4.length === 4294967295);
+checks.push(arr4.hasOwnProperty("4294967294"));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Fixes [paserati#174](https://github.com/nooga/paserati/issues/174).

## What's broken

`objectAssignWithVM`'s copy loop dispatches on the target's type inline at three separate call sites (one per source type), each only handling `vm.TypeObject` and `vm.TypeDictObject`. None handled `vm.TypeArray`, so when the target was an array none of the `if`/`else if` branches matched — the copy silently did nothing, with no error, as if the call had been a no-op.

This blocked `glob`: `PathBase.children()` does `Object.assign([], { provisional: 0 })` to tag metadata onto a results array without a wrapper object — a common pattern. Distinct from #168 (a wrong enumerable flag on object *targets*, already fixed) — this is array targets never being handled at all.

## Fix

Extract the three call sites' shared two-branch dispatch into a new `setObjectAssignTargetProperty` helper and add the missing `TypeArray` case:
- A numeric-index key becomes a real indexed element via `ArrayObject.Set`, extending the array as needed — matching `arr[idx] = value`'s own dispatch in `op_setprop.go`'s `TypeArray` branch.
- Anything else becomes a plain named property via `SetOwn`, matching the `.provisional` case above.

**Large-index guard**: `ArrayObject.Set` is O(idx) — it fills every slot up to `idx` with a `Hole` before writing — so a source key like `"4294967294"` (valid per `ParseArrayIndex`, which accepts indices up to 2^32-2) would hang/OOM trying to grow a dense slice that far. I initially missed this; caught by advisor review before commit, confirmed with a real 5s+ hang on `Object.assign([], {4294967294: "x"})`. Guarded it with the same `maxDenseArraySetIndex` bound (2^24) `arrayLikeSet` already uses for the identical hazard in `push`/`splice`/etc. on huge array-likes (`array_generic.go`); past the bound, the index is stored as a sparse named property via `DefineOwnProperty` instead — same tradeoff `arrayLikeSet` and `ArrayDefineOwnProperty` already make.

Also added a comment (no behavior change) to the separate "copy length property" block: it deliberately has no `TypeArray` case, since an array's own `length` isn't enumerable and copying it at all is a pre-existing spec deviation (see #168) — extending it to array targets would overwrite the target's own length instead of adding a property, which is worse, not a fix.

## Found but not fixed here

While verifying the large-index case, I found reading a `DefineOwnProperty`-stored sparse index back via `arr[idx]` or `arr["idx"]` (when `idx < arr.length` but the index isn't in the dense `elements` slice) returns `undefined` instead of the stored value — both `op_getprop.go` and `OpGetIndex` short-circuit to `Undefined` once `idx < arr.Length()` without ever falling back to the named-property store. This is a separate, pre-existing gap (also latent in `arrayLikeSet`'s existing sparse-write path, not introduced by this PR) — flagged as its own follow-up rather than fixed here, since fixing the general array bracket-read path is a bigger, riskier change than this PR's scope. `hasOwnProperty`/`getOwnPropertyDescriptor` correctly see the property either way, so this PR's own regression test verifies via `hasOwnProperty` rather than a bracket read.

## Testing

- `go test ./...` — all packages pass
- Manual repro of the huge-index case: previously hung for 5s+ (timed out), now resolves instantly matching Node's sparse-array behavior
- Test262: diff against `baseline.txt` on `language/` and `built-ins/` at `-timeout 0.2s` — net change **+0** on both, zero regressions
- New coverage: [`tests/scripts/object_assign_array_target.ts`](tests/scripts/object_assign_array_target.ts) — the exact repro shape, existing elements surviving a merge, numeric-string keys becoming real indexed elements with holes, and the huge-index case resolving instantly; confirmed red→green against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
