### PR TITLE
fix(vm): expand \p{ID_Start} / \p{ID_Continue} for both regex engines

### DIFF
--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -91,7 +91,7 @@ func NewRegExp(pattern, flags string) (Value, error) {
 		// gains, unrelated to lookaround, don't resolve inside that window.)
 		if needsRegexp2Fallback(pattern) {
 			opts := regexp2ECMAScriptOptions(flags)
-			compiledRegex2, err = regexp2.Compile(pattern, opts)
+			compiledRegex2, err = regexp2.Compile(expandDerivedUnicodeProperties(pattern), opts)
 		}
 		if compiledRegex2 == nil {
 			return Undefined, err
@@ -167,7 +167,7 @@ func compileRegexEngines(pattern, flags string) *cachedCompiledRegex {
 	// deliberately narrower fallback for the RegExp constructor - see its
 	// comment) - this function's own behavior is unchanged by paserati#172.
 	if compiledRegex == nil {
-		compiledRegex2, err = regexp2.Compile(pattern, regexp2ECMAScriptOptions(flags))
+		compiledRegex2, err = regexp2.Compile(expandDerivedUnicodeProperties(pattern), regexp2ECMAScriptOptions(flags))
 		if err != nil {
 			compileError = err.Error()
 		}
@@ -804,6 +804,12 @@ func rewriteECMAClasses(pattern string, dotAll bool) string {
 func translateJSFlagsToGo(pattern, flags string) (string, error) {
 	// Preprocess Unicode escapes (\uXXXX, \xXX) that Go's regexp doesn't support
 	pattern = preprocessUnicodeEscapes(pattern)
+
+	// Expand the two derived properties neither engine knows by name
+	// (paserati#190). After preprocessUnicodeEscapes on purpose: the expansion
+	// spells ASCII members as \xHH so class metacharacters stay escaped, and
+	// that pass would otherwise turn them back into bare syntax.
+	pattern = expandDerivedUnicodeProperties(pattern)
 
 	// Check for JavaScript features that Go's regexp doesn't support
 	// Go's regexp library doesn't support numbered backreferences like \1, \2, etc.

--- a/pkg/vm/regex_properties.go
+++ b/pkg/vm/regex_properties.go
@@ -1,0 +1,238 @@
+package vm
+
+import (
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// ECMAScript's Unicode property escapes include two derived binary
+// properties - ID_Start and ID_Continue (UAX #31, the definitions JavaScript
+// itself uses for identifier characters) - that neither RE2 nor regexp2
+// recognizes by name (paserati#190). Both engines do accept explicit
+// character-class ranges, and both derived properties are fixed set algebra
+// over categories Go's unicode package already ships, so the tables are
+// computed here once and spliced into the pattern as ranges before either
+// engine parses it.
+//
+// The expansion is unconditional on flags, matching how the two engines
+// already treat every other \p{...} name in this runtime.
+//
+// Coverage follows Go's own Unicode version (unicode.Version), so code points
+// newer than that are absent from both sets until the toolchain catches up.
+
+// runeRange is an inclusive [lo, hi] span of code points.
+type runeRange struct{ lo, hi rune }
+
+// derivedProperty holds a property's member spans and their gaps.
+type derivedProperty struct {
+	ranges     []runeRange
+	complement []runeRange
+}
+
+var (
+	derivedOnce        sync.Once
+	idStartProperty    derivedProperty
+	idContinueProperty derivedProperty
+)
+
+// derivedUnicodeProperties maps every spelling ECMAScript accepts for the two
+// properties (the canonical names and their UCD aliases) to their tables.
+// Property names are case-sensitive in ECMAScript, so the lookup is too.
+var derivedUnicodeProperties = map[string]*derivedProperty{
+	"ID_Start":    &idStartProperty,
+	"IDS":         &idStartProperty,
+	"ID_Continue": &idContinueProperty,
+	"IDC":         &idContinueProperty,
+}
+
+// buildDerivedProperties fills both tables on first use, in a few
+// milliseconds: membership is painted into a bitmap straight from the source
+// tables' ranges rather than probed rune by rune across the code space.
+//
+//	ID_Start    = L + Nl + Other_ID_Start - Pattern_Syntax - Pattern_White_Space
+//	ID_Continue = ID_Start + Mn + Mc + Nd + Pc + Other_ID_Continue
+//	              - Pattern_Syntax - Pattern_White_Space
+func buildDerivedProperties() {
+	derivedOnce.Do(func() {
+		set := newRuneSet()
+		set.include(unicode.L, unicode.Nl, unicode.Other_ID_Start)
+		set.exclude(unicode.Pattern_Syntax, unicode.Pattern_White_Space)
+		idStartProperty = set.property()
+
+		set.include(unicode.Mn, unicode.Mc, unicode.Nd, unicode.Pc, unicode.Other_ID_Continue)
+		set.exclude(unicode.Pattern_Syntax, unicode.Pattern_White_Space)
+		idContinueProperty = set.property()
+	})
+}
+
+// runeSet is one bit per code point.
+type runeSet []uint64
+
+func newRuneSet() runeSet { return make(runeSet, (unicode.MaxRune+1+63)/64) }
+
+func (s runeSet) has(r rune) bool { return s[r>>6]&(1<<(uint(r)&63)) != 0 }
+
+func (s runeSet) paint(tables []*unicode.RangeTable, on bool) {
+	for _, t := range tables {
+		for _, r := range t.R16 {
+			for c := rune(r.Lo); c <= rune(r.Hi); c += rune(r.Stride) {
+				s.set(c, on)
+			}
+		}
+		for _, r := range t.R32 {
+			for c := rune(r.Lo); c <= rune(r.Hi); c += rune(r.Stride) {
+				s.set(c, on)
+			}
+		}
+	}
+}
+
+func (s runeSet) set(r rune, on bool) {
+	if on {
+		s[r>>6] |= 1 << (uint(r) & 63)
+	} else {
+		s[r>>6] &^= 1 << (uint(r) & 63)
+	}
+}
+
+func (s runeSet) include(tables ...*unicode.RangeTable) { s.paint(tables, true) }
+func (s runeSet) exclude(tables ...*unicode.RangeTable) { s.paint(tables, false) }
+
+// property reads the bitmap back out as member spans and their gaps.
+// Surrogates are left out of the complement: a Go string can't carry one as
+// a literal rune, and no UTF-8 subject can contain one either.
+func (s runeSet) property() derivedProperty {
+	var p derivedProperty
+	inRun := false
+	var start rune
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if !inRun && s[r>>6] == 0 {
+			// Skip an empty word of the bitmap in one step.
+			r |= 63
+			continue
+		}
+		if s.has(r) {
+			if !inRun {
+				start, inRun = r, true
+			}
+			continue
+		}
+		if inRun {
+			p.ranges = append(p.ranges, runeRange{start, r - 1})
+			inRun = false
+		}
+	}
+	if inRun {
+		p.ranges = append(p.ranges, runeRange{start, unicode.MaxRune})
+	}
+
+	next := rune(0)
+	for _, rr := range p.ranges {
+		if rr.lo > next {
+			p.complement = appendWithoutSurrogates(p.complement, next, rr.lo-1)
+		}
+		next = rr.hi + 1
+	}
+	if next <= unicode.MaxRune {
+		p.complement = appendWithoutSurrogates(p.complement, next, unicode.MaxRune)
+	}
+	return p
+}
+
+func appendWithoutSurrogates(dst []runeRange, lo, hi rune) []runeRange {
+	const surrogateLo, surrogateHi = 0xD800, 0xDFFF
+	if hi < surrogateLo || lo > surrogateHi {
+		return append(dst, runeRange{lo, hi})
+	}
+	if lo < surrogateLo {
+		dst = append(dst, runeRange{lo, surrogateLo - 1})
+	}
+	if hi > surrogateHi {
+		dst = append(dst, runeRange{surrogateHi + 1, hi})
+	}
+	return dst
+}
+
+// writeClassRune spells one code point as a character-class member both
+// engines read the same way: \xHH for ASCII (which also keeps the class
+// metacharacters and control characters out of the pattern text), the
+// literal rune for everything else. Neither engine shares an escape for
+// astral code points (RE2 wants \x{...}, regexp2 knows only \uHHHH), but
+// both are rune-based and take the character itself.
+func writeClassRune(b *strings.Builder, r rune) {
+	if r < 0x80 {
+		const hex = "0123456789abcdef"
+		b.WriteString(`\x`)
+		b.WriteByte(hex[r>>4])
+		b.WriteByte(hex[r&0xf])
+		return
+	}
+	b.WriteRune(r)
+}
+
+func writeClassRanges(b *strings.Builder, ranges []runeRange) {
+	for _, rr := range ranges {
+		writeClassRune(b, rr.lo)
+		if rr.hi != rr.lo {
+			b.WriteByte('-')
+			writeClassRune(b, rr.hi)
+		}
+	}
+}
+
+// expandDerivedUnicodeProperties rewrites \p{ID_Start}, \p{ID_Continue} and
+// their \P negations (plus the IDS/IDC aliases) into explicit ranges. Inside
+// a character class only the members are emitted; outside, they're wrapped
+// in a class of their own. Every other escape - including every other
+// \p{...} name - passes through untouched for the engines to judge.
+//
+// Operates on bytes like rewriteECMAClasses: every construct inspected is
+// ASCII, so multi-byte runes copy through as-is.
+func expandDerivedUnicodeProperties(pattern string) string {
+	if !strings.Contains(pattern, `\p{`) && !strings.Contains(pattern, `\P{`) {
+		return pattern
+	}
+	var b strings.Builder
+	b.Grow(len(pattern))
+	inClass := false
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' && i+1 < len(pattern) {
+			if e := pattern[i+1]; (e == 'p' || e == 'P') && i+2 < len(pattern) && pattern[i+2] == '{' {
+				if end := strings.IndexByte(pattern[i+3:], '}'); end >= 0 {
+					if prop, ok := derivedUnicodeProperties[pattern[i+3:i+3+end]]; ok {
+						buildDerivedProperties()
+						ranges := prop.ranges
+						if e == 'P' {
+							ranges = prop.complement
+						}
+						if !inClass {
+							b.WriteByte('[')
+						}
+						writeClassRanges(&b, ranges)
+						if !inClass {
+							b.WriteByte(']')
+						}
+						i += 3 + end
+						continue
+					}
+				}
+			}
+			// Any other escape passes through with its operand, which also
+			// keeps \\ and \[ from being read as syntax below.
+			b.WriteByte(c)
+			b.WriteByte(pattern[i+1])
+			i++
+			continue
+		}
+		switch {
+		case c == '[' && !inClass:
+			inClass = true
+		case c == ']' && inClass:
+			inClass = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}

--- a/tests/scripts/regexp_unicode_id_start_property.ts
+++ b/tests/scripts/regexp_unicode_id_start_property.ts
@@ -1,0 +1,51 @@
+// expect: true
+// \p{ID_Start} / \p{ID_Continue} are ECMAScript derived binary properties
+// neither RE2 nor regexp2 knows by name (paserati#190). They're expanded to
+// explicit ranges before compilation, on both the literal and constructor
+// paths, inside and outside character classes, negated or not.
+
+// The exact typebox/compile pattern that surfaced the gap.
+const ident = /^[\p{ID_Start}_$][\p{ID_Continue}_$]*$/u;
+const identCtor = new RegExp("^[\\p{ID_Start}_$][\\p{ID_Continue}_$]*$", "u");
+
+const validIdents = ["hello", "_x", "$y", "héllo", "变量", "π2", "𝒳y", "á", "ª"];
+const invalidIdents = ["1abc", "a-b", "", "a b", "é!", "a.b", "ⸯ"];
+
+const checks: boolean[] = [];
+for (const s of validIdents) {
+  checks.push(ident.test(s) && identCtor.test(s));
+}
+for (const s of invalidIdents) {
+  checks.push(!ident.test(s) && !identCtor.test(s));
+}
+
+// Bare (outside a class), negated, aliases, and a negated class.
+checks.push(/^\p{ID_Start}$/u.test("a"));
+checks.push(!/^\p{ID_Start}$/u.test("1"));
+checks.push(/^\p{ID_Continue}$/u.test("1"));
+checks.push(!/^\p{ID_Continue}$/u.test("-"));
+checks.push(/^\P{ID_Start}$/u.test("1"));
+checks.push(!/^\P{ID_Start}$/u.test("a"));
+checks.push(/^[\P{ID_Start}]$/u.test("-"));
+checks.push(!/^[\P{ID_Start}]$/u.test("z"));
+checks.push(/^[^\p{ID_Start}]$/u.test("9"));
+checks.push(!/^[^\p{ID_Start}]$/u.test("Z"));
+checks.push(/^\p{IDS}\p{IDC}*$/u.test("a1"));
+
+// ZWNJ is Cf, not ID_Continue - typebox lists it explicitly for that reason.
+checks.push(!ident.test("x\u200c"));
+checks.push(/^[\p{ID_Start}_$][\p{ID_Continue}_$\u200c\u200d]*$/u.test("x\u200c"));
+
+// Unrelated property names are left to the engines and still work.
+checks.push(/^\p{L}+$/u.test("abc"));
+checks.push(/^\p{Lu}$/u.test("A") && !/^\p{Lu}$/u.test("a"));
+
+// Combined with lookahead so the regexp2 path is exercised as well.
+checks.push(/^(?=\p{ID_Start})\w+$/u.test("abc"));
+checks.push(!/^(?=\p{ID_Start})\w+$/u.test("1abc"));
+checks.push(new RegExp("^(?!\\p{ID_Start})\\p{ID_Continue}+$", "u").test("123"));
+
+// Source is reported as written, not as expanded.
+checks.push(ident.source === "^[\\p{ID_Start}_$][\\p{ID_Continue}_$]*$");
+
+checks.every((c) => c);


### PR DESCRIPTION
## Summary

`\p{ID_Start}` and `\p{ID_Continue}` — the two ECMAScript derived binary properties used for identifier validation — failed on both regex paths, per #190. RE2 has no such property names, and neither does `regexp2`, so the literal path (which falls back to regexp2 unconditionally) and the `new RegExp(...)` path (whose fallback is gated on lookaround) both threw a `SyntaxError`, with different messages.

## Fix

Take the direction the issue suggests: expand exactly these properties into explicit character-class ranges before either engine parses the pattern.

- **`pkg/vm/regex_properties.go`** (new). Derives both sets from Go's own `unicode` tables per UAX #31 (`L + Nl + Other_ID_Start`, then `+ Mn + Mc + Nd + Pc + Other_ID_Continue`, both minus `Pattern_Syntax` and `Pattern_White_Space`), so no Unicode data is vendored. Membership is painted into a bitmap straight from the source tables' ranges on first use (~0.7ms), then read back as spans and their complement. Handles `\p` and `\P`, inside and outside a class, plus the `IDS`/`IDC` aliases. Every other `\p{...}` name passes through untouched for the engines to judge.
- **`pkg/vm/regex.go`**. Calls the expansion in the RE2 translation and both regexp2 fallbacks. It runs after `preprocessUnicodeEscapes` on purpose: ASCII members are spelled `\xHH` so class metacharacters in the negated form stay escaped, and that pass would otherwise turn them back into bare syntax. Non-ASCII members are literal runes, the one spelling both engines read identically (RE2 wants `\x{...}` for astral code points, regexp2 only knows `\uHHHH`). `source` still reports the pattern as written.

## Testing

- The exact typebox/compile pattern from #190 works on both the literal and constructor paths.
- Added `tests/scripts/regexp_unicode_id_start_property.ts`: ASCII and non-ASCII identifiers including an astral one, negation inside and outside classes, aliases, the lookahead-driven regexp2 path, and the ZWNJ case (Cf, not ID_Continue, which is why typebox lists it explicitly).
- Verified the generated tables rune by rune against the UAX #31 predicate definition with a throwaway test (not committed).
- `go test ./tests -run TestScripts` green; `go build ./...` and `go vet ./pkg/vm` clean.
- Test262 diff against baseline at `-timeout 2s`: `built-ins/RegExp` +0/-0 attributable to this change (the three property-escape tests that flip at 2s are the known timing-dependent ones noted in `NewRegExp`), `language/literals/regexp` +0/-0.

## Not covered

- `built-ins/RegExp/property-escapes/generated/ID_Start.js` / `ID_Continue.js` now run through all of Unicode 15 and fail only at U+1138B, a Unicode 16 addition: Go 1.26 ships Unicode 15.0 tables while test262 targets 17.0. They pass once the toolchain's tables catch up.
- `XID_Start` / `XID_Continue` remain unsupported; they need NFKC closure and are a separate piece of work.

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)