### PR TITLE
feat(builtins): minimal ReadableStream primitive (#205)

### DIFF
--- a/pkg/builtins/readable_stream_goroutine_test.go
+++ b/pkg/builtins/readable_stream_goroutine_test.go
@@ -1,0 +1,154 @@
+package builtins
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestReadableStreamGoroutineFed proves paserati's Promise/VM layer can
+// safely settle a ReadableStream read() from a background goroutine - the
+// fork question #205's design turned on ("can this VM resolve a Promise
+// from a Go goroutine?"). It deliberately mirrors fetch()'s own existing
+// goroutine-resolves-a-promise pattern (doFetchRequestWithContext in
+// fetch_init.go calls vm.ResolvePromise from its own goroutine with no
+// extra synchronization at that call site) rather than introducing a new
+// one, and exercises ReadableStreamController - the primitive a host
+// integration (e.g. noderati's own incrementally-streamed fetch(), per
+// #205's scope) would drive from its own HTTP-reading goroutine.
+func TestReadableStreamGoroutineFed(t *testing.T) {
+	vmInstance := vm.NewVM()
+
+	// createReadableStreamObject wires up [Symbol.asyncIterator], which
+	// normally comes from SymbolInitializer running first (see standard.go's
+	// priority ordering); set it directly here rather than bootstrapping the
+	// rest of that initializer's Symbol.prototype setup, which needs more of
+	// the VM realm than this narrow test cares about.
+	SymbolAsyncIterator = vm.NewSymbol("Symbol.asyncIterator")
+
+	initializer := &ReadableStreamInitializer{}
+	ctx := &RuntimeContext{
+		VM:           vmInstance,
+		DefineGlobal: func(name string, value vm.Value) error { return nil },
+	}
+	if err := initializer.InitRuntime(ctx); err != nil {
+		t.Fatalf("InitRuntime failed: %v", err)
+	}
+
+	streamVal, controller := NewHostFedReadableStream(vmInstance)
+
+	getReaderFn, ok := streamVal.AsPlainObject().GetOwn("getReader")
+	if !ok || !getReaderFn.IsCallable() {
+		t.Fatal("stream has no callable getReader")
+	}
+	readerVal, err := vmInstance.Call(getReaderFn, streamVal, nil)
+	if err != nil {
+		t.Fatalf("getReader() failed: %v", err)
+	}
+	readFn, ok := readerVal.AsPlainObject().GetOwn("read")
+	if !ok || !readFn.IsCallable() {
+		t.Fatal("reader has no callable read")
+	}
+
+	rt := vmInstance.GetAsyncRuntime()
+
+	// Background goroutine, deliberately separate from the one driving the
+	// VM below - the same shape fetch()'s own request goroutine takes,
+	// bracketed with BeginExternalOp/EndExternalOp so DrainUntilIdle-style
+	// waiting (reproduced manually below) knows to wait for it.
+	rt.BeginExternalOp()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		controller.EnqueueBytes([]byte("hello"))
+		controller.Close()
+		rt.EndExternalOp()
+	}()
+
+	// read() itself must run on the "main" goroutine (it's always reached via
+	// a native-function call from JS bytecode), same as any real reader.read().
+	promiseVal, err := vmInstance.Call(readFn, readerVal, nil)
+	if err != nil {
+		t.Fatalf("read() failed: %v", err)
+	}
+	promise := promiseVal.AsPromise()
+	if promise == nil {
+		t.Fatal("read() did not return a Promise")
+	}
+
+	waitForSettled(t, rt, promise)
+
+	if promise.State != vm.PromiseFulfilled {
+		t.Fatalf("expected promise to be fulfilled, got state=%v result=%v", promise.State, promise.Result)
+	}
+
+	resultObj := promise.Result.AsPlainObject()
+	if resultObj == nil {
+		t.Fatalf("resolved value is not a plain object: %+v", promise.Result)
+	}
+	if doneVal, _ := resultObj.GetOwn("done"); doneVal.Type() != vm.TypeBoolean || doneVal.AsBoolean() {
+		t.Fatalf("expected done=false on first chunk, got %v", doneVal)
+	}
+	valueVal, _ := resultObj.GetOwn("value")
+	if valueVal.Type() != vm.TypeTypedArray {
+		t.Fatalf("expected a Uint8Array chunk, got type %v", valueVal.Type())
+	}
+	ta := valueVal.AsTypedArray()
+	got := make([]byte, ta.GetLength())
+	for i := range got {
+		got[i] = byte(ta.GetElement(i).ToFloat())
+	}
+	if string(got) != "hello" {
+		t.Fatalf("expected chunk %q, got %q", "hello", string(got))
+	}
+
+	// The goroutine also called Close() right after the one chunk, so a
+	// second read() must resolve (immediately, no further waiting needed)
+	// with done: true.
+	promiseVal2, err := vmInstance.Call(readFn, readerVal, nil)
+	if err != nil {
+		t.Fatalf("second read() failed: %v", err)
+	}
+	promise2 := promiseVal2.AsPromise()
+	if promise2 == nil || promise2.State != vm.PromiseFulfilled {
+		t.Fatalf("expected second read() to be immediately fulfilled, got %+v", promise2)
+	}
+	resultObj2 := promise2.Result.AsPlainObject()
+	if doneVal2, _ := resultObj2.GetOwn("done"); doneVal2.Type() != vm.TypeBoolean || !doneVal2.AsBoolean() {
+		t.Fatalf("expected done=true after close, got %v", doneVal2)
+	}
+}
+
+// waitForSettled waits for promise to settle without ever reading its State
+// before establishing a happens-before edge with whatever goroutine might
+// still be resolving it: WaitForExternalOp/EndExternalOp share the runtime's
+// own mutex (pkg/runtime/async.go), so a State read taken right after
+// WaitForExternalOp returns is guaranteed to see every mutation the
+// external-op goroutine made before its matching EndExternalOp call. This
+// matters because plain "read promise.State" *before ever synchronizing at
+// all* - even in a spin/poll loop - is a genuine, reproducible data race
+// with a concurrent ResolvePromise/RejectPromise call (confirmed independent
+// of ReadableStream: `go test -race` flags a bare NewPendingPromise() +
+// goroutine-calls-ResolvePromise() + polling-read repro with no
+// ReadableStream code involved at all). That gap also lives in the VM's own
+// `await` opcode (pkg/vm/vm.go, `switch awaitedPromise.State` reads it with
+// no synchronization whatsoever, not even this runtime's mutex) - out of
+// scope to fix here, flagged separately.
+func waitForSettled(t *testing.T, rt interface {
+	HasPendingExternalOps() bool
+	WaitForExternalOp()
+}, promise *vm.PromiseObject) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if rt.HasPendingExternalOps() {
+			rt.WaitForExternalOp()
+		}
+		if promise.State != vm.PromisePending {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for goroutine-fed read() to settle")
+		}
+	}
+}

--- a/pkg/builtins/readable_stream_init.go
+++ b/pkg/builtins/readable_stream_init.go
@@ -1,0 +1,494 @@
+package builtins
+
+import (
+	"sync"
+
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// PriorityReadableStream places ReadableStream before Blob (190), so a future
+// Blob.stream() (currently a stub in blob_init.go) can build on this
+// primitive without a reordering.
+const PriorityReadableStream = 185
+
+// ReadableStreamInitializer implements a minimal ReadableStream /
+// ReadableStreamDefaultReader, sized to the surface real streaming
+// consumers (the OpenAI/Anthropic/Google SDKs' shared
+// ReadableStreamToAsyncIterable-style helper) actually need (#205):
+//
+//	stream[Symbol.asyncIterator]   // preferred if present, OR:
+//	stream.getReader() -> {
+//	  read(): Promise<{ done, value }>,
+//	  releaseLock(): void,
+//	  cancel(): Promise<void>,
+//	}
+//
+// Not the full Web Streams API - no pipeThrough/tee backpressure semantics,
+// no WritableStream, no BYOB readers. Per #205's scope, real incremental
+// network streaming (feeding this from an HTTP response body as bytes
+// arrive) is noderati's responsibility; this file's job is the primitive
+// itself, plus a Go-facing feeding API (ReadableStreamController /
+// NewHostFedReadableStream below) proven safe to drive from a background
+// goroutine - see that type's doc comment for why.
+type ReadableStreamInitializer struct{}
+
+func (r *ReadableStreamInitializer) Name() string  { return "ReadableStream" }
+func (r *ReadableStreamInitializer) Priority() int { return PriorityReadableStream }
+
+func (r *ReadableStreamInitializer) InitTypes(ctx *TypeContext) error {
+	readerType := types.NewObjectType().
+		WithProperty("read", types.NewSimpleFunction([]types.Type{}, types.Any)). // Promise<{value, done}>
+		WithProperty("releaseLock", types.NewSimpleFunction([]types.Type{}, types.Undefined)).
+		WithProperty("cancel", types.NewOptionalFunction([]types.Type{types.Any}, types.Any, []bool{true}))
+
+	streamType := types.NewObjectType().
+		WithProperty("locked", types.Boolean).
+		WithProperty("getReader", types.NewSimpleFunction([]types.Type{}, readerType)).
+		WithProperty("cancel", types.NewOptionalFunction([]types.Type{types.Any}, types.Any, []bool{true}))
+
+	streamCtorType := types.NewObjectType().
+		WithSimpleCallSignature([]types.Type{}, streamType).             // new ReadableStream()
+		WithSimpleCallSignature([]types.Type{types.Any}, streamType).    // new ReadableStream(underlyingSource)
+		WithProperty("prototype", streamType)
+
+	return ctx.DefineGlobal("ReadableStream", streamCtorType)
+}
+
+func (r *ReadableStreamInitializer) InitRuntime(ctx *RuntimeContext) error {
+	vmInstance := ctx.VM
+
+	streamProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	readerProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	// Stashed so NewHostFedReadableStream (a Go-facing constructor with no
+	// JS underlyingSource) can build stream/reader objects that share the
+	// same prototypes as ones constructed from script.
+	readableStreamProto = streamProto
+	readableStreamReaderProto = readerProto
+
+	ctorFn := func(args []vm.Value) (vm.Value, error) {
+		state := newReadableStreamState(vmInstance)
+		streamVal := createReadableStreamObject(vmInstance, state, streamProto, readerProto)
+
+		if len(args) > 0 && (args[0].Type() == vm.TypeObject || args[0].Type() == vm.TypeDictObject) {
+			state.underlyingSource = args[0]
+			if startFn, err := vmInstance.GetProperty(args[0], "start"); err == nil && startFn.IsCallable() {
+				controllerVal := createReadableStreamControllerObject(vmInstance, state)
+				if _, callErr := vmInstance.Call(startFn, args[0], []vm.Value{controllerVal}); callErr != nil {
+					return vm.Undefined, callErr
+				}
+			}
+		}
+
+		return streamVal, nil
+	}
+
+	ctor := vm.NewConstructorWithProps(1, false, "ReadableStream", ctorFn)
+	if ctor.Type() == vm.TypeNativeFunctionWithProps {
+		ctor.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(streamProto))
+	}
+	streamProto.SetOwnNonEnumerable("constructor", ctor)
+
+	return ctx.DefineGlobal("ReadableStream", ctor)
+}
+
+// Package-level prototypes, set once during InitRuntime - mirrors the
+// SymbolIterator/SymbolAsyncIterator package-var convention in
+// symbol_init.go. Only valid after ReadableStreamInitializer.InitRuntime has
+// run (i.e. after normal Paserati/driver initialization).
+var (
+	readableStreamProto       *vm.PlainObject
+	readableStreamReaderProto *vm.PlainObject
+)
+
+// pendingStreamRead is a read() call that arrived while the queue was empty
+// and the stream neither closed nor errored; it is settled the moment a
+// chunk is enqueued, the stream closes, or the stream errors.
+type pendingStreamRead struct {
+	promise *vm.PromiseObject
+}
+
+// readableStreamState is the internal, non-JS-visible state backing a
+// ReadableStream. All mutation goes through its methods, which take `mu` -
+// this is what makes enqueue/close/errorOut safe to call from a goroutine
+// that isn't the VM's own execution goroutine (see ReadableStreamController).
+type readableStreamState struct {
+	mu sync.Mutex
+
+	vmInstance *vm.VM
+	streamObj  *vm.PlainObject // for keeping the JS-visible `locked` property in sync
+
+	queue        []vm.Value
+	pendingReads []*pendingStreamRead
+
+	closed     bool
+	errored    bool
+	errorValue vm.Value
+
+	locked bool
+
+	underlyingSource vm.Value // Undefined if none was given
+}
+
+func newReadableStreamState(vmInstance *vm.VM) *readableStreamState {
+	return &readableStreamState{vmInstance: vmInstance, underlyingSource: vm.Undefined}
+}
+
+// iterResultValue builds a plain {value, done} object, the shape read()/
+// next() promises resolve to. Safe to call from any goroutine: it only
+// allocates a brand-new, not-yet-shared PlainObject (see NewObject/SetOwn's
+// own internal Shape.mu locking in pkg/vm/object.go for why concurrent
+// object creation is already relied upon - fetch()'s response-building
+// goroutine does the same).
+func iterResultValue(vmInstance *vm.VM, value vm.Value, done bool) vm.Value {
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	obj.SetOwnNonEnumerable("value", value)
+	obj.SetOwnNonEnumerable("done", vm.BooleanValue(done))
+	return vm.NewValueFromPlainObject(obj)
+}
+
+// errorValueFromGoError unwraps a Go error from vm.Call/NewTypeError etc.
+// into the actual thrown Value, mirroring the identical unwrap in
+// pkg/vm/promise.go's triggerPromiseReactions (a plain NewString(err.Error())
+// would silently replace a real Error object with a message-less string).
+func errorValueFromGoError(err error) vm.Value {
+	if err == nil {
+		return vm.Undefined
+	}
+	if ee, ok := err.(vm.ExceptionError); ok {
+		return ee.GetExceptionValue()
+	}
+	return vm.NewString(err.Error())
+}
+
+// enqueue makes a chunk available to the stream. Safe to call from any
+// goroutine - see the type doc comment on readableStreamState/
+// ReadableStreamController.
+func (s *readableStreamState) enqueue(chunk vm.Value) {
+	s.mu.Lock()
+	if s.closed || s.errored {
+		s.mu.Unlock()
+		return
+	}
+	if len(s.pendingReads) > 0 {
+		pr := s.pendingReads[0]
+		s.pendingReads = s.pendingReads[1:]
+		s.mu.Unlock()
+		s.vmInstance.ResolvePromise(pr.promise, iterResultValue(s.vmInstance, chunk, false))
+		return
+	}
+	s.queue = append(s.queue, chunk)
+	s.mu.Unlock()
+}
+
+// close signals a normal end of stream. Safe to call from any goroutine.
+func (s *readableStreamState) close() {
+	s.mu.Lock()
+	if s.closed || s.errored {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	pending := s.pendingReads
+	s.pendingReads = nil
+	s.mu.Unlock()
+
+	for _, pr := range pending {
+		s.vmInstance.ResolvePromise(pr.promise, iterResultValue(s.vmInstance, vm.Undefined, true))
+	}
+}
+
+// errorOut signals an abnormal end of stream, rejecting any read() already
+// waiting and every one still to come. Safe to call from any goroutine.
+func (s *readableStreamState) errorOut(reason vm.Value) {
+	s.mu.Lock()
+	if s.closed || s.errored {
+		s.mu.Unlock()
+		return
+	}
+	s.errored = true
+	s.errorValue = reason
+	pending := s.pendingReads
+	s.pendingReads = nil
+	s.mu.Unlock()
+
+	for _, pr := range pending {
+		s.vmInstance.RejectPromise(pr.promise, reason)
+	}
+}
+
+// read implements reader.read()/the async-iterator's next(). Unlike
+// enqueue/close/errorOut, this must only be called from the main VM
+// goroutine - it's always reached via a native-function call from JS, and it
+// may itself synchronously call back into JS (the underlying source's
+// pull() hook).
+func (s *readableStreamState) read() vm.Value {
+	s.mu.Lock()
+	if len(s.queue) > 0 {
+		chunk := s.queue[0]
+		s.queue = s.queue[1:]
+		s.mu.Unlock()
+		return s.vmInstance.NewResolvedPromise(iterResultValue(s.vmInstance, chunk, false))
+	}
+	if s.errored {
+		reason := s.errorValue
+		s.mu.Unlock()
+		return s.vmInstance.NewRejectedPromise(reason)
+	}
+	if s.closed {
+		s.mu.Unlock()
+		return s.vmInstance.NewResolvedPromise(iterResultValue(s.vmInstance, vm.Undefined, true))
+	}
+
+	promiseVal := s.vmInstance.NewPendingPromise()
+	s.pendingReads = append(s.pendingReads, &pendingStreamRead{promise: promiseVal.AsPromise()})
+	source := s.underlyingSource
+	s.mu.Unlock()
+
+	// Best-effort backpressure signal: ask a JS-authored underlying source
+	// for more data now that a consumer is waiting on an empty queue. Not
+	// spec-accurate (no highWaterMark bookkeeping), but enough to drive a
+	// simple pull-based source.
+	if source.Type() == vm.TypeObject || source.Type() == vm.TypeDictObject {
+		if pullFn, err := s.vmInstance.GetProperty(source, "pull"); err == nil && pullFn.IsCallable() {
+			controllerVal := createReadableStreamControllerObject(s.vmInstance, s)
+			_, _ = s.vmInstance.Call(pullFn, source, []vm.Value{controllerVal})
+		}
+	}
+
+	return promiseVal
+}
+
+// cancel implements reader.cancel()/stream.cancel(): it stops the stream
+// (as if closed) and forwards to the underlying source's cancel() hook, if
+// any.
+func (s *readableStreamState) cancel(reason vm.Value) vm.Value {
+	s.mu.Lock()
+	if s.closed || s.errored {
+		s.mu.Unlock()
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	s.closed = true
+	// Per spec, cancelling resets the queue - a cancelled stream must not
+	// keep handing out chunks it had already buffered before the cancel.
+	s.queue = nil
+	pending := s.pendingReads
+	s.pendingReads = nil
+	source := s.underlyingSource
+	s.mu.Unlock()
+
+	for _, pr := range pending {
+		s.vmInstance.ResolvePromise(pr.promise, iterResultValue(s.vmInstance, vm.Undefined, true))
+	}
+
+	if source.Type() == vm.TypeObject || source.Type() == vm.TypeDictObject {
+		if cancelFn, err := s.vmInstance.GetProperty(source, "cancel"); err == nil && cancelFn.IsCallable() {
+			result, callErr := s.vmInstance.Call(cancelFn, source, []vm.Value{reason})
+			if callErr != nil {
+				return s.vmInstance.NewRejectedPromise(errorValueFromGoError(callErr))
+			}
+			return s.vmInstance.NewResolvedPromise(result)
+		}
+	}
+	return s.vmInstance.NewResolvedPromise(vm.Undefined)
+}
+
+// release implements reader.releaseLock(), unlocking the stream so a new
+// reader can be acquired via getReader().
+func (s *readableStreamState) release() {
+	s.mu.Lock()
+	s.locked = false
+	obj := s.streamObj
+	s.mu.Unlock()
+	if obj != nil {
+		obj.SetOwn("locked", vm.False)
+	}
+}
+
+func createReadableStreamObject(vmInstance *vm.VM, state *readableStreamState, streamProto, readerProto *vm.PlainObject) vm.Value {
+	obj := vm.NewObject(vm.NewValueFromPlainObject(streamProto)).AsPlainObject()
+	state.streamObj = obj
+	obj.SetOwn("locked", vm.False)
+
+	obj.SetOwnNonEnumerable("getReader", vm.NewNativeFunction(0, false, "getReader", func(args []vm.Value) (vm.Value, error) {
+		state.mu.Lock()
+		if state.locked {
+			state.mu.Unlock()
+			return vm.Undefined, vmInstance.NewTypeError("ReadableStream is already locked to a reader")
+		}
+		state.locked = true
+		state.mu.Unlock()
+		obj.SetOwn("locked", vm.True)
+		return createReadableStreamReaderObject(vmInstance, state, readerProto), nil
+	}))
+
+	obj.SetOwnNonEnumerable("cancel", vm.NewNativeFunction(1, false, "cancel", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		return state.cancel(reason), nil
+	}))
+
+	// [Symbol.asyncIterator] - the surface every real SDK's own
+	// ReadableStreamToAsyncIterable shim tries first (#205's scope note).
+	asyncIterFn := vm.NewNativeFunction(0, false, "[Symbol.asyncIterator]", func(args []vm.Value) (vm.Value, error) {
+		return createReadableStreamAsyncIteratorObject(vmInstance, state), nil
+	})
+	w, e, c := true, false, true
+	obj.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolAsyncIterator), asyncIterFn, &w, &e, &c)
+
+	return vm.NewValueFromPlainObject(obj)
+}
+
+func createReadableStreamReaderObject(vmInstance *vm.VM, state *readableStreamState, readerProto *vm.PlainObject) vm.Value {
+	obj := vm.NewObject(vm.NewValueFromPlainObject(readerProto)).AsPlainObject()
+	released := false
+
+	obj.SetOwnNonEnumerable("read", vm.NewNativeFunction(0, false, "read", func(args []vm.Value) (vm.Value, error) {
+		if released {
+			err := vmInstance.NewTypeError("Cannot read a stream using a released reader")
+			return vmInstance.NewRejectedPromise(errorValueFromGoError(err)), nil
+		}
+		return state.read(), nil
+	}))
+
+	obj.SetOwnNonEnumerable("releaseLock", vm.NewNativeFunction(0, false, "releaseLock", func(args []vm.Value) (vm.Value, error) {
+		released = true
+		state.release()
+		return vm.Undefined, nil
+	}))
+
+	obj.SetOwnNonEnumerable("cancel", vm.NewNativeFunction(1, false, "cancel", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		return state.cancel(reason), nil
+	}))
+
+	return vm.NewValueFromPlainObject(obj)
+}
+
+// createReadableStreamControllerObject builds the controller object handed
+// to a JS-authored underlying source's start(controller)/pull(controller)
+// hooks (enqueue/close/error), per the standard ReadableStreamController
+// shape.
+func createReadableStreamControllerObject(vmInstance *vm.VM, state *readableStreamState) vm.Value {
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	obj.SetOwnNonEnumerable("enqueue", vm.NewNativeFunction(1, false, "enqueue", func(args []vm.Value) (vm.Value, error) {
+		var chunk vm.Value = vm.Undefined
+		if len(args) > 0 {
+			chunk = args[0]
+		}
+		state.enqueue(chunk)
+		return vm.Undefined, nil
+	}))
+
+	obj.SetOwnNonEnumerable("close", vm.NewNativeFunction(0, false, "close", func(args []vm.Value) (vm.Value, error) {
+		state.close()
+		return vm.Undefined, nil
+	}))
+
+	obj.SetOwnNonEnumerable("error", vm.NewNativeFunction(1, false, "error", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		state.errorOut(reason)
+		return vm.Undefined, nil
+	}))
+
+	return vm.NewValueFromPlainObject(obj)
+}
+
+// createReadableStreamAsyncIteratorObject implements the object returned by
+// stream[Symbol.asyncIterator](), consuming the stream directly (it does not
+// go through getReader()'s single-lock bookkeeping - matching real
+// browsers/Node, where for-await-of a stream doesn't observe `locked`).
+func createReadableStreamAsyncIteratorObject(vmInstance *vm.VM, state *readableStreamState) vm.Value {
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	obj.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
+		return state.read(), nil
+	}))
+
+	obj.SetOwnNonEnumerable("return", vm.NewNativeFunction(1, false, "return", func(args []vm.Value) (vm.Value, error) {
+		var val vm.Value = vm.Undefined
+		if len(args) > 0 {
+			val = args[0]
+		}
+		state.cancel(vm.Undefined)
+		return iterResultValue(vmInstance, val, true), nil
+	}))
+
+	selfFn := vm.NewNativeFunction(0, false, "[Symbol.asyncIterator]", func(args []vm.Value) (vm.Value, error) {
+		return vm.NewValueFromPlainObject(obj), nil
+	})
+	w, e, c := true, false, true
+	obj.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolAsyncIterator), selfFn, &w, &e, &c)
+
+	return vm.NewValueFromPlainObject(obj)
+}
+
+// ReadableStreamController is the host-facing (Go) handle for feeding a
+// ReadableStream from outside JS - typically a background goroutine reading
+// an HTTP response body incrementally (the piece #205 scopes to noderati's
+// own streaming fetch(), not to paserati's built-in one). Every method is
+// safe to call concurrently with the VM's own execution goroutine:
+//
+//   - It uses the exact promise-resolved-from-a-goroutine pattern fetch()
+//     already relies on today: doFetchRequestWithContext (fetch_init.go)
+//     calls vm.ResolvePromise/vm.RejectPromise from its own goroutine once
+//     the HTTP round-trip completes, with no additional synchronization at
+//     that call site.
+//   - The object/value allocation those calls do under the hood (a fresh
+//     {value, done} object per chunk) is itself safe from any goroutine:
+//     PlainObject shape transitions are protected by their own Shape.mu
+//     (pkg/vm/object.go's SetOwn), which is exactly the mechanism that lets
+//     fetch()'s goroutine build its whole Response object off-thread before
+//     handing it to ResolvePromise.
+//   - This type's own state (readableStreamState) adds its own mutex around
+//     the queue/pending-reads bookkeeping that promise resolution alone
+//     doesn't cover.
+//
+// A host would typically call rt.BeginExternalOp()/EndExternalOp() (see
+// vm.VM.GetAsyncRuntime) around the feeding goroutine's lifetime, the same
+// way fetch() does, so DrainUntilIdle knows to wait for it.
+type ReadableStreamController struct {
+	state *readableStreamState
+}
+
+// Enqueue makes a chunk (typically a Uint8Array) available to the stream.
+func (c *ReadableStreamController) Enqueue(chunk vm.Value) { c.state.enqueue(chunk) }
+
+// EnqueueBytes wraps raw bytes as a Uint8Array chunk before enqueuing it -
+// the representation real fetch()/HTTP consumers expect from a byte stream.
+func (c *ReadableStreamController) EnqueueBytes(data []byte) {
+	bufVal := vm.NewArrayBuffer(len(data))
+	backing := bufVal.AsArrayBuffer()
+	copy(backing.GetData(), data)
+	c.state.enqueue(vm.NewTypedArray(vm.TypedArrayUint8, backing, 0, -1))
+}
+
+// Close signals a normal end of stream.
+func (c *ReadableStreamController) Close() { c.state.close() }
+
+// Error signals an abnormal end of stream, rejecting every pending and
+// future read() with reason.
+func (c *ReadableStreamController) Error(reason vm.Value) { c.state.errorOut(reason) }
+
+// NewHostFedReadableStream creates a ReadableStream with no JS-authored
+// underlying source, whose contents are instead fed entirely from Go via the
+// returned ReadableStreamController. This is the primitive a real
+// incrementally-streamed fetch() Response.body (left to noderati per #205)
+// would be built on. Only valid once ReadableStreamInitializer.InitRuntime
+// has already run against vmInstance (i.e. after normal
+// Paserati/driver initialization).
+func NewHostFedReadableStream(vmInstance *vm.VM) (vm.Value, *ReadableStreamController) {
+	state := newReadableStreamState(vmInstance)
+	streamVal := createReadableStreamObject(vmInstance, state, readableStreamProto, readableStreamReaderProto)
+	return streamVal, &ReadableStreamController{state: state}
+}

--- a/pkg/builtins/standard.go
+++ b/pkg/builtins/standard.go
@@ -55,6 +55,7 @@ func GetStandardInitializers() []BuiltinInitializer {
 	initializers = append(initializers, &ReflectInitializer{})
 	initializers = append(initializers, &ProxyInitializer{})
 	initializers = append(initializers, &ConsoleInitializer{})
+	initializers = append(initializers, &ReadableStreamInitializer{})
 	initializers = append(initializers, &BlobInitializer{})
 	initializers = append(initializers, &FormDataInitializer{})
 	initializers = append(initializers, &AbortControllerInitializer{})

--- a/tests/scripts/readable_stream_basic.ts
+++ b/tests/scripts/readable_stream_basic.ts
@@ -1,0 +1,89 @@
+// expect: true
+// #205: a minimal ReadableStream/ReadableStreamDefaultReader, sized to what
+// real streaming SDK consumers need: stream[Symbol.asyncIterator] and
+// stream.getReader() -> { read(), releaseLock(), cancel() }.
+const results: unknown[] = [];
+
+async function main(): Promise<boolean> {
+  // getReader()/read()/releaseLock(), plus a pull-based source (backpressure).
+  let pullCount = 0;
+  const pulled = new ReadableStream({
+    pull(controller: any) {
+      pullCount++;
+      if (pullCount <= 2) controller.enqueue(pullCount);
+      else controller.close();
+    },
+  });
+  const reader = pulled.getReader();
+  const r1 = await reader.read();
+  const r2 = await reader.read();
+  const r3 = await reader.read();
+  reader.releaseLock();
+  results.push(r1.value === 1 && r1.done === false);
+  results.push(r2.value === 2 && r2.done === false);
+  results.push(r3.value === undefined && r3.done === true);
+
+  // [Symbol.asyncIterator] / for-await-of.
+  const iterable = new ReadableStream({
+    start(controller: any) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+      controller.close();
+    },
+  });
+  const collected: string[] = [];
+  for await (const chunk of iterable as any) {
+    collected.push(chunk);
+  }
+  results.push(collected.length === 2 && collected[0] === "a" && collected[1] === "b");
+
+  // locked / getReader() single-lock enforcement.
+  const lockable = new ReadableStream({ start(c: any) { c.enqueue("x"); } });
+  results.push(lockable.locked === false);
+  const r = lockable.getReader();
+  results.push(lockable.locked === true);
+  let threw = false;
+  try {
+    lockable.getReader();
+  } catch {
+    threw = true;
+  }
+  results.push(threw);
+  r.releaseLock();
+  results.push(lockable.locked === false);
+
+  // cancel() forwards to the underlying source and discards the buffered
+  // queue (a cancelled stream must not keep handing out old chunks).
+  let cancelReason = "";
+  const cancellable = new ReadableStream({
+    start(c: any) { c.enqueue("buffered"); },
+    cancel(reason: any) { cancelReason = reason; },
+  });
+  const cReader = cancellable.getReader();
+  await cReader.cancel("bye");
+  const afterCancel = await cReader.read();
+  results.push(cancelReason === "bye");
+  results.push(afterCancel.done === true);
+
+  // controller.error() rejects reads.
+  const erroring = new ReadableStream({
+    start(controller: any) {
+      controller.enqueue("first");
+      controller.error(new Error("boom"));
+    },
+  });
+  const eReader = erroring.getReader();
+  const first = await eReader.read();
+  results.push(first.value === "first" && first.done === false);
+  let rejected = false;
+  try {
+    await eReader.read();
+  } catch (e) {
+    rejected = (e as any).message === "boom";
+  }
+  results.push(rejected);
+
+  return results.every((v) => v === true);
+}
+
+await main();


### PR DESCRIPTION
## Summary

Addresses the paserati-side scope of [#205](https://github.com/nooga/paserati/issues/205). Adds `ReadableStream`/`ReadableStreamDefaultReader`, sized to the surface real streaming SDK consumers actually need (the OpenAI/Anthropic/Google SDKs' shared `ReadableStreamToAsyncIterable`-style helper, per #205's own scope note):

```js
stream[Symbol.asyncIterator]   // preferred if present, OR:
stream.getReader() -> {
  read(): Promise<{ done, value }>,
  releaseLock(): void,
  cancel(): Promise<void>,
}
```

Not the full Web Streams API — no `pipeThrough`/`tee`, no `WritableStream`, no BYOB readers, no real `highWaterMark`/backpressure bookkeeping (`pull()` is invoked on every empty-queue `read()` as a best-effort signal instead).

**Scope note, per discussion:** real incremental network streaming — actually feeding a `ReadableStream` from an HTTP response body as bytes arrive — belongs to noderati's own streaming `fetch()`, not to paserati's built-in one (`pkg/builtins/fetch_init.go` is untouched by this PR). This PR's job is the primitive itself, plus proving paserati's Promise/VM layer is ready to be driven from a background goroutine the way a host integration would:

- `ReadableStreamController` is a Go-facing handle (`Enqueue`/`EnqueueBytes`/`Close`/`Error`) safe to call from any goroutine, mirroring `fetch()`'s own existing goroutine-resolves-a-promise pattern (`fetch_init.go`'s `doFetchRequestWithContext` already calls `vm.ResolvePromise` from a goroutine with no extra synchronization at that call site).
- `NewHostFedReadableStream(vm)` creates a stream with no JS-authored underlying source, fed entirely from Go — the primitive a real streaming `fetch()` `Response.body` would be built on.
- `TestReadableStreamGoroutineFed` exercises exactly this: a background goroutine enqueues a chunk and closes the stream while the test drives `reader.read()` the same way JS bytecode would. Passes under `go test -race` (run repeatedly).

### Bug found and fixed along the way

`cancel()` wasn't resetting the internal queue, so a cancelled stream kept handing out chunks it had already buffered before the cancel instead of resolving `done: true` immediately (spec requires the queue to be reset on cancel).

### Found but NOT fixed here (flagged separately)

A pre-existing, reproducible data race in the VM's core Promise machinery: the `await` opcode implementation (`pkg/vm/vm.go`) reads a Promise's `State`/`Result` with zero synchronization, which already races against `fetch()`'s goroutine-driven `ResolvePromise` call in real usage (`const p = fetch(url); doWork(); await p;`). Confirmed independent of this change with a bare `NewPendingPromise()` + goroutine-`ResolvePromise()` repro under `go test -race`. Out of scope for this primitive (would need a redesign of core Promise synchronization) — spun off as its own follow-up. The new test added here was written carefully to avoid the same gap in its own polling (see its doc comment for the exact happens-before reasoning).

## Verification

- Construction with/without an underlying source; `start(controller)` called synchronously per spec
- `enqueue`/`close`/`error`; pull-based backpressure
- `getReader()` single-lock enforcement and `releaseLock()`
- stream/reader `cancel()` forwarding to the underlying source's `cancel()` hook, including the queue-reset fix above
- buffered-chunk-then-error and genuinely-pending-read-then-error rejection
- `for await...of` via `[Symbol.asyncIterator]`
- test262 `built-ins/*` and `language/*` show **zero diff** against main (checked via a separate worktree, not stash, to be sure)
- Smoke tests (`TestScripts`) green
- `go vet`/`go build ./...` clean
- `go test -race ./pkg/builtins/...` clean (run 20x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)