### PR TITLE
fix: finish member-expression for-inits (#194) and contextually type literals through union expected types

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3642,6 +3642,18 @@ func (c *Checker) visitWithContext(node parser.Node, context *ContextualType) {
 
 	debugPrintf("// [Checker VisitContext] Node: %T, Expected: %s\n", node, context.ExpectedType.String())
 
+	// A union expected type (`number[] | null`, `Options | undefined`,
+	// `(() => void) | null`) contextually types a literal through the one
+	// constituent the literal could be, so `[]` against `number[] | null` is
+	// `number[]` rather than the context-free `unknown[]`, which the union
+	// would then reject.
+	if union, ok := context.ExpectedType.(*types.UnionType); ok {
+		if narrowed := c.contextualTypeFromUnion(node, union); narrowed != nil {
+			debugPrintf("// [Checker VisitContext] Narrowed union context to constituent: %s\n", narrowed.String())
+			context = &ContextualType{ExpectedType: narrowed, IsContextual: context.IsContextual}
+		}
+	}
+
 	// Handle specific node types that benefit from contextual typing
 	switch node := node.(type) {
 	case *parser.ArrayLiteral:
@@ -3665,6 +3677,114 @@ func (c *Checker) visitWithContext(node parser.Node, context *ContextualType) {
 		// For other node types, use regular visit for now
 		c.visit(node)
 	}
+}
+
+// contextualTypeFromUnion picks, out of a union expected type, the constituent
+// that should contextually type the literal `node`: array/tuple members for an
+// array literal, non-callable object members for an object literal, callable
+// members for an arrow function. It returns nil when no single constituent
+// applies; the caller then keeps the union, and the literal is checked without
+// context as before.
+func (c *Checker) contextualTypeFromUnion(node parser.Node, union *types.UnionType) types.Type {
+	var candidates []types.Type
+	switch n := node.(type) {
+	case *parser.ArrayLiteral:
+		for _, t := range union.Types {
+			switch t.(type) {
+			case *types.ArrayType, *types.TupleType:
+				candidates = append(candidates, t)
+			}
+		}
+		// An empty literal cannot disambiguate between several array
+		// constituents (tsc types it `never[]`, which fits any of them), so
+		// take the first plain array one: `[]` against `number[] | string[]`.
+		if len(n.Elements) == 0 && len(candidates) > 1 {
+			for _, t := range candidates {
+				if _, isArray := t.(*types.ArrayType); isArray {
+					return t
+				}
+			}
+		}
+	case *parser.ObjectLiteral:
+		for _, t := range union.Types {
+			switch ot := t.(type) {
+			case *types.ObjectType:
+				if !ot.IsCallable() {
+					candidates = append(candidates, t)
+				}
+			case *types.MappedType:
+				candidates = append(candidates, t)
+			}
+		}
+		if len(candidates) > 1 {
+			candidates = discriminateObjectCandidates(n, candidates)
+		}
+	case *parser.ArrowFunctionLiteral:
+		for _, t := range union.Types {
+			if ot, isObj := t.(*types.ObjectType); isObj && ot.IsCallable() {
+				candidates = append(candidates, t)
+			}
+		}
+	}
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	return nil
+}
+
+// discriminateObjectCandidates narrows the object constituents of a union by
+// the literal-valued properties of an object literal, the way tsc picks the
+// member of a discriminated union: `{ k: "b", v: [] }` against
+// `{ k: "a"; v: number[] } | { k: "b"; v: string[] }` keeps only the second,
+// because `"b"` is not assignable to the first's `k`. A candidate is dropped
+// only when it declares the property and the literal does not fit it; other
+// properties (missing, non-literal values) leave the candidate list alone.
+func discriminateObjectCandidates(lit *parser.ObjectLiteral, candidates []types.Type) []types.Type {
+	for _, prop := range lit.Properties {
+		var keyName string
+		switch key := prop.Key.(type) {
+		case *parser.Identifier:
+			keyName = key.Value
+		case *parser.StringLiteral:
+			keyName = key.Value
+		default:
+			continue
+		}
+		var litType types.Type
+		switch v := prop.Value.(type) {
+		case *parser.StringLiteral:
+			litType = &types.LiteralType{Value: vm.String(v.Value)}
+		case *parser.NumberLiteral:
+			litType = &types.LiteralType{Value: vm.Number(v.Value)}
+		case *parser.BooleanLiteral:
+			litType = &types.LiteralType{Value: vm.BooleanValue(v.Value)}
+		default:
+			continue
+		}
+		var kept []types.Type
+		for _, cand := range candidates {
+			objType, isObj := cand.(*types.ObjectType)
+			if !isObj {
+				kept = append(kept, cand)
+				continue
+			}
+			propType, declared := objType.Properties[keyName]
+			if !declared || types.IsAssignable(litType, propType) {
+				kept = append(kept, cand)
+			}
+		}
+		if len(kept) == 0 {
+			// Nothing matches this property; keep the full list so the
+			// caller falls back to context-free checking and reports the
+			// mismatch against the whole union.
+			return candidates
+		}
+		candidates = kept
+		if len(candidates) == 1 {
+			break
+		}
+	}
+	return candidates
 }
 
 // checkArrowFunctionLiteralWithContext handles contextual typing for arrow functions

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2001,6 +2001,16 @@ func (p *Parser) parseExpression(precedence int) Expression {
 	}
 	debugPrint("parseExpression(prec=%d): after prefix, leftExp=%T, cur='%s', peek='%s'", precedence, leftExp, p.curToken.Literal, p.peekToken.Literal)
 
+	return p.parseInfixContinuation(leftExp, precedence)
+}
+
+// parseInfixContinuation runs the Pratt infix-climb loop over an already-parsed
+// left operand: it keeps consuming infix operators whose precedence is above
+// `precedence` and returns the combined expression. parseExpression is
+// prefix-parse + this loop; callers that had to stop an expression early (the
+// for-head, which parses at LESSGREATER so a following `in`/`of` is not eaten
+// as an operator) use it to resume once the stop is no longer needed.
+func (p *Parser) parseInfixContinuation(leftExp Expression, precedence int) Expression {
 	for !p.peekTokenIs(lexer.SEMICOLON) && !p.curTokenIs(lexer.SEMICOLON) && precedence < p.peekPrecedence() {
 		// ASI restricted production: [no LineTerminator here] before postfix ++/--
 		// Per ECMAScript §12.9.3, if there is a LineTerminator between the left-hand
@@ -9405,6 +9415,21 @@ func (p *Parser) parseRegularForStatementWithVar(forToken *lexer.Token, varStmt 
 	stmt := &ForStatement{Token: forToken}
 	stmt.Initializer = varStmt
 
+	// A head that is a plain expression (member/this/bracket/brace/paren
+	// prefixed) was parsed at LESSGREATER by parseForStatementOrForOf so that a
+	// following `in`/`of` would not be consumed as an infix operator. Neither
+	// followed, so this is a C-style for: resume the infix climb down to LOWEST
+	// to pick up the rest of the initializer - `=`, compound assignment, `||`,
+	// `&&`, `??`, `==`, `|`, `?:`, `,` (issue #194). Without this, `=` used to
+	// be consumed below and its RHS silently discarded, and every other
+	// operator below LESSGREATER was a "';' expected" parse error.
+	if exprStmt, ok := varStmt.(*ExpressionStatement); ok && exprStmt.Expression != nil {
+		exprStmt.Expression = p.parseInfixContinuation(exprStmt.Expression, LOWEST)
+		if exprStmt.Expression == nil {
+			return nil
+		}
+	}
+
 	// Continue parsing the initializer (might have type annotation or assignment)
 	if p.peekTokenIs(lexer.COLON) {
 		// Handle type annotation for let statements
@@ -9434,7 +9459,8 @@ func (p *Parser) parseRegularForStatementWithVar(forToken *lexer.Token, varStmt 
 			// Use COMMA precedence to stop at comma separators for multi-variable declarations
 			vs.Value = p.parseExpression(COMMA)
 		}
-		// For expression statements, we'd need to create an assignment expression
+		// An *ExpressionStatement head never reaches here with '=' pending:
+		// parseInfixContinuation above already consumed it as an assignment.
 	}
 
 	// Sync Declarations with legacy fields for all statement types

--- a/tests/scripts/contextual_type_union_literal.ts
+++ b/tests/scripts/contextual_type_union_literal.ts
@@ -1,0 +1,37 @@
+// expect: 3|number[]|x|b|2|ok
+// A union expected type must contextually type a literal through the one
+// constituent it could be. Previously `[]` against `number[] | null` was
+// checked without context as `unknown[]`, which the union then rejected
+// (false TS2322) - also for `e.body || (e.body = [])`, the fallback idiom.
+let e: { body: number[] | null; x: number } = { body: null, x: 0 };
+e.body || (e.body = []);
+e.body!.push(1, 2, 3);
+let out: string[] = [String(e.body!.length)];
+
+// Empty array literal against an array-or-null union, via initializer and assignment.
+let b: number[] | null = [];
+b = [];
+b!.push(1);
+out.push(typeof b![0] + "[]");
+
+// Object literal against object-or-null union; its nested `[]` gets typed too.
+let o: { a: string[] } | null = { a: [] };
+o!.a.push("x");
+out.push(o!.a[0]);
+
+// Discriminated union: the literal-valued property picks the constituent.
+type D = { k: "a"; v: number[] } | { k: "b"; v: string[] };
+let d: D = { k: "b", v: [] };
+out.push(d.k);
+
+// Several array constituents: `[]` fits any of them.
+let m: number[] | string[] = [];
+m = [1, 2];
+out.push(String(m.length));
+
+// Arrow function against function-or-null union keeps contextual parameter typing.
+let f: ((s: string) => string) | null = null;
+f = (s) => s.toLowerCase();
+if (f) out.push(f("OK"));
+
+out.join("|");

--- a/tests/scripts/for_init_member_expr_operators.ts
+++ b/tests/scripts/for_init_member_expr_operators.ts
@@ -1,0 +1,62 @@
+// expect: 42|true|43|7|1,2|5|8,9|3|a,b,1,2
+// Issue #194: a C-style for-init that starts with a member/bracket/paren/this
+// expression must keep parsing past LESSGREATER precedence: `=`, compound
+// assignment, ||, &&, ??, ==, |, ?:, and the comma operator. Previously `=`
+// silently discarded its RHS and the rest were "';' expected" parse errors.
+let e: any = { body: null, x: 0, y: 0, k: null };
+let out: string[] = [];
+
+for (e.x = 42; false; ) {}
+out.push(String(e.x));
+
+for (e.body || (e.body = []); false; ) {}
+out.push(String(Array.isArray(e.body)));
+
+for (e.x += 1; false; ) {}
+out.push(String(e.x));
+
+for (e.y ||= 7; false; ) {}
+out.push(String(e.y));
+
+// Operators below LESSGREATER that are not assignments must still parse.
+for (e.x && e.y; false; ) {}
+for (e.x ?? 0; false; ) {}
+for (e.x == 43; false; ) {}
+for (e.x === 43; false; ) {}
+for (e.x != 43; false; ) {}
+for (e.x !== 43; false; ) {}
+for (e.x | 1; false; ) {}
+for (e.x ^ 1; false; ) {}
+for (e.x & 1; false; ) {}
+for (e.x ? 1 : 2; false; ) {}
+for ((1) || 1; false; ) {}
+for ([1, 2].length || 1; false; ) {}
+for (({} as any).x || 1; false; ) {}
+
+for (e.x = 1, e.y = 2; false; ) {}
+out.push(e.x + "," + e.y);
+
+for (e["x"] = 5; false; ) {}
+out.push(String(e.x));
+
+let arr: number[] = [0, 0];
+for ([arr[0], arr[1]] = [8, 9]; false; ) {}
+out.push(arr[0] + "," + arr[1]);
+
+class C {
+  n: number = 0;
+  run(): number {
+    for (this.n = 3; false; ) {}
+    for (this.n || (this.n = 4); false; ) {}
+    return this.n;
+  }
+}
+out.push(String(new C().run()));
+
+// for-in / for-of over a member-expression target still work.
+let seen: string[] = [];
+for (e.k in { a: 1, b: 2 }) seen.push(e.k);
+for (e.k of [1, 2]) seen.push(String(e.k));
+out.push(seen.join(","));
+
+out.join("|");


### PR DESCRIPTION
## Summary

Two independent fixes, one per commit. The second was found while writing type-checked tests for the first.

### 1. Parser: a for-init starting with a member expression lost everything below `LESSGREATER` (closes #194)

`parseForStatementOrForOf` parses a head that starts with a member, `this`, bracket, brace, or paren expression at `LESSGREATER` precedence so a following `in`/`of` is not eaten as an infix operator. When the loop turned out to be a C-style `for`, nothing resumed parsing the initializer:

- a bare `=` was consumed by the declaration-only assignment branch in `parseRegularForStatementWithVar` and its RHS **silently discarded**: `for (e.x = 42; false;) {}` left `e.x` at 0 with no error;
- every other operator below `LESSGREATER` (`||`, `&&`, `??`, `==`-family, `|`, `^`, `&`, `?:`, compound assignment, the comma operator) was a `';' expected` parse error.

Fix: `parseExpression` is split into its prefix step plus `parseInfixContinuation(left, precedence)`, the existing Pratt infix-climb loop over an already-parsed left operand (moved verbatim). `parseRegularForStatementWithVar` resumes the climb down to `LOWEST` for an expression head once `in`/`of` are ruled out.

Found via jiti's bundled acorn, which contains `for(e.body||(e.body=[]);this.type!==O.eof;){...}` verbatim.

### 2. Checker: literals got no contextual type from a union expected type

`visitWithContext` only recognized an expected type that was directly an array, tuple, object, or callable type. Against a union such as `number[] | null` a literal fell back to context-free checking, so `[]` became `unknown[]` and the union rejected it with a false TS2322. This hit `e.body || (e.body = [])`, `e.body = []`, and `let b: number[] | null = []` alike.

Fix: `contextualTypeFromUnion` picks the one constituent the literal could be (array/tuple members for an array literal, non-callable object members for an object literal, callable members for an arrow function) and uses it as the expected type; otherwise the union is kept and behavior is unchanged. An empty array literal against several array constituents takes the first one, matching tsc's `never[]`. Object literals against several object constituents are discriminated by their literal-valued properties (`discriminateObjectCandidates`), so `{ k: "b", v: [] }` against `{ k: "a"; v: number[] } | { k: "b"; v: string[] }` types `v` as `string[]`.

## Tests

- `tests/scripts/for_init_member_expr_operators.ts`: every operator from the issue plus bracket/paren/array/object-literal heads, `this.x`, array-destructuring assignment, and for-in/for-of over a member target.
- `tests/scripts/contextual_type_union_literal.ts`: the fallback idiom, initializer and assignment forms, nested `[]` in an object literal, discriminated unions, several array constituents, arrow function against a function-or-null union.
- `go test ./tests/... ./pkg/...` green.
- test262 `language/`, main vs this branch (full dumps compared): identical pass sets, 23158 each.
- Strict TS conformance (`paserati-testtsc -strict-errors`), main vs this branch: identical except `genericCallWithObjectTypeArgsAndConstraints2.ts`, which fails identically on both when run alone (known batch-run flake). Clean-fail count unchanged at 340.

## Notes for review

- After `let b: number[] | null = []`, tsc narrows `b` to `number[]` by assignment; paserati does not narrow union-declared variables on assignment, so the checker smoke test uses `!` and an `if` guard for those accesses. Separate feature, not touched here.
- Continuing the for-head at `LOWEST` means `for (a.x = b in c;;)` parses leniently as `a.x = (b in c)`, the same leniency the bare-identifier head path already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)