### PR TITLE
fix(vm): Promise own properties/prototype override, async arrow lexical this

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -259,8 +259,17 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		// Check if this is an async function - wrap execution in a Promise
 		// Skip this if we're executing a generator (including async generators)
 		if calleeFunc.IsAsync && !isGeneratorExecution {
+			// An async arrow function still has a lexical 'this' binding -
+			// it must use its captured 'this', not the call site's receiver.
+			// This check has to happen here, ahead of the IsArrowFunction
+			// branch below, because the async path returns early without
+			// ever reaching it (see paserati#199).
+			asyncThis := thisValue
+			if calleeFunc.IsArrowFunction {
+				asyncThis = calleeClosure.CapturedThis
+			}
 			// Create a Promise and start async execution
-			promiseVal := vm.executeAsyncFunction(calleeVal, thisValue, args)
+			promiseVal := vm.executeAsyncFunction(calleeVal, asyncThis, args)
 			callerRegisters[destReg] = promiseVal
 			return false, nil // Don't switch frames - async execution happens via microtasks
 		}

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -726,6 +726,47 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 		return true, InterpretOK, *dest
 	}
 
+	// 10aa. Promise objects - check user-defined properties first, then prototype chain
+	if objVal.Type() == TypePromise {
+		promiseObj := objVal.AsPromise()
+		// First check user-defined properties on this Promise instance
+		if promiseObj.Properties != nil {
+			if v, ok := promiseObj.Properties.GetOwn(propName); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+		}
+		// Consult the per-instance prototype (set by subclass ctor for
+		// `class S extends Promise {}`) before falling back to the intrinsic.
+		proto := promiseObj.prototype
+		if !proto.IsObject() {
+			proto = vm.PromisePrototype
+		}
+		if proto.IsObject() {
+			po := proto.AsPlainObject()
+			if v, ok := po.GetOwn(propName); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+			// Walk the prototype chain
+			current := po.prototype
+			for current.typ != TypeNull && current.typ != TypeUndefined {
+				if current.IsObject() {
+					cpo := current.AsPlainObject()
+					if v, ok := cpo.GetOwn(propName); ok {
+						*dest = v
+						return true, InterpretOK, *dest
+					}
+					current = cpo.prototype
+				} else {
+					break
+				}
+			}
+		}
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+
 	// 10a. WeakMap objects - consult WeakMap.prototype chain for properties like get, set, has, delete
 	if objVal.Type() == TypeWeakMap {
 		proto := vm.WeakMapPrototype

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -958,6 +958,17 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			return vm.setOwnChecked(setObj.Properties, propName, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
+	case TypePromise:
+		// Promise objects can have user-defined properties (e.g. a subclass
+		// constructor doing `this.foo = 1` after super()).
+		promiseObj := objVal.AsPromise()
+		if promiseObj != nil {
+			if promiseObj.Properties == nil {
+				promiseObj.Properties = newPropertiesTable()
+			}
+			return vm.setOwnChecked(promiseObj.Properties, propName, *valueToSet)
+		}
+		return true, InterpretOK, *valueToSet
 	case TypeArrayBuffer:
 		// ArrayBuffer objects can have user-defined properties (e.g., constructor override)
 		ab := objVal.AsArrayBuffer()

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -39,7 +39,8 @@ type PromiseObject struct {
 	Function  Value           // The async function (for resumption)
 	ThisValue Value           // The 'this' value when async function was called
 
-	prototype Value // Per-instance [[Prototype]] override for subclassing; Undefined = intrinsic
+	prototype  Value        // Per-instance [[Prototype]] override for subclassing; Undefined = intrinsic
+	Properties *PlainObject // User-defined properties on the Promise object (e.g. `class X extends Promise { constructor() { super(...); this.foo = 1; } }`)
 }
 
 func (p *PromiseObject) GetPrototype() Value  { return p.prototype }

--- a/pkg/vm/properties_table.go
+++ b/pkg/vm/properties_table.go
@@ -94,6 +94,10 @@ func ownPropertiesSlot(v Value) **PlainObject {
 		if s := v.AsSet(); s != nil {
 			return &s.Properties
 		}
+	case TypePromise:
+		if p := v.AsPromise(); p != nil {
+			return &p.Properties
+		}
 	}
 	return nil
 }

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -566,7 +566,13 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 			prototype = vm.AsyncGeneratorPrototype.AsPlainObject()
 		}
 	case TypePromise:
-		if vm.PromisePrototype.Type() == TypeObject {
+		if pr := objVal.AsPromise(); pr != nil && pr.prototype.Type() == TypeObject {
+			// Per-instance [[Prototype]] override set by a subclass ctor
+			// (`class S extends Promise {}`) takes precedence, so an
+			// overridden method like `then` resolves to the subclass's
+			// before falling back to the intrinsic - see paserati#198.
+			prototype = pr.prototype.AsPlainObject()
+		} else if vm.PromisePrototype.Type() == TypeObject {
 			prototype = vm.PromisePrototype.AsPlainObject()
 		}
 	case TypeTypedArray:

--- a/tests/scripts/async_arrow_lexical_this.ts
+++ b/tests/scripts/async_arrow_lexical_this.ts
@@ -1,0 +1,38 @@
+// expect: obj
+// An async arrow function must capture `this` lexically at creation time,
+// exactly like a non-async arrow - never from the call site. Regression test
+// for paserati#199, where an async arrow's `this` tracked the call's receiver
+// (undefined for a bare call, the receiver object for a member call) as if
+// the arrow flag were being ignored for async functions specifically.
+
+const obj = {
+    name: "obj",
+    make() {
+        return async () => this.name;
+    },
+};
+
+const h = obj.make();
+const holder = { h };
+
+// Same function value, two different call shapes, neither receiver is `obj` -
+// a correct lexical capture must return "obj" both times.
+const bare = await h();
+const member = await holder.h();
+
+console.log("bare:", bare);
+console.log("member:", member);
+
+// The shape from the original report: an auto-bind class-field arrow handed
+// off to a native as a detached callback (`agent.subscribe(this._handler)`).
+// Promise.prototype.then calls it with no meaningful receiver of its own.
+class Handler {
+    name = "handler";
+    onEvent = async () => this.name;
+}
+const detached = await Promise.resolve(undefined).then(new Handler().onEvent);
+console.log("detached:", detached);
+
+bare === "obj" && member === "obj" && detached === "handler"
+    ? "obj"
+    : "FAIL: bare=" + bare + " member=" + member + " detached=" + detached;

--- a/tests/scripts/promise_subclass_own_property.ts
+++ b/tests/scripts/promise_subclass_own_property.ts
@@ -1,0 +1,57 @@
+// Subclassing Promise and setting an own instance property on `this` after
+// super() must work the same way it already does for Array/Error/Map/Set.
+// Regression test for paserati#198, where the VM's own-property-set switch
+// had no case for TypePromise and fell through to a strict-mode TypeError.
+// expect: ok
+// no-typecheck
+
+class APIPromise extends Promise {
+    constructor(client, responsePromise, parseResponse) {
+        super((resolve) => { resolve(null); });
+        this.responsePromise = responsePromise;
+        this.parseResponse = parseResponse;
+    }
+}
+
+const p = new APIPromise({}, Promise.resolve({ value: 42 }), (c, d) => d.value);
+
+const checks = [
+    p.responsePromise instanceof Promise,
+    typeof p.parseResponse === "function",
+    p instanceof Promise,
+    // The own property isn't just readable - it has to be callable through
+    // OpCallMethod too (a different opcode from the plain-read path above).
+    p.parseResponse("client", { value: 7 }) === 7,
+];
+
+const r = await p;
+
+checks.push(r === null);
+
+const resolved = await p.responsePromise;
+checks.push(resolved.value === 42);
+
+// A subclass method that shadows an intrinsic Promise.prototype method (e.g.
+// `then`, the exact pattern @anthropic-ai/sdk's APIPromise uses) must resolve
+// to the subclass's override, not the intrinsic - and `constructor` must
+// report the subclass, not Promise.
+class Overriding extends Promise {
+    ranOverride = false;
+    then(onFulfilled, onRejected) {
+        this.ranOverride = true;
+        return super.then(onFulfilled, onRejected);
+    }
+}
+const o = new Overriding((resolve) => resolve(5));
+checks.push(o.constructor === Overriding);
+// Call .then() directly (rather than `await o`) so this only exercises
+// property/method resolution on the subclass instance - `await`'s own
+// PromiseResolve-thenable-job handling for a subclassed promise is a
+// separate, wider spec-compliance question outside paserati#198's scope.
+const overrideResult = await new Promise((resolve) => {
+    o.then((v) => resolve(v));
+});
+checks.push(o.ranOverride === true);
+checks.push(overrideResult === 5);
+
+checks.every((c) => c === true) ? "ok" : "FAIL: " + JSON.stringify(checks);


### PR DESCRIPTION
Fixes #198 and #199.

## #198 — subclassing Promise and setting an own property after `super()` throws

`op_setprop.go`'s own-property-set switch had no `case TypePromise:` (unlike `Array`/`Error`/`Map`/`Set`), so it fell through to the strict-mode default and threw a raw-Go-struct-flavored `TypeError`. This is exactly the shape `@anthropic-ai/sdk`'s `APIPromise` class uses.

Fix, mirroring the existing `Map`/`Set` pattern:
- Added a `Properties *PlainObject` side table to `PromiseObject` ([promise.go](pkg/vm/promise.go)).
- Wired it into the write path (`op_setprop.go`), the read path (`op_getprop.go`), and the generic own-properties-table helper (`properties_table.go`) used by `Object.freeze`/`seal`/`isExtensible`.
- While there: `handlePrimitiveMethod`'s `TypePromise` case ([property_helpers.go](pkg/vm/property_helpers.go)) always resolved to the intrinsic `Promise.prototype`, ignoring a subclass's per-instance `[[Prototype]]` override. That meant a subclass method overriding an intrinsic one (e.g. `then` — exactly what `APIPromise` does) never ran, and `.constructor` reported `Promise` instead of the subclass. Fixed to check the instance override first, matching `Map`/`Set`.

## #199 — async arrow function's `this` tracks the call site instead of lexical capture

`prepareCallWithGeneratorMode`'s async branch ([call.go](pkg/vm/call.go)) returned early with the call's raw `thisValue`, before ever reaching the `IsArrowFunction` check further down that sets `newFrame.thisValue = calleeClosure.CapturedThis` for a sync arrow. So an async arrow silently behaved like an ordinary function for `this` binding — `undefined` for a bare call, the receiver for a method call. Fixed by resolving `this` to the captured lexical value ahead of the async dispatch when the callee is an arrow.

## Testing

- `go test ./tests -run TestScripts` — all green, plus two new regression tests: [async_arrow_lexical_this.ts](tests/scripts/async_arrow_lexical_this.ts), [promise_subclass_own_property.ts](tests/scripts/promise_subclass_own_property.ts).
- `go test ./...` — all green.
- Test262 `language/` (23,523 tests) and `built-ins/Promise` (639 tests) dumped and diffed before/after: zero regressions, zero new passes (these opcodes aren't exercised by any currently-passing/failing test262 case either way).