### PR TITLE
fix(vm): array bracket-read consults the named-property store for sparse indices

### DIFF
--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -576,7 +576,26 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 					idx = idx*10 + int(c-'0')
 				}
 				if idx < arr.Length() {
-					*dest = arr.Get(idx)
+					if idx < len(arr.elements) && arr.elements[idx].typ != TypeHole {
+						*dest = arr.elements[idx]
+						return true, InterpretOK, *dest
+					}
+					// idx is within .length but not backed by a dense
+					// element - either a genuine sparse hole, or (see
+					// paserati#176) an index that DefineOwnProperty stored
+					// as a named property instead of growing .elements
+					// (ArrayObject.Set is O(idx); see
+					// maxDenseArrayDefineIndex/maxDenseArraySetIndex).
+					// Consult the named-property store before defaulting
+					// to Undefined - falling through to the same
+					// arr.GetOwn(propName) check just below would also
+					// work, but returning here keeps this branch
+					// self-contained and mirrors OpGetIndex's identical fix.
+					if v, ok := arr.GetOwn(propName); ok {
+						*dest = v
+						return true, InterpretOK, *dest
+					}
+					*dest = Undefined
 					return true, InterpretOK, *dest
 				}
 			}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2288,6 +2288,33 @@ func (a *ArrayObject) SetLength(newLength int) {
 	}
 	// Don't expand elements slice - JavaScript arrays are sparse
 	// Elements beyond len(a.elements) will return undefined when accessed
+
+	// ArraySetLength (ECMA-262 10.4.2.4) step 3.l: truncating length also
+	// deletes every own property whose key is an array index >= the new
+	// length - not just the dense elements just truncated above, but also
+	// any index stored in .properties instead (an index beyond
+	// maxDenseArraySetIndex/maxDenseArrayDefineIndex - see paserati#176,
+	// whose read-path fix is what exposed this: previously such an index
+	// always read back as undefined anyway, masking this never having run).
+	// The spec's refinement - a non-configurable such property instead
+	// clamps newLength rather than being deleted - isn't implemented here,
+	// matching this codebase's existing posture of not enforcing per-index
+	// non-configurability elsewhere (see ArrayDefineOwnProperty's comment).
+	//
+	// Only scan .properties when length actually *shrinks*: growing can
+	// never delete anything, and SetLength runs on every `arr.length = n`
+	// (plus push/pop's own length maintenance) - RegExp match results in
+	// particular always have .properties (index/input/groups via SetOwn),
+	// so an unconditional scan would tax that hot, unrelated path for
+	// every length write instead of only real truncations.
+	if newLength < a.length && a.properties != nil {
+		for key := range a.properties {
+			if idx, ok := tryParseArrayIndex(key); ok && idx >= newLength {
+				a.DeleteOwn(key)
+			}
+		}
+	}
+
 	a.length = newLength
 }
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -7359,7 +7359,17 @@ startExecution:
 					}
 
 					if idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
-						registers[destReg] = Undefined // Out of bounds or hole -> undefined
+						// Not in the dense elements slice - fall back to the
+						// named-property store before defaulting to
+						// Undefined: an index beyond maxDenseArraySetIndex/
+						// maxDenseArrayDefineIndex is stored there instead
+						// of growing .elements (ArrayObject.Set is O(idx)) -
+						// see paserati#176.
+						if v, ok := arr.GetOwn(strconv.Itoa(idx)); ok {
+							registers[destReg] = v
+						} else {
+							registers[destReg] = Undefined // Out of bounds or hole -> undefined
+						}
 					} else {
 						registers[destReg] = arr.elements[idx]
 					}
@@ -7383,7 +7393,16 @@ startExecution:
 							}
 							// Convert string index to numeric and access array element
 							if idx < 0 || idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
-								registers[destReg] = Undefined
+								// See paserati#176: fall back to the
+								// named-property store (idx < 0 can't be
+								// stored there, but parseArrayIndex never
+								// returns a negative idx, so this is just
+								// the shared bounds check).
+								if v, ok := arr.GetOwn(key); ok {
+									registers[destReg] = v
+								} else {
+									registers[destReg] = Undefined
+								}
 							} else {
 								registers[destReg] = arr.elements[idx]
 							}
@@ -7980,7 +7999,17 @@ startExecution:
 						if IsNumber(indexVal) {
 							idx := int(AsNumber(indexVal))
 							if idx < 0 || idx >= len(arr.elements) || arr.elements[idx].typ == TypeHole {
-								registers[destReg] = Undefined
+								// See paserati#176: fall back to the
+								// named-property store before Undefined.
+								if idx >= 0 {
+									if v, ok := arr.GetOwn(strconv.Itoa(idx)); ok {
+										registers[destReg] = v
+									} else {
+										registers[destReg] = Undefined
+									}
+								} else {
+									registers[destReg] = Undefined
+								}
 							} else {
 								registers[destReg] = arr.elements[idx]
 							}

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -417,7 +417,17 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			}
 			// Check for numeric index access (e.g., "0", "1", "2")
 			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 && idx < arr.Length() {
-				return arr.Get(idx), nil
+				if idx < len(arr.elements) && arr.elements[idx].typ != TypeHole {
+					return arr.elements[idx], nil
+				}
+				// idx is within .length but not backed by a dense element -
+				// see paserati#176: fall back to the named-property store
+				// (where an index beyond maxDenseArraySetIndex/
+				// maxDenseArrayDefineIndex lives) before Undefined.
+				if v, ok := arr.GetOwn(propName); ok {
+					return v, nil
+				}
+				return Undefined, nil
 			}
 			// Check own named properties on the array
 			if v, ok := arr.GetOwn(propName); ok {

--- a/tests/scripts/array_sparse_index_read.ts
+++ b/tests/scripts/array_sparse_index_read.ts
@@ -1,0 +1,54 @@
+// expect: true
+// paserati#176: when a numeric array index is stored as a named property
+// via ArrayObject.DefineOwnProperty rather than in the dense .elements
+// slice - because the index is too large to grow .elements into (see
+// maxDenseArraySetIndex/maxDenseArrayDefineIndex, 2^24) - reading it back
+// via arr[idx] or arr["idx"] used to always return undefined: the
+// bracket-read fast paths (op_getprop.go, OpGetIndex, and the Proxy
+// array-target fallback in vm.go, plus vm.GetProperty in vm_init.go) all
+// short-circuited to Undefined whenever the index fell inside .length but
+// outside .elements, without ever consulting the named-property store the
+// value actually lives in. hasOwnProperty/getOwnPropertyDescriptor always
+// saw the property correctly - only the bracket read was broken.
+const checks: boolean[] = [];
+
+const a: any[] = [];
+Object.defineProperty(a, "4294967294", {
+  value: "z",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+checks.push(a.length === 4294967295);
+checks.push(a[4294967294] === "z"); // numeric-literal index read
+checks.push(a["4294967294"] === "z"); // string-key index read
+checks.push((a as any).hasOwnProperty("4294967294"));
+
+// A genuine sparse hole (no property ever defined at that index) must
+// still read back as undefined - this fix must not turn every gap into a
+// property-store probe that finds something that isn't there.
+const b: any[] = [];
+b[5] = "only-element";
+checks.push(b[2] === undefined);
+checks.push(b.length === 6);
+
+// Companion fix: ArraySetLength (10.4.2.4 step 3.l) must also delete an
+// array-index property stored in .properties once it truncates below the
+// new length, not just dense .elements - this was dead code before the
+// read-path fix above (such an index always read back as undefined
+// anyway, so nothing could tell the property had survived the
+// truncation). Regressed test262's built-ins/Array/length/S15.4.5.2_A3_T4
+// until fixed alongside the read path.
+const d: any[] = [0, 1, 2];
+Object.defineProperty(d, "4294967294", {
+  value: "gone",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+d.length = 2;
+checks.push(d[0] === 0 && d[1] === 1);
+checks.push(d[4294967294] === undefined);
+checks.push(!(d as any).hasOwnProperty("4294967294"));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Fixes [paserati#176](https://github.com/nooga/paserati/issues/176).

## What's broken

When a numeric array index is too large to grow the dense `.elements` slice into (`ArrayObject.Set`/`ArrayDefineOwnProperty` are O(idx) - see `maxDenseArraySetIndex`/`maxDenseArrayDefineIndex`, 2^24), it's stored as a named property via `ArrayObject.DefineOwnProperty` instead. Every bracket-read fast path checked only `.elements` and defaulted straight to `Undefined` once the index fell outside it, never falling back to the named-property store even though the value was sitting right there — `hasOwnProperty`/`getOwnPropertyDescriptor` always saw it correctly, only `arr[idx]`/`arr["idx"]` didn't.

```ts
const a = [];
Object.defineProperty(a, "4294967294", { value: "z", writable: true, enumerable: true, configurable: true });
a[4294967294];      // undefined - should be "z"
a.hasOwnProperty("4294967294"); // true - the value IS there
```

Discovered while fixing #174 (`Object.assign` onto an array target, which needed the same sparse-index storage for its own large-index guard) but independent of it and reproducible on `main` today via `Object.defineProperty` directly, or `arrayLikeSet`'s existing sparse path (`push`/`splice`/etc. on huge array-likes).

## Fix

Four call sites had the identical gap - each now falls back to `arr.GetOwn(key)` before defaulting to `Undefined`, mirroring the named-property check each already does for non-numeric keys:
- `op_getprop.go`'s numeric-index-as-string-key branch
- `vm.go`'s `OpGetIndex`, both the numeric-literal and numeric-string-key branches
- `vm.go`'s Proxy array-target `[[Get]]` fallback (no get trap defined)
- `vm_init.go`'s `vm.GetProperty` (the generic Go-side property accessor)

## A second bug this unmasked

Fixing the read path alone regressed test262's `built-ins/Array/length/S15.4.5.2_A3_T4.js` (net **-1**). That test does `x[4294967294] = v; x.length = 2;` and expects `x[4294967294]` to then be `undefined` again. It turns out `ArrayObject.SetLength` only ever truncated the dense `.elements` slice — it never pruned array-index properties stored in `.properties`, per ECMA-262 10.4.2.4 `ArraySetLength` step 3.l ("every property whose name is an array index >= the new length is deleted"). This had been dead code the whole time: such an index always read back as `undefined` anyway (the bug this PR fixes), so nothing could ever observe whether truncation had actually pruned it.

Fixed alongside the read fix rather than shipped as a known regression. Guarded behind `newLength < a.length` so a length *growth* — the common `push`/`pop` case, including on RegExp match-result arrays which always carry named `.properties` for `index`/`input`/`groups` — never pays the property-map scan; only a genuine truncation does. (Caught in advisor review before this became a hot-path regression - the first pass scanned unconditionally.)

The spec's further refinement — a *non-configurable* such property instead clamps `newLength` rather than being deleted — isn't implemented; matches this codebase's existing posture of not enforcing per-index non-configurability elsewhere (see `ArrayDefineOwnProperty`'s own comment).

## Found but not fixed here

While probing the non-configurable-property edge case above, found that `Object.defineProperty` on an array-index property silently ignores explicit `writable`/`enumerable`/`configurable` flags entirely (always stores `{writable:true,enumerable:true,configurable:true}`), unlike the same call on a plain object, which honors them correctly. A separate, pre-existing bug, unrelated to the read-path/`SetLength` fixes here - flagged as its own follow-up rather than fixed in this PR.

## Testing

- `go test ./...` — all packages pass
- Both fixes (the read-path fallback and the `SetLength` pruning) independently confirmed red→green by reverting each in isolation
- Test262 diff against `baseline.txt` on `language/` and `built-ins/` at `-timeout 0.2s` (run sequentially, not in parallel — a full concurrent sweep OOMs): **+0** on `language`, **+13/-0** on `built-ins`
- New coverage: [`tests/scripts/array_sparse_index_read.ts`](tests/scripts/array_sparse_index_read.ts) — the sparse-index read (numeric-literal and string-key), a genuine sparse hole still reading as `undefined` (guards against the fix turning every gap into a false positive), and the `length`-truncation pruning case; confirmed red→green against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
