### PR TITLE
fix(regex): d and v flags with match indices and named groups (#195); expand all computable Unicode binary properties (#196)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -431,6 +431,9 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 && idx < arr.Length() {
 				return vm.BooleanValue(true), nil
 			}
+			if _, enumerable, ok := arr.GetNamedPropertyDescriptor(propName); ok {
+				return vm.BooleanValue(enumerable), nil
+			}
 			return vm.BooleanValue(false), nil
 		case vm.TypeClosure:
 			// Closure own properties: name, length are configurable but not enumerable
@@ -1939,6 +1942,16 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		for i := 0; i < arrObj.Length(); i++ {
 			keysArray.Append(vm.NewString(strconv.Itoa(i)))
 		}
+		// Named own properties (an exec result's index/input/groups/indices,
+		// or anything stored on the array) follow the indices.
+		for _, key := range arrObj.NamedPropertyKeys() {
+			if vm.LooksLikeArrayIndex(key) {
+				continue
+			}
+			if _, enumerable, ok := arrObj.GetNamedPropertyDescriptor(key); ok && enumerable {
+				keysArray.Append(vm.NewString(key))
+			}
+		}
 	case vm.TypeArguments:
 		argsObj := obj.AsArguments()
 		// Arguments object: return numeric indices as keys
@@ -2531,6 +2544,11 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			arrObj.Append(vm.NewString(strconv.Itoa(i)))
 		}
 		arrObj.Append(vm.NewString("length"))
+		for _, key := range a.NamedPropertyKeys() {
+			if !vm.LooksLikeArrayIndex(key) {
+				arrObj.Append(vm.NewString(key))
+			}
+		}
 	case vm.TypeFunction:
 		fn := obj.AsFunction()
 		// Per ECMAScript OrdinaryOwnPropertyKeys:

--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -80,7 +80,9 @@ func regexpUnicodeEscape(c rune) string {
 // $' -> portion after match
 // $n -> nth capture group (1-9)
 // $nn -> nth capture group (01-99)
-func processReplacementPattern(str string, match []int, replacement string) string {
+// $<name> -> named capture group (names is the pattern's GroupNames; nil
+//            when it has none, in which case "$<" is literal text)
+func processReplacementPattern(str string, match []int, names []string, replacement string) string {
 	var result strings.Builder
 	i := 0
 	for i < len(replacement) {
@@ -90,6 +92,24 @@ func processReplacementPattern(str string, match []int, replacement string) stri
 				// $$ -> $
 				result.WriteByte('$')
 				i += 2
+			case '<':
+				// $<name> -> named capture. Per GetSubstitution it is literal
+				// when the pattern has no named groups or the '>' is missing;
+				// an unknown or unmatched name substitutes the empty string.
+				end := strings.IndexByte(replacement[i+2:], '>')
+				if names == nil || end < 0 {
+					result.WriteByte('$')
+					i++
+					continue
+				}
+				name := replacement[i+2 : i+2+end]
+				for k := 1; k < len(names) && 2*k+1 < len(match); k++ {
+					if names[k] == name && match[2*k] >= 0 {
+						result.WriteString(str[match[2*k]:match[2*k+1]])
+						break
+					}
+				}
+				i += 3 + end
 			case '&':
 				// $& -> matched substring
 				result.WriteString(str[match[0]:match[1]])
@@ -150,6 +170,85 @@ func processReplacementPattern(str string, match []int, replacement string) stri
 		}
 	}
 	return result.String()
+}
+
+// namedGroupsObject builds the null-prototype `groups` object of a match at
+// byte offsets loc - each named capture's text, undefined when it did not
+// participate - or Undefined when the pattern has no named groups.
+func namedGroupsObject(regex *vm.RegExpObject, str string, loc []int) vm.Value {
+	names := regex.GroupNames()
+	if names == nil {
+		return vm.Undefined
+	}
+	groups := vm.NewObject(vm.Null)
+	gobj := groups.AsPlainObject()
+	for k := 1; k < len(names) && 2*k+1 < len(loc); k++ {
+		if names[k] == "" {
+			continue
+		}
+		if loc[2*k] == -1 {
+			gobj.SetOwn(names[k], vm.Undefined)
+		} else {
+			gobj.SetOwn(names[k], vm.NewString(str[loc[2*k]:loc[2*k+1]]))
+		}
+	}
+	return groups
+}
+
+// buildRegExpExecResult builds the array RegExpBuiltinExec returns for a match
+// whose capture spans are the byte-offset pairs loc: the captures themselves,
+// then index/input/groups, and with the d flag an `indices` array holding a
+// [start, end] code-unit pair (or undefined) per capture plus its own groups
+// object (paserati#195). Both groups objects have a null prototype and hold
+// the named captures in capture order, per spec.
+func buildRegExpExecResult(regex *vm.RegExpObject, str string, loc []int) vm.Value {
+	result := vm.NewArray()
+	arr := result.AsArray()
+	for i := 0; i < len(loc); i += 2 {
+		if loc[i] == -1 {
+			// Non-participating group: undefined (JavaScript semantics)
+			arr.Append(vm.Undefined)
+		} else {
+			arr.Append(vm.NewString(str[loc[i]:loc[i+1]]))
+		}
+	}
+	// index is JS-visible, so it is reported in code units even though loc
+	// speaks bytes.
+	arr.SetExecMeta(byteToUTF16Offset(str, loc[0]), str)
+
+	names := regex.GroupNames()
+	if names != nil {
+		arr.SetExecGroups(namedGroupsObject(regex, str, loc))
+	}
+
+	if regex.HasIndices() {
+		indices := vm.NewArray()
+		iarr := indices.AsArray()
+		for i := 0; i < len(loc); i += 2 {
+			if loc[i] == -1 {
+				iarr.Append(vm.Undefined)
+				continue
+			}
+			pair := vm.NewArray()
+			parr := pair.AsArray()
+			parr.Append(vm.NumberValue(float64(byteToUTF16Offset(str, loc[i]))))
+			parr.Append(vm.NumberValue(float64(byteToUTF16Offset(str, loc[i+1]))))
+			iarr.Append(pair)
+		}
+		igroups := vm.Undefined
+		if names != nil {
+			igroups = vm.NewObject(vm.Null)
+			gobj := igroups.AsPlainObject()
+			for k := 1; k < len(names) && k < iarr.Length(); k++ {
+				if names[k] != "" {
+					gobj.SetOwn(names[k], iarr.Get(k))
+				}
+			}
+		}
+		iarr.SetOwn("groups", igroups)
+		arr.SetExecIndices(indices)
+	}
+	return result
 }
 
 // processReplacementPatternEx processes $ patterns with captures as values
@@ -276,6 +375,7 @@ func (r *RegExpInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("sticky", types.Boolean).
 		WithProperty("unicode", types.Boolean).
 		WithProperty("hasIndices", types.Boolean).
+		WithProperty("unicodeSets", types.Boolean).
 		WithProperty("lastIndex", types.Number).
 		WithProperty("test", types.NewSimpleFunction([]types.Type{types.String}, types.Boolean)).
 		WithProperty("exec", types.NewSimpleFunction([]types.Type{types.String}, types.NewUnionType(types.Null, &types.ArrayType{ElementType: types.String}))).
@@ -447,25 +547,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Null, nil
 		}
 
-		// Create result array with matches
-		// Use FindStringSubmatchIndex to detect non-participating groups
-		// (they have indices of -1, -1)
-		result := vm.NewArray()
-		arr := result.AsArray()
-		// loc contains pairs of indices [start0, end0, start1, end1, ...]
-		for i := 0; i < len(loc); i += 2 {
-			start, end := loc[i], loc[i+1]
-			if start == -1 {
-				// Non-participating group: use undefined (JavaScript semantics)
-				arr.Append(vm.Undefined)
-			} else {
-				arr.Append(vm.NewString(str[start:end]))
-			}
-		}
-		// Set required properties: index, input, groups. The index is JS-visible,
-		// so it is reported in code units even though loc speaks bytes.
-		arr.SetExecMeta(byteToUTF16Offset(str, loc[0]), str)
-		return result, nil
+		return buildRegExpExecResult(regex, str, loc), nil
 	}))
 
 	regexpProto.SetOwnNonEnumerable("toString", vm.NewNativeFunction(0, false, "toString", func(args []vm.Value) (vm.Value, error) {
@@ -524,7 +606,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		allMatches := regex.FindAllStringSubmatchIndex(str, -1)
 
 		// Create and return a RegExp String Iterator (using the same iterator as String.prototype.matchAll)
-		return createMatchAllIterator(vmInstance, str, allMatches), nil
+		return createMatchAllIterator(vmInstance, regex, str, allMatches), nil
 	})
 	regexpProto.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolMatchAll), matchAllFunc, &w, &e, &c)
 
@@ -725,20 +807,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 				if loc == nil {
 					return vm.Null, nil
 				}
-				result := vm.NewArray()
-				arr := result.AsArray()
-				for i := 0; i < len(loc); i += 2 {
-					start, end := loc[i], loc[i+1]
-					if start == -1 {
-						arr.Append(vm.Undefined)
-					} else {
-						arr.Append(vm.NewString(str[start:end]))
-					}
-				}
-				arr.SetOwn("index", vm.NumberValue(float64(byteToUTF16Offset(str, loc[0]))))
-				arr.SetOwn("input", vm.NewString(str))
-				arr.SetOwn("groups", vm.Undefined)
-				return result, nil
+				return buildRegExpExecResult(regex, str, loc), nil
 			}
 		}
 
@@ -758,7 +827,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// Step 6: Global match
-		fullUnicode := strings.Contains(flags, "u")
+		fullUnicode := strings.ContainsAny(flags, "uv")
 
 		if err := vmInstance.SetProperty(rx, "lastIndex", vm.NumberValue(0)); err != nil {
 			return vm.Undefined, err
@@ -944,6 +1013,9 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 							}
 							callArgs = append(callArgs, vm.NumberValue(float64(byteToUTF16Offset(str, match[0]))))
 							callArgs = append(callArgs, vm.NewString(str))
+							if groups := namedGroupsObject(regex, str, match); groups.Type() != vm.TypeUndefined {
+								callArgs = append(callArgs, groups)
+							}
 							vmInstance.EnterHelperCall()
 							res, err := vmInstance.Call(replaceValue, vm.Undefined, callArgs)
 							vmInstance.ExitHelperCall()
@@ -952,7 +1024,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 							}
 							replacement = res.ToString()
 						} else {
-							replacement = processReplacementPattern(str, match, replaceValue.ToString())
+							replacement = processReplacementPattern(str, match, regex.GroupNames(), replaceValue.ToString())
 						}
 						result.WriteString(replacement)
 						lastIndex = match[1]
@@ -974,6 +1046,9 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 							}
 							callArgs = append(callArgs, vm.NumberValue(float64(byteToUTF16Offset(str, match[0]))))
 							callArgs = append(callArgs, vm.NewString(str))
+							if groups := namedGroupsObject(regex, str, match); groups.Type() != vm.TypeUndefined {
+								callArgs = append(callArgs, groups)
+							}
 							vmInstance.EnterHelperCall()
 							res, err := vmInstance.Call(replaceValue, vm.Undefined, callArgs)
 							vmInstance.ExitHelperCall()
@@ -982,7 +1057,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 							}
 							replacement = res.ToString()
 						} else {
-							replacement = processReplacementPattern(str, match, replaceValue.ToString())
+							replacement = processReplacementPattern(str, match, regex.GroupNames(), replaceValue.ToString())
 						}
 						result.WriteString(replacement)
 						lastIndex = match[1]
@@ -1004,7 +1079,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Step 7-8: Check for global and unicode flags
 		isGlobal := strings.Contains(flags, "g")
-		fullUnicode := strings.Contains(flags, "u")
+		fullUnicode := strings.ContainsAny(flags, "uv")
 
 		// Step 9: If global, reset lastIndex to 0
 		if isGlobal {
@@ -1238,7 +1313,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		flags := flagsVal.ToString()
 
 		// Step 8: Check for unicode flag
-		unicodeMatching := strings.Contains(flags, "u")
+		unicodeMatching := strings.ContainsAny(flags, "uv")
 
 		// Step 9-10: Add sticky flag if not present (for our matching logic)
 		// We'll handle sticky logic manually
@@ -1395,8 +1470,12 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 				}
 				return result, nil
 			} else {
-				// new RegExp(pattern) - convert to string and use empty flags
-				pattern := arg.ToString()
+				// new RegExp(pattern) - convert to string and use empty flags;
+				// an undefined pattern is the empty pattern.
+				pattern := "(?:)"
+				if arg.Type() != vm.TypeUndefined {
+					pattern = toStringJS(arg)
+				}
 				result, err := vm.NewRegExp(pattern, "")
 				if err != nil {
 					return vm.Undefined, vmInstance.NewSyntaxError(err.Error())
@@ -1405,9 +1484,19 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
-		// new RegExp(pattern, flags)
-		pattern := args[0].ToString()
-		flags := args[1].ToString()
+		// new RegExp(pattern, flags). A RegExp pattern contributes its source
+		// (and its own flags when flags is undefined); an undefined pattern is
+		// the empty pattern; undefined flags are "".
+		pattern, flags := "(?:)", ""
+		if args[0].IsRegExp() {
+			existing := args[0].AsRegExpObject()
+			pattern, flags = existing.GetSource(), existing.GetFlags()
+		} else if args[0].Type() != vm.TypeUndefined {
+			pattern = toStringJS(args[0])
+		}
+		if args[1].Type() != vm.TypeUndefined {
+			flags = toStringJS(args[1])
+		}
 		result, err := vm.NewRegExp(pattern, flags)
 		if err != nil {
 			return vm.Undefined, vmInstance.NewSyntaxError(err.Error())
@@ -1455,7 +1544,8 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 		regexpProto.DefineAccessorProperty("dotAll", makeFlagGetter("dotAll", func(r *vm.RegExpObject) bool { return r.IsDotAll() }), true, vm.Undefined, false, &eFalse, &cTrue)
 		regexpProto.DefineAccessorProperty("sticky", makeFlagGetter("sticky", func(r *vm.RegExpObject) bool { return r.IsSticky() }), true, vm.Undefined, false, &eFalse, &cTrue)
 		regexpProto.DefineAccessorProperty("unicode", makeFlagGetter("unicode", func(r *vm.RegExpObject) bool { return strings.Contains(r.GetFlags(), "u") }), true, vm.Undefined, false, &eFalse, &cTrue)
-		regexpProto.DefineAccessorProperty("hasIndices", makeFlagGetter("hasIndices", func(r *vm.RegExpObject) bool { return strings.Contains(r.GetFlags(), "d") }), true, vm.Undefined, false, &eFalse, &cTrue)
+		regexpProto.DefineAccessorProperty("hasIndices", makeFlagGetter("hasIndices", func(r *vm.RegExpObject) bool { return r.HasIndices() }), true, vm.Undefined, false, &eFalse, &cTrue)
+		regexpProto.DefineAccessorProperty("unicodeSets", makeFlagGetter("unicodeSets", func(r *vm.RegExpObject) bool { return r.IsUnicodeSets() }), true, vm.Undefined, false, &eFalse, &cTrue)
 
 		// source accessor
 		sourceGetter := vm.NewNativeFunction(0, false, "get source", func(args []vm.Value) (vm.Value, error) {
@@ -1501,7 +1591,9 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if v, err := vmInstance.GetProperty(thisVal, "unicode"); err == nil && v.IsTruthy() {
 				result += "u"
 			}
-			// TODO: unicodeSets (v flag)
+			if v, err := vmInstance.GetProperty(thisVal, "unicodeSets"); err == nil && v.IsTruthy() {
+				result += "v"
+			}
 			if v, err := vmInstance.GetProperty(thisVal, "sticky"); err == nil && v.IsTruthy() {
 				result += "y"
 			}

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -2393,7 +2393,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 }
 
 // createMatchAllIterator creates an iterator for String.prototype.matchAll
-func createMatchAllIterator(vmInstance *vm.VM, str string, allMatches [][]int) vm.Value {
+func createMatchAllIterator(vmInstance *vm.VM, regex *vm.RegExpObject, str string, allMatches [][]int) vm.Value {
 	// Create iterator object inheriting from %RegExpStringIteratorPrototype%
 	iterator := vm.NewObject(vmInstance.RegExpStringIteratorPrototype).AsPlainObject()
 
@@ -2410,33 +2410,9 @@ func createMatchAllIterator(vmInstance *vm.VM, str string, allMatches [][]int) v
 			result.SetOwn("value", vm.Undefined)
 			result.SetOwn("done", vm.BooleanValue(true))
 		} else {
-			// Get current match indices
-			matchIndices := allMatches[currentMatchIndex]
-
-			// Create match result array (similar to RegExp.exec result)
-			matchResult := vm.NewArray()
-			arr := matchResult.AsArray()
-
-			// Add full match first
-			if matchIndices[0] >= 0 && matchIndices[1] >= 0 {
-				arr.Append(vm.NewString(str[matchIndices[0]:matchIndices[1]]))
-			} else {
-				arr.Append(vm.Undefined)
-			}
-
-			// Add capture groups
-			for i := 2; i < len(matchIndices); i += 2 {
-				if matchIndices[i] >= 0 && matchIndices[i+1] >= 0 {
-					arr.Append(vm.NewString(str[matchIndices[i]:matchIndices[i+1]]))
-				} else {
-					arr.Append(vm.Undefined)
-				}
-			}
-
-			// Add index property, in code units — matchIndices speaks bytes.
-			arr.SetOwn("index", vm.NumberValue(float64(byteToUTF16Offset(str, matchIndices[0]))))
-			// Add input property
-			arr.SetOwn("input", vm.NewString(str))
+			// Each value is shaped like a RegExp.prototype.exec result:
+			// captures, index, input, groups (and indices under the d flag).
+			matchResult := buildRegExpExecResult(regex, str, allMatches[currentMatchIndex])
 
 			result.SetOwn("value", matchResult)
 			result.SetOwn("done", vm.BooleanValue(false))

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -2213,8 +2213,8 @@ func (l *Lexer) readRegexLiteral() (pattern string, flags string, success bool, 
 			seenFlags := make(map[byte]bool)
 			for i := 0; i < len(flagsStr); i++ {
 				flag := flagsStr[i]
-				// Valid JavaScript regex flags: g, i, m, s, u, y
-				if flag != 'g' && flag != 'i' && flag != 'm' && flag != 's' && flag != 'u' && flag != 'y' {
+				// Valid JavaScript regex flags: d, g, i, m, s, u, v, y (#195)
+				if !strings.ContainsRune("dgimsuvy", rune(flag)) {
 					debugPrintf("readRegexLiteral: invalid flag '%c' found, backtracking", flag)
 					// Backtrack on invalid flag
 					l.position = savedPosition
@@ -2234,6 +2234,16 @@ func (l *Lexer) readRegexLiteral() (pattern string, flags string, success bool, 
 					return "", "", false, true // Duplicate flag but complete regex
 				}
 				seenFlags[flag] = true
+			}
+			// `u` and `v` are mutually exclusive: a pattern is in Unicode mode
+			// or UnicodeSets mode, never both.
+			if seenFlags['u'] && seenFlags['v'] {
+				l.position = savedPosition
+				l.readPosition = savedReadPosition
+				l.ch = savedCh
+				l.line = savedLine
+				l.column = savedColumn
+				return "", "", false, true // Conflicting flags but complete regex
 			}
 
 			return patternBuilder.String(), flagsStr, true, true

--- a/pkg/vm/regex.go
+++ b/pkg/vm/regex.go
@@ -27,7 +27,7 @@ type RegExpObject struct {
 	compiledRegex  *regexp.Regexp  // Go's compiled regex engine (fast, RE2)
 	compiledRegex2 *regexp2.Regexp // Fallback regex engine (slower, full ECMAScript support)
 	source         string          // Original pattern string (without slashes)
-	flags          string          // JavaScript flags (g, i, m, s, u, y)
+	flags          string          // JavaScript flags (d, g, i, m, s, u, v, y)
 	global         bool            // Cached global flag for performance
 	ignoreCase     bool            // Cached ignoreCase flag
 	multiline      bool            // Cached multiline flag
@@ -44,6 +44,13 @@ func (re *RegExpObject) SetPrototype(p Value) { re.prototype = p }
 
 // NewRegExp creates a new RegExp object from pattern and flags
 func NewRegExp(pattern, flags string) (Value, error) {
+	if err := ValidateRegExpFlags(flags); err != nil {
+		return Undefined, err
+	}
+	if strings.Contains(flags, "v") && unicodeSetsUnsupportedSyntax(pattern) {
+		return Undefined, fmt.Errorf("Invalid regular expression: %s", unicodeSetsUnsupportedMessage)
+	}
+
 	// ECMAScript forbids line terminators (U+2028, U+2029) in regex patterns
 	if strings.ContainsRune(pattern, '\u2028') || strings.ContainsRune(pattern, '\u2029') {
 		return Undefined, fmt.Errorf("Invalid regular expression: line terminator in pattern")
@@ -155,6 +162,10 @@ func compileRegexEngines(pattern, flags string) *cachedCompiledRegex {
 	var compiledRegex *regexp.Regexp
 	var compiledRegex2 *regexp2.Regexp
 	var compileError string
+
+	if strings.Contains(flags, "v") && unicodeSetsUnsupportedSyntax(pattern) {
+		return &cachedCompiledRegex{compileError: unicodeSetsUnsupportedMessage}
+	}
 
 	// Try Go's standard regexp (RE2) first - it's faster
 	goPattern, err := translateJSFlagsToGo(pattern, flags)
@@ -407,21 +418,147 @@ func (r *RegExpObject) FindStringSubmatchIndexAt(s string, byteStartAt int) []in
 	return nil
 }
 
-// matchToByteIndices converts a regexp2 Match to byte index pairs
+// matchToByteIndices converts a regexp2 Match to byte index pairs, in
+// ECMAScript capture order, with -1/-1 for a group that did not participate.
 func (r *RegExpObject) matchToByteIndices(s string, match *regexp2.Match) []int {
 	groups := match.Groups()
-	runeIndices := make([]int, len(groups)*2)
-	for i, g := range groups {
-		if g.Length > 0 {
-			runeIndices[i*2] = g.Index
-			runeIndices[i*2+1] = g.Index + g.Length
-		} else {
-			runeIndices[i*2] = -1
-			runeIndices[i*2+1] = -1
+	order := r.regexp2GroupOrder()
+	runeIndices := make([]int, 0, len(order)*2)
+	for _, gi := range order {
+		// A group that took part in the match has a capture, even an empty
+		// one; only a group with no capture at all is unmatched.
+		if gi < 0 || gi >= len(groups) || len(groups[gi].Captures) == 0 {
+			runeIndices = append(runeIndices, -1, -1)
+			continue
 		}
+		g := groups[gi]
+		runeIndices = append(runeIndices, g.Index, g.Index+g.Length)
 	}
 	// Convert rune indices to byte indices
 	return runeIndexToByteIndex(s, runeIndices)
+}
+
+// regexp2GroupOrder maps ECMAScript capture numbers (source order, named and
+// unnamed alike; 0 is the whole match) to positions in a regexp2 Match's
+// Groups(). regexp2 follows .NET and numbers every unnamed group before any
+// named one, so a pattern mixing the two would otherwise report its captures
+// shuffled.
+func (r *RegExpObject) regexp2GroupOrder() []int {
+	names := ecmaCaptureNames(r.source)
+	order := make([]int, len(names))
+	unnamed := 0
+	for k := 1; k < len(names); k++ {
+		if names[k] == "" {
+			unnamed++
+			order[k] = unnamed
+		} else {
+			order[k] = r.compiledRegex2.GroupNumberFromName(names[k])
+		}
+	}
+	return order
+}
+
+// ecmaCaptureNames lists a pattern's capture groups in source order - the
+// order ECMAScript numbers them - as their names ("" for an unnamed group),
+// with element 0 standing for the whole match.
+func ecmaCaptureNames(pattern string) []string {
+	names := []string{""}
+	inClass := false
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch {
+		case c == '\\':
+			i++ // the escaped character is never syntax
+		case inClass:
+			if c == ']' {
+				inClass = false
+			}
+		case c == '[':
+			inClass = true
+		case c == '(':
+			if i+1 >= len(pattern) || pattern[i+1] != '?' {
+				names = append(names, "")
+			} else if i+3 < len(pattern) && pattern[i+2] == '<' && pattern[i+3] != '=' && pattern[i+3] != '!' {
+				// (?<name>...) - but not the lookbehinds (?<= and (?<!
+				if end := strings.IndexByte(pattern[i+3:], '>'); end >= 0 {
+					names = append(names, pattern[i+3:i+3+end])
+					i += 3 + end
+				}
+			}
+			// Every other (?...) form is a non-capturing construct.
+		}
+	}
+	return names
+}
+
+// GroupNames returns the pattern's capture-group names by ECMAScript capture
+// number (element 0 is the whole match, an unnamed group is ""), or nil when
+// the pattern has no named group at all.
+func (r *RegExpObject) GroupNames() []string {
+	names := ecmaCaptureNames(r.source)
+	for _, n := range names {
+		if n != "" {
+			return names
+		}
+	}
+	return nil
+}
+
+// ValidateRegExpFlags is the RegExp constructor's flag check: each flag must
+// be one of d g i m s u v y, none may repeat, and u and v are mutually
+// exclusive (a pattern is in Unicode mode or UnicodeSets mode, never both).
+func ValidateRegExpFlags(flags string) error {
+	var seen [256]bool
+	for i := 0; i < len(flags); i++ {
+		f := flags[i]
+		if !strings.ContainsRune("dgimsuvy", rune(f)) || seen[f] {
+			return fmt.Errorf("Invalid flags supplied to RegExp constructor '%s'", flags)
+		}
+		seen[f] = true
+	}
+	if seen['u'] && seen['v'] {
+		return fmt.Errorf("Invalid flags supplied to RegExp constructor '%s'", flags)
+	}
+	return nil
+}
+
+const unicodeSetsUnsupportedMessage = "UnicodeSets mode (v flag) class set operations - nested classes, --, &&, \\q{...} - are not supported"
+
+// unicodeSetsUnsupportedSyntax reports whether a v-flag pattern uses the
+// class-set syntax only UnicodeSets mode has: a nested class, `--`
+// difference, `&&` intersection, or a \q{...} string literal. Neither engine
+// implements those, and letting them through would silently match the wrong
+// thing (RE2 reads `[a--b]` as a plain class), so such a pattern is refused
+// instead. Every pattern the u flag accepts works under v as usual.
+func unicodeSetsUnsupportedSyntax(pattern string) bool {
+	inClass := false
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' && i+1 < len(pattern) {
+			if inClass && pattern[i+1] == 'q' && i+2 < len(pattern) && pattern[i+2] == '{' {
+				return true
+			}
+			i++
+			continue
+		}
+		if !inClass {
+			if c == '[' {
+				inClass = true
+			}
+			continue
+		}
+		switch {
+		case c == '[':
+			return true
+		case c == ']':
+			inClass = false
+		case c == '-' && i+1 < len(pattern) && pattern[i+1] == '-':
+			return true
+		case c == '&' && i+1 < len(pattern) && pattern[i+1] == '&':
+			return true
+		}
+	}
+	return false
 }
 
 // FindAllStringSubmatchIndex returns all matches with their indices
@@ -840,8 +977,10 @@ func translateJSFlagsToGo(pattern, flags string) (string, error) {
 	// including inside `(?s:...)` in a pattern carrying no s flag at all.
 	flagPrefixes = append(flagPrefixes, "(?s)")
 
-	// Note: 'g' (global) and 'y' (sticky) are handled at the JavaScript level,
-	// not in Go's regex engine. 'u' (unicode) is default in Go.
+	// Note: 'g' (global), 'y' (sticky) and 'd' (hasIndices) are handled at
+	// the JavaScript level, not in Go's regex engine. 'u' (unicode) is the
+	// default in Go, and 'v' (unicodeSets) is a superset of it whose extra
+	// class-set syntax is refused up front (see unicodeSetsUnsupportedSyntax).
 
 	// Prepend all flag prefixes to the pattern
 	if len(flagPrefixes) > 0 {
@@ -908,6 +1047,16 @@ func (r *RegExpObject) IsMultiline() bool {
 
 func (r *RegExpObject) IsDotAll() bool {
 	return r.dotAll
+}
+
+// HasIndices reports the d flag: exec results carry an `indices` array.
+func (r *RegExpObject) HasIndices() bool {
+	return strings.Contains(r.flags, "d")
+}
+
+// IsUnicodeSets reports the v flag (UnicodeSets mode).
+func (r *RegExpObject) IsUnicodeSets() bool {
+	return strings.Contains(r.flags, "v")
 }
 
 func (r *RegExpObject) GetLastIndex() int {

--- a/pkg/vm/regex_properties.go
+++ b/pkg/vm/regex_properties.go
@@ -6,64 +6,168 @@ import (
 	"unicode"
 )
 
-// ECMAScript's Unicode property escapes include two derived binary
-// properties - ID_Start and ID_Continue (UAX #31, the definitions JavaScript
-// itself uses for identifier characters) - that neither RE2 nor regexp2
-// recognizes by name (paserati#190). Both engines do accept explicit
-// character-class ranges, and both derived properties are fixed set algebra
-// over categories Go's unicode package already ships, so the tables are
-// computed here once and spliced into the pattern as ranges before either
-// engine parses it.
+// ECMAScript's Unicode property escapes name a set of binary properties that
+// neither RE2 nor regexp2 fully recognizes: RE2 knows only general categories
+// and scripts, regexp2 a subset of the UCD property names under their
+// canonical spelling and none of the UCD aliases, and the derived properties
+// of DerivedCoreProperties.txt - ID_Start, Alphabetic,
+// Default_Ignorable_Code_Point, ... - are absent from both (paserati#190,
+// paserati#196). Both engines do accept explicit character-class ranges, and
+// every property below is either a table Go's unicode package ships verbatim
+// or fixed set algebra over such tables, so the sets are computed here on
+// first use and spliced into the pattern as ranges before either engine
+// parses it.
 //
 // The expansion is unconditional on flags, matching how the two engines
 // already treat every other \p{...} name in this runtime.
 //
 // Coverage follows Go's own Unicode version (unicode.Version), so code points
-// newer than that are absent from both sets until the toolchain catches up.
+// newer than that are absent from the sets until the toolchain catches up.
+// Properties whose data Go does not carry - the Emoji family,
+// Extended_Pictographic, Bidi_Mirrored, Case_Ignorable, the Changes_When_*
+// family, XID_Start and XID_Continue - pass through untouched for the engines
+// to judge.
 
 // runeRange is an inclusive [lo, hi] span of code points.
 type runeRange struct{ lo, hi rune }
 
-// derivedProperty holds a property's member spans and their gaps.
+// derivedProperty holds one property's member spans and their gaps, computed
+// on first use from its build function.
 type derivedProperty struct {
+	once       sync.Once
+	build      func(set runeSet)
 	ranges     []runeRange
 	complement []runeRange
 }
 
-var (
-	derivedOnce        sync.Once
-	idStartProperty    derivedProperty
-	idContinueProperty derivedProperty
-)
-
-// derivedUnicodeProperties maps every spelling ECMAScript accepts for the two
-// properties (the canonical names and their UCD aliases) to their tables.
-// Property names are case-sensitive in ECMAScript, so the lookup is too.
-var derivedUnicodeProperties = map[string]*derivedProperty{
-	"ID_Start":    &idStartProperty,
-	"IDS":         &idStartProperty,
-	"ID_Continue": &idContinueProperty,
-	"IDC":         &idContinueProperty,
+func (p *derivedProperty) get() *derivedProperty {
+	p.once.Do(func() {
+		set := newRuneSet()
+		p.build(set)
+		p.ranges, p.complement = set.spans()
+	})
+	return p
 }
 
-// buildDerivedProperties fills both tables on first use, in a few
-// milliseconds: membership is painted into a bitmap straight from the source
-// tables' ranges rather than probed rune by rune across the code space.
-//
-//	ID_Start    = L + Nl + Other_ID_Start - Pattern_Syntax - Pattern_White_Space
-//	ID_Continue = ID_Start + Mn + Mc + Nd + Pc + Other_ID_Continue
-//	              - Pattern_Syntax - Pattern_White_Space
-func buildDerivedProperties() {
-	derivedOnce.Do(func() {
-		set := newRuneSet()
+// tableProperty is a property that is exactly the union of Go's tables.
+func tableProperty(tables ...*unicode.RangeTable) *derivedProperty {
+	return &derivedProperty{build: func(set runeSet) { set.include(tables...) }}
+}
+
+// derivedUnicodeProperties maps every spelling ECMAScript accepts (the
+// canonical names and their UCD aliases) to the property's table. Property
+// names are case-sensitive in ECMAScript, so the lookup is too.
+var derivedUnicodeProperties = map[string]*derivedProperty{}
+
+func registerDerivedProperty(p *derivedProperty, names ...string) {
+	for _, n := range names {
+		derivedUnicodeProperties[n] = p
+	}
+}
+
+func init() {
+	// Properties Go ships as tables, under their canonical name and alias.
+	registerDerivedProperty(tableProperty(unicode.ASCII_Hex_Digit), "ASCII_Hex_Digit", "AHex")
+	registerDerivedProperty(tableProperty(unicode.Bidi_Control), "Bidi_Control", "Bidi_C")
+	registerDerivedProperty(tableProperty(unicode.Dash), "Dash")
+	registerDerivedProperty(tableProperty(unicode.Deprecated), "Deprecated", "Dep")
+	registerDerivedProperty(tableProperty(unicode.Diacritic), "Diacritic", "Dia")
+	registerDerivedProperty(tableProperty(unicode.Extender), "Extender", "Ext")
+	registerDerivedProperty(tableProperty(unicode.Hex_Digit), "Hex_Digit", "Hex")
+	registerDerivedProperty(tableProperty(unicode.IDS_Binary_Operator), "IDS_Binary_Operator", "IDSB")
+	registerDerivedProperty(tableProperty(unicode.IDS_Trinary_Operator), "IDS_Trinary_Operator", "IDST")
+	registerDerivedProperty(tableProperty(unicode.Ideographic), "Ideographic", "Ideo")
+	registerDerivedProperty(tableProperty(unicode.Join_Control), "Join_Control", "Join_C")
+	registerDerivedProperty(tableProperty(unicode.Logical_Order_Exception), "Logical_Order_Exception", "LOE")
+	registerDerivedProperty(tableProperty(unicode.Noncharacter_Code_Point), "Noncharacter_Code_Point", "NChar")
+	registerDerivedProperty(tableProperty(unicode.Pattern_Syntax), "Pattern_Syntax", "Pat_Syn")
+	registerDerivedProperty(tableProperty(unicode.Pattern_White_Space), "Pattern_White_Space", "Pat_WS")
+	registerDerivedProperty(tableProperty(unicode.Quotation_Mark), "Quotation_Mark", "QMark")
+	registerDerivedProperty(tableProperty(unicode.Radical), "Radical")
+	registerDerivedProperty(tableProperty(unicode.Regional_Indicator), "Regional_Indicator", "RI")
+	registerDerivedProperty(tableProperty(unicode.Sentence_Terminal), "Sentence_Terminal", "STerm")
+	registerDerivedProperty(tableProperty(unicode.Soft_Dotted), "Soft_Dotted", "SD")
+	registerDerivedProperty(tableProperty(unicode.Terminal_Punctuation), "Terminal_Punctuation", "Term")
+	registerDerivedProperty(tableProperty(unicode.Unified_Ideograph), "Unified_Ideograph", "UIdeo")
+	registerDerivedProperty(tableProperty(unicode.Variation_Selector), "Variation_Selector", "VS")
+	registerDerivedProperty(tableProperty(unicode.White_Space), "White_Space", "space")
+
+	// The three ECMAScript-only names.
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.includeRange(0, unicode.MaxRune)
+	}}, "Any")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.includeRange(0, 0x7F)
+	}}, "ASCII")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		// Everything with a General_Category other than Cn: the union of
+		// every category table Go ships.
+		for _, t := range unicode.Categories {
+			set.include(t)
+		}
+	}}, "Assigned")
+
+	// Derived binary properties, each per its DerivedCoreProperties.txt
+	// definition.
+	//
+	//	Alphabetic      = L + Nl + Other_Alphabetic
+	//	Lowercase       = Ll + Other_Lowercase
+	//	Uppercase       = Lu + Other_Uppercase
+	//	Cased           = Lowercase + Uppercase + Lt
+	//	Math            = Sm + Other_Math
+	//	Grapheme_Extend = Me + Mn + Other_Grapheme_Extend
+	//	Grapheme_Base   = Assigned - Cc - Cf - Cs - Co - Zl - Zp - Grapheme_Extend
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.L, unicode.Nl, unicode.Other_Alphabetic)
+	}}, "Alphabetic", "Alpha")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.Ll, unicode.Other_Lowercase)
+	}}, "Lowercase", "Lower")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.Lu, unicode.Other_Uppercase)
+	}}, "Uppercase", "Upper")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.Ll, unicode.Other_Lowercase, unicode.Lu, unicode.Other_Uppercase, unicode.Lt)
+	}}, "Cased")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.Sm, unicode.Other_Math)
+	}}, "Math")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.Me, unicode.Mn, unicode.Other_Grapheme_Extend)
+	}}, "Grapheme_Extend", "Gr_Ext")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		for _, t := range unicode.Categories {
+			set.include(t)
+		}
+		set.exclude(unicode.Cc, unicode.Cf, unicode.Cs, unicode.Co, unicode.Zl, unicode.Zp,
+			unicode.Me, unicode.Mn, unicode.Other_Grapheme_Extend)
+	}}, "Grapheme_Base", "Gr_Base")
+
+	//	ID_Start    = L + Nl + Other_ID_Start - Pattern_Syntax - Pattern_White_Space
+	//	ID_Continue = ID_Start + Mn + Mc + Nd + Pc + Other_ID_Continue
+	//	              - Pattern_Syntax - Pattern_White_Space
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
 		set.include(unicode.L, unicode.Nl, unicode.Other_ID_Start)
 		set.exclude(unicode.Pattern_Syntax, unicode.Pattern_White_Space)
-		idStartProperty = set.property()
-
-		set.include(unicode.Mn, unicode.Mc, unicode.Nd, unicode.Pc, unicode.Other_ID_Continue)
+	}}, "ID_Start", "IDS")
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.L, unicode.Nl, unicode.Other_ID_Start,
+			unicode.Mn, unicode.Mc, unicode.Nd, unicode.Pc, unicode.Other_ID_Continue)
 		set.exclude(unicode.Pattern_Syntax, unicode.Pattern_White_Space)
-		idContinueProperty = set.property()
-	})
+	}}, "ID_Continue", "IDC")
+
+	//	Default_Ignorable_Code_Point = Other_Default_Ignorable_Code_Point
+	//	    + Cf + Variation_Selector
+	//	    - White_Space
+	//	    - FFF9..FFFB (interlinear annotation format characters)
+	//	    - 13430..13440 (Egyptian hieroglyph format characters)
+	//	    - Prepended_Concatenation_Mark (format characters that must stay visible)
+	registerDerivedProperty(&derivedProperty{build: func(set runeSet) {
+		set.include(unicode.Other_Default_Ignorable_Code_Point, unicode.Cf, unicode.Variation_Selector)
+		set.exclude(unicode.White_Space, unicode.Prepended_Concatenation_Mark)
+		set.excludeRange(0xFFF9, 0xFFFB)
+		set.excludeRange(0x13430, 0x13440)
+	}}, "Default_Ignorable_Code_Point", "DI")
 }
 
 // runeSet is one bit per code point.
@@ -99,11 +203,23 @@ func (s runeSet) set(r rune, on bool) {
 func (s runeSet) include(tables ...*unicode.RangeTable) { s.paint(tables, true) }
 func (s runeSet) exclude(tables ...*unicode.RangeTable) { s.paint(tables, false) }
 
-// property reads the bitmap back out as member spans and their gaps.
-// Surrogates are left out of the complement: a Go string can't carry one as
-// a literal rune, and no UTF-8 subject can contain one either.
-func (s runeSet) property() derivedProperty {
-	var p derivedProperty
+func (s runeSet) includeRange(lo, hi rune) {
+	for c := lo; c <= hi; c++ {
+		s.set(c, true)
+	}
+}
+
+func (s runeSet) excludeRange(lo, hi rune) {
+	for c := lo; c <= hi; c++ {
+		s.set(c, false)
+	}
+}
+
+// spans reads the bitmap back out as member spans and their gaps. Surrogates
+// are left out of both: a Go string can't carry one as a literal rune, and
+// no UTF-8 subject can contain one either.
+func (s runeSet) spans() (ranges, complement []runeRange) {
+	var members []runeRange
 	inRun := false
 	var start rune
 	for r := rune(0); r <= unicode.MaxRune; r++ {
@@ -119,25 +235,26 @@ func (s runeSet) property() derivedProperty {
 			continue
 		}
 		if inRun {
-			p.ranges = append(p.ranges, runeRange{start, r - 1})
+			members = append(members, runeRange{start, r - 1})
 			inRun = false
 		}
 	}
 	if inRun {
-		p.ranges = append(p.ranges, runeRange{start, unicode.MaxRune})
+		members = append(members, runeRange{start, unicode.MaxRune})
 	}
 
 	next := rune(0)
-	for _, rr := range p.ranges {
+	for _, rr := range members {
 		if rr.lo > next {
-			p.complement = appendWithoutSurrogates(p.complement, next, rr.lo-1)
+			complement = appendWithoutSurrogates(complement, next, rr.lo-1)
 		}
+		ranges = appendWithoutSurrogates(ranges, rr.lo, rr.hi)
 		next = rr.hi + 1
 	}
 	if next <= unicode.MaxRune {
-		p.complement = appendWithoutSurrogates(p.complement, next, unicode.MaxRune)
+		complement = appendWithoutSurrogates(complement, next, unicode.MaxRune)
 	}
-	return p
+	return ranges, complement
 }
 
 func appendWithoutSurrogates(dst []runeRange, lo, hi rune) []runeRange {
@@ -181,11 +298,12 @@ func writeClassRanges(b *strings.Builder, ranges []runeRange) {
 	}
 }
 
-// expandDerivedUnicodeProperties rewrites \p{ID_Start}, \p{ID_Continue} and
-// their \P negations (plus the IDS/IDC aliases) into explicit ranges. Inside
-// a character class only the members are emitted; outside, they're wrapped
-// in a class of their own. Every other escape - including every other
-// \p{...} name - passes through untouched for the engines to judge.
+// expandDerivedUnicodeProperties rewrites every \p{Name} / \P{Name} whose
+// Name is in derivedUnicodeProperties into explicit ranges. Inside a
+// character class only the members are emitted; outside, they're wrapped in
+// a class of their own. Every other escape - including every other \p{...}
+// name, and the \p{Script=...} / \p{General_Category=...} forms - passes
+// through untouched for the engines to judge.
 //
 // Operates on bytes like rewriteECMAClasses: every construct inspected is
 // ASCII, so multi-byte runes copy through as-is.
@@ -202,7 +320,7 @@ func expandDerivedUnicodeProperties(pattern string) string {
 			if e := pattern[i+1]; (e == 'p' || e == 'P') && i+2 < len(pattern) && pattern[i+2] == '{' {
 				if end := strings.IndexByte(pattern[i+3:], '}'); end >= 0 {
 					if prop, ok := derivedUnicodeProperties[pattern[i+3:i+3+end]]; ok {
-						buildDerivedProperties()
+						prop.get()
 						ranges := prop.ranges
 						if e == 'P' {
 							ranges = prop.complement

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -180,8 +180,36 @@ func (v Value) CanBeHeldWeakly() bool {
 // execResultMeta stores lazy exec/match result metadata.
 // Only allocated for arrays returned by RegExp.exec or String.match.
 type execResultMeta struct {
-	index int
-	input string
+	index      int
+	input      string
+	groups     Value // null-prototype object of named captures, or Undefined
+	indices    Value // the d flag's indices array; only meaningful when hasIndices
+	hasIndices bool
+}
+
+// get returns the exec-result property `name` holds, if it is one of them.
+func (m *execResultMeta) get(name string) (Value, bool) {
+	switch name {
+	case "index":
+		return NumberValue(float64(m.index)), true
+	case "input":
+		return NewString(m.input), true
+	case "groups":
+		return m.groups, true
+	case "indices":
+		if m.hasIndices {
+			return m.indices, true
+		}
+	}
+	return Undefined, false
+}
+
+// keys lists the exec-result properties in their creation order.
+func (m *execResultMeta) keys() []string {
+	if m.hasIndices {
+		return []string{"index", "input", "groups", "indices"}
+	}
+	return []string{"index", "input", "groups"}
 }
 
 type ArrayObject struct {
@@ -2377,19 +2405,58 @@ func (a *ArrayObject) HasIndex(index int) bool {
 // SetExecMeta stores exec result metadata for lazy property access.
 // This avoids allocating a map for index/input/groups on every exec call.
 func (a *ArrayObject) SetExecMeta(index int, input string) {
-	a.execMeta = &execResultMeta{index: index, input: input}
+	a.execMeta = &execResultMeta{index: index, input: input, groups: Undefined}
+}
+
+// SetExecGroups records an exec result's `groups`: the null-prototype object
+// of named captures, or Undefined when the pattern has no group names.
+func (a *ArrayObject) SetExecGroups(groups Value) {
+	if a.execMeta != nil {
+		a.execMeta.groups = groups
+	}
+}
+
+// SetExecIndices records the `indices` array a d-flag exec result carries.
+func (a *ArrayObject) SetExecIndices(indices Value) {
+	if a.execMeta != nil {
+		a.execMeta.indices = indices
+		a.execMeta.hasIndices = true
+	}
+}
+
+// materializeExecMeta moves an exec result's lazily held index/input/groups
+// (and indices) into ordinary named properties, so that a user write,
+// redefinition or delete of one of those keys then behaves as on any other
+// array instead of being shadowed by the lazy values.
+func (a *ArrayObject) materializeExecMeta() {
+	m := a.execMeta
+	if m == nil {
+		return
+	}
+	a.execMeta = nil
+	if a.properties == nil {
+		a.properties = make(map[string]Value)
+	}
+	for _, k := range m.keys() {
+		a.properties[k], _ = m.get(k)
+	}
+}
+
+// isExecMetaKey reports whether name is one of the lazily held exec-result
+// properties of this array.
+func (a *ArrayObject) isExecMetaKey(name string) bool {
+	if a.execMeta == nil {
+		return false
+	}
+	_, ok := a.execMeta.get(name)
+	return ok
 }
 
 // GetOwn returns a named property from the array (e.g., "index", "input" for match results)
 func (a *ArrayObject) GetOwn(name string) (Value, bool) {
 	if a.execMeta != nil {
-		switch name {
-		case "index":
-			return NumberValue(float64(a.execMeta.index)), true
-		case "input":
-			return NewString(a.execMeta.input), true
-		case "groups":
-			return Undefined, true
+		if v, ok := a.execMeta.get(name); ok {
+			return v, true
 		}
 	}
 	if a.properties == nil {
@@ -2401,6 +2468,9 @@ func (a *ArrayObject) GetOwn(name string) (Value, bool) {
 
 // SetOwn sets a named property on the array (e.g., "index", "input" for match results)
 func (a *ArrayObject) SetOwn(name string, value Value) {
+	if a.isExecMetaKey(name) {
+		a.materializeExecMeta()
+	}
 	if a.properties == nil {
 		a.properties = make(map[string]Value)
 	}
@@ -2417,6 +2487,9 @@ func (a *ArrayObject) SetOwn(name string, value Value) {
 // DefineOwnProperty/DefineAccessorProperty) has the ES default
 // configurable: true.
 func (a *ArrayObject) DeleteOwn(name string) bool {
+	if a.isExecMetaKey(name) {
+		a.materializeExecMeta()
+	}
 	if a.propertyDesc != nil {
 		if desc, ok := a.propertyDesc[name]; ok && !desc.Configurable {
 			return false
@@ -2439,6 +2512,9 @@ func (a *ArrayObject) DeleteOwn(name string) bool {
 
 // DefineOwnProperty sets a named property with specified descriptor attributes
 func (a *ArrayObject) DefineOwnProperty(name string, value Value, writable, enumerable, configurable bool) {
+	if a.isExecMetaKey(name) {
+		a.materializeExecMeta()
+	}
 	if a.properties == nil {
 		a.properties = make(map[string]Value)
 	}
@@ -2473,14 +2549,8 @@ func (a *ArrayObject) GetIndexAttributesOverride(key string) (PropertyDesc, bool
 // GetOwnPropertyDescriptor returns the descriptor for a named property
 func (a *ArrayObject) GetOwnPropertyDescriptor(name string) (Value, PropertyDesc, bool) {
 	if a.execMeta != nil {
-		desc := PropertyDesc{Writable: true, Enumerable: true, Configurable: true}
-		switch name {
-		case "index":
-			return NumberValue(float64(a.execMeta.index)), desc, true
-		case "input":
-			return NewString(a.execMeta.input), desc, true
-		case "groups":
-			return Undefined, desc, true
+		if v, ok := a.execMeta.get(name); ok {
+			return v, PropertyDesc{Writable: true, Enumerable: true, Configurable: true}, true
 		}
 	}
 	if a.properties == nil {
@@ -2732,18 +2802,39 @@ func (a *ArrayObject) GetOwnAccessor(name string) (Value, Value, bool, bool, boo
 
 // NamedPropertyKeys returns all named (non-numeric) property keys on the array
 func (a *ArrayObject) NamedPropertyKeys() []string {
-	if a.properties == nil {
-		return nil
+	var keys []string
+	if a.execMeta != nil {
+		// index, input, groups (and indices) are own enumerable properties
+		// of an exec result, created in this order right after the captures.
+		keys = append(keys, a.execMeta.keys()...)
 	}
-	keys := make([]string, 0, len(a.properties))
 	for k := range a.properties {
 		keys = append(keys, k)
 	}
 	return keys
 }
 
+// LooksLikeArrayIndex reports whether key is a canonical array index string
+// ("0", "17", but never "01" or "length"), as opposed to a named property.
+func LooksLikeArrayIndex(key string) bool {
+	if key == "" || (len(key) > 1 && key[0] == '0') {
+		return false
+	}
+	for i := 0; i < len(key); i++ {
+		if key[i] < '0' || key[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // GetNamedPropertyDescriptor returns the value and descriptor for a named property
 func (a *ArrayObject) GetNamedPropertyDescriptor(name string) (Value, bool, bool) {
+	if a.execMeta != nil {
+		if v, ok := a.execMeta.get(name); ok {
+			return v, true, true
+		}
+	}
 	if a.properties == nil {
 		return Undefined, false, false
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14044,6 +14044,18 @@ startExecution:
 						}
 					}
 				}
+				// Then the named (non-index) own properties: an exec result's
+				// index/input/groups/indices, or anything a program stored on
+				// the array. Sparse indices living in the named store were
+				// already handled by the index loop above.
+				for _, key := range arr.NamedPropertyKeys() {
+					if LooksLikeArrayIndex(key) {
+						continue
+					}
+					if _, enumerable, ok := arr.GetNamedPropertyDescriptor(key); ok && enumerable {
+						keys = append(keys, key)
+					}
+				}
 			case TypeArguments:
 				// Arguments objects enumerate their indices as strings, skipping
 				// any made non-enumerable (or deleted) via Object.defineProperty/

--- a/tests/scripts/regex_dv_flags.ts
+++ b/tests/scripts/regex_dv_flags.ts
@@ -1,0 +1,53 @@
+// expect: true|v|true|false|d|true|dgimsuy|dgimsvy|1,3|2,3|-|1,2|2,3|null|b|c|null|a,-|abc,a,b,c|a[b]c|a[b]c|b,b|ok|ok|ok|ok|ok
+// Issue #195: the d (hasIndices) and v (unicodeSets) regex flags. The lexer
+// used to reject the whole literal ("Expression expected"), and the RegExp
+// constructor accepted any flag string silently. Also covers the plumbing d
+// needs: exec results carry `indices` and named `groups`.
+let out: string[] = [];
+
+// v parses, is reported by flags/unicodeSets, and matches in Unicode mode.
+const zeroWidth = /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v;
+out.push(String(zeroWidth.test("​‍")));
+out.push(/abc/v.flags, String(/abc/v.unicodeSets), String(/abc/v.unicode));
+
+// d parses and is reported.
+out.push(/abc/d.flags, String(/abc/d.hasIndices));
+
+// Canonical flag order, with u or with v.
+out.push(/a/dgimsuy.flags, /a/dgimsvy.flags);
+
+// indices: [start, end] in code units per capture, undefined when unmatched.
+const m: any = /b(c)(x)?/d.exec("abc");
+out.push(m.indices[0].join(","), m.indices[1].join(","), m.indices[2] === undefined ? "-" : "?");
+
+// indices.groups mirrors the named captures; groups is undefined without names.
+const n: any = /(?<first>b)(?<second>c)/d.exec("abc");
+out.push(n.indices.groups.first.join(","), n.indices.groups.second.join(","));
+out.push(String(Object.getPrototypeOf(n.indices.groups)));
+out.push(n.groups.first, n.groups.second);
+out.push(String(Object.getPrototypeOf(n.groups)));
+const u: any = /(?<a>a).|(?<x>x)/.exec("ab");
+out.push(u.groups.a + "," + (u.groups.x === undefined ? "-" : "?"));
+
+// Mixed named/unnamed captures keep source order on the regexp2 path too
+// (a lookahead forces it); regexp2 numbers named groups last.
+const mixed: any = /(?<x>a)(b)(?<y>c)(?=$)/.exec("abc");
+out.push(mixed.slice(0).join(","));
+
+// $<name> in replacements, and the groups argument of a replacer function.
+out.push("abc".replace(/(?<x>b)/, "[$<x>]"));
+out.push("abc".replace(/(?<x>b)/, (...args: any[]) => "[" + args[args.length - 1].x + "]"));
+out.push(Array.from("abab".matchAll(/(?<x>b)/g), (r: any) => r.groups.x).join(","));
+
+// The constructor validates flags: unknown, duplicate, and u together with v.
+function throwsSyntax(f: () => any): string {
+  try { f(); return "no-throw"; } catch (e) { return e instanceof SyntaxError ? "ok" : "wrong"; }
+}
+out.push(throwsSyntax(() => new RegExp("a", "q")));
+out.push(throwsSyntax(() => new RegExp("a", "gg")));
+out.push(throwsSyntax(() => new RegExp("a", "uv")));
+// v-mode class set operations are refused rather than silently mis-matched.
+out.push(throwsSyntax(() => new RegExp("[\\p{L}--[a-z]]", "v")));
+out.push(new RegExp("a", "dv").flags === "dv" ? "ok" : "bad");
+
+out.join("|");

--- a/tests/scripts/regex_unicode_binary_properties.ts
+++ b/tests/scripts/regex_unicode_binary_properties.ts
@@ -1,0 +1,38 @@
+// expect: true|true|false|true|false|true|true|true|false|true|true|true|true|true|true|true|true
+// Issue #196: \p{Default_Ignorable_Code_Point} - and, more generally, every
+// ECMAScript binary Unicode property Go's unicode tables can express - is
+// expanded into explicit ranges before either regex engine sees it, on both
+// the literal and the RegExp-constructor path. Previously only ID_Start and
+// ID_Continue were handled; RE2 knows no binary properties at all and
+// regexp2 only a subset under canonical names.
+let out: boolean[] = [];
+
+// Default_Ignorable_Code_Point, its DI alias, and the \P negation.
+out.push(/^\p{Default_Ignorable_Code_Point}$/u.test("​")); // ZERO WIDTH SPACE
+out.push(new RegExp("^\\p{DI}$", "u").test("­"));          // SOFT HYPHEN
+out.push(/^\p{DI}$/u.test("a"));
+out.push(/^\P{DI}$/u.test("a"));
+// U+0605 is Cf but Prepended_Concatenation_Mark, so it is excluded.
+out.push(/^\p{DI}$/u.test("؅"));
+// U+061C ARABIC LETTER MARK is Cf and stays in.
+out.push(/^\p{DI}$/u.test("؜"));
+
+// Derived properties from DerivedCoreProperties.txt.
+out.push(/^\p{Alphabetic}+$/u.test("héllo"));
+out.push(new RegExp("^\\p{Lower}+$", "u").test("abc"));
+out.push(/^\p{Uppercase}$/u.test("a"));
+out.push(/^\p{Math}$/u.test("+"));
+out.push(/^\p{Cased}+$/u.test("aB"));
+
+// Table properties under their UCD aliases, on the constructor path where RE2
+// used to reject every one of them.
+out.push(new RegExp("^\\p{space}$", "u").test(" "));
+out.push(new RegExp("^\\p{AHex}+$", "u").test("0aF"));
+out.push(new RegExp("^\\p{Dash}$", "u").test("-"));
+
+// The ECMAScript-only names.
+out.push(/^\p{Any}+$/u.test("a\u{10FFFF}"));
+out.push(/^\p{ASCII}+$/u.test("abc"));
+out.push(/^\p{Assigned}$/u.test("a"));
+
+out.join("|");


### PR DESCRIPTION
## Summary

Two fixes for the same real-world regex from `@earendil-works/pi-tui` (`/^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v`), one commit each.

### 1. `d` and `v` regex flags (closes #195)

The lexer's flag whitelist stopped at `gimsuy`, so `/x/d` and `/x/v` failed to parse as a whole with `Expression expected`, and the `RegExp` constructor accepted any flag string silently.

- **Lexer** accepts `d` and `v`; `u` together with `v` is rejected.
- **Constructor** validates flags per spec: unknown, duplicate, or `uv` throw `SyntaxError`. Pattern and flags are read through the spec's ToString (a flags object whose `toString` returns `""` is fine), `undefined` means the empty pattern / no flags, and `new RegExp(/re/g, "i")` keeps the source with the new flags.
- **`v` mode** shares `u`'s Unicode matching path; `unicodeSets` accessor added and reported by the `flags` getter; `u`-or-`v` selects full Unicode advancement in match/replace/split. The class-set syntax only `v` has (nested classes, `--`, `&&`, `\q{}`) is refused with a clear `SyntaxError` rather than silently mis-matched, since neither engine implements it. **That is the documented remaining `v` gap.**
- **`d` mode** produces the `indices` array on exec results (UTF-16 offsets, `undefined` for unmatched groups, its own null-prototype `groups`).
- **Named groups**, which `indices.groups` needs, were never implemented: exec, `match`, and `matchAll` results now build through one helper (`buildRegExpExecResult`) that adds `index`/`input`/`groups` and, under `d`, `indices`. `$<name>` in replacement strings and the `groups` argument of replacer functions follow.
- **regexp2 fallback fixes**: it numbered named groups after unnamed ones (.NET order), so mixed patterns reported captures shuffled; and it reported an empty-but-participating capture as unmatched. Captures are now reordered to ECMAScript numbering and participation is read from the group's captures.
- **Array named properties** (exec-result `index`/`input`/`groups`/`indices`, or anything a program stores on an array) are now visible to `for-in`, `Object.keys`, `propertyIsEnumerable`, and `getOwnPropertyNames`, which skipped them entirely.

### 2. `\p{Default_Ignorable_Code_Point}` and every other computable binary property (closes #196)

The #190 mechanism was a hardcoded map of exactly `ID_Start`/`ID_Continue`. RE2 knows no binary properties at all, regexp2 only a subset under canonical names, and the derived properties of `DerivedCoreProperties.txt` are absent from both. `regex_properties.go` is now a lazily built table keyed by every ECMAScript spelling (canonical name and UCD alias):

- the 24 properties Go's `unicode` package ships verbatim (`White_Space`/`space`, `Dash`, `Hex_Digit`/`Hex`, `Variation_Selector`/`VS`, ...);
- the derived ones: `Alphabetic`, `Lowercase`, `Uppercase`, `Cased`, `Math`, `Grapheme_Base`, `Grapheme_Extend`, `ID_Start`, `ID_Continue`, `Default_Ignorable_Code_Point`;
- `Any`, `ASCII`, `Assigned`.

`Default_Ignorable_Code_Point` follows the current UCD formula (`Other_DICP + Cf + Variation_Selector - White_Space - FFF9..FFFB - 13430..13440 - Prepended_Concatenation_Mark`, not the one in the issue text) and matches test262's expected set. Still passed through untouched for lack of data in Go: the Emoji family, `Extended_Pictographic`, `Changes_When_*`, `Case_Ignorable`, `Bidi_Mirrored`, `XID_*`.

## Tests

- `tests/scripts/regex_dv_flags.ts` and `tests/scripts/regex_unicode_binary_properties.ts`, both passing under the type checker.
- `go test ./tests/... ./pkg/...` green.
- test262, main vs this branch, sequential full dumps compared with `comm`:

| Suite | main | branch |
|---|---|---|
| built-ins/RegExp (2s timeout) | 1002 | 1102 |
| built-ins (all, 0.2s) | 16204 | 16291 |
| language (0.2s) | 23158 | 23158 |

Zero regressions in any of them. New passes are in `match-indices`, `named-groups`, `prototype/unicodeSets`, `property-escapes`, `unicodeSets/generated` (plain-class cases), `Object.getOwnPropertyNames`, `String.prototype.match`/`replace`.

## Notes for review

- Pre-existing array property-model gaps found along the way and deliberately left alone: on arrays, a prototype accessor shadows an own named data property on read, prototype setters are never invoked on write, and `delete` of a named property is a no-op. They account for the few remaining `verifyProperty`-based `match-indices`/`named-groups` failures.
- Also unrelated and untouched: non-Unicode-mode surrogate-half matching (`/./d` on an astral char), Unicode identifier characters in group names (`(?<π>…)`), duplicate named groups (ES2025).
- `regexp2GroupOrder` scans the pattern per match; patterns are short and this only runs on the regexp2 fallback path (lookarounds), so I kept it simple rather than caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
