### PR TITLE
fix(driver): ModuleBuilder.Class constructors support instanceof

### DIFF
--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -179,7 +179,7 @@ func (m *ModuleBuilder) Class(name string, goStruct interface{}, constructor int
 	m.exports[name] = constructorType
 
 	// Create a constructor function that properly creates instances with prototypes
-	constructorValue := m.createClassConstructor(goStruct, constructor)
+	constructorValue := m.createClassConstructor(name, goStruct, constructor)
 	m.values[name] = constructorValue
 
 	return m
@@ -324,7 +324,7 @@ func (m *ModuleBuilder) goFunctionToVM(fn interface{}) vm.Value {
 // 1. Can be called with 'new' to create instances
 // 2. Binds methods from the Go struct to the created instance
 // 3. Sets up proper prototype chain
-func (m *ModuleBuilder) createClassConstructor(goStruct interface{}, constructor interface{}) vm.Value {
+func (m *ModuleBuilder) createClassConstructor(name string, goStruct interface{}, constructor interface{}) vm.Value {
 	constructorFn := reflect.ValueOf(constructor)
 	constructorType := reflect.TypeOf(constructor)
 	structType := reflect.TypeOf(goStruct).Elem() // Remove pointer to get struct type
@@ -333,7 +333,19 @@ func (m *ModuleBuilder) createClassConstructor(goStruct interface{}, constructor
 		return vm.Undefined
 	}
 
-	return vm.NewNativeConstructor(constructorType.NumIn(), constructorType.IsVariadic(), "class_constructor", func(args []vm.Value) (vm.Value, error) {
+	// A shared prototype object for instances to point at, so `instanceof`
+	// has something to walk to instead of throwing "Function has non-object
+	// prototype in instanceof check" (paserati#201). bindStructMethods binds
+	// methods directly onto each *instance* rather than this prototype, so
+	// it only needs to exist and carry `constructor` - nothing else reads it.
+	protoParent := vm.Undefined
+	if m.vm != nil {
+		protoParent = m.vm.ObjectPrototype
+	}
+	classPrototype := vm.NewObject(protoParent).AsPlainObject()
+	classPrototypeVal := vm.NewValueFromPlainObject(classPrototype)
+
+	constructorValue := vm.NewConstructorWithProps(constructorType.NumIn(), constructorType.IsVariadic(), name, func(args []vm.Value) (vm.Value, error) {
 		// Convert VM values to Go values for constructor call
 		goArgs := make([]reflect.Value, len(args))
 		for i, arg := range args {
@@ -370,8 +382,9 @@ func (m *ModuleBuilder) createClassConstructor(goStruct interface{}, constructor
 			return vm.Undefined, nil
 		}
 
-		// Create a VM object to represent the instance
-		instance := vm.NewObject(vm.Undefined)
+		// Create a VM object to represent the instance, chained to the
+		// class's shared prototype so `instance instanceof Class` resolves.
+		instance := vm.NewObject(classPrototypeVal)
 		instanceObj := instance.AsPlainObject()
 
 		// Bind all methods from the Go struct to the VM object
@@ -383,6 +396,13 @@ func (m *ModuleBuilder) createClassConstructor(goStruct interface{}, constructor
 
 		return instance, nil
 	})
+
+	if constructorValue.Type() == vm.TypeNativeFunctionWithProps {
+		constructorValue.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", classPrototypeVal)
+	}
+	classPrototype.SetOwnNonEnumerable("constructor", constructorValue)
+
+	return constructorValue
 }
 
 // bindStructMethods binds all exported methods from a Go struct to a VM object

--- a/pkg/driver/native_module_test.go
+++ b/pkg/driver/native_module_test.go
@@ -264,3 +264,60 @@ func TestNativeModuleClass(t *testing.T) {
 		t.Errorf("Expected 'class_test_passed', got: %v", result.ToString())
 	}
 }
+
+// TestNativeModuleClassInstanceof is a regression test for paserati#201:
+// `ModuleBuilder.Class`-registered constructors threw
+// "Function has non-object prototype in instanceof check" on `instanceof`
+// instead of the instance's prototype chain actually including the
+// constructor's `.prototype`, because createClassConstructor built its
+// constructor with no Properties table (and so nowhere to put one) and gave
+// created instances Undefined as their [[Prototype]].
+func TestNativeModuleClassInstanceof(t *testing.T) {
+	p := NewPaserati()
+
+	p.DeclareModule("geometry2", func(m *ModuleBuilder) {
+		m.Class("Point", (*Point)(nil), func(x, y float64) *Point {
+			return &Point{X: x, Y: y}
+		})
+	})
+
+	tsCode := `
+		import { Point } from "geometry2";
+
+		let p1 = new Point(3, 4);
+
+		let checks: any[] = [
+			p1 instanceof Point,
+			(new Point(0, 0)) instanceof Point,
+			typeof Point.prototype === "object",
+			p1.constructor === Point,
+			(({} as any) instanceof Point) === false,
+			// 'constructor' lives on the shared prototype as a non-enumerable
+			// property, same as FormData's - it must not leak into
+			// enumeration or serialization of an instance.
+			JSON.stringify(p1).indexOf("constructor") === -1,
+			Object.keys(p1).indexOf("constructor") === -1,
+			// Instances now chain to Object.prototype (previously
+			// Undefined), so ordinary Object.prototype methods resolve
+			// instead of being undefined.
+			typeof p1.hasOwnProperty === "function",
+			p1.hasOwnProperty("x") === true,
+			p1.hasOwnProperty("constructor") === false,
+			// The constructor's own .name should be the class name given to
+			// Class(), not the generic internal placeholder it used to be.
+			(Point as any).name === "Point",
+			p1.constructor.name === "Point",
+		];
+
+		checks.every((c) => c === true) ? "instanceof_test_passed" : "FAIL: " + JSON.stringify(checks);
+	`
+
+	result, errs := p.RunStringWithModules(tsCode)
+	if len(errs) > 0 {
+		t.Fatalf("Failed to evaluate instanceof test: %v", errs[0])
+	}
+
+	if result.ToString() != "instanceof_test_passed" {
+		t.Errorf("Expected 'instanceof_test_passed', got: %v", result.ToString())
+	}
+}


### PR DESCRIPTION
Fixes #201.

`createClassConstructor` built its constructor with `vm.NewNativeConstructor`, which produces a plain `TypeNativeFunction` with no `Properties` table — nowhere to even put a `.prototype`. Every instance it created also had `Undefined` as its `[[Prototype]]`. `instanceof`'s `TypeNativeFunction` fallback found no `.prototype`, failed the spec's `Type(P) is Object` check, and threw `TypeError: Function has non-object prototype in instanceof check` instead of just evaluating `false` — for every `ModuleBuilder.Class`-registered class (e.g. the built-in `URL` class), not something specific to one class.

## Fix

Switched to `vm.NewConstructorWithProps` (the same pattern already used by builtins like `FormData` in [formdata_init.go](pkg/builtins/formdata_init.go)):
- Allocate one shared prototype object per class, chained to `Object.prototype`.
- Set it as the constructor's own `.prototype`.
- Give it a non-enumerable `.constructor` back-pointer.
- Chain new instances to it instead of `Undefined`.

This also fixes a second bug on the way: `instance.constructor` now correctly reports the class instead of being unreachable entirely (previously the instance's prototype chain terminated immediately at `Undefined`).

While touching this function's signature, also threaded the class's real name through to the constructor — it was hardcoded to `"class_constructor"` for every class, so `obj.constructor.name` was always wrong.

## Testing

- New regression test `TestNativeModuleClassInstanceof` in [native_module_test.go](pkg/driver/native_module_test.go), covering: `instanceof` true/false cases, `.prototype` existing as an object, `.constructor` identity, `constructor` not leaking into `JSON.stringify`/`Object.keys` enumeration, instances correctly inheriting `Object.prototype` methods (e.g. `hasOwnProperty`) now that they have a real prototype chain, and `.name` on both the constructor and `.constructor.name` on instances.
- Existing `TestNativeModuleClass` output is unchanged (verified instance field/method output byte-for-byte against the pre-fix run).
- `go test ./...` and the `TestScripts` smoke suite are green.