### PR TITLE
fix(compiler): a derived class handles a comma-joined super() call

### DIFF
--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -969,6 +969,51 @@ func (c *Compiler) addSetterToPrototype(method *parser.MethodDefinition, prototy
 	return nil
 }
 
+// flattenCommaExpression returns expr's comma-joined ("," InfixExpression)
+// sub-expressions in left-to-right evaluation order. Comma chains parse
+// left-associatively (`a,b,c` is `((a,b),c)`), so this recurses down the
+// Left spine, collecting terms as it unwinds. Anything that isn't a comma
+// InfixExpression is returned as a single-element result unchanged - in
+// particular, a "," inside a call's argument list or an object/array
+// literal is part of a *different* Expression node entirely (arguments,
+// elements, ...), never seen here, so this can't misfire on those.
+func flattenCommaExpression(expr parser.Expression) []parser.Expression {
+	infix, ok := expr.(*parser.InfixExpression)
+	if !ok || infix.Operator != "," {
+		return []parser.Expression{expr}
+	}
+	return append(flattenCommaExpression(infix.Left), infix.Right)
+}
+
+// flattenTopLevelCommaStatements expands any top-level ExpressionStatement
+// whose expression is a comma chain into one ExpressionStatement per
+// sub-expression, in order - the reverse of what a minifier's "join
+// consecutive statements with the comma operator" pass did to produce it.
+// Behavior-preserving: a bare ExpressionStatement's value is always
+// discarded, so `a(), b();` and `a(); b();` run identically. Every other
+// statement kind (declarations, control flow, ...) passes through
+// untouched. See injectFieldInitializers' derived-class branch (paserati#180)
+// for why this needs to run before searching for a bare super() call.
+func flattenTopLevelCommaStatements(statements []parser.Statement) []parser.Statement {
+	out := make([]parser.Statement, 0, len(statements))
+	for _, stmt := range statements {
+		exprStmt, ok := stmt.(*parser.ExpressionStatement)
+		if !ok {
+			out = append(out, stmt)
+			continue
+		}
+		parts := flattenCommaExpression(exprStmt.Expression)
+		if len(parts) == 1 {
+			out = append(out, stmt)
+			continue
+		}
+		for _, part := range parts {
+			out = append(out, &parser.ExpressionStatement{Token: exprStmt.Token, Expression: part})
+		}
+	}
+	return out
+}
+
 // injectFieldInitializers creates a new function literal with field initializers prepended to the constructor body
 func (c *Compiler) injectFieldInitializers(node *parser.ClassDeclaration, functionLiteral *parser.FunctionLiteral) *parser.FunctionLiteral {
 	// Collect field initializer statements
@@ -1191,10 +1236,25 @@ func (c *Compiler) injectFieldInitializers(node *parser.ClassDeclaration, functi
 
 	isDerivedClass := node.SuperClass != nil
 	if isDerivedClass {
+		// A minifier commonly merges `super(...);` with the statement right
+		// after it into one `super(...), <next>;` via the comma operator -
+		// legal JS (a bare ExpressionStatement's value is always discarded,
+		// so splitting the chain back into separate statements is behavior-
+		// preserving) and a real, common shape (paserati#180: esbuild's
+		// bundling of glob@13.0.6 produces exactly
+		// `super(t,mi,"/",{...e,nocase:s}),this.nocase=s` for one
+		// constructor). The search below only recognizes a super() call
+		// that IS the entire expression of its statement, so flatten any
+		// top-level comma chain into separate statements first - this
+		// also correctly relocates whatever followed super() in the same
+		// chain to *after* the injected field initializers, not before
+		// them, which a "detect but don't restructure" fix could not do.
+		statements := flattenTopLevelCommaStatements(functionLiteral.Body.Statements)
+
 		// Find the super() call and insert field initializers after it
 		insertPos := 0
 		foundSuper := false
-		for i, stmt := range functionLiteral.Body.Statements {
+		for i, stmt := range statements {
 			// Check if this statement contains a super() call
 			if exprStmt, ok := stmt.(*parser.ExpressionStatement); ok {
 				if callExpr, ok := exprStmt.Expression.(*parser.CallExpression); ok {
@@ -1209,15 +1269,15 @@ func (c *Compiler) injectFieldInitializers(node *parser.ClassDeclaration, functi
 
 		if foundSuper {
 			// Insert field initializers after super() call
-			newStatements = append(newStatements, functionLiteral.Body.Statements[:insertPos]...)
+			newStatements = append(newStatements, statements[:insertPos]...)
 			newStatements = append(newStatements, fieldInitializers...)
-			newStatements = append(newStatements, functionLiteral.Body.Statements[insertPos:]...)
+			newStatements = append(newStatements, statements[insertPos:]...)
 		} else {
 			// No explicit super() call found - this is an error in real code,
 			// but for now prepend (will fail at runtime when fields try to access this)
 			debugPrintf("// WARNING: Derived class constructor without explicit super() call\n")
 			newStatements = append(newStatements, fieldInitializers...)
-			newStatements = append(newStatements, functionLiteral.Body.Statements...)
+			newStatements = append(newStatements, statements...)
 		}
 	} else {
 		// Regular class - prepend field initializers

--- a/tests/scripts/class_super_comma_field_init.ts
+++ b/tests/scripts/class_super_comma_field_init.ts
@@ -1,0 +1,32 @@
+// expect: true
+// paserati#180: a minifier commonly merges `super(...);` with the very next
+// statement into one `super(...), <next>;` via the comma operator - legal
+// JS (a bare ExpressionStatement's value is always discarded, so this is
+// behavior-identical to two separate statements) and exactly what esbuild's
+// bundling of glob@13.0.6 produces for one of its derived-class
+// constructors. injectFieldInitializers' "find the super() call" search
+// only recognized a super() call that IS the entire expression of its
+// statement - a comma-joined super() call never matched, so a derived
+// class with an instance field always fell into the "no super() call
+// found" fallback and prepended the field initializer at the very start
+// of the constructor, before 'this' exists at all - throwing "Must call
+// super constructor..." even though the source does call super() first.
+class Base {
+  constructor(t: number) {
+    this.baseVal = t;
+  }
+  baseVal: number;
+}
+
+class Derived extends Base {
+  field = "field-init-value";
+  own = 0;
+  constructor(t: number) {
+    // The comma here is the exact shape that broke: super() and the
+    // following assignment merged into one statement.
+    super(t), (this.own = t + 1);
+  }
+}
+
+const d = new Derived(41);
+d.baseVal === 41 && d.field === "field-init-value" && d.own === 42;


### PR DESCRIPTION
Fixes [paserati#180](https://github.com/nooga/paserati/issues/180).

## What's broken

A minifier commonly merges `super(...);` with the very next statement into one `super(...), <next>;` via the comma operator — legal JS (a bare `ExpressionStatement`'s value is always discarded, so this is behavior-identical to two separate statements) and exactly what esbuild's bundling of `glob@13.0.6` produces for one of its derived-class constructors:

```js
super(t, mi, "/", { ...e, nocase: s }), this.nocase = s
```

`injectFieldInitializers`'s "find the super() call" search only recognized a super() call that **is** the entire expression of its statement (`exprStmt.Expression.(*parser.CallExpression)` with a `SuperExpression` callee). A comma-joined super() call never matched that shape, so any derived class with an instance field — whose constructor's super() call happened to get comma-merged with the statement after it — always fell into the "no super() call found" fallback and prepended the field initializer at the very start of the constructor, before `this` exists at all. That field access then throws `"Must call super constructor in derived class before accessing 'this'..."` even though the source clearly calls super() first.

## The minimal repro — not "needs 65KB of glob"

The issue's own bisection concluded the bug needed the real file's first 66040 bytes and reproduced in no smaller hand-written case. That conclusion turned out to be an artifact of the bisection method (cutting source text hits token/scope boundaries that mask the shape), not a real size dependency. The actual minimal repro is three lines:

```ts
class Derived extends Base {
  field = "x";
  constructor(t) {
    super(t), (this.own = t + 1);
  }
}
new Derived(1); // throws "Must call super constructor..." before this fix
```

## How I found it (worth recording since the trail was misleading)

Root cause found via bisection down from the real repro to a bytecode disassembly showing the field initializer's `OpLoadThis` executing before `OpGetSuperConstructor`. That pointed at `injectFieldInitializers`, but a detour along the way suspected a much scarier bug: a standalone AST dump of the truncated 66KB repro appeared to show ~17KB of source (including the `It`/`rt`/`St` class chain itself) missing from the parsed `Program.Statements` entirely, with no parse error — looked like a parser silently dropping content at scale. That turned out to be a **false lead**: `VarStatement.String()` only prints its *first* declarator (a "legacy" field kept for backward compatibility), so a large multi-declarator `var` statement's later declarators — including the derived class — were parsed completely correctly all along; they just didn't show up in a `.String()`-based debug dump. Walking the real AST (`vs.Declarations`, not `.String()`) confirmed the parse was fine and isolated the actual defect to the comma-joined super() call above.

## Fix

Before searching for the super() call, flatten each top-level `ExpressionStatement` whose expression is a comma chain into one `ExpressionStatement` per sub-expression, in left-to-right order — the reverse of what the minifier's statement-joining pass did. This makes the existing search find the (now bare) super() call unchanged, and correctly relocates whatever followed it in the same chain to *after* the injected field initializers rather than before them — something a detect-only fix (without restructuring the statement list) couldn't do, since the "next statement" needs to actually move.

A no-op for the overwhelmingly common case: `flattenCommaExpression` returns any non-comma expression unchanged as a single-element result, so a constructor with no top-level comma chain is untouched. `createDefaultConstructor`'s synthesized `super(...args)` is already a bare `ExpressionStatement` and is unaffected either way.

## Confirmed unrelated (from the issue, not touched here)

- **Every frame reporting a fallback `"3:1"` position** in the reproduced error's stack trace — reproduces identically before and after this fix, so it's a separate, pre-existing position-tracking gap, not caused by (or fixed by) this change.
- **The secondary `.some()` type-checker false positive** the issue's comment describes (`ws`'s return type inferred as `void` instead of `boolean`, likely because paserati's builtin lib declares `some`'s predicate as `=> boolean` where real TypeScript's `lib.es5.d.ts` uses `=> unknown` specifically to avoid this) — a distinct, separately-fixable checker bug, not touched here. Doesn't gate this issue's impact assessment either way, since the reporter's host embedding skips type checking entirely.

## Testing

- `go test ./...` — all packages pass
- Confirmed red→green via `git stash`
- Manually reran the full original `glob@13.0.6` bundle repro from the issue end-to-end (with `globalThis.URL` stubbed — an unrelated host-global gap outside plain paserati's runtime, not part of this bug) — now completes successfully (`OK / true`) instead of throwing
- Test262 diff against a freshly regenerated true-`main` baseline (the checked-in `baseline.txt` was itself stale here — from a PR merged before this session's other two independent PRs landed on top of it) on `language/` and `built-ins/` at `-timeout 0.2s`: net change **+0** on both
- New coverage: [`tests/scripts/class_super_comma_field_init.ts`](tests/scripts/class_super_comma_field_init.ts) — the minimal 3-line repro shape; confirmed red→green against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
