### PR TITLE
fix(compiler): optional call on a member-expression callee handles spread args

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -3972,6 +3972,51 @@ func (c *Compiler) compileOptionalIndexExpression(node *parser.OptionalIndexExpr
 	return hint, nil
 }
 
+// compileOptionalMethodCallArgs compiles the arguments of a method-style optional call
+// (i.e. one with a `this` binding: obj.method?.(...), obj[key]?.(...), super.method?.(...))
+// and emits the call itself. When any argument is a spread element, the arguments are
+// collected into an array at runtime and OpSpreadCallMethod is used - mirroring how
+// compileMultiSpreadCall handles the non-optional `obj.method(...args)` case; without this,
+// a spread argument here would either fail to compile (a *parser.SpreadElement isn't a plain
+// expression) or, in the array/index-callee shape, be silently mishandled.
+func (c *Compiler) compileOptionalMethodCallArgs(node *parser.OptionalCallExpression, methodReg, thisReg, callResultReg Register, tempRegs *[]Register, line int) errors.PaseratiError {
+	if c.hasSpreadArgument(node.Arguments) {
+		arrayReg := c.regAlloc.Alloc()
+		*tempRegs = append(*tempRegs, arrayReg)
+
+		arrayLiteral := &parser.ArrayLiteral{
+			Elements: node.Arguments,
+			Token:    node.Token,
+		}
+		_, err := c.compileArrayLiteral(arrayLiteral, arrayReg)
+		if err != nil {
+			return NewCompileError(node, "error compiling spread arguments in optional call expression").CausedBy(err)
+		}
+
+		c.emitSpreadCallMethod(callResultReg, methodReg, thisReg, arrayReg, line)
+		return nil
+	}
+
+	totalArgCount := len(node.Arguments)
+	blockSize := 1 + totalArgCount
+	funcCallReg := c.regAlloc.AllocContiguous(blockSize)
+	for i := 0; i < blockSize; i++ {
+		*tempRegs = append(*tempRegs, funcCallReg+Register(i))
+	}
+	c.emitMove(funcCallReg, methodReg, line)
+
+	for i, arg := range node.Arguments {
+		argReg := funcCallReg + Register(1+i)
+		_, err := c.compileNode(arg, argReg)
+		if err != nil {
+			return NewCompileError(arg, "error compiling argument in optional call expression").CausedBy(err)
+		}
+	}
+
+	c.emitCallMethod(callResultReg, funcCallReg, thisReg, byte(totalArgCount), line)
+	return nil
+}
+
 // compileOptionalCallExpression compiles optional function calls (e.g., func?.())
 func (c *Compiler) compileOptionalCallExpression(node *parser.OptionalCallExpression, hint Register) (Register, errors.PaseratiError) {
 	// Manage temporary registers with automatic cleanup
@@ -4020,32 +4065,14 @@ func (c *Compiler) compileOptionalCallExpression(node *parser.OptionalCallExpres
 			// Method is not null/undefined - do method call with this binding
 			c.patchJump(jumpToCallPos)
 
-			// 4. Allocate contiguous block for function + arguments
-			totalArgCount := len(node.Arguments)
-			blockSize := 1 + totalArgCount
-			funcCallReg := c.regAlloc.AllocContiguous(blockSize)
-			for i := 0; i < blockSize; i++ {
-				tempRegs = append(tempRegs, funcCallReg+Register(i))
-			}
-
-			// 5. Move method to call block
-			c.emitMove(funcCallReg, methodReg, node.Token.Line)
-
-			// 6. Compile arguments
-			for i, arg := range node.Arguments {
-				argReg := funcCallReg + Register(1+i)
-				_, err := c.compileNode(arg, argReg)
-				if err != nil {
-					c.inTailPosition = oldTailPos
-					return BadRegister, NewCompileError(arg, "error compiling argument in super optional call expression").CausedBy(err)
-				}
+			// 4. Compile arguments (spread-aware) and emit the call
+			if err := c.compileOptionalMethodCallArgs(node, methodReg, thisReg, hint, &tempRegs, node.Token.Line); err != nil {
+				c.inTailPosition = oldTailPos
+				return BadRegister, err
 			}
 			c.inTailPosition = oldTailPos
 
-			// 7. Emit method call with proper this binding
-			c.emitCallMethod(hint, funcCallReg, thisReg, byte(totalArgCount), node.Token.Line)
-
-			// 8. Patch end jump
+			// 5. Patch end jump
 			c.patchJump(endJumpPos)
 
 			return hint, nil
@@ -4090,32 +4117,14 @@ func (c *Compiler) compileOptionalCallExpression(node *parser.OptionalCallExpres
 			tempRegs = append(tempRegs, callResultReg)
 		}
 
-		// 4. Allocate contiguous block for function + arguments
-		totalArgCount := len(node.Arguments)
-		blockSize := 1 + totalArgCount
-		funcCallReg := c.regAlloc.AllocContiguous(blockSize)
-		for i := 0; i < blockSize; i++ {
-			tempRegs = append(tempRegs, funcCallReg+Register(i))
-		}
-
-		// 5. Move method to call block
-		c.emitMove(funcCallReg, methodReg, node.Token.Line)
-
-		// 6. Compile arguments
-		for i, arg := range node.Arguments {
-			argReg := funcCallReg + Register(1+i)
-			_, err := c.compileNode(arg, argReg)
-			if err != nil {
-				c.inTailPosition = oldTailPos
-				return BadRegister, NewCompileError(arg, "error compiling argument in optional call expression").CausedBy(err)
-			}
+		// 4. Compile arguments (spread-aware) and emit the call with proper this binding
+		if err := c.compileOptionalMethodCallArgs(node, methodReg, thisReg, callResultReg, &tempRegs, node.Token.Line); err != nil {
+			c.inTailPosition = oldTailPos
+			return BadRegister, err
 		}
 		c.inTailPosition = oldTailPos
 
-		// 7. Emit method call with proper this binding
-		c.emitCallMethod(callResultReg, funcCallReg, thisReg, byte(totalArgCount), node.Token.Line)
-
-		// 8. Apply continuation if present (e.g., the .c in obj.method?.().c)
+		// 5. Apply continuation if present (e.g., the .c in obj.method?.().c)
 		if node.Continuation != nil {
 			_, err := c.compileOptionalContinuation(node.Continuation, callResultReg, hint, &tempRegs, node.Token.Line)
 			if err != nil {
@@ -4123,7 +4132,7 @@ func (c *Compiler) compileOptionalCallExpression(node *parser.OptionalCallExpres
 			}
 		}
 
-		// 9. Patch end jump
+		// 6. Patch end jump
 		c.patchJump(endJumpPos)
 
 		return hint, nil
@@ -4173,32 +4182,14 @@ func (c *Compiler) compileOptionalCallExpression(node *parser.OptionalCallExpres
 		// Method is not null/undefined - do method call with this binding
 		c.patchJump(jumpToCallPos)
 
-		// 5. Allocate contiguous block for function + arguments
-		totalArgCount := len(node.Arguments)
-		blockSize := 1 + totalArgCount
-		funcCallReg := c.regAlloc.AllocContiguous(blockSize)
-		for i := 0; i < blockSize; i++ {
-			tempRegs = append(tempRegs, funcCallReg+Register(i))
-		}
-
-		// 6. Move method to call block
-		c.emitMove(funcCallReg, methodReg, node.Token.Line)
-
-		// 7. Compile arguments
-		for i, arg := range node.Arguments {
-			argReg := funcCallReg + Register(1+i)
-			_, err := c.compileNode(arg, argReg)
-			if err != nil {
-				c.inTailPosition = oldTailPos
-				return BadRegister, NewCompileError(arg, "error compiling argument in optional call expression").CausedBy(err)
-			}
+		// 5. Compile arguments (spread-aware) and emit the call with proper this binding
+		if err := c.compileOptionalMethodCallArgs(node, methodReg, thisReg, hint, &tempRegs, node.Token.Line); err != nil {
+			c.inTailPosition = oldTailPos
+			return BadRegister, err
 		}
 		c.inTailPosition = oldTailPos
 
-		// 8. Emit method call with proper this binding
-		c.emitCallMethod(hint, funcCallReg, thisReg, byte(totalArgCount), node.Token.Line)
-
-		// 9. Patch end jump
+		// 6. Patch end jump
 		c.patchJump(endJumpPos)
 
 		return hint, nil
@@ -4236,27 +4227,12 @@ func (c *Compiler) compileOptionalCallExpression(node *parser.OptionalCallExpres
 			tempRegs = append(tempRegs, callResultReg)
 		}
 
-		// 5. Method is not nullish - do the method call with this binding
-		totalArgCount := len(node.Arguments)
-		blockSize := 1 + totalArgCount
-		funcCallReg := c.regAlloc.AllocContiguous(blockSize)
-		for i := 0; i < blockSize; i++ {
-			tempRegs = append(tempRegs, funcCallReg+Register(i))
-		}
-
-		c.emitMove(funcCallReg, methodReg, node.Token.Line)
-
-		for i, arg := range node.Arguments {
-			argReg := funcCallReg + Register(1+i)
-			_, err := c.compileNode(arg, argReg)
-			if err != nil {
-				c.inTailPosition = oldTailPos
-				return BadRegister, NewCompileError(arg, "error compiling argument in optional call expression").CausedBy(err)
-			}
+		// 5. Method is not nullish - compile arguments (spread-aware) and call with this binding
+		if err := c.compileOptionalMethodCallArgs(node, methodReg, thisReg, callResultReg, &tempRegs, node.Token.Line); err != nil {
+			c.inTailPosition = oldTailPos
+			return BadRegister, err
 		}
 		c.inTailPosition = oldTailPos
-
-		c.emitCallMethod(callResultReg, funcCallReg, thisReg, byte(totalArgCount), node.Token.Line)
 
 		// Apply continuation if present (e.g., the .c in a?.b?.().c)
 		if node.Continuation != nil {

--- a/tests/scripts/optional_call_member_spread.ts
+++ b/tests/scripts/optional_call_member_spread.ts
@@ -1,0 +1,41 @@
+// Optional calls (?.()) whose callee is a member expression must support
+// spread arguments, not just literal ones (issue #185... #188).
+const o: any = { f: (a: number, b: number) => a + b };
+const args = [3, 4];
+
+// obj.method?.(...args)
+const r1 = o.f?.(...args);
+
+// obj["method"]?.(...args)
+const r2 = o["f"]?.(...args);
+
+// obj[computedKey]?.(...args) -- dynamic index callee
+const o2: any = { 2: (a: number, b: number) => ["two", a, b] };
+const r3 = o2[args.length]?.(...args);
+
+// Wrapped in ?? : must call through, not silently become undefined.
+const r4 = o2[args.length]?.(...args) ?? "fallback";
+
+// Nullish member callee still short-circuits correctly with spread present.
+const n: any = null;
+const r5 = n?.f?.(...args);
+
+// a?.b?.(...) - optional chaining base callee with spread.
+const o3: any = { inner: { g: (a: number, b: number) => a - b } };
+const r6 = o3?.inner?.g?.(...[10, 3]);
+
+// super.method?.(...) with spread.
+class Base {
+  m(a: number, b: number): number {
+    return a * b;
+  }
+}
+class Derived extends Base {
+  m2(a: number, b: number): number | undefined {
+    return super.m?.(...[a, b]);
+  }
+}
+const r7 = new Derived().m2(3, 4);
+
+JSON.stringify([r1, r2, r3, r4, r5, r6, r7]);
+// expect: [7,7,["two",3,4],["two",3,4],null,7,12]


### PR DESCRIPTION
## Summary

`obj.method?.(...args)`, `obj[key]?.(...args)`, `a?.b?.(...args)`, and `super.method?.(...args)` didn't support spread arguments, per #188:

1. Standalone: hard **compile error** ("error compiling argument in optional call expression").
2. Wrapped in `?? fallback` (the `OptionalChainingExpression`-as-callee shape): compiled, but the compile error from the argument was being swallowed rather than propagated, so the expression **silently evaluated to `undefined`** instead of calling the method or running the fallback.

A plain-identifier callee (`f?.(...args)`) already worked, since that path special-cased spread with `OpSpreadCall`. The four member-expression-callee branches (plain member, computed/index member, optional-chaining base, `super.method`) had no equivalent — each just looped over arguments compiling them directly into fixed call-block register slots, which chokes on a `*parser.SpreadElement`.

## Fix

Added `compileOptionalMethodCallArgs`, mirroring how the existing non-optional `obj.method(...args)` path (`compileMultiSpreadCall`) already builds an argument array at runtime and uses `OpSpreadCallMethod` when a spread is present. Wired it into all four call sites that need a `this` binding.

## Testing

- All repro/control cases from #188 verified against real behavior (member/bracket/computed callee, `??`-wrapped, nullish short-circuit, `super.method?.()`, `a?.b?.()` base callee, and a post-call continuation like `.c`).
- Added `tests/scripts/optional_call_member_spread.ts` as a smoke-test regression.
- `go test ./...` — all green.
- Test262 diff against baseline: `language/expressions/optional-chaining` +0/-0, `language/expressions/call` +0/-0, full `language` +0/-0 (no regressions).

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)