### PR TITLE
fix(vm): spreading the arguments object no longer throws "not iterable"

### DIFF
--- a/pkg/vm/op_spreadnew.go
+++ b/pkg/vm/op_spreadnew.go
@@ -2,6 +2,62 @@ package vm
 
 import "fmt"
 
+// populateSpreadCallRegisters copies spreadArgs into a newly-created frame's
+// parameter registers and builds any rest-parameter array, mirroring what
+// prepareCallWithGeneratorMode (call.go) already does for every other kind
+// of call (a direct call, and a spread call to an ordinary function).
+// handleOpSpreadNew (super(...)/new Foo(...) with a spread argument) had
+// neither of these (paserati#182):
+//   - without Undefined-padding, a declared parameter beyond argCount but
+//     within the callee's arity kept whatever stale value already happened
+//     to be sitting in that register-stack slot from an earlier frame that
+//     used the same slots (register-stack space is reused across frames,
+//     not zeroed per call) - only reachable, and only observable, once a
+//     spread call passes fewer arguments than the callee declares;
+//   - without rest-parameter handling, a variadic constructor's `...rest`
+//     parameter received whatever got copied positionally into its
+//     register (the first spread argument, or undefined) instead of a real
+//     array - the exact shape of a `super(...arguments)` pass-through
+//     constructor once the "arguments is not iterable" bug this issue is
+//     about stopped masking it.
+func populateSpreadCallRegisters(vmInstance *VM, calleeFunc *FunctionObject, spreadArgs []Value, registers []Value) {
+	argCount := len(spreadArgs)
+	maxArgsToCopy := argCount
+	if calleeFunc.Arity > maxArgsToCopy {
+		maxArgsToCopy = calleeFunc.Arity
+	}
+	if maxArgsToCopy > len(registers) {
+		maxArgsToCopy = len(registers)
+	}
+	for i := 0; i < maxArgsToCopy; i++ {
+		if i < argCount {
+			registers[i] = spreadArgs[i]
+		} else {
+			registers[i] = Undefined
+		}
+	}
+
+	if calleeFunc.Variadic {
+		extraArgCount := argCount - calleeFunc.Arity
+		var restArray Value
+		if extraArgCount <= 0 {
+			restArray = vmInstance.emptyRestArray
+		} else {
+			restArray = NewArray()
+			restArrayObj := restArray.AsArray()
+			for i := 0; i < extraArgCount; i++ {
+				argIndex := calleeFunc.Arity + i
+				if argIndex < len(spreadArgs) {
+					restArrayObj.Append(spreadArgs[argIndex])
+				}
+			}
+		}
+		if calleeFunc.Arity < len(registers) {
+			registers[calleeFunc.Arity] = restArray
+		}
+	}
+}
+
 // handleOpSpreadNew handles OpSpreadNew bytecode instruction for constructor calls with spread arguments
 func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, registers []Value) (InterpretResult, Value) {
 	destReg := code[*ip]
@@ -175,10 +231,11 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 			newFrame.spillSlots = nil
 		}
 
-		// Copy spread arguments to new frame
-		for i := 0; i < argCount && i < len(newFrame.registers); i++ {
-			newFrame.registers[i] = spreadArgs[i]
-		}
+		// Copy spread arguments to new frame, padding any declared parameter
+		// beyond argCount with Undefined and building a real rest-parameter
+		// array if the constructor is variadic - see populateSpreadCallRegisters
+		// (paserati#182).
+		populateSpreadCallRegisters(vm, constructorFunc, spreadArgs, newFrame.registers)
 		vm.frameCount++
 
 		// Store instance in caller's destination register
@@ -289,10 +346,11 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 			newFrame.spillSlots = nil
 		}
 
-		// Copy spread arguments to new frame
-		for i := 0; i < argCount && i < len(newFrame.registers); i++ {
-			newFrame.registers[i] = spreadArgs[i]
-		}
+		// Copy spread arguments to new frame, padding any declared parameter
+		// beyond argCount with Undefined and building a real rest-parameter
+		// array if the constructor is variadic - see populateSpreadCallRegisters
+		// (paserati#182).
+		populateSpreadCallRegisters(vm, constructorFunc, spreadArgs, newFrame.registers)
 		vm.frameCount++
 
 		// Store instance in caller's destination register

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17237,6 +17237,40 @@ func (vm *VM) extractSpreadArguments(iterableVal Value) ([]Value, error) {
 		copy(args, arrayObj.elements)
 		return args, nil
 
+	case TypeArguments:
+		// Fast path for the arguments object (paserati#182). It's genuinely
+		// iterable - argsObj[Symbol.iterator] is set as a real own property
+		// at creation time (see OpLoadArguments), which is exactly why
+		// for-of/Array.from/destructuring already work on it - but this
+		// switch's default branch below only walks a hand-picked list of
+		// types (TypeObject/TypeGenerator/TypeAsyncGenerator/TypeDictObject)
+		// looking for Symbol.iterator via their *prototype chain*, and
+		// TypeArguments was never one of them, so it always fell through to
+		// "is not iterable". Read each index through argumentsGet (not the
+		// raw args/mappedRegs slices directly) so a live-mapped parameter
+		// register, a deleted index, or a defineProperty-installed accessor
+		// on some index is honored exactly the way plain property access on
+		// arguments already respects it elsewhere. Likewise for "length"
+		// itself: `arguments.length = n` stores an override in namedProps
+		// rather than the raw length field (see op_setprop.go's TypeArguments
+		// case) - check it first, matching the same "check GetNamedProp
+		// before the raw field" pattern property_helpers.go's own
+		// "length" lookup already uses for arguments.
+		argsObj := AsArguments(iterableVal)
+		length := argsObj.length
+		if v, ok := argsObj.GetNamedProp("length"); ok {
+			length = int(v.ToFloat())
+		}
+		args := make([]Value, 0, length)
+		for i := 0; i < length; i++ {
+			val, err := vm.argumentsGet(argsObj, strconv.Itoa(i))
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, val)
+		}
+		return args, nil
+
 	case TypeString:
 		// Strings are iterable - spread into individual characters
 		str := AsString(iterableVal)

--- a/tests/scripts/spread_arguments_object.ts
+++ b/tests/scripts/spread_arguments_object.ts
@@ -1,0 +1,104 @@
+// expect: true
+// skip-typecheck
+// paserati#182: spreading the arguments object (fn(...arguments),
+// [...arguments], super(...arguments)) threw "TypeError: object is not
+// iterable", even though arguments is genuinely iterable by every other
+// means (for-of, Array.from, destructuring). extractSpreadArguments' fast
+// paths didn't have a TypeArguments case, and its generic fallback only
+// recognized Symbol.iterator on a hand-picked list of prototype-walkable
+// types that never included TypeArguments (whose Symbol.iterator is a
+// real own property, not reachable via a prototype chain at all).
+//
+// Spreading `arguments` is itself rejected by the type checker separately
+// (its declared type isn't recognized as spreadable) - unrelated to this
+// issue, which is specifically about the *runtime* behavior real,
+// checker-bypassing JS/TS hosts (plain paserati's own --no-typecheck flag,
+// and embeddings like noderati) hit - hence skip-typecheck above.
+const checks = [];
+
+function basicSpread() {
+  return [...arguments];
+}
+checks.push(JSON.stringify(basicSpread(1, 2, 3)) === "[1,2,3]");
+
+function callSpread(a, b, c) {
+  return a + b + c;
+}
+function callSpreadArgs() {
+  return callSpread(...arguments);
+}
+checks.push(callSpreadArgs(10, 20, 30) === 60);
+
+// The exact real-world shape this issue's impact section calls out:
+// super(...arguments) in a pass-through derived-class constructor, where
+// the base constructor has a rest parameter. This also exercises a
+// second, independent bug found while verifying the fix's real-world
+// impact: handleOpSpreadNew (used for both super(...)/new Foo(...) with a
+// spread argument) never handled a variadic callee's rest parameter at
+// all - it copied spread arguments positionally into registers, so a
+// `...args` rest parameter received the raw first argument (or undefined)
+// instead of a real array.
+class Base {
+  constructor(...args) {
+    this.args = args;
+  }
+}
+class PassThrough extends Base {
+  constructor() {
+    super(...arguments);
+  }
+}
+const pt = new PassThrough(1, 2, 3);
+checks.push(JSON.stringify(pt.args) === "[1,2,3]");
+
+// A third bug found alongside the rest-parameter one: handleOpSpreadNew
+// never padded registers beyond the spread argument count with Undefined,
+// so a declared parameter past what was actually spread kept whatever
+// stale value happened to already be sitting in that register-stack slot
+// from an earlier, unrelated frame - reachable only when something else
+// dirties the same register-stack range first.
+function dirtyRegisters(a, b, c, d) {
+  return a + b + c + d;
+}
+dirtyRegisters("W", "X", "Y", "Z");
+class Fixed4 {
+  constructor(a, b, c, d) {
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+  }
+}
+class FewerArgs extends Fixed4 {
+  constructor() {
+    super(...[1, 2]);
+  }
+}
+const fa = new FewerArgs();
+checks.push(fa.a === 1 && fa.b === 2 && fa.c === undefined && fa.d === undefined);
+
+// handleOpSpreadNew backs BOTH super(...) and plain `new Foo(...)` - the two
+// bugs above were fixed at that shared call site, so verify the non-super
+// direction too rather than assuming super() coverage implies it.
+dirtyRegisters("W", "X", "Y", "Z");
+const plainNew = new Fixed4(...[1, 2]);
+checks.push(plainNew.a === 1 && plainNew.b === 2 && plainNew.c === undefined && plainNew.d === undefined);
+class PlainRest {
+  constructor(...r) {
+    this.r = r;
+  }
+}
+checks.push(JSON.stringify(new PlainRest(...[1, 2, 3]).r) === "[1,2,3]");
+
+// arguments.length is itself a writable own property (op_setprop.go stores
+// a reassignment as a namedProps override rather than touching the raw
+// length field) - spread must read the current, possibly-reassigned
+// length the same way Array.from(arguments) already does, not the raw
+// original argument count.
+function reassignedLength() {
+  arguments.length = 1;
+  return [...arguments];
+}
+checks.push(JSON.stringify(reassignedLength(1, 2, 3)) === "[1]");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Fixes [paserati#182](https://github.com/nooga/paserati/issues/182).

## What's broken

`[...arguments]`, `fn(...arguments)`, and `super(...arguments)` all threw `TypeError: object is not iterable`, even though `arguments` is genuinely iterable by every other means (`for...of`, `Array.from`, destructuring).

`extractSpreadArguments` (pkg/vm/vm.go) has fast paths for a hand-picked list of iterable types, then falls back to walking a value's *prototype chain* looking for `Symbol.iterator`. `TypeArguments` was never in that fast-path list, and an `arguments` object's `Symbol.iterator` is a real **own** property set at creation time (see `OpLoadArguments`) — not reachable via a prototype walk at all — so it always fell through to "is not iterable".

## What else this uncovered

Fixing that exposed two more, pre-existing bugs at `handleOpSpreadNew` (pkg/vm/op_spreadnew.go) — the shared implementation behind **both** `super(...)` and plain `new Foo(...)` with a spread argument. Both are independently reproducible with a plain array spread, no `arguments` involved, so they're fixed here rather than filed separately — the first bug above was the only thing that had been masking them from ever being reachable via `arguments` at all, and the issue's own stated real-world impact (`super(...arguments)` pass-through constructors) runs straight through this exact code path:

1. **A variadic (rest-parameter) callee never got a real array.** `handleOpSpreadNew` copied spread arguments positionally into registers with no concept of a rest parameter, so `constructor(...args)` received the raw first spread argument (or `undefined`) instead of an array built from the remaining arguments. Repro: `super(...[1,2,3])` against a rest-param base constructor, or `new Foo(...[1,2,3])`.
2. **Unfilled registers weren't padded with `Undefined`.** A declared parameter past the actual spread count kept whatever stale value happened to already occupy that register-stack slot from an earlier, unrelated frame — only visible once something else dirties the same register range first, which is exactly what made it easy to miss.

## Fix

- Added a `TypeArguments` case to `extractSpreadArguments`'s fast path. It reads each index through `argumentsGet` — the same accessor plain property access on `arguments` already goes through — so a live-mapped parameter register, a deleted index, or a `defineProperty`-installed accessor on some index is honored exactly as it is everywhere else `arguments` is touched. Length is read via `GetNamedProp("length")` first, since `arguments.length = n` reassignment stores an override there (see `op_setprop.go`'s `TypeArguments` case) rather than touching the raw length field — matching the same pattern `Array.from(arguments)` already uses. (Confirmed `for...of` on `arguments` does **not** respect a reassigned `.length` — a separate, pre-existing, unrelated bug, left untouched here.)
- Added a `populateSpreadCallRegisters` helper and applied it at both call sites inside `handleOpSpreadNew` (the `TypeClosure` and `TypeFunction` branches), fixing both of the uncovered bugs together. It mirrors logic that already exists, correctly, inline in `prepareCallWithGeneratorMode` (pkg/vm/call.go) for the ordinary non-spread call path — `handleOpSpreadNew` simply never had it. Chose to mirror rather than refactor the two call paths into one shared implementation, to keep this fix's blast radius limited to the path that was actually broken.

## Testing

- `go test ./...` — all packages pass
- Confirmed red → green via `git stash`, both for the fix as a whole and for the `op_spreadnew.go` half in isolation
- New coverage: [`tests/scripts/spread_arguments_object.ts`](tests/scripts/spread_arguments_object.ts) — basic `[...arguments]`, call-spread, `super(...arguments)` against a rest-param base (the issue's own stated real-world impact), `super(...[1,2])` against a fixed-arity base with deliberately dirtied registers (bug 2 above), plain `new Foo(...)` exercising both the rest-param and register-padding fixes directly (not just via `super()`, since `handleOpSpreadNew` backs both), and `arguments.length` reassignment respected by spread
- Test262 diff against a freshly regenerated true-`main` baseline on both `language/` and `built-ins/` at `-timeout 0.2s`: net change **+0** on both

## Confirmed unrelated (found, not touched here)

`for...of` on `arguments` does not respect a reassigned `arguments.length` (e.g. `arguments.length = 1; for (const x of arguments) ...` still iterates the original count), while `Array.from(arguments)` and this fix's spread path both correctly respect it. A real, separate, pre-existing bug — noted here since it was found directly while verifying this fix, but out of scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
