### PR TITLE
fix(builtins): String.prototype.split(regex) interleaves captured groups

### DIFF
--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -1149,14 +1149,15 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			str = toStringJS(args[0])
 		}
 
-		// Fast path: native RegExp object - use Go's regex Split directly
+		// Fast path: native RegExp object - implement the spec algorithm
+		// directly against Go's submatch-index API (captures included).
 		if rx.IsRegExp() {
 			regex := rx.AsRegExpObject()
 			if regex != nil && !regex.HasCompileError() {
 				resultArr := vm.NewArray()
 				arr := resultArr.AsArray()
 
-				// Handle limit per ECMAScript: split fully, then truncate
+				// Handle limit per ECMAScript
 				var limit uint32 = 0xFFFFFFFF
 				if len(args) >= 2 && args[1].Type() != vm.TypeUndefined {
 					lim := args[1].ToFloat()
@@ -1168,14 +1169,58 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 					}
 				}
 
-				// Split fully (unlimited), then truncate to limit
-				parts := regex.Split(str, -1)
-				for i, part := range parts {
-					if uint32(i) >= limit {
+				// Special case: empty input string (spec step 14)
+				if len(str) == 0 {
+					if regex.MatchString("") {
+						return resultArr, nil
+					}
+					arr.Append(vm.NewString(""))
+					return resultArr, nil
+				}
+
+				appendLimited := func(v vm.Value) bool {
+					arr.Append(v)
+					return uint32(arr.Length()) >= limit
+				}
+
+				// Non-overlapping matches (whole match + capture groups), byte indices.
+				allMatches := regex.FindAllStringSubmatchIndex(str, -1)
+				p := 0 // start of the next substring to emit
+				for _, match := range allMatches {
+					matchStart, matchEnd := match[0], match[1]
+					// The spec's search loop only considers positions q < size
+					// (a match can never be attempted with q at the very end of
+					// the string), so ignore a zero-length match sitting exactly
+					// at the end - it doesn't produce a trailing empty piece.
+					if matchStart >= len(str) {
 						break
 					}
-					arr.Append(vm.NewString(part))
+					// Spec step 23: a zero-length match right at the current split
+					// position doesn't split (avoids empty pieces / no progress);
+					// skip it.
+					if matchEnd == p {
+						continue
+					}
+
+					if appendLimited(vm.NewString(str[p:matchStart])) {
+						return resultArr, nil
+					}
+					p = matchEnd
+
+					for i := 2; i < len(match); i += 2 {
+						var capVal vm.Value
+						if match[i] >= 0 && match[i+1] >= 0 {
+							capVal = vm.NewString(str[match[i]:match[i+1]])
+						} else {
+							capVal = vm.Undefined
+						}
+						if appendLimited(capVal) {
+							return resultArr, nil
+						}
+					}
 				}
+
+				arr.Append(vm.NewString(str[p:]))
 				return resultArr, nil
 			}
 		}

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -1501,20 +1501,59 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		if isRegExp {
-			// RegExp separator
+			// RegExp separator. This mirrors RegExp.prototype[Symbol.split]
+			// (which normally handles this via the lookup above); kept as a
+			// spec-correct fallback in case that lookup doesn't fire, and must
+			// interleave captured groups per ECMA-262, not just emit the pieces
+			// around each match.
 			regex := separatorArg.AsRegExpObject()
 			// Check for deferred compile error
 			if regex.HasCompileError() {
 				return vm.Undefined, vmInstance.NewSyntaxError("Invalid regular expression: " + regex.GetCompileError())
 			}
 
-			parts := regex.Split(thisStr, -1)
-			if uint32(len(parts)) > limit {
-				parts = parts[:limit]
+			if len(thisStr) == 0 {
+				if regex.MatchString("") {
+					return vm.NewArray(), nil
+				}
+				return vm.NewArrayWithArgs([]vm.Value{vm.NewString("")}), nil
 			}
-			elements := make([]vm.Value, len(parts))
-			for i, part := range parts {
-				elements[i] = vm.NewString(part)
+
+			var elements []vm.Value
+			appendLimited := func(v vm.Value) bool {
+				elements = append(elements, v)
+				return uint32(len(elements)) >= limit
+			}
+
+			allMatches := regex.FindAllStringSubmatchIndex(thisStr, -1)
+			p := 0
+		splitLoop:
+			for _, match := range allMatches {
+				matchStart, matchEnd := match[0], match[1]
+				if matchStart >= len(thisStr) {
+					break
+				}
+				if matchEnd == p {
+					continue
+				}
+				if appendLimited(vm.NewString(thisStr[p:matchStart])) {
+					break splitLoop
+				}
+				p = matchEnd
+				for i := 2; i < len(match); i += 2 {
+					var capVal vm.Value
+					if match[i] >= 0 && match[i+1] >= 0 {
+						capVal = vm.NewString(thisStr[match[i]:match[i+1]])
+					} else {
+						capVal = vm.Undefined
+					}
+					if appendLimited(capVal) {
+						break splitLoop
+					}
+				}
+			}
+			if uint32(len(elements)) < limit {
+				elements = append(elements, vm.NewString(thisStr[p:]))
 			}
 			return vm.NewArrayWithArgs(elements), nil
 		} else {

--- a/tests/scripts/string_split_regex_captures.ts
+++ b/tests/scripts/string_split_regex_captures.ts
@@ -1,0 +1,9 @@
+// Test string.split(regex) interleaves captured groups per ECMA-262,
+// rather than dropping them (issue #185).
+let a = "a\nb\nc\n".split(/(\n|\r\n)/);
+let b = "2023-01-15".split(/(-)/);
+let c = "a1b2c3".split(/([a-z])(\d)/);
+// Non-capturing groups are unaffected.
+let d = "a,b;c".split(/(?:,|;)/);
+JSON.stringify([a, b, c, d]);
+// expect: [["a","\n","b","\n","c","\n",""],["2023","-","01","-","15"],["","a","1","","b","2","","c","3",""],["a","b","c"]]


### PR DESCRIPTION
## Summary

`String.prototype.split(regex)` was dropping captured groups from the result instead of interleaving them, per ECMA-262 §22.2.6.13 (`RegExp.prototype[Symbol.split]`).

## Root cause

The "fast path" for native `RegExp` objects in `RegExp.prototype[Symbol.split]` called Go's `regexp.Split()`, which only returns the substrings between matches — it has no concept of capture groups. A spec-compliant slow-path algorithm already existed right below it, but was never reached for native regexes since the fast path short-circuited first.

## Fix

Reimplemented the fast path against `FindAllStringSubmatchIndex` (already used elsewhere for `replace`), replicating the ECMA-262 algorithm: interleave each capture group's text (or `undefined` if unmatched) between the split pieces, skip zero-length matches that make no progress, handle the empty-string special case, and respect `limit`. Also hardened the equivalent (normally unreachable, since `Symbol.split` intercepts first) fallback path in `String.prototype.split` for the same bug.

## Testing

- All three repro cases from #185 now match Node exactly, including the "outright wrong" multi-capturing-group case.
- Added `tests/scripts/string_split_regex_captures.ts` as a smoke-test regression.
- `go test ./...` — all green.
- Test262: `built-ins/String/prototype/split` 100% (120/120), `built-ins/RegExp/prototype/Symbol.split` +2 new passes, full `built-ins` diff +8/-0, full `language` diff +0/-0 (no regressions).

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)