### PR TITLE
fix(parser,compiler): object-literal methods accept reserved-word names (#203, #204)

### DIFF
--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -830,14 +830,18 @@ func (c *Compiler) compileObjectLiteral(node *parser.ObjectLiteral, hint Registe
 				}
 			}
 
-			// Compile the function value
+			// Compile the function value. Use compileFunctionLiteralAsObjectMethod (not the
+			// generic compileNode dispatch) so this method is compiled with isMethod=true -
+			// otherwise its synthesized display Name (set above) gets checked as if it were
+			// a real named-function-expression binding identifier (#204).
 			valueReg := c.regAlloc.Alloc()
 			regsToFree = append(regsToFree, valueReg)
-			_, err := c.compileNode(methodDef.Value, valueReg)
+			funcConstIndex, freeSymbols, err := c.compileFunctionLiteralAsObjectMethod(methodDef.Value, "")
 			if err != nil {
 				freePropertyRegs()
 				return BadRegister, err
 			}
+			c.emitClosure(valueReg, funcConstIndex, methodDef.Value, freeSymbols)
 
 			// Handle accessor properties (getters/setters)
 			if methodDef.Kind == "getter" || methodDef.Kind == "setter" {
@@ -1131,6 +1135,18 @@ func (c *Compiler) compileFunctionLiteralAsMethod(node *parser.FunctionLiteral, 
 	return c.compileFunctionLiteralWithOptions(node, nameHint, true, true)
 }
 
+// compileFunctionLiteralAsObjectMethod compiles a function literal as an object-literal
+// method (regular method, getter, or setter). Like class methods it has [[HomeObject]] for
+// super property access (isMethod=true), but unlike class methods it is NOT unconditionally
+// strict - object literals only become strict if the enclosing scope already is (#204: a
+// method's Name is a display name synthesized from its PropertyName for the function's own
+// .name property, not a real BindingIdentifier, so isMethod=true also exempts it from the
+// eval/arguments/FutureReservedWord binding-identifier checks that only apply to genuine
+// named function expressions).
+func (c *Compiler) compileFunctionLiteralAsObjectMethod(node *parser.FunctionLiteral, nameHint string) (uint16, []*Symbol, errors.PaseratiError) {
+	return c.compileFunctionLiteralWithOptions(node, nameHint, false, true)
+}
+
 // compileFunctionLiteralAsFieldInitializer compiles a function literal as a class field initializer.
 // Field initializers are strict mode (class bodies are strict) and forbid 'arguments' access in eval.
 // This is used when wrapping class field initializer expressions in functions.
@@ -1178,8 +1194,12 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 		debugPrintf("// [compileFunctionLiteral] Detected 'use strict' directive in function body\n")
 	}
 
-	// 1.6. Strict mode validation: cannot use 'eval' or 'arguments' as function names
-	if functionCompiler.chunk.IsStrict && node.Name != nil {
+	// 1.6. Strict mode validation: cannot use 'eval' or 'arguments' as function names.
+	// This only applies to a genuine named-function-expression binding identifier,
+	// not a method's Name - for a method, node.Name is a display name synthesized
+	// from its PropertyName (an IdentifierName, which explicitly allows every
+	// reserved word) purely so the function's own .name property is correct (#204).
+	if functionCompiler.chunk.IsStrict && node.Name != nil && !isMethod {
 		if node.Name.Value == "eval" || node.Name.Value == "arguments" {
 			functionCompiler.addError(node.Name, fmt.Sprintf("SyntaxError: Function name '%s' is not allowed in strict mode", node.Name.Value))
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -7155,11 +7155,10 @@ func (p *Parser) parseObjectLiteral() Expression {
 				var key Expression
 				var funcLit *FunctionLiteral
 
-				// Handle different name types
-				if p.curTokenIs(lexer.IDENT) || p.curTokenIs(lexer.YIELD) ||
-					p.curTokenIs(lexer.GET) || p.curTokenIs(lexer.SET) ||
-					p.curTokenIs(lexer.THROW) || p.curTokenIs(lexer.RETURN) ||
-					p.curTokenIs(lexer.LET) || p.curTokenIs(lexer.AWAIT) {
+				// Handle different name types. A method's PropertyName is an
+				// IdentifierName, which includes every reserved word (#203) -
+				// not just the handful this branch used to hand-maintain.
+				if p.isIdentifierNameToken(p.curToken) {
 					key = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
 					funcLit = &FunctionLiteral{
 						Token:       asyncToken,
@@ -7290,12 +7289,12 @@ func (p *Parser) parseObjectLiteral() Expression {
 				var key Expression
 				var funcLit *FunctionLiteral
 
-				// Handle different name types for generator methods
-				if p.curTokenIs(lexer.IDENT) || p.curTokenIs(lexer.YIELD) ||
-					p.curTokenIs(lexer.GET) || p.curTokenIs(lexer.SET) ||
-					p.curTokenIs(lexer.THROW) || p.curTokenIs(lexer.RETURN) ||
-					p.curTokenIs(lexer.LET) || p.curTokenIs(lexer.AWAIT) {
-					// *foo() or *yield() or other contextual keywords
+				// Handle different name types for generator methods. A method's
+				// PropertyName is an IdentifierName, which includes every
+				// reserved word (#203) - not just the handful this branch used
+				// to hand-maintain.
+				if p.isIdentifierNameToken(p.curToken) {
+					// *foo() or *class() or other IdentifierName
 					key = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
 					funcLit = &FunctionLiteral{
 						Token:       asteriskToken,

--- a/tests/scripts/object_method_reserved_word_names.ts
+++ b/tests/scripts/object_method_reserved_word_names.ts
@@ -1,0 +1,18 @@
+// expect: 10
+// #203/#204: object-literal methods' PropertyName is an IdentifierName, which
+// includes every reserved word - async/generator methods and plain methods
+// alike must accept reserved-word names like real Node does.
+const o = {
+  import(e: number) { return e; },
+  async class(e: number) { return e; },
+  static(e: number) { return e; },
+  implements(e: number) { return e; },
+  *interface(e: number) { yield e; },
+};
+
+o.class(5).then((v: number) => console.log("async class:", v));
+
+let total = o.import(1) + o.static(2) + o.implements(3);
+for (const v of o.interface(4)) total += v;
+
+total;


### PR DESCRIPTION
## Summary

Fixes both [#203](https://github.com/nooga/paserati/issues/203) and [#204](https://github.com/nooga/paserati/issues/204). Both bugs share the same root cause category: an object-literal method's `PropertyName` is an `IdentifierName`, which explicitly includes every reserved word — a method's key is never a `BindingIdentifier`, so none of the usual reserved-word/strict-mode restrictions apply. Real Node/V8 accepts every reserved word as a method name in every form.

### #203 — parser

The async-method and generator-method branches in the object-literal parser each hand-maintained a narrow allowlist of token types for the method name instead of accepting any `IdentifierName`, so `async import(e) {}`, `async class(e) {}`, `*class(e) {}`, etc. all failed to parse — even though plain (non-async, non-generator) methods and class methods of any kind already accepted these names correctly. Replaced both allowlists with the existing `isIdentifierNameToken()` helper.

### #204 — compiler

`compileObjectLiteral` sets a method's `FunctionLiteral.Name` to its property key purely so the function's own `.name` reflects the method name at runtime. That synthesized display name was then compiled through the generic `FunctionLiteral` dispatch path (`isMethod=false`), which subjected it to the `eval`/`arguments`/`FutureReservedWord` binding-identifier checks meant for genuine named function expressions — so methods named `static`, `implements`, `interface`, `package`, `private`, `protected`, or `public` failed to compile under strict mode (e.g. every TypeScript module, which is implicitly strict).

Added `compileFunctionLiteralAsObjectMethod` (`isMethod=true`, *not* force-strict, unlike class methods) and routed object-literal method compilation through it instead of the generic dispatch; the strict-mode name-validation block now also skips synthesized method names via `isMethod`.

As a side effect, object-literal methods now correctly report `HasSuperBinding` for `eval()` calls in their body (e.g. `{ m() { return eval("super.foo()") } }`), matching class methods — this was previously inconsistent because `isMethodCompilation` was never set for object-literal methods either.

## Verification

- Full matrix of reserved-word names (`import`, `class`, `static`, `delete`, `typeof`, `default`, `new`, `this`, `super`, `of`, `async`, `get`, `set`, `yield`, `await`) as plain/async/generator object-literal methods and getters/setters
- Class methods and named-function-expression strict-mode rejection remain unaffected (control cases)
- `eval`/`arguments` as method names
- `async`-as-property-name disambiguation (`{ async }`, `{ async: 1 }`, `{ async, b }`)
- `super` via `eval()` in object-literal methods
- test262 `language/expressions` and `language/statements/class` show **zero diff** against main
- Smoke tests (`TestScripts`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)