### PR TITLE
fix(builtins): Object.defineProperty honors attributes on array indices

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -4113,12 +4113,36 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			return vm.NewValueFromPlainObject(descriptor), nil
 		} else if index, err := strconv.Atoi(propName); err == nil && index >= 0 && index < arrObj.Length() {
 			value = arrObj.Get(index)
+			// arrObj.Get only looks at the dense .elements slice; an index
+			// beyond maxDenseArrayDefineIndex/maxDenseArraySetIndex is
+			// tracked as a named property instead (see ArrayDefineOwnProperty),
+			// so fall back the same way the bracket-read opcodes already do
+			// (paserati#176) rather than reporting an empty value for it here.
+			if !arrObj.HasIndex(index) {
+				if v, ok := arrObj.GetOwn(propName); ok {
+					value = v
+				}
+			}
+			// The ES default (writable/configurable true unless frozen,
+			// enumerable always true) unless an earlier Object.defineProperty
+			// call on this same index tracked a different combination in
+			// propertyDesc instead (paserati#178) - the write side
+			// (ArrayDefineOwnProperty) is the only thing that ever puts an
+			// entry there for a plain (non-accessor) index. Object.freeze
+			// only ever flips the array-wide `frozen` flag (SetFrozen), never
+			// touching propertyDesc, so a tracked writable/configurable:true
+			// from before the freeze must still be ANDed with !isFrozen here -
+			// freeze can only take capabilities away, never hand back one an
+			// explicit defineProperty granted.
+			writable, enumerable, configurable := !isFrozen, true, !isFrozen
+			if desc, ok := arrObj.GetIndexAttributesOverride(propName); ok {
+				writable, enumerable, configurable = desc.Writable && !isFrozen, desc.Enumerable, desc.Configurable && !isFrozen
+			}
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 			descriptor.SetOwn("value", value)
-			// When frozen, elements are not writable and not configurable
-			descriptor.SetOwn("writable", vm.BooleanValue(!isFrozen))
-			descriptor.SetOwn("enumerable", vm.BooleanValue(true))
-			descriptor.SetOwn("configurable", vm.BooleanValue(!isFrozen))
+			descriptor.SetOwn("writable", vm.BooleanValue(writable))
+			descriptor.SetOwn("enumerable", vm.BooleanValue(enumerable))
+			descriptor.SetOwn("configurable", vm.BooleanValue(configurable))
 			return vm.NewValueFromPlainObject(descriptor), nil
 		}
 		// Check custom properties on the array (e.g., "raw" for template objects, "index"/"input" for regex matches)

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -63,16 +63,21 @@ func (vm *VM) ArrayPrototypeSetterFor(receiver Value, idx int, val Value) (bool,
 // covering both a numeric index (an element of the array) and an arbitrary
 // named property.
 //
-// Array elements have no per-index attribute storage: the elements slice
-// holds only values (or Hole for a sparse gap), not a writable/enumerable/
-// configurable triple per slot. So a plain data element's "current"
-// descriptor is always reported as the ES default (value, true, true,
-// true) - this codebase's existing posture of not enforcing per-element
-// non-writable/non-configurable (see e.g. Object.freeze's array handling,
-// which sets a single array-wide `frozen` flag rather than per-index
-// descriptors). An index that has been explicitly turned into an accessor
-// *is* tracked precisely, through the same getters/setters/propertyDesc
-// maps a named property uses (see ArrayObject.DefineAccessorProperty).
+// The elements slice itself holds only values (or Hole for a sparse gap),
+// not a writable/enumerable/configurable triple per slot - so a plain data
+// element's descriptor defaults to the ES default (value, true, true, true)
+// when nothing has ever said otherwise. An explicit Object.defineProperty
+// call that requests a non-default combination for an in-range index is
+// tracked in propertyDesc instead (keyed by the index's string form, same
+// map a named property or an accessor index already uses - see
+// ArrayObject.DefineAccessorProperty) - GetOwnPropertyDescriptor,
+// DeleteIndex, and this function's own re-entry all check it first before
+// falling back to the default (paserati#178; a plain `arr[i] = v` never
+// goes through this function and so never creates an entry, keeping the
+// common case free of any per-element bookkeeping). This codebase still
+// doesn't enforce non-writable/non-configurable at the *whole-array*
+// level any more precisely than a single `frozen` flag (Object.freeze),
+// independent of this per-index tracking.
 //
 // Mirrors ArgumentsDefineOwnProperty's structure (arguments_props.go) for a
 // different exotic object with the same shape of problem: numeric indices
@@ -100,7 +105,17 @@ func (vm *VM) ArrayDefineOwnProperty(
 	if _, _, e, c, ok := a.GetOwnAccessor(key); ok {
 		exists, isAccessor, curEnumerable, curConfigurable = true, true, e, c
 	} else if isIndex && idx < len(a.elements) && a.elements[idx].typ != TypeHole {
+		// The ES default for a plain element (paserati#178: a prior
+		// ArrayDefineOwnProperty call on this same index may have tracked a
+		// non-default combination in propertyDesc instead - see the write
+		// side below - and DeleteIndex already checks propertyDesc first
+		// for exactly this reason).
 		exists, curWritable, curEnumerable, curConfigurable = true, true, true, true
+		if a.propertyDesc != nil {
+			if desc, ok := a.propertyDesc[key]; ok {
+				curWritable, curEnumerable, curConfigurable = desc.Writable, desc.Enumerable, desc.Configurable
+			}
+		}
 	} else if _, desc, ok := a.GetOwnPropertyDescriptor(key); ok {
 		exists, curWritable, curEnumerable, curConfigurable = true, desc.Writable, desc.Enumerable, desc.Configurable
 	}
@@ -193,26 +208,35 @@ func (vm *VM) ArrayDefineOwnProperty(
 		}
 		if idx <= maxDenseArrayDefineIndex {
 			a.Set(idx, newValue)
+			// A plain element's descriptor otherwise reports the ES
+			// default (value, true, true, true) - see this file's doc
+			// comment. Track a non-default writable/enumerable/
+			// configurable combination explicitly in propertyDesc instead
+			// (paserati#178) - GetOwnPropertyDescriptor, DeleteIndex, and
+			// this function's own "resolve current descriptor" step above
+			// all already check propertyDesc first for exactly this
+			// reason. An all-default combination needs no entry, matching
+			// the delete just above (which also clears whatever an
+			// earlier defineProperty call on this index may have left).
+			if !(writable && enumerable && configurable) {
+				if a.propertyDesc == nil {
+					a.propertyDesc = make(map[string]PropertyDesc)
+				}
+				a.propertyDesc[key] = PropertyDesc{Writable: writable, Enumerable: enumerable, Configurable: configurable}
+			}
 		} else {
 			// Beyond the dense-allocation bound: track it as a named
 			// property instead of materializing the elements slice up to
-			// idx (see maxDenseArrayDefineIndex). Known gap, shared with
-			// OpSetIndex's identical fallback: a direct `arr[idx]`/
-			// arrayLikeGet read for an index this large that's still below
-			// the (now-grown) `length` hits the elements-array fast path
-			// first and misses this map, rather than falling through to
-			// the named-property lookup that would find it. Rare enough in
-			// practice (an index this close to the 2^32-2 boundary) that
-			// this codebase accepts it elsewhere rather than adding a
-			// sparse-index data structure.
-			a.DefineOwnProperty(key, newValue, true, true, true)
+			// idx (see maxDenseArrayDefineIndex). DefineOwnProperty stores
+			// the actual attributes here (unlike the old hardcoded
+			// true/true/true - paserati#178), since it always tracks a
+			// full descriptor for a named property regardless of index
+			// size.
+			a.DefineOwnProperty(key, newValue, writable, enumerable, configurable)
 			if idx+1 > a.length {
 				a.length = idx + 1
 			}
 		}
-		// writable/enumerable/configurable for a plain element have nowhere
-		// to live (see doc comment) - dropped here, matching this
-		// codebase's existing non-enforcement of per-element attributes.
 		return nil
 	}
 
@@ -239,7 +263,16 @@ func (a *ArrayObject) DeleteIndex(idx int) bool {
 	configurable := !a.frozen
 	if a.propertyDesc != nil {
 		if desc, ok := a.propertyDesc[key]; ok {
-			configurable = desc.Configurable
+			// Object.freeze only ever flips the array-wide `frozen` flag,
+			// never touching propertyDesc (see ArrayDefineOwnProperty's doc
+			// comment) - so a tracked configurable:true from before the
+			// freeze must still be ANDed with !a.frozen here (paserati#178):
+			// freeze can only take the capability away, never hand back one
+			// an explicit defineProperty granted. Before #178 tracked a
+			// plain data index's own attributes at all, this branch could
+			// only ever fire for an accessor index, where the same
+			// intersection already applies for the same reason.
+			configurable = desc.Configurable && !a.frozen
 		}
 	}
 	if !configurable {

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2426,6 +2426,23 @@ func (a *ArrayObject) DefineOwnProperty(name string, value Value, writable, enum
 	}
 }
 
+// GetIndexAttributesOverride returns the writable/enumerable/configurable
+// combination ArrayDefineOwnProperty tracked for a dense-element index
+// (paserati#178), if any. Unlike GetOwnPropertyDescriptor, this isn't
+// gated on the .properties map: a dense index's value lives in .elements,
+// never in .properties, so GetOwnPropertyDescriptor would never find an
+// entry that lives only in propertyDesc for it. Callers reading a dense
+// element's descriptor (Object.getOwnPropertyDescriptor's array path) use
+// this to detect a non-default combination instead of assuming the ES
+// default.
+func (a *ArrayObject) GetIndexAttributesOverride(key string) (PropertyDesc, bool) {
+	if a.propertyDesc == nil {
+		return PropertyDesc{}, false
+	}
+	desc, ok := a.propertyDesc[key]
+	return desc, ok
+}
+
 // GetOwnPropertyDescriptor returns the descriptor for a named property
 func (a *ArrayObject) GetOwnPropertyDescriptor(name string) (Value, PropertyDesc, bool) {
 	if a.execMeta != nil {
@@ -2497,23 +2514,44 @@ func (a *ArrayObject) SealProperties() {
 }
 
 func (a *ArrayObject) sealOrFreezeProperties(freeze bool) {
-	if a.properties == nil {
-		return
+	if a.properties != nil {
+		if a.propertyDesc == nil {
+			a.propertyDesc = make(map[string]PropertyDesc)
+		}
+		for name, val := range a.properties {
+			_ = val
+			desc, hasDesc := a.propertyDesc[name]
+			if !hasDesc {
+				desc = PropertyDesc{Writable: true, Enumerable: true, Configurable: true}
+			}
+			desc.Configurable = false
+			if freeze {
+				desc.Writable = false
+			}
+			a.propertyDesc[name] = desc
+		}
 	}
-	if a.propertyDesc == nil {
-		a.propertyDesc = make(map[string]PropertyDesc)
-	}
-	for name, val := range a.properties {
-		_ = val
-		desc, hasDesc := a.propertyDesc[name]
-		if !hasDesc {
-			desc = PropertyDesc{Writable: true, Enumerable: true, Configurable: true}
+
+	// A dense-element index can also carry its own propertyDesc entry -
+	// tracked by ArrayDefineOwnProperty when an explicit Object.defineProperty
+	// call requested a non-default writable/enumerable/configurable
+	// combination for it (paserati#178). Such an index has no entry in
+	// .properties (its value lives in .elements), so the loop above never
+	// reaches it. Lock it down the same way, or a leftover
+	// writable/configurable:true entry makes IsFrozen()'s own
+	// re-validation loop (which walks every propertyDesc entry looking for
+	// exactly this) incorrectly report the array as not frozen even though
+	// SetFrozen(true) just ran.
+	for key, desc := range a.propertyDesc {
+		idx, isIndex := tryParseArrayIndex(key)
+		if !isIndex || idx >= len(a.elements) || a.elements[idx].typ == TypeHole {
+			continue // not a dense-element override - e.g. an accessor's own entry, left alone
 		}
 		desc.Configurable = false
 		if freeze {
 			desc.Writable = false
 		}
-		a.propertyDesc[name] = desc
+		a.propertyDesc[key] = desc
 	}
 }
 

--- a/tests/scripts/array_define_property_attrs.ts
+++ b/tests/scripts/array_define_property_attrs.ts
@@ -1,0 +1,99 @@
+// expect: true
+// paserati#178: Object.defineProperty on an array-index property silently
+// ignored the requested writable/enumerable/configurable attributes and
+// always stored {writable:true, enumerable:true, configurable:true} -
+// both for a dense in-range index (backed by ArrayObject's .elements
+// slice) and a huge sparse index (beyond maxDenseArrayDefineIndex /
+// maxDenseArraySetIndex, 2^24, tracked in the named-property map
+// instead) - unlike the identical call on a plain object, which already
+// honored the flags and defaulted unspecified ones to false.
+const checks: boolean[] = [];
+
+// Dense index: explicit configurable:false must be honored.
+const a: any[] = [];
+Object.defineProperty(a, "2", { value: "v", configurable: false });
+const descA = Object.getOwnPropertyDescriptor(a, "2")!;
+checks.push(descA.value === "v");
+checks.push(descA.writable === false); // unspecified -> defaults to false
+checks.push(descA.enumerable === false); // unspecified -> defaults to false
+checks.push(descA.configurable === false);
+
+// Redefining a non-configurable dense index must throw.
+let threw = false;
+try {
+  Object.defineProperty(a, "2", { configurable: true });
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+checks.push(threw);
+
+// Deleting a non-configurable dense index must fail (sloppy mode:
+// silently - the property must still be there afterward).
+delete a[2];
+checks.push((a as any).hasOwnProperty("2"));
+checks.push(a[2] === "v");
+
+// A dense index explicitly defined with every attribute true must report
+// exactly the ES default - no accidental non-default leftover.
+const b: any[] = [];
+Object.defineProperty(b, "5", {
+  value: "w",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+const descB = Object.getOwnPropertyDescriptor(b, "5")!;
+checks.push(
+  descB.writable === true &&
+    descB.enumerable === true &&
+    descB.configurable === true,
+);
+delete b[5]; // configurable: true -> must succeed
+checks.push(!(b as any).hasOwnProperty("5"));
+
+// A plain arr[i] = v assignment (never through defineProperty) must still
+// report the ES default - this fix must not change that common path.
+const c: any[] = [1, 2, 3];
+const descC = Object.getOwnPropertyDescriptor(c, "1")!;
+checks.push(
+  descC.writable === true &&
+    descC.enumerable === true &&
+    descC.configurable === true,
+);
+
+// Huge sparse index (beyond the dense-allocation bound): same attribute
+// handling as the dense case above.
+const d: any[] = [];
+Object.defineProperty(d, "4294967290", { value: "z", configurable: false });
+const descD = Object.getOwnPropertyDescriptor(d, "4294967290")!;
+checks.push(descD.value === "z");
+checks.push(
+  descD.writable === false &&
+    descD.enumerable === false &&
+    descD.configurable === false,
+);
+delete d[4294967290];
+checks.push((d as any).hasOwnProperty("4294967290")); // survives: non-configurable
+
+// Object.freeze must still win over an earlier defineProperty-tracked
+// writable:true/configurable:true on a dense index - freeze can only take
+// capabilities away, never leave one an explicit defineProperty granted.
+// This also exercises Object.isFrozen(), which re-validates by walking
+// every tracked descriptor: a stale writable/configurable:true entry left
+// behind by freeze would make isFrozen() wrongly report false even though
+// Object.freeze just ran.
+const e: any[] = [];
+Object.defineProperty(e, "2", {
+  value: "v",
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+Object.freeze(e);
+checks.push(Object.isFrozen(e));
+const descE = Object.getOwnPropertyDescriptor(e, "2")!;
+checks.push(descE.writable === false && descE.configurable === false);
+delete e[2];
+checks.push((e as any).hasOwnProperty("2")); // survives: freeze wins
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Fixes [paserati#178](https://github.com/nooga/paserati/issues/178).

## What's broken

`Object.defineProperty` on an array-index property silently ignored the requested `writable`/`enumerable`/`configurable` attributes: `ArrayDefineOwnProperty` computed the correct (defaulted-to-`false`-when-unspecified) values but then discarded them for any array-index key, always storing/reporting the ES default `{writable:true, enumerable:true, configurable:true}` regardless of what was passed — both for a dense in-range index (backed by `.elements`) and a huge sparse index (beyond `maxDenseArrayDefineIndex`/`maxDenseArraySetIndex`, tracked in the named-property map instead, which hardcoded `true,true,true` rather than passing the real values through). The identical call on a plain object already worked correctly.

```ts
const a = []; Object.defineProperty(a, "2", { value: "v", configurable: false });
Object.getOwnPropertyDescriptor(a, "2"); // {value:"v", writable:true, enumerable:true, configurable:true} - configurable:false ignored
```

## Fix

Track a non-default combination for a dense index in `ArrayObject`'s existing `propertyDesc` map — the same map an accessor index or a named property already uses — keyed by the index's string form. An all-default combination needs no entry, so a plain `arr[i] = v` write (which never goes through this function) stays free of any per-element bookkeeping. Also fixed `ArrayDefineOwnProperty`'s own "resolve current descriptor" step to consult that entry (it previously hardcoded `true,true,true` unconditionally for any existing dense element — meaning a non-configurable index could always be silently redefined anyway), and the sparse-index branch to pass the real computed values instead of the old hardcoded `true,true,true`.

## Two paths this made newly reachable

Adding `propertyDesc` entries for plain *data* indices (not just accessors) made two existing code paths — which could previously only ever see an accessor's entry there — reachable for a new case, and both needed adjusting:

- **`DeleteIndex`** read the entry's `Configurable` directly, without ANDing it with the array-wide `frozen` flag. Harmless before (freeze never left a data-index entry to find), but now reachable: a frozen array with a `configurable:true`-defined index would let `delete` succeed. Fixed by intersecting with `!a.frozen` — freeze can only take capabilities away, never hand back one an explicit `defineProperty` granted.
- **`sealOrFreezeProperties`** (`Object.freeze`/`seal`) only ever walked `.properties` (named/sparse keys), never a dense index's own entry — so freezing an array with such an index left it stale (still `writable`/`configurable:true`), and `IsFrozen()`'s own re-validation loop (which checks *every* `propertyDesc` entry) then incorrectly reported the array as **not** frozen at all, even right after `Object.freeze()` ran. Fixed by also locking down any `propertyDesc` entry that resolves to a dense (non-hole, in-bounds) index. Same `!isFrozen` intersection applied where `Object.getOwnPropertyDescriptor` reads a dense index's tracked override.

## A #176-class bug this same block had

Also fixed, in the same code block: `Object.getOwnPropertyDescriptor`'s `"value"` fetch for a huge sparse index used `arrObj.Get()` directly, which only checks `.elements` and returns `undefined` for an index living in the named-property map instead. This is exactly the class of bug [#177](https://github.com/nooga/paserati/pull/177) (still open) fixed elsewhere — this specific call site was missed. Falls back to `GetOwn` the same way the bracket-read opcodes already do. **#177 and this PR are independent** (both branched from `main`); merge order doesn't matter.

## Found but not fixed here (pre-existing, verified identical on `main`)

- `Object.seal` never affects a dense element's reported `configurable` at all — there's no separate "sealed" flag for elements, only the single `frozen` bool.
- `arr[idx] = v` bypasses the frozen check entirely in `OpSetIndex`'s fast path.
- An accessor index sitting past the elements bound (or on a hole) still isn't locked down by `sealOrFreezeProperties`, so `Object.isFrozen()` can still report `false` for an array frozen with such an accessor defined — pre-existing (accessor entries were never covered by the old `.properties`-only loop either).

All three verified byte-for-byte identical on `main` via `git stash` before and after this change — architectural gaps, not this fix's shape. Noted for visibility, not fixed.

## Testing

- `go test ./...` — all packages pass
- The full fix, and separately just the freeze-interaction half, each confirmed red→green by reverting in isolation
- Test262 diff against a **freshly regenerated** `main` baseline (not reused from a prior branch — a gitignored `baseline.txt` survives branch switches unchanged and can silently compare against stale leftovers) on `language/` and `built-ins/` at `-timeout 0.2s`: **+0** on `language`, **+11/-0** on `built-ins`
- New coverage: [`tests/scripts/array_define_property_attrs.ts`](tests/scripts/array_define_property_attrs.ts) — dense and sparse index attribute honoring, unspecified-defaults-to-`false`, redefine/delete rejection on a non-configurable index, a plain `arr[i]=v` index still reporting the ES default, and the freeze-wins-over-an-earlier-`defineProperty` interaction (including `Object.isFrozen()` itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
