### PR TITLE
fix(modules): key module caches by resolved path, not specifier text (#183)

### DIFF
--- a/pkg/checker/module_environment.go
+++ b/pkg/checker/module_environment.go
@@ -130,7 +130,7 @@ func (me *ModuleEnvironment) ResolveImportedType(localName string) types.Type {
 
 	// Try to resolve the type from the source module using ModuleLoader
 	if me.ModuleLoader != nil {
-		sourceModule := me.ModuleLoader.GetModule(binding.SourceModule)
+		sourceModule := me.ModuleLoader.GetModule(binding.SourceModule, me.ModulePath)
 		// If module not loaded yet, trigger loading (needed for type checking before compilation)
 		if sourceModule == nil {
 			loaded, err := me.ModuleLoader.LoadModule(binding.SourceModule, me.ModulePath)
@@ -257,7 +257,7 @@ func (me *ModuleEnvironment) resolveReExportType(binding *ExportBinding) types.T
 	debugPrintf("// [ModuleEnv] Resolving re-export: %s from %s\n", binding.LocalName, binding.SourceModule)
 
 	// Get the source module
-	sourceModule := me.ModuleLoader.GetModule(binding.SourceModule)
+	sourceModule := me.ModuleLoader.GetModule(binding.SourceModule, me.ModulePath)
 	if sourceModule == nil {
 		debugPrintf("// [ModuleEnv] Source module '%s' not found for re-export\n", binding.SourceModule)
 		return nil

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -787,6 +787,7 @@ func newFunctionCompiler(enclosingCompiler *Compiler) *Compiler {
 	// Inherit strict mode and the source file from enclosing compiler
 	chunk.IsStrict = enclosingCompiler.chunk.IsStrict
 	chunk.Source = enclosingCompiler.chunk.Source
+	chunk.ModulePath = enclosingCompiler.chunk.ModulePath
 	return &Compiler{
 		chunk:                    chunk,
 		regAlloc:                 NewRegisterAllocator(),
@@ -892,6 +893,12 @@ func (c *Compiler) Compile(node parser.Node) (*vm.Chunk, []errors.PaseratiError)
 	// while executing it can quote that file rather than the entry script
 	// (#148). Nested function compilers inherit it in newFunctionCompiler.
 	c.chunk.Source = program.Source
+	// And which module, so code in this chunk that runs later (a function
+	// called from another module) still resolves import() and import.meta
+	// against its own module. Nested function compilers inherit it too.
+	if c.moduleBindings != nil {
+		c.chunk.ModulePath = c.moduleBindings.ModulePath
+	}
 	c.regAlloc = NewRegisterAllocator()
 	c.currentSymbolTable = NewSymbolTable()
 	c.allLocalNames = make(map[Register]string) // Reset local name tracking
@@ -4982,7 +4989,8 @@ func (c *Compiler) collectExportAllNames(rec vm.ModuleRecord, specifier string, 
 	if c.moduleLoader == nil {
 		return nil
 	}
-	concreteRec := c.moduleLoader.GetModule(specifier)
+	// rec is this very module's record; only the concrete type exposes the AST.
+	concreteRec, _ := rec.(*modules.ModuleRecord)
 	if concreteRec == nil || concreteRec.AST == nil {
 		return nil
 	}
@@ -5168,9 +5176,37 @@ func (c *Compiler) emitImportResolve(destReg Register, importName string, line i
 	}
 }
 
+// canonicalModulePath maps an import specifier, as written in the module being
+// compiled, to the loader's resolved path for it. The bytecode names the file
+// rather than the specifier text because the same relative spelling
+// ("./_helper.mjs") means different files from different directories, and an
+// import binding read inside a function body executes long after the importing
+// module finished running, when the VM's notion of "current module" is the
+// caller's (#183). Resolving here mirrors ESM link-time resolution. Falls back
+// to the specifier when it cannot be resolved; the VM then reports the load
+// failure at run time exactly as before.
+func (c *Compiler) canonicalModulePath(specifier string) string {
+	if c.moduleLoader == nil {
+		return specifier
+	}
+	fromPath := "."
+	if c.moduleBindings != nil && c.moduleBindings.ModulePath != "" {
+		fromPath = c.moduleBindings.ModulePath
+	}
+	rec, err := c.moduleLoader.LoadModule(specifier, fromPath)
+	if err != nil || rec == nil {
+		return specifier
+	}
+	if resolved := rec.GetResolvedPath(); resolved != "" {
+		return resolved
+	}
+	return specifier
+}
+
 // emitEvalModule generates OpEvalModule bytecode to execute a module
 func (c *Compiler) emitEvalModule(modulePath string, line int) {
 	// Add module path as a string constant
+	modulePath = c.canonicalModulePath(modulePath)
 	modulePathValue := vm.String(modulePath)
 	constantIdx := c.chunk.AddConstant(modulePathValue)
 
@@ -5193,6 +5229,7 @@ func (c *Compiler) emitLoadJSONModule(modulePath string, line int) {
 // emitCreateNamespace generates bytecode to create a namespace object from module exports
 func (c *Compiler) emitCreateNamespace(destReg Register, modulePath string, line int) {
 	// Add module path as a string constant
+	modulePath = c.canonicalModulePath(modulePath)
 	modulePathValue := vm.String(modulePath)
 	modulePathIdx := c.chunk.AddConstant(modulePathValue)
 
@@ -5208,6 +5245,7 @@ func (c *Compiler) emitCreateNamespace(destReg Register, modulePath string, line
 // emitGetModuleExport generates OpGetModuleExport bytecode to get an exported value
 func (c *Compiler) emitGetModuleExport(destReg Register, modulePath string, exportName string, line int) {
 	// Add module path as a string constant
+	modulePath = c.canonicalModulePath(modulePath)
 	modulePathValue := vm.String(modulePath)
 	modulePathIdx := c.chunk.AddConstant(modulePathValue)
 

--- a/pkg/compiler/module_bindings.go
+++ b/pkg/compiler/module_bindings.go
@@ -151,7 +151,7 @@ func (mb *ModuleBindings) ResolveImportedValue(localName string) vm.Value {
 
 	// Try to resolve the value from the source module using ModuleLoader
 	if mb.ModuleLoader != nil {
-		if sourceModule := mb.ModuleLoader.GetModule(reference.SourceModule); sourceModule != nil {
+		if sourceModule := mb.ModuleLoader.GetModule(reference.SourceModule, mb.ModulePath); sourceModule != nil {
 			// Look up the exported value from the source module
 			if reference.ImportType == ImportNamespaceRef {
 				// For namespace imports, create a namespace object with all exports

--- a/pkg/driver/host_embed_test.go
+++ b/pkg/driver/host_embed_test.go
@@ -61,8 +61,8 @@ func TestHostDeclareModuleAliasSameRecord(t *testing.T) {
 		t.Fatal("fs and node:fs must be the same module record")
 	}
 
-	fsRecord := p.GetModuleLoader().GetModule("fs")
-	nodeRecord := p.GetModuleLoader().GetModule("node:fs")
+	fsRecord := p.GetModuleLoader().GetModule("fs", ".")
+	nodeRecord := p.GetModuleLoader().GetModule("node:fs", ".")
 	if fsRecord == nil || nodeRecord == nil {
 		t.Fatal("expected both specifiers to be cached")
 	}

--- a/pkg/driver/host_script_test.go
+++ b/pkg/driver/host_script_test.go
@@ -71,7 +71,7 @@ func TestHostRunScriptNoModuleRecord(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("RunScript failed: %v", errs[0])
 	}
-	if rec := p.GetModuleLoader().GetModule(filename); rec != nil {
+	if rec := p.GetModuleLoader().GetModule(filename, "."); rec != nil {
 		t.Fatal("RunScript must not invent a ModuleRecord")
 	}
 }

--- a/pkg/driver/native_module_test.go
+++ b/pkg/driver/native_module_test.go
@@ -68,7 +68,7 @@ func TestNativeModuleBasic(t *testing.T) {
 	`
 
 	// Test that the native module can be resolved
-	moduleRecord := p.moduleLoader.GetModule("math-utils")
+	moduleRecord := p.moduleLoader.GetModule("math-utils", ".")
 	if moduleRecord == nil {
 		// Let's try resolving it directly
 		if p.nativeResolver != nil {

--- a/pkg/modules/interfaces.go
+++ b/pkg/modules/interfaces.go
@@ -59,8 +59,11 @@ type ModuleLoader interface {
 	// SetVMInstance sets the VM instance for native module initialization
 	SetVMInstance(vm *vm.VM)
 
-	// GetModule retrieves a cached module record
-	GetModule(specifier string) *ModuleRecord
+	// GetModule retrieves a cached module record for specifier as imported
+	// from fromPath, without loading it. The importer matters: the same
+	// relative specifier text names different files from different
+	// directories. A specifier that is itself a resolved path is also found.
+	GetModule(specifier, fromPath string) *ModuleRecord
 
 	// ClearCache clears the module cache
 	ClearCache()
@@ -80,14 +83,15 @@ type ModuleLoader interface {
 
 // ModuleRegistry manages the cache of loaded modules
 type ModuleRegistry interface {
-	// Get retrieves a module record by specifier
+	// Get retrieves a module record by cache key (see ModuleCacheKey), or by
+	// resolved path when the key misses.
 	Get(specifier string) *ModuleRecord
 
 	// GetByResolvedPath retrieves a module record by canonical resolved path.
 	// Specifier aliases (fs vs node:fs, ./foo vs ./foo.ts) share one record.
 	GetByResolvedPath(resolvedPath string) *ModuleRecord
 
-	// Set stores a module record
+	// Set stores a module record under a cache key (see ModuleCacheKey)
 	Set(specifier string, record *ModuleRecord)
 
 	// SetParsed updates a module record with parse results

--- a/pkg/modules/loader.go
+++ b/pkg/modules/loader.go
@@ -128,12 +128,22 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 		return ml.loadJSONModule(specifier, fromPath)
 	}
 
-	// Check cache first
-	cachedRecord := ml.registry.Get(specifier)
+	// Check cache first. The key includes the importer: the same relative
+	// specifier text names different files from different directories (#183).
+	cacheKey := ModuleCacheKey(specifier, fromPath)
+	cachedRecord := ml.registry.Get(cacheKey)
 	debugPrintf("// [ModuleLoader] Cache check for %s: %v\n", specifier, cachedRecord != nil)
 	if cachedRecord != nil {
 		debugPrintf("// [ModuleLoader] Returning cached module: %s (has error: %v)\n", specifier, cachedRecord.GetError() != nil)
 		return cachedRecord, nil
+	}
+
+	// A specifier that is already a canonical resolved path (the compiler emits
+	// those into bytecode, see Compiler.canonicalModulePath) maps straight to
+	// its record without going through the resolvers.
+	if existing := ml.registry.GetByResolvedPath(specifier); existing != nil {
+		ml.registry.Set(cacheKey, existing)
+		return existing, nil
 	}
 
 	// Resolve the module
@@ -148,7 +158,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 			if resolved.Source != nil {
 				_ = resolved.Source.Close()
 			}
-			ml.registry.Set(specifier, existing)
+			ml.registry.Set(cacheKey, existing)
 			debugPrintf("// [ModuleLoader] Aliased specifier %s -> existing %s\n", specifier, resolved.ResolvedPath)
 			return existing, nil
 		}
@@ -164,7 +174,7 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 
 	// Store in registry
 	debugPrintf("// [ModuleLoader] Storing in registry: specifier=%s, resolvedPath=%s\n", specifier, record.ResolvedPath)
-	ml.registry.Set(specifier, record)
+	ml.registry.Set(cacheKey, record)
 
 	// Actually parse the module
 	err = ml.parseModuleSequential(record, resolved)
@@ -337,11 +347,16 @@ func (ml *moduleLoader) loadModuleSequential(specifier string, fromPath string) 
 func (ml *moduleLoader) loadJSONModule(specifier string, fromPath string) (*ModuleRecord, error) {
 	debugPrintf("// [ModuleLoader] loadJSONModule START: %s from %s\n", specifier, fromPath)
 
-	// Check cache first
-	cachedRecord := ml.registry.Get(specifier)
+	// Check cache first (keyed by importer + specifier, see ModuleCacheKey)
+	cacheKey := ModuleCacheKey(specifier, fromPath)
+	cachedRecord := ml.registry.Get(cacheKey)
 	if cachedRecord != nil {
 		debugPrintf("// [ModuleLoader] Returning cached JSON module: %s\n", specifier)
 		return cachedRecord, nil
+	}
+	if existing := ml.registry.GetByResolvedPath(specifier); existing != nil {
+		ml.registry.Set(cacheKey, existing)
+		return existing, nil
 	}
 
 	// Resolve the module
@@ -360,7 +375,7 @@ func (ml *moduleLoader) loadJSONModule(specifier string, fromPath string) (*Modu
 	}
 
 	// Store in registry
-	ml.registry.Set(specifier, record)
+	ml.registry.Set(cacheKey, record)
 
 	// Read JSON content
 	defer resolved.Source.Close()
@@ -726,9 +741,14 @@ func (ml *moduleLoader) AddResolver(resolver ModuleResolver) {
 	})
 }
 
-// GetModule retrieves a cached module record
-func (ml *moduleLoader) GetModule(specifier string) *ModuleRecord {
-	return ml.registry.Get(specifier)
+// GetModule retrieves a cached module record for specifier as imported from
+// fromPath, without loading it. Falls back to treating specifier as a
+// resolved path, so callers holding a canonical path can look up by it.
+func (ml *moduleLoader) GetModule(specifier, fromPath string) *ModuleRecord {
+	if record := ml.registry.Get(ModuleCacheKey(specifier, fromPath)); record != nil {
+		return record
+	}
+	return ml.registry.GetByResolvedPath(specifier)
 }
 
 // ClearCache clears the module cache

--- a/pkg/modules/registry.go
+++ b/pkg/modules/registry.go
@@ -28,12 +28,28 @@ func NewRegistry(config *LoaderConfig) ModuleRegistry {
 	}
 }
 
-// Get retrieves a module record by specifier
+// ModuleCacheKey builds the key a module is cached under in the specifier
+// map. The raw specifier text alone is not a valid key: a relative specifier
+// names a different file from every importing directory ("./_helper.mjs"
+// from dirA/ vs dirB/), and a bare one can resolve differently under nested
+// node_modules (#183). Folding in the importer's path keeps those apart;
+// specifiers that resolve to the same file still share one record through
+// the byPath index.
+func ModuleCacheKey(specifier, fromPath string) string {
+	return fromPath + "\x00" + specifier
+}
+
+// Get retrieves a module record by cache key (see ModuleCacheKey). A key
+// that misses is also tried as a resolved path, so callers holding a
+// canonical path can look a module up directly.
 func (r *registry) Get(specifier string) *ModuleRecord {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
 	record := r.modules[specifier]
+	if record == nil {
+		record = r.byPath[specifier]
+	}
 	if record != nil {
 		r.stats.CacheHits++
 

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -797,7 +797,15 @@ type Chunk struct {
 	// source the embedder passed - the entry script - printing a line of the
 	// wrong file underneath an otherwise-correct line number (#148). Nil for
 	// hand-assembled chunks and any compile path that has no source file.
-	Source         *source.SourceFile
+	Source *source.SourceFile
+	// ModulePath is the module this chunk was compiled as part of (the loader's
+	// resolved path, or the driver's entry-module name), inherited by nested
+	// function chunks. Dynamic import() and import.meta inside a function body
+	// resolve against it, because the function may run long after its module
+	// finished, called from code in another module: the VM's "current module"
+	// is then the caller's, not the one containing the code (#183 follow-up).
+	// Empty for script (non-module) compiles.
+	ModulePath     string
 	ExceptionTable []ExceptionHandler // Exception handlers for try/catch blocks
 	// BuiltinGlobalNames and GlobalNames record the compiler's indexed global
 	// layout. InterpretChunk consumers use them to reject incompatible VMs before

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -114,6 +114,7 @@ type ModuleContext struct {
 	globalNames       []string         // Module-specific global variable names (for debugging)
 	namespace         Value            // Cached namespace object (ES6 9.4.6 Module Namespace Exotic Object)
 	resolvedPath      string           // Canonical path, used as fromPath for nested relative imports
+	record            ModuleRecord     // Loader record; nil for contexts pre-registered by the driver
 	collectingExports bool             // Guard against re-export collection recursion
 }
 
@@ -1002,6 +1003,31 @@ func (vm *VM) moduleFromPath() string {
 		return "."
 	}
 	return vm.currentModulePath
+}
+
+// moduleContextKey maps an import specifier, as written at the current import
+// site, to the key its ModuleContext lives under: the loader's canonical
+// resolved path. Keying by the raw specifier text conflated distinct files
+// imported by the same relative spelling from different directories (#183).
+// The loader record comes back too so callers need not resolve twice. When
+// there is no loader or resolution fails the raw specifier is returned and
+// the caller surfaces the failure through its own load path.
+func (vm *VM) moduleContextKey(modulePath string) (string, ModuleRecord) {
+	// Bytecode carries resolved paths already; those hit directly.
+	if ctx, exists := vm.moduleContexts[modulePath]; exists && ctx != nil {
+		return modulePath, ctx.record
+	}
+	if vm.moduleLoader == nil {
+		return modulePath, nil
+	}
+	rec, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
+	if err != nil || rec == nil {
+		return modulePath, nil
+	}
+	if resolved := rec.GetResolvedPath(); resolved != "" {
+		return resolved, rec
+	}
+	return modulePath, rec
 }
 
 // RegisterExecutingModule pre-registers a module context for a module that the driver
@@ -13317,7 +13343,13 @@ startExecution:
 			importMetaObj := importMetaValue.AsDictObject()
 
 			// Set import.meta.url to a file:// URL for filesystem modules (native:// unchanged).
-			if url := ImportMetaURLWithBase(vm.currentModulePath, vm.importMetaBaseDir); url != "" {
+			// The chunk's own module, not whichever module is running now (see
+			// Chunk.ModulePath); a function's import.meta must name its file.
+			metaModulePath := vm.currentModulePath
+			if function.Chunk.ModulePath != "" {
+				metaModulePath = function.Chunk.ModulePath
+			}
+			if url := ImportMetaURLWithBase(metaModulePath, vm.importMetaBaseDir); url != "" {
 				importMetaObj.SetOwn("url", NewString(url))
 			} else {
 				// If not in a module context, use undefined (though this shouldn't happen)
@@ -13401,7 +13433,28 @@ startExecution:
 
 			// Execute the module using the standard module loading infrastructure
 			// This goes through the resolver chain (fs, virtual, data URLs, native modules)
+			//
+			// A relative specifier resolves against the module containing this
+			// import() call, which is not necessarily the module running right
+			// now: a function exported from dirA/user.mjs and called from
+			// main.mjs still imports "./_helper.mjs" from dirA/. The chunk
+			// records its module; pin the VM's current module to it while
+			// loading, then restore.
+			prevImportFrom := vm.currentModulePath
+			if mp := function.Chunk.ModulePath; mp != "" {
+				vm.currentModulePath = mp
+			}
 			status, moduleErrVal := vm.executeModule(specifier)
+			var moduleCtx *ModuleContext
+			var ctxExists bool
+			if status == InterpretOK {
+				contextKey, _ := vm.moduleContextKey(specifier)
+				moduleCtx, ctxExists = vm.moduleContexts[contextKey]
+				if ctxExists && len(moduleCtx.exports) == 0 {
+					vm.collectModuleExports(specifier, moduleCtx)
+				}
+			}
+			vm.currentModulePath = prevImportFrom
 			if status != InterpretOK {
 				// Module load failed - reject the promise with the error.
 				// Prefer the actual thrown value (moduleErrVal) as the rejection
@@ -13437,20 +13490,14 @@ startExecution:
 				continue
 			}
 
-			// Get the module context to access its exports
-			moduleCtx, exists := vm.moduleContexts[specifier]
-			if !exists {
+			// The module context (exports already collected above)
+			if !ctxExists {
 				errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
 				errObj.SetOwn("name", NewString("Error"))
 				errObj.SetOwn("message", NewString(fmt.Sprintf("Module '%s' was loaded but context is missing", specifier)))
 				vm.rejectPromise(promiseObj, NewValueFromPlainObject(errObj))
 				registers[destReg] = promiseVal
 				continue
-			}
-
-			// Ensure exports are collected
-			if len(moduleCtx.exports) == 0 {
-				vm.collectModuleExports(specifier, moduleCtx)
 			}
 
 			// Create a namespace object containing all exports
@@ -19548,8 +19595,11 @@ func (vm *VM) convertJSONToValue(value interface{}) Value {
 }
 func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	// fmt.Printf("// [VM] executeModule: CALLED for module '%s'\n", modulePath)
+	// Contexts are keyed by resolved path, not by the specifier text (#183).
+	contextKey, moduleRecord := vm.moduleContextKey(modulePath)
+
 	// Check if module is already cached and executed
-	if moduleCtx, exists := vm.moduleContexts[modulePath]; exists {
+	if moduleCtx, exists := vm.moduleContexts[contextKey]; exists {
 		if moduleCtx.executed {
 			// Module already executed, ensure exports are collected and return success
 			if len(moduleCtx.exports) == 0 {
@@ -19567,7 +19617,7 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	}
 
 	// Load the module if not cached
-	if _, exists := vm.moduleContexts[modulePath]; !exists {
+	if _, exists := vm.moduleContexts[contextKey]; !exists {
 		// Before asking the module loader to resolve+compile this path, check whether
 		// it's actually a currently-executing module already registered under a
 		// different (but equivalent) specifier -- most commonly the entry module,
@@ -19576,8 +19626,8 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 		// re-execution of the same source and, just as importantly, avoids compiling
 		// an independent copy of it whose global-index bindings would diverge from
 		// the copy actually running.
-		if aliased := vm.findExecutingModuleContext(modulePath); aliased != nil {
-			vm.moduleContexts[modulePath] = aliased
+		if aliased := vm.findExecutingModuleContext(contextKey); aliased != nil {
+			vm.moduleContexts[contextKey] = aliased
 			return InterpretOK, Undefined
 		}
 
@@ -19585,10 +19635,14 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 			return vm.runtimeError("No module loader available"), Undefined
 		}
 
-		// Load the module using the module loader. Relative specifiers must
-		// resolve against the importing module, not cwd.
-		moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
-		if err != nil {
+		// moduleContextKey already asked the loader for the record, resolving
+		// the specifier against the importing module rather than cwd. A nil
+		// record means that failed; repeat the load to surface the error.
+		if moduleRecord == nil {
+			_, err := vm.moduleLoader.LoadModule(modulePath, vm.moduleFromPath())
+			if err == nil {
+				err = fmt.Errorf("module loader returned no record")
+			}
 			return vm.runtimeErrorFrom(err, "Failed to load module '%s': %s", modulePath, err.Error()), Undefined
 		}
 
@@ -19598,27 +19652,23 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 			return vm.runtimeErrorFrom(moduleErr, "Module '%s' failed to load: %s", modulePath, moduleErr.Error()), Undefined
 		}
 
-		// The module loader already dedupes *records* by resolved path (so this
-		// specifier and some other specifier that reaches the same file on disk
-		// share one ModuleRecord, one parse, one compile). But moduleContexts here
-		// is keyed by the raw specifier text as written at *this* import site, not
-		// by resolved path -- so without this check, a second distinct specifier
-		// string resolving to a module already executed (or currently executing)
-		// under a different spelling would fall through to "create a new context
-		// and run the chunk", re-running that module's top-level code and
-		// duplicating its side effects. findExecutingModuleContext (above) already
-		// guards the in-flight/circular case by resolved path; this guards the
-		// already-finished case the same way.
+		// Contexts are keyed by resolved path, so a second spelling of the same
+		// file normally lands on the same key above. The exception is a context
+		// the driver pre-registered (RegisterExecutingModule) under a path
+		// spelled differently from the loader's resolved path; without this
+		// check that module would be run a second time, duplicating its
+		// top-level side effects. findExecutingModuleContext (above) guards the
+		// in-flight/circular case; this guards the already-finished case.
 		if resolvedPath := moduleRecord.GetResolvedPath(); resolvedPath != "" {
 			for path, ctx := range vm.moduleContexts {
-				if path == modulePath || ctx == nil || ctx.resolvedPath != resolvedPath {
+				if path == contextKey || ctx == nil || ctx.resolvedPath != resolvedPath {
 					continue
 				}
 				// Only alias the key when we can actually skip re-running the
 				// chunk below; otherwise leave moduleContexts untouched so the
 				// fresh-context path below (unchanged) is the single writer.
 				if ctx.executed || ctx.executing {
-					vm.moduleContexts[modulePath] = ctx
+					vm.moduleContexts[contextKey] = ctx
 					return InterpretOK, Undefined
 				}
 				break
@@ -19635,11 +19685,12 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 			}
 
 			// Create module context for JSON module with default export
-			vm.moduleContexts[modulePath] = &ModuleContext{
+			vm.moduleContexts[contextKey] = &ModuleContext{
 				chunk:        nil, // JSON modules don't have chunks
 				exports:      map[string]Value{"default": jsonValue},
 				executed:     true, // JSON modules are immediately "executed"
 				resolvedPath: moduleRecord.GetResolvedPath(),
+				record:       moduleRecord,
 			}
 			return InterpretOK, Undefined
 		}
@@ -19654,17 +19705,18 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 
 		// Create module context without module-scoped globals
 		// All modules now use the unified heap
-		vm.moduleContexts[modulePath] = &ModuleContext{
+		vm.moduleContexts[contextKey] = &ModuleContext{
 			chunk:        chunk,
 			exports:      make(map[string]Value),
 			executed:     false,
 			globals:      nil, // No longer used - unified heap replaces this
 			globalNames:  nil, // No longer used - unified heap replaces this
 			resolvedPath: moduleRecord.GetResolvedPath(),
+			record:       moduleRecord,
 		}
 	}
 
-	moduleCtx := vm.moduleContexts[modulePath]
+	moduleCtx := vm.moduleContexts[contextKey]
 
 	// If already executed, return success
 	if moduleCtx.executed {
@@ -19678,27 +19730,13 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 		moduleCtx.executing = false
 	}()
 
-	// Push current execution context onto stack with deep copy of registers
-	if vm.frameCount > 0 {
-		currentFrame := vm.frames[vm.frameCount-1]
-
-		// Deep copy the register values for proper isolation
-		registerCount := len(currentFrame.registers)
-		savedRegisters := make([]Value, registerCount)
-		copy(savedRegisters, currentFrame.registers)
-
-		ctx := ExecutionContext{
-			frame:              currentFrame,
-			frameCount:         vm.frameCount,
-			nextRegSlot:        vm.nextRegSlot,
-			currentModulePath:  vm.currentModulePath,
-			savedRegisters:     savedRegisters,
-			savedRegisterCount: registerCount,
-		}
-		vm.executionContextStack = append(vm.executionContextStack, ctx)
-
-		// fmt.Printf("// [VM] executeModule: Saved execution context with %d registers deep copied\n", registerCount)
-	}
+	// The module frame runs on top of the current stack (see below), so the
+	// caller's frames and registers are left untouched; only the current
+	// module path needs saving. (This used to deep-copy the innermost frame's
+	// registers because the module was run in frame slot 0, over the entry
+	// frame; that also silently reverted writes the module made through
+	// upvalues into the caller's registers.)
+	savedModulePath := vm.currentModulePath
 
 	// Set current module context for nested relative imports and import.meta
 	if moduleCtx.resolvedPath != "" {
@@ -19767,22 +19805,53 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 		return vm.runtimeError("Register stack overflow during module execution"), Undefined
 	}
 
-	// Save current frame state for isolation
+	// Save current frame state. The module frame is popped by its own OpReturn,
+	// or left in place by an uncaught exception; either way both are restored
+	// below.
 	savedFrameCount := vm.frameCount
 	savedNextRegSlot := vm.nextRegSlot
+	savedCrossedNative := vm.unwindingCrossedNative
+	if vm.frameCount >= len(vm.frames) {
+		return vm.runtimeError("Frame stack overflow during module execution"), Undefined
+	}
 
-	// Execute module as top-level frame (frameCount=1) for proper isolation
-	vm.frameCount = 0
-	vm.nextRegSlot = 0
-
-	// Push module frame as the ONLY frame (frameCount will become 1)
+	// Push the module frame ON TOP of the current stack, like a nested eval
+	// (Interpret) or a native-to-bytecode call (CallFunctionDirectly). It used
+	// to reset frameCount and nextRegSlot to 0 and run the module in frame
+	// slot 0: fine for an import at the entry module's top level, whose frame
+	// is slot 0 and was saved and restored, but whenever the import happened
+	// inside a function call - a dynamic import() in a function body - the
+	// module overwrote the entry frame and every outer register window, and
+	// only the innermost frame was restored, so the caller resumed with
+	// garbage in its registers. isDirectCall makes vm.run() return when this
+	// frame returns, and makes the exception unwinder stop at it instead of
+	// walking into the caller's handlers.
 	frame := &vm.frames[vm.frameCount]
 	frame.closure = mainClosureObj
 	frame.ip = 0
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+scriptRegSize]
+	for i := range frame.registers {
+		frame.registers[i] = Undefined // slots above nextRegSlot hold stale values
+	}
 	frame.allocatedRegSize = scriptRegSize // Track actual allocation for proper cleanup
-	frame.targetRegister = 0
+	frame.targetRegister = 0               // a direct-call return writes no caller register
 	frame.thisValue = Undefined
+	frame.homeObject = Undefined
+	frame.isConstructorCall = false
+	frame.newTargetValue = Undefined
+	frame.isDirectCall = vm.frameCount > 0
+	frame.isSentinelFrame = false
+	frame.isGeneratorPrologue = false
+	frame.argCount = 0
+	frame.args = nil
+	frame.argumentsObject = Undefined
+	frame.calleeValue = Undefined
+	frame.isNativeFrame = false
+	frame.nativeReturnCh = nil
+	frame.nativeYieldCh = nil
+	frame.nativeCompleteCh = nil
+	frame.generatorObj = nil
+	frame.promiseObj = nil
 	frame.openUpvalues = nil // frame slot may have been used before; start with no open upvalues
 	// Allocate this frame's spill slots, matching every other frame-setup site
 	// (Interpret, Call, Construct): a module whose top level spills a binding
@@ -19798,10 +19867,8 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	vm.nextRegSlot += scriptRegSize
 	vm.frameCount++
 
-	// fmt.Printf("// [VM DEBUG] executeModule: Module '%s' executing with frameCount=%d (isolated)\n", modulePath, vm.frameCount)
-
-	// Execute module directly using isolated vm.run() call
-	// Now the module will execute as frameCount=1 and OpReturn will exit at frameCount=0
+	// Run the module; vm.run() returns when the module frame returns (direct
+	// call) or, when there was no caller frame, when the stack empties.
 	resultStatus, result := vm.run()
 
 	// Capture any JavaScript exception that was thrown but not caught
@@ -19819,13 +19886,17 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	if vm.unwinding && vm.currentException != Null {
 		moduleException = vm.currentException
 		hasModuleException = true
-		// Clear the unwinding state since we're handling the exception here
+		// Clear the unwinding state since we're handling the exception here.
+		// The unwinder stopped at our direct-call frame and flagged the
+		// crossing; we consume the exception, so put that flag back too.
 		vm.unwinding = false
 		vm.currentException = Null
+		vm.unwindingCrossedNative = savedCrossedNative
 		resultStatus = InterpretRuntimeError
 	}
 
-	// Restore frame state after module execution
+	// Restore frame state after module execution (pops the module frame, and
+	// anything an uncaught exception left above it)
 	vm.frameCount = savedFrameCount
 	vm.nextRegSlot = savedNextRegSlot
 	// fmt.Printf("// [VM DEBUG] executeModule: Module '%s' completed, frameCount restored to %d\n", modulePath, vm.frameCount)
@@ -19873,31 +19944,8 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	//	}
 	// }
 
-	// Pop and restore execution context from stack with deep copied registers
-	if len(vm.executionContextStack) > 0 {
-		ctx := vm.executionContextStack[len(vm.executionContextStack)-1]
-		vm.executionContextStack = vm.executionContextStack[:len(vm.executionContextStack)-1]
-
-		vm.frameCount = ctx.frameCount
-		vm.nextRegSlot = ctx.nextRegSlot
-		if vm.frameCount > 0 {
-			vm.frames[vm.frameCount-1] = ctx.frame
-
-			// Restore the deep copied register values for proper isolation
-			if len(ctx.savedRegisters) > 0 && ctx.savedRegisterCount > 0 {
-				// Ensure we don't exceed the current frame's register capacity
-				restoreCount := ctx.savedRegisterCount
-				if restoreCount > len(vm.frames[vm.frameCount-1].registers) {
-					restoreCount = len(vm.frames[vm.frameCount-1].registers)
-				}
-
-				copy(vm.frames[vm.frameCount-1].registers[:restoreCount], ctx.savedRegisters[:restoreCount])
-				// fmt.Printf("// [VM] executeModule: Restored execution context with %d registers deep copied back\n", restoreCount)
-			}
-		}
-		// fmt.Printf("// [VM DEBUG] executeModule: Context restore from '%s' to '%s'\n", vm.currentModulePath, ctx.currentModulePath)
-		vm.currentModulePath = ctx.currentModulePath
-	}
+	// Back to the importing module's context
+	vm.currentModulePath = savedModulePath
 
 	// With unified heap, success is determined by execution status rather than module globals
 	// Since moduleCtx.globals is nil (unified heap replaces it), check execution status directly
@@ -19942,13 +19990,18 @@ func (vm *VM) collectModuleExports(modulePath string, moduleCtx *ModuleContext) 
 	if vm.moduleLoader == nil {
 		return
 	}
-	from := vm.moduleFromPath()
-	if moduleCtx != nil && moduleCtx.resolvedPath != "" {
-		from = moduleCtx.resolvedPath
-	}
-	moduleRecord, err := vm.moduleLoader.LoadModule(modulePath, from)
-	if err != nil {
-		return
+	moduleRecord := moduleCtx.record
+	if moduleRecord == nil {
+		// Contexts pre-registered by the driver carry no record; re-resolve.
+		from := vm.moduleFromPath()
+		if moduleCtx.resolvedPath != "" {
+			from = moduleCtx.resolvedPath
+		}
+		rec, err := vm.moduleLoader.LoadModule(modulePath, from)
+		if err != nil {
+			return
+		}
+		moduleRecord = rec
 	}
 
 	if moduleCtx.collectingExports {
@@ -20033,7 +20086,8 @@ func (vm *VM) GetModuleExport(fromResolvedPath, modulePath, exportName string) V
 
 // getModuleExport retrieves an exported value from a module
 func (vm *VM) getModuleExport(modulePath string, exportName string) Value {
-	moduleCtx, exists := vm.moduleContexts[modulePath]
+	contextKey, _ := vm.moduleContextKey(modulePath)
+	moduleCtx, exists := vm.moduleContexts[contextKey]
 	if !exists {
 		moduleCtx, exists = vm.findModuleContextByResolved(modulePath)
 	}
@@ -20081,9 +20135,10 @@ func (vm *VM) DebugPrintGlobals() {
 }
 
 func (vm *VM) createModuleNamespace(modulePath string) Value {
+	contextKey, _ := vm.moduleContextKey(modulePath)
 
 	// Check if module context exists
-	if moduleCtx, exists := vm.moduleContexts[modulePath]; exists {
+	if moduleCtx, exists := vm.moduleContexts[contextKey]; exists {
 
 		// Always try to collect exports if they haven't been collected yet
 		// This is crucial for having complete export lists before caching

--- a/tests/scripts/dynamic_import_same_basename_dirs.ts
+++ b/tests/scripts/dynamic_import_same_basename_dirs.ts
@@ -1,0 +1,13 @@
+// expect: 10|105|A-value|B-value
+// Follow-up to #183 for dynamic import(): a function exported from a/dyn.ts
+// and called from here must resolve its import("./_helper.ts") against a/,
+// not against this file's directory (which has no _helper.ts) or against
+// whichever module happened to run last.
+import { dynA, dynOnlyA } from "./import_same_basename/a/dyn.ts";
+import { dynB, dynOnlyB } from "./import_same_basename/b/dyn.ts";
+
+const a = await dynA(5);
+const b = await dynB(5);
+const onlyA = await dynOnlyA();
+const onlyB = await dynOnlyB();
+`${a}|${b}|${onlyA}|${onlyB}`;

--- a/tests/scripts/import_same_basename/a/_helper.ts
+++ b/tests/scripts/import_same_basename/a/_helper.ts
@@ -1,0 +1,2 @@
+export function transform(x: number): number { return x * 2; }
+export function onlyInA(): string { return "A-value"; }

--- a/tests/scripts/import_same_basename/a/dyn.ts
+++ b/tests/scripts/import_same_basename/a/dyn.ts
@@ -1,0 +1,8 @@
+export async function dynA(x: number): Promise<number> {
+  const m = await import("./_helper.ts");
+  return m.transform(x);
+}
+export async function dynOnlyA(): Promise<string> {
+  const m = await import("./_helper.ts");
+  return m.onlyInA();
+}

--- a/tests/scripts/import_same_basename/a/user.ts
+++ b/tests/scripts/import_same_basename/a/user.ts
@@ -1,0 +1,3 @@
+import { transform, onlyInA } from "./_helper.ts";
+export function useA(x: number): number { return transform(x); }
+export function a(): string { return onlyInA(); }

--- a/tests/scripts/import_same_basename/b/_helper.ts
+++ b/tests/scripts/import_same_basename/b/_helper.ts
@@ -1,0 +1,2 @@
+export function transform(x: number): number { return x + 100; }
+export function onlyInB(): string { return "B-value"; }

--- a/tests/scripts/import_same_basename/b/dyn.ts
+++ b/tests/scripts/import_same_basename/b/dyn.ts
@@ -1,0 +1,8 @@
+export async function dynB(x: number): Promise<number> {
+  const m = await import("./_helper.ts");
+  return m.transform(x);
+}
+export async function dynOnlyB(): Promise<string> {
+  const m = await import("./_helper.ts");
+  return m.onlyInB();
+}

--- a/tests/scripts/import_same_basename/b/user.ts
+++ b/tests/scripts/import_same_basename/b/user.ts
@@ -1,0 +1,3 @@
+import { transform, onlyInB } from "./_helper.ts";
+export function useB(x: number): number { return transform(x); }
+export function b(): string { return onlyInB(); }

--- a/tests/scripts/import_same_basename_dirs.ts
+++ b/tests/scripts/import_same_basename_dirs.ts
@@ -1,0 +1,9 @@
+// expect: A-value|B-value|10|105
+// Regression test for #183: two files in different directories imported with
+// the identical relative specifier ("./_helper.ts") must each load their own
+// file. Before the fix, whichever resolved first was silently reused for both,
+// so useB(5) returned 10 and onlyInB was undefined.
+import { useA, a } from "./import_same_basename/a/user.ts";
+import { useB, b } from "./import_same_basename/b/user.ts";
+
+`${a()}|${b()}|${useA(5)}|${useB(5)}`;

--- a/tests/scripts/import_same_basename_dirs_reversed.ts
+++ b/tests/scripts/import_same_basename_dirs_reversed.ts
@@ -1,0 +1,7 @@
+// expect: B-value|A-value|105|10
+// Same as import_same_basename_dirs.ts with the import order flipped; before
+// the fix this flipped which side broke.
+import { useB, b } from "./import_same_basename/b/user.ts";
+import { useA, a } from "./import_same_basename/a/user.ts";
+
+`${b()}|${a()}|${useB(5)}|${useA(5)}`;


### PR DESCRIPTION
Fixes #183.

## What changed

Two files in different directories imported with the identical relative specifier (`./_helper.mjs` from `dirA/` and from `dirB/`) collided: whichever resolved first was silently reused for both. The second importer got a module missing its exports (`TypeError: undefined is not a function`) or, worse, a same-named export with the wrong implementation and no error at all. This was the sole blocker for `typebox`'s real entry point.

Three things conspired, and all three are fixed:

- **Loader registry keyed by raw specifier.** `pkg/modules/registry.go` now keys the cache by importer path plus specifier (`ModuleCacheKey`). Records that resolve to the same file still share one entry through the resolved-path index. `GetModule` takes the importer path; the checker, compiler bindings, and driver tests pass it.
- **VM `moduleContexts` keyed by raw specifier.** Now keyed by resolved path, and each context carries its loader record so export collection no longer re-resolves the specifier.
- **Run-time resolution can never be right for static imports.** An import binding read inside a function body executes long after the importing module finished, when the VM's "current module" is the caller's. The compiler now resolves static imports at compile time and emits the canonical path into the bytecode (`Compiler.canonicalModulePath`), mirroring ESM link-time resolution. The loader accepts a resolved path directly.

Dynamic `import()` and `import.meta` have the same problem without a static specifier to resolve, so each `vm.Chunk` now records the module it belongs to (inherited by nested function chunks), and `OpDynamicImport` / `OpLoadImportMeta` use that instead of whichever module happens to be running.

## Pre-existing VM bug fixed along the way

Testing the dynamic case exposed that `executeModule` reset `frameCount` and `nextRegSlot` to 0 and ran the module in frame slot 0. That clobbered the entry frame and every outer register window whenever a not-yet-loaded module was imported from inside a function call; only the innermost frame was saved and restored, so the caller resumed with garbage registers (printed as `<unknown 34>`). Reproducible on `main` with a same-directory dynamic import inside any function.

The module frame is now pushed on top of the stack as a direct-call frame, the mechanism nested `eval` and native-to-JS calls already use. The exception unwinder stops at that boundary, so a module that throws during a nested import is caught by the importer instead of aborting the process (it aborted on `main`). The old deep-copy register save/restore is gone; it also silently reverted writes a module made through upvalues into the caller's registers.

## Tests

- New smoke tests: `import_same_basename_dirs.ts`, `import_same_basename_dirs_reversed.ts`, `dynamic_import_same_basename_dirs.ts`, with helpers under `tests/scripts/import_same_basename/{a,b}/` (subdirectories are not run as tests themselves).
- `go test ./tests -run TestScripts` and `go test ./pkg/...` green.
- Test262 against a clean `main` build: `language/expressions/dynamic-import` gains 18 passes (nested function/async `catch` cases and `import-errored-module`); `module-code`, `import`, `export`, `expressions/await`, `statements/async-function` unchanged.

## Reviewer notes

- Bytecode for static imports now carries resolved paths rather than specifier text, so `-bytecode` output and "Failed to load module" messages show the canonical path.
- `ModuleLoader.GetModule` signature changed to `(specifier, fromPath string)`; embedders calling it directly need to pass the importer (or `"."`).
- The `ExecutionContext` type and `executionContextStack` field are now unused by `executeModule` and left in place; they can be removed in a follow-up.
