### PR TITLE
fix(compiler): hoisted function refs to a module's later top-level binding resolve to the right heap slot

### DIFF
--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -291,10 +291,7 @@ func (c *Compiler) compileAssignmentExpression(node *parser.AssignmentExpression
 						// module mode) write to, or GlobalExists wrongly reports "doesn't
 						// exist" and this gets misdiagnosed as an undeclared-variable
 						// ReferenceError.
-						globalKey := lhsNode.Value
-						if c.moduleBindings != nil && c.moduleBindings.TopLevelDeclNames[lhsNode.Value] {
-							globalKey = c.moduleGlobalKey(lhsNode.Value)
-						}
+						globalKey := c.unresolvedGlobalKey(lhsNode.Value)
 						if c.chunk.IsStrict && !c.GlobalExists(globalKey) && lhsNode.Value != "arguments" && lhsNode.Value != "eval" {
 							// Emit runtime error for strict mode undeclared variable assignment
 							c.emitStrictUndeclaredAssignmentError(lhsNode.Value, line)
@@ -322,10 +319,7 @@ func (c *Compiler) compileAssignmentExpression(node *parser.AssignmentExpression
 					// Also skip for 'arguments' and 'eval' which have special error handling elsewhere
 					//
 					// See the identical globalKey comment in the callerScopeDesc branch above.
-					globalKey := lhsNode.Value
-					if c.moduleBindings != nil && c.moduleBindings.TopLevelDeclNames[lhsNode.Value] {
-						globalKey = c.moduleGlobalKey(lhsNode.Value)
-					}
+					globalKey := c.unresolvedGlobalKey(lhsNode.Value)
 					if c.chunk.IsStrict && !c.GlobalExists(globalKey) && lhsNode.Value != "arguments" && lhsNode.Value != "eval" {
 						// Emit runtime error for strict mode undeclared variable assignment
 						c.emitStrictUndeclaredAssignmentError(lhsNode.Value, line)
@@ -1436,11 +1430,13 @@ func (c *Compiler) compileArrayDestructuringAssignment(node *parser.ArrayDestruc
 								c.emitMove(identSymbol.Register, restArrayReg, line)
 							}
 						}
-					} else if c.chunk.IsStrict {
+					} else if key := c.unresolvedGlobalKey(targetNode.Value); c.chunk.IsStrict && !c.GlobalExists(key) {
 						c.emitStrictUnresolvableReferenceError(targetNode.Value, line)
 					} else {
-						// Implicit global in non-strict
-						globalIdx := c.GetOrAssignGlobalIndex(targetNode.Value)
+						// Implicit global in non-strict, or an existing global slot -
+						// including this module's own not-yet-compiled top-level
+						// declaration (see unresolvedGlobalKey, #192).
+						globalIdx := c.GetOrAssignGlobalIndex(key)
 						c.emitSetGlobal(globalIdx, restArrayReg, line)
 					}
 
@@ -1683,14 +1679,18 @@ func (c *Compiler) compileIdentifierAssignment(identTarget *parser.Identifier, v
 	// Resolve the identifier to determine how to store it
 	symbol, _, found := c.currentSymbolTable.Resolve(identTarget.Value)
 	if !found {
-		// Variable not found in any scope
-		// In strict mode, this is a ReferenceError per ECMAScript spec
-		if c.chunk.IsStrict {
+		// Variable not found in any scope. In strict mode an unresolvable
+		// reference is a ReferenceError per ECMAScript spec; a name that already
+		// has a global slot (including this module's own not-yet-compiled
+		// top-level declaration, see unresolvedGlobalKey) is resolvable and is
+		// assigned like compileAssignmentExpression does for `x = v` (#192).
+		globalKey := c.unresolvedGlobalKey(identTarget.Value)
+		if c.chunk.IsStrict && !c.GlobalExists(globalKey) {
 			c.emitStrictUnresolvableReferenceError(identTarget.Value, line)
 			return nil
 		}
-		// In non-strict mode, treat as implicit global assignment
-		globalIdx := c.GetOrAssignGlobalIndex(identTarget.Value)
+		// Non-strict mode or existing global: treat as global assignment
+		globalIdx := c.GetOrAssignGlobalIndex(globalKey)
 		c.emitSetGlobal(globalIdx, valueReg, line)
 		return nil
 	}

--- a/pkg/compiler/compile_assignment_helpers.go
+++ b/pkg/compiler/compile_assignment_helpers.go
@@ -66,13 +66,16 @@ func (c *Compiler) compileDestructuringTargetRef(target parser.Expression, line 
 
 		symbol, _, found := c.currentSymbolTable.Resolve(targetNode.Value)
 		if !found {
-			// In strict mode, this is a ReferenceError
-			// In non-strict mode, it's an implicit global
-			if c.chunk.IsStrict {
+			// In strict mode an unresolvable reference is a ReferenceError; in
+			// non-strict mode it's an implicit global. A name that already has a
+			// global slot - including this module's own not-yet-compiled top-level
+			// declaration, see unresolvedGlobalKey - is resolvable either way (#192).
+			globalKey := c.unresolvedGlobalKey(targetNode.Value)
+			if c.chunk.IsStrict && !c.GlobalExists(globalKey) {
 				ref.IsGlobal = false // Will emit error at assignment time
 			} else {
 				ref.IsGlobal = true
-				ref.GlobalIdx = c.GetOrAssignGlobalIndex(targetNode.Value)
+				ref.GlobalIdx = c.GetOrAssignGlobalIndex(globalKey)
 			}
 		} else {
 			ref.Symbol = &symbol

--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -362,9 +362,10 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 						c.emitImportResolve(superConstructorReg, superClassName, node.Token.Line)
 					} else {
 						// Not in symbol table and not an import - might be a built-in
-						// class (Object, Array, etc.). Emit code to look up the global
+						// class (Object, Array, etc.) or one of this module's own classes
+						// declared further down (#192). Emit code to look up the global
 						// variable at runtime.
-						globalIdx := c.GetOrAssignGlobalIndex(superClassName)
+						globalIdx := c.GetOrAssignGlobalIndex(c.unresolvedGlobalKey(superClassName))
 						superConstructorReg = c.regAlloc.Alloc()
 						needToFreeSuperReg = true
 						c.emitGetGlobal(superConstructorReg, globalIdx, node.Token.Line)

--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -697,8 +697,10 @@ func (c *Compiler) compileUpdateExpression(node *parser.UpdateExpression, hint R
 				// Variable not found in symbol table
 				// In JavaScript mode, treat as potential global variable (will throw ReferenceError at runtime if doesn't exist)
 				// In TypeScript mode, this is a compile error
-				// For now, treat as global and let runtime handle it
-				globalIdx := c.GetOrAssignGlobalIndex(argNode.Value)
+				// For now, treat as global and let runtime handle it. The key must
+				// agree with the read side (compileIdentifier) for a module's own
+				// not-yet-compiled top-level binding - see unresolvedGlobalKey (#192).
+				globalIdx := c.GetOrAssignGlobalIndex(c.unresolvedGlobalKey(argNode.Value))
 				identInfo.isGlobal = true
 				identInfo.globalIndex = globalIdx
 				currentValueReg = c.regAlloc.Alloc()
@@ -1999,7 +2001,9 @@ func (c *Compiler) compileTypeofExpression(node *parser.TypeofExpression, hint R
 			if hint == NoHint || hint == BadRegister {
 				hint = c.regAlloc.Alloc()
 			}
-			c.emitTypeofIdentifier(hint, ident.Value, node.Token.Line)
+			// Under the key the binding actually lives at, when it is one of this
+			// module's own not-yet-compiled top-level declarations (#192).
+			c.emitTypeofIdentifier(hint, c.unresolvedGlobalKey(ident.Value), node.Token.Line)
 			return hint, nil
 		}
 		// If identifier exists (or is 'arguments'/an import), fall through to normal compilation

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -370,8 +370,12 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 			symbolRef, definingTable, found := c.currentSymbolTable.Resolve(target.Value)
 			if !found {
 				// Variable not found in any scope
-				// In strict mode, this is a ReferenceError per ECMAScript spec
-				if c.chunk.IsStrict {
+				// A name that already has a global slot - including this module's own
+				// not-yet-compiled top-level declaration, see unresolvedGlobalKey - is
+				// resolvable and is assigned in place rather than shadowed (#192).
+				if key := c.unresolvedGlobalKey(target.Value); c.GlobalExists(key) {
+					c.emitSetGlobal(c.GetOrAssignGlobalIndex(key), valueReg, node.Token.Line)
+				} else if c.chunk.IsStrict {
 					c.emitStrictUnresolvableReferenceError(target.Value, node.Token.Line)
 				} else {
 					// In non-strict mode, define a function/global-scoped binding (var semantics)

--- a/pkg/compiler/compile_statement.go
+++ b/pkg/compiler/compile_statement.go
@@ -2376,7 +2376,12 @@ func (c *Compiler) compileForInStatementLabeled(node *parser.ForInStatement, lab
 			if !found {
 				// fmt.Printf("// [ForInAssign] unresolved %s, defining var in outermost scope\n", target.Value)
 				// Define a function/global-scoped binding (var semantics)
-				if c.enclosing == nil {
+				// - unless the name already has a global slot, including this module's
+				// own not-yet-compiled top-level declaration (see unresolvedGlobalKey),
+				// which is assigned in place rather than shadowed (#192).
+				if key := c.unresolvedGlobalKey(target.Value); c.enclosing != nil && c.GlobalExists(key) {
+					c.emitSetGlobal(c.GetOrAssignGlobalIndex(key), currentKeyReg, node.Token.Line)
+				} else if c.enclosing == nil {
 					idx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(target.Value))
 					c.currentSymbolTable.DefineGlobal(target.Value, idx)
 					c.emitSetGlobal(idx, currentKeyReg, node.Token.Line)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -629,6 +629,23 @@ func (c *Compiler) moduleGlobalKey(name string) string {
 	return name
 }
 
+// unresolvedGlobalKey is the heap key for a name the symbol table could not
+// resolve at this point in compilation. Usually that is a genuinely external
+// global and the bare name is right. The exception is one of this module's own
+// top-level var/let/const/class declarations that simply hasn't compiled yet
+// (a hoisted function body compiles before the module's sequential statements
+// are reached): its declaration will write to a moduleGlobalKey-namespaced
+// slot, so the reference must use that same key or it lands on a different,
+// never-written slot ("X is not defined", or a silently stale value - #117,
+// #192). Every not-found fallback that allocates a global index for a user
+// identifier must go through here so all of them agree.
+func (c *Compiler) unresolvedGlobalKey(name string) string {
+	if c.moduleBindings != nil && c.moduleBindings.TopLevelDeclNames[name] {
+		return c.moduleGlobalKey(name)
+	}
+	return name
+}
+
 // GetAllGlobalNames returns a snapshot of every name registered in this
 // compiler's heap allocator, mapped to its heap index - not just this
 // compiler's own exports (see GetExportGlobalIndices for that).
@@ -2440,11 +2457,7 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 			// the same namespaced key rather than a bare one, or it resolves to
 			// a different, never-written slot ("X is not defined" - #117, and
 			// its var-specific counterpart).
-			globalKey := node.Value
-			if c.moduleBindings != nil && c.moduleBindings.TopLevelDeclNames[node.Value] {
-				globalKey = c.moduleGlobalKey(node.Value)
-			}
-			globalIdx := c.GetOrAssignGlobalIndex(globalKey)
+			globalIdx := c.GetOrAssignGlobalIndex(c.unresolvedGlobalKey(node.Value))
 			c.emitGetGlobal(hint, globalIdx, node.Token.Line)
 			return hint, nil // Handle as global access
 		}
@@ -5495,7 +5508,8 @@ func (c *Compiler) compileClassExpression(node *parser.ClassDeclaration, hint Re
 						c.emitImportResolve(superConstructorReg, superClassName, node.Token.Line)
 					} else {
 						// Not in symbol table and not an import - might be a built-in class
-						globalIdx := c.GetOrAssignGlobalIndex(superClassName)
+						// - or one of this module's own classes declared further down.
+						globalIdx := c.GetOrAssignGlobalIndex(c.unresolvedGlobalKey(superClassName))
 						superConstructorReg = c.regAlloc.Alloc()
 						needToFreeSuperReg = true
 						c.emitGetGlobal(superConstructorReg, globalIdx, node.Token.Line)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2115,6 +2115,22 @@ startExecution:
 			// Use the heap's nameToIndex map if available
 			if heapIdx, exists := vm.heap.nameToIndex[identifierName]; exists {
 				val, _ := vm.heap.Get(heapIdx)
+				// A let/const/class binding still in its temporal dead zone throws
+				// on typeof like on any other read (spec: typeof evaluates the
+				// reference first). The name may carry a module prefix, see the
+				// compiler's moduleGlobalKey; report the bare name (#192).
+				if val.typ == TypeUninitialized {
+					frame.ip = ip
+					bare := identifierName
+					if i := strings.LastIndexByte(bare, 0); i >= 0 {
+						bare = bare[i+1:]
+					}
+					vm.ThrowReferenceError(fmt.Sprintf("Cannot access '%s' before initialization", bare))
+					if vm.unwinding {
+						return InterpretRuntimeError, Undefined
+					}
+					goto reloadFrame
+				}
 				typeofStr := getTypeofString(val)
 				registers[destReg] = String(typeofStr)
 			} else if vm.GlobalObject != nil && vm.GlobalObject.HasOwn(identifierName) {

--- a/tests/scripts/module_hoisted_ref/counter.ts
+++ b/tests/scripts/module_hoisted_ref/counter.ts
@@ -1,0 +1,9 @@
+// Helper for module_hoisted_ref_later_decl*.ts (#192). Mirrors typebox's
+// schema/engine/_unique.mjs: a non-exported module-level `let` that a hoisted
+// function declaration mutates with ++. The function body compiles before the
+// module's statements are reached, so `index` is unresolved at that point.
+let index = 0;
+
+export function Unique(): string {
+  return `var_${index++}`;
+}

--- a/tests/scripts/module_hoisted_ref/targets.ts
+++ b/tests/scripts/module_hoisted_ref/targets.ts
@@ -1,0 +1,44 @@
+// Helper for module_hoisted_ref_later_decl*.ts (#192). Every construct here
+// writes to or inspects a module-level binding from inside a hoisted function
+// declaration, which compiles before the declarations themselves. All of them
+// used to land on a different heap slot than the declaration (bare name vs.
+// module-namespaced key), so writes were lost and reads came back stale.
+let a = 0;
+let b = 0;
+let rest: number[] = [];
+let c = 0;
+let d = "";
+let n = 0;
+class Base {
+  tag = "base";
+}
+
+export function destructure(): string {
+  [a] = [7];
+  ({ b } = { b: 8 });
+  [...rest] = [1, 2];
+  return `${a}|${b}|${rest.length}`;
+}
+
+export function loops(): string {
+  for (c of [3]) {
+  }
+  for (d in { k: 1 }) {
+  }
+  return `${c}|${d}`;
+}
+
+export function kind(): string {
+  return typeof a;
+}
+
+export function derived(): string {
+  return new (class extends Base {})().tag;
+}
+
+export function bump(): number {
+  ++n;
+  n++;
+  n += 1;
+  return n;
+}

--- a/tests/scripts/module_hoisted_ref_later_decl.ts
+++ b/tests/scripts/module_hoisted_ref_later_decl.ts
@@ -1,0 +1,10 @@
+// expect: var_0|var_1|7|8|2|3|k|number|base|3
+// #192: a hoisted function declaration in an imported module referencing that
+// module's own top-level let/class. A plain read already resolved to the
+// module-namespaced heap slot (#117), but ++/--, destructuring assignment,
+// for-of/for-in targets, typeof and `class extends` still allocated the slot
+// under the bare name, so typebox's Unique() threw "index is not defined".
+import { Unique } from "./module_hoisted_ref/counter.ts";
+import { destructure, loops, kind, derived, bump } from "./module_hoisted_ref/targets.ts";
+
+`${Unique()}|${Unique()}|${destructure()}|${loops()}|${kind()}|${derived()}|${bump()}`;

--- a/tests/scripts/module_hoisted_ref_later_decl_dynamic.ts
+++ b/tests/scripts/module_hoisted_ref_later_decl_dynamic.ts
@@ -1,0 +1,7 @@
+// expect: var_0|var_1|7|8|2|3|k|number|base|3
+// Dynamic-import form of module_hoisted_ref_later_decl.ts, the shape #192 was
+// reported with (typebox and typebox/compile reached via import()).
+const { Unique } = await import("./module_hoisted_ref/counter.ts");
+const { destructure, loops, kind, derived, bump } = await import("./module_hoisted_ref/targets.ts");
+
+`${Unique()}|${Unique()}|${destructure()}|${loops()}|${kind()}|${derived()}|${bump()}`;

--- a/tests/scripts/typeof_tdz_module_binding.ts
+++ b/tests/scripts/typeof_tdz_module_binding.ts
@@ -1,0 +1,17 @@
+// expect: Cannot access 'later' before initialization|number
+// typeof on a let/const binding evaluates the reference first, so inside the
+// temporal dead zone it throws like any other read, and after initialization
+// it reports the real type. Both used to come back "undefined" for a module's
+// own top-level binding referenced from a hoisted function (#192), because
+// the lookup used the bare name while the binding lives under the module key.
+function probe(): string {
+  return typeof later;
+}
+let inTdz: string;
+try {
+  inTdz = probe();
+} catch (e) {
+  inTdz = (e as Error).message;
+}
+let later = 1;
+`${inTdz}|${probe()}`;


### PR DESCRIPTION
## Summary

typebox's `Compile()` on a `Type.Record(...)` schema threw `ReferenceError: index is not defined`, per #192. The report frames it as a dynamic-import problem, but in plain paserati the static-import form fails identically: it is a compiler scoping bug in modules loaded through the loader, and the dynamic/static difference was a host artifact.

## Root cause

typebox's `schema/engine/_unique.mjs` is just:

```js
let index = 0;
export function Unique() { return `var_${index++}`; }
```

A module's top-level bindings live in the heap under a module-namespaced key (`moduleGlobalKey`, #103/#106). Function declarations are hoisted, so `Unique`'s body compiles before the `let` statement is reached and `index` isn't in the symbol table yet. The plain-read fallback in `compileIdentifier` already knew to use the namespaced key for the module's own top-level names (#117), and so did `x = v`. The update-expression fallback did not: `index++` allocated a second slot under the bare name that nothing ever writes. Reads worked, plain assignment worked, arrow functions worked (compiled after the `let`), and `++` threw.

Probing the sibling not-found fallbacks turned up the same bug in five more places, each producing a silently wrong result rather than an error:

| construct in a hoisted function | before | after |
|---|---|---|
| `index++` / `++index` | ReferenceError | works |
| `[a] = [7]`, `({ b } = …)`, `[...rest] = …` | stale value / `undefined` | works |
| `for (c of …)`, `for (d in …)` | stale value | works |
| `typeof a` (after init) | `"undefined"` | `"number"` |
| `class extends Base` (Base declared later) | ReferenceError | works |

## Fix

- **`pkg/compiler/compiler.go`**: new `unresolvedGlobalKey(name)` encodes the #117 rule once: a not-found name that is one of this module's own top-level var/let/const/class declarations gets the namespaced key, anything else stays bare. The three sites that had this inline now call it.
- Routed through it: the update-expression fallback (`compile_expression.go`), destructuring targets and rest elements (`compile_assignment.go`, `compile_assignment_helpers.go`), `for-of` / `for-in` identifier targets (`compile_for_of_new.go`, `compile_statement.go`), `typeof` (`compile_expression.go`), and both `class extends` fallbacks (`compile_class.go`, `compiler.go`). The strict-mode branches now treat a name with an existing global slot as resolvable and assign it, matching what `compileAssignmentExpression` already did for `x = v`.
- **`pkg/vm/vm.go`**: `OpTypeofIdentifier` throws the spec-mandated `ReferenceError` for a `let`/`const` binding still in its temporal dead zone. Before, the bare-name miss returned `"undefined"`; with the key fix alone it would have reported `"object"` for the uninitialized sentinel. This applies to script mode too.

## Testing

- Reproduced with real `typebox@1.1.38` (copied into a scratch dir, `URL` stubbed since plain paserati has no `URL` global). `Compile()` on the issue's `Type.Record` schema now returns `OK: true` on both the dynamic and static import paths.
- Added `tests/scripts/module_hoisted_ref_later_decl.ts` and a dynamic-import twin covering every construct in the table via helper modules under `tests/scripts/module_hoisted_ref/`, plus `tests/scripts/typeof_tdz_module_binding.ts` for the dead-zone case.
- `go test ./tests -run TestScripts` green; `go test ./pkg/compiler ./pkg/modules ./pkg/driver` green; `go build ./...` and vet clean.
- Test262 `built-ins` diff against baseline: +0/-0. The hook's baseline has no `language` coverage, so I built a clean-`main` runner in a throwaway worktree, dumped a `language` baseline (23158/23523), and diffed the final binary against it: +0/-0.

## Noticed, not touched

- The CLI only resolves relative imports when run from the script's own directory; from another cwd every `./x.mjs` import fails with "no resolver could handle specifier".
- The parser rejects a typed catch parameter (`catch (e: any)`).

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)