### PR TITLE
fix(vm): synchronize Promise state/reactions against goroutine-driven settlement

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -2744,7 +2744,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 							// If mappedValue is a promise, wait for it
 							if mappedValue.Type() == vm.TypePromise {
 								mp := mappedValue.AsPromise()
-								if mp != nil && mp.State == vm.PromisePending {
+								if mp != nil && mp.GetState() == vm.PromisePending {
 									vmInstance.AddPromiseReaction(mappedValue, true, func(v vm.Value) {
 										// Add to result array
 										if A.IsArray() {
@@ -2759,10 +2759,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 										rejectWithError(errors.New(r.ToString()))
 									})
 									return
-								} else if mp != nil && mp.State == vm.PromiseFulfilled {
-									mappedValue = mp.Result
-								} else if mp != nil && mp.State == vm.PromiseRejected {
-									rejectWithError(errors.New(mp.Result.ToString()))
+								} else if mp != nil && mp.GetState() == vm.PromiseFulfilled {
+									mappedValue = mp.GetResult()
+								} else if mp != nil && mp.GetState() == vm.PromiseRejected {
+									rejectWithError(errors.New(mp.GetResult().ToString()))
 									return
 								}
 							}
@@ -2780,16 +2780,16 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 						// If value is a promise (for sync iterator with promise elements), wait for it
 						if value.Type() == vm.TypePromise {
 							vp := value.AsPromise()
-							if vp != nil && vp.State == vm.PromisePending {
+							if vp != nil && vp.GetState() == vm.PromisePending {
 								vmInstance.AddPromiseReaction(value, true, handleValue)
 								vmInstance.AddPromiseReaction(value, false, func(r vm.Value) {
 									rejectWithError(errors.New(r.ToString()))
 								})
 								return
-							} else if vp != nil && vp.State == vm.PromiseFulfilled {
-								value = vp.Result
-							} else if vp != nil && vp.State == vm.PromiseRejected {
-								rejectWithError(errors.New(vp.Result.ToString()))
+							} else if vp != nil && vp.GetState() == vm.PromiseFulfilled {
+								value = vp.GetResult()
+							} else if vp != nil && vp.GetState() == vm.PromiseRejected {
+								rejectWithError(errors.New(vp.GetResult().ToString()))
 								return
 							}
 						}
@@ -2799,16 +2799,16 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 					// If nextResult is a promise (async iterator), wait for it
 					if usingAsyncIterator && nextResult.Type() == vm.TypePromise {
 						np := nextResult.AsPromise()
-						if np != nil && np.State == vm.PromisePending {
+						if np != nil && np.GetState() == vm.PromisePending {
 							vmInstance.AddPromiseReaction(nextResult, true, handleNextResult)
 							vmInstance.AddPromiseReaction(nextResult, false, func(r vm.Value) {
 								rejectWithError(errors.New(r.ToString()))
 							})
 							return
-						} else if np != nil && np.State == vm.PromiseFulfilled {
-							nextResult = np.Result
-						} else if np != nil && np.State == vm.PromiseRejected {
-							rejectWithError(errors.New(np.Result.ToString()))
+						} else if np != nil && np.GetState() == vm.PromiseFulfilled {
+							nextResult = np.GetResult()
+						} else if np != nil && np.GetState() == vm.PromiseRejected {
+							rejectWithError(errors.New(np.GetResult().ToString()))
 							return
 						}
 					}
@@ -2877,7 +2877,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 						// If mappedValue is a promise, wait for it
 						if mappedValue.Type() == vm.TypePromise {
 							mp := mappedValue.AsPromise()
-							if mp != nil && mp.State == vm.PromisePending {
+							if mp != nil && mp.GetState() == vm.PromisePending {
 								vmInstance.AddPromiseReaction(mappedValue, true, func(v vm.Value) {
 									// Add to result array
 									if A.IsArray() {
@@ -2892,10 +2892,10 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 									rejectWithError(errors.New(r.ToString()))
 								})
 								return
-							} else if mp != nil && mp.State == vm.PromiseFulfilled {
-								mappedValue = mp.Result
-							} else if mp != nil && mp.State == vm.PromiseRejected {
-								rejectWithError(errors.New(mp.Result.ToString()))
+							} else if mp != nil && mp.GetState() == vm.PromiseFulfilled {
+								mappedValue = mp.GetResult()
+							} else if mp != nil && mp.GetState() == vm.PromiseRejected {
+								rejectWithError(errors.New(mp.GetResult().ToString()))
 								return
 							}
 						}
@@ -2913,16 +2913,16 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 					// If kValue is a promise, wait for it
 					if kValue.Type() == vm.TypePromise {
 						kp := kValue.AsPromise()
-						if kp != nil && kp.State == vm.PromisePending {
+						if kp != nil && kp.GetState() == vm.PromisePending {
 							vmInstance.AddPromiseReaction(kValue, true, handleKValue)
 							vmInstance.AddPromiseReaction(kValue, false, func(r vm.Value) {
 								rejectWithError(errors.New(r.ToString()))
 							})
 							return
-						} else if kp != nil && kp.State == vm.PromiseFulfilled {
-							kValue = kp.Result
-						} else if kp != nil && kp.State == vm.PromiseRejected {
-							rejectWithError(errors.New(kp.Result.ToString()))
+						} else if kp != nil && kp.GetState() == vm.PromiseFulfilled {
+							kValue = kp.GetResult()
+						} else if kp != nil && kp.GetState() == vm.PromiseRejected {
+							rejectWithError(errors.New(kp.GetResult().ToString()))
 							return
 						}
 					}

--- a/pkg/driver/promise_goroutine_race_test.go
+++ b/pkg/driver/promise_goroutine_race_test.go
@@ -1,0 +1,80 @@
+package driver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestAwaitGoroutineResolvedPromiseRace is a regression test for a data
+// race in the VM's core Promise machinery: resolving/settling a Promise
+// from a goroutine other than the one executing the `await` opcode - which
+// is exactly what fetch() does today (doFetchRequestWithContext in
+// pkg/builtins/fetch_init.go calls vm.ResolvePromise from its own request
+// goroutine) - used to race unsynchronized against `await`'s own direct
+// reads of that promise's State/Result in pkg/vm/vm.go. `go test -race`
+// caught this with nothing more than a bare pending promise, a goroutine
+// calling ResolvePromise, and a naive polling read - no fetch() or any
+// other feature involved.
+//
+// This test drives the *real* `await` opcode (both the in-async-function
+// path and the top-level-await path), not a hand-rolled polling loop like
+// the minimal repro, by registering a native module function that hands
+// back a genuinely pending Promise which a background goroutine resolves a
+// few milliseconds later - the same shape a real streaming/async host
+// integration takes.
+func TestAwaitGoroutineResolvedPromiseRace(t *testing.T) {
+	p := NewPaserati()
+	vmInstance := p.GetVM()
+
+	p.DeclareModule("race-test", func(m *ModuleBuilder) {
+		m.Function("makeGoroutineFedPromise", func() vm.Value {
+			promiseVal := vmInstance.NewPendingPromise()
+			promise := promiseVal.AsPromise()
+			rt := vmInstance.GetAsyncRuntime()
+			rt.BeginExternalOp()
+			go func() {
+				time.Sleep(5 * time.Millisecond)
+				vmInstance.ResolvePromise(promise, vm.NumberValue(42))
+				rt.EndExternalOp()
+			}()
+			return promiseVal
+		})
+	})
+
+	t.Run("await inside an async function", func(t *testing.T) {
+		tsCode := `
+			import { makeGoroutineFedPromise } from "race-test";
+
+			async function main(): Promise<number> {
+				const v = await makeGoroutineFedPromise();
+				return v + 1;
+			}
+
+			await main();
+		`
+		result, errs := p.RunStringWithModules(tsCode)
+		if len(errs) > 0 {
+			t.Fatalf("script failed: %v", errs[0])
+		}
+		if result.ToFloat() != 43 {
+			t.Fatalf("expected 43, got %v", result.Inspect())
+		}
+	})
+
+	t.Run("top-level await", func(t *testing.T) {
+		tsCode := `
+			import { makeGoroutineFedPromise } from "race-test";
+			const v = await makeGoroutineFedPromise();
+			v + 1;
+		`
+		result, errs := p.RunStringWithModules(tsCode)
+		if len(errs) > 0 {
+			t.Fatalf("script failed: %v", errs[0])
+		}
+		if result.ToFloat() != 43 {
+			t.Fatalf("expected 43, got %v", result.Inspect())
+		}
+	})
+}

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"sync"
 	"unsafe"
 )
 
@@ -29,6 +30,28 @@ type PromiseReaction struct {
 // PromiseObject represents a JavaScript Promise
 type PromiseObject struct {
 	Object
+
+	// mu guards State, Result, FulfillReactions and RejectReactions - the
+	// fields a Promise created via NewPromiseFromExecutor/NewPendingPromise
+	// can have settled from a goroutine other than the VM's own execution
+	// goroutine (e.g. fetch()'s doFetchRequestWithContext calling
+	// vm.ResolvePromise/vm.RejectPromise once its HTTP round-trip
+	// completes). Before this lock existed, every read of these fields -
+	// most notably the `await` opcode's `switch awaitedPromise.State`
+	// (vm.go) and the top-level-await drain loop's `for awaitedPromise.State
+	// == PromisePending` - raced unsynchronized against that goroutine's
+	// writes; `go test -race` flags this with nothing more than a bare
+	// NewPendingPromise() + a goroutine calling ResolvePromise() + a naive
+	// polling read, no fetch() or other feature involved. All access to
+	// these four fields must go through the methods below (snapshot/
+	// trySettle/takeReactions/addReaction), never direct field access.
+	//
+	// Frame/Function/ThisValue (async-function suspension state) and
+	// Properties/prototype are NOT guarded here: they are only ever read or
+	// written from the VM's own execution goroutine (resumed exclusively via
+	// scheduled microtasks, which always run on that same goroutine), never
+	// from an external host goroutine.
+	mu               sync.Mutex
 	State            PromiseState
 	Result           Value // Fulfillment value or rejection reason
 	FulfillReactions []PromiseReaction
@@ -46,14 +69,120 @@ type PromiseObject struct {
 func (p *PromiseObject) GetPrototype() Value  { return p.prototype }
 func (p *PromiseObject) SetPrototype(v Value) { p.prototype = v }
 
-// GetState returns the promise state
+// GetState returns the promise state. Safe to call from any goroutine.
 func (p *PromiseObject) GetState() PromiseState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.State
 }
 
-// GetResult returns the promise result (value or reason)
+// GetResult returns the promise result (value or reason). Safe to call from
+// any goroutine.
 func (p *PromiseObject) GetResult() Value {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.Result
+}
+
+// snapshot returns a mutually consistent (State, Result) pair. Safe to call
+// from any goroutine. Prefer this over GetState()+GetResult() separately
+// when both are needed together, since two separate locked reads could
+// otherwise observe an in-between settlement (a Pending State paired with a
+// Result written moments later).
+func (p *PromiseObject) snapshot() (PromiseState, Value) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.State, p.Result
+}
+
+// trySettle atomically transitions the promise from Pending to state/value
+// and reports whether this call performed the transition (false if the
+// promise had already settled - matches the spec's [[AlreadyResolved]]
+// guard). It does not touch reactions or invoke any callback; the caller is
+// responsible for calling triggerPromiseReactions itself on success. Safe to
+// call from any goroutine.
+func (p *PromiseObject) trySettle(state PromiseState, value Value) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.State != PromisePending {
+		return false
+	}
+	p.State = state
+	p.Result = value
+	return true
+}
+
+// takeReactions atomically reads and clears the reaction list for the given
+// disposition (isFulfilled selects FulfillReactions vs RejectReactions).
+// Idempotent: a second call with nothing newly added since the first
+// returns an empty slice, which is what makes concurrent addReaction +
+// trySettle-triggered dispatch race-free without ever double-firing a
+// reaction (see the two call sites in triggerPromiseReactions callers).
+// Safe to call from any goroutine.
+func (p *PromiseObject) takeReactions(isFulfilled bool) []PromiseReaction {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if isFulfilled {
+		r := p.FulfillReactions
+		p.FulfillReactions = nil
+		return r
+	}
+	r := p.RejectReactions
+	p.RejectReactions = nil
+	return r
+}
+
+// addReaction appends a reaction for the given disposition and, in the same
+// critical section, reports the promise's current State - so a caller never
+// has to separately (and racily) check State before deciding whether to
+// also trigger dispatch immediately: whichever of {this append} or {a
+// concurrent trySettle+takeReactions pair} the mutex serializes first is
+// exactly what determines whether the newly added reaction is picked up by
+// that concurrent dispatch or needs to be dispatched by this caller instead
+// - and because takeReactions is idempotent, doing both is always safe: at
+// most one of them will find the reaction still present. Safe to call from
+// any goroutine.
+func (p *PromiseObject) addReaction(isFulfilled bool, reaction PromiseReaction) PromiseState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if isFulfilled {
+		p.FulfillReactions = append(p.FulfillReactions, reaction)
+	} else {
+		p.RejectReactions = append(p.RejectReactions, reaction)
+	}
+	return p.State
+}
+
+// addAwaitReactions is addReaction's counterpart for `await`'s own internal
+// bookkeeping (vm.go's OpAwait), where - unlike .then()'s chaining, which
+// always needs both a fulfill and a reject reaction structurally paired to
+// build its returned promise - only ONE of onFulfill/onReject will ever
+// actually matter, because a promise's disposition is immutable once
+// settled. Determining that disposition and registering only the reaction
+// that can still fire happens in one critical section (no separate,
+// TOCTOU-prone State check beforehand): if already Fulfilled or Rejected,
+// only the matching reaction is appended; if still Pending, both are
+// appended (either could still end up firing). This is what keeps a loop
+// like `for (;;) { await cachedResolvedPromise; }` from leaking one dead
+// reaction (and its captured closure) per iteration onto the opposite,
+// permanently-inert reaction list forever - registering unconditionally via
+// two addReaction calls, as an earlier version of this fix did, avoided the
+// race but not that leak. Returns the disposition observed in the same
+// critical section, so the caller knows whether to also trigger dispatch
+// immediately. Safe to call from any goroutine.
+func (p *PromiseObject) addAwaitReactions(onFulfill, onReject PromiseReaction) PromiseState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	switch p.State {
+	case PromiseFulfilled:
+		p.FulfillReactions = append(p.FulfillReactions, onFulfill)
+	case PromiseRejected:
+		p.RejectReactions = append(p.RejectReactions, onReject)
+	default: // Pending
+		p.FulfillReactions = append(p.FulfillReactions, onFulfill)
+		p.RejectReactions = append(p.RejectReactions, onReject)
+	}
+	return p.State
 }
 
 // NewPromiseFromExecutor creates a new Promise with an executor function
@@ -145,70 +274,68 @@ func (vm *VM) NewRejectedPromise(reason Value) Value {
 	return Value{typ: TypePromise, obj: promiseToUnsafe(promise)}
 }
 
-// resolvePromise fulfills a promise with a value
+// resolvePromise fulfills a promise with a value. Safe to call from any
+// goroutine (see PromiseObject's mu doc comment).
 func (vm *VM) resolvePromise(promise *PromiseObject, value Value) {
-	if promise.State != PromisePending {
-		return // Already settled
-	}
-
 	// Handle promise resolution with thenable chaining
 	if value.Type() == TypePromise {
 		otherPromise := value.AsPromise()
 		if otherPromise == nil {
-			promise.State = PromiseFulfilled
-			promise.Result = value
-			vm.triggerPromiseReactions(promise, true)
+			if promise.trySettle(PromiseFulfilled, value) {
+				vm.triggerPromiseReactions(promise, true)
+			}
 			return
 		}
 
-		if otherPromise.State == PromiseFulfilled {
-			value = otherPromise.Result
-		} else if otherPromise.State == PromiseRejected {
-			vm.rejectPromise(promise, otherPromise.Result)
-			return
-		} else {
-			// Chain to pending promise
+		otherState, otherResult := otherPromise.snapshot()
+		switch otherState {
+		case PromiseFulfilled:
+			if promise.trySettle(PromiseFulfilled, otherResult) {
+				vm.triggerPromiseReactions(promise, true)
+			}
+		case PromiseRejected:
+			vm.rejectPromise(promise, otherResult)
+		default: // Pending: chain to it
 			vm.addPromiseReaction(value, true, func(v Value) {
 				vm.resolvePromise(promise, v)
 			})
 			vm.addPromiseReaction(value, false, func(r Value) {
 				vm.rejectPromise(promise, r)
 			})
-			return
 		}
+		return
 	}
 
-	promise.State = PromiseFulfilled
-	promise.Result = value
-	vm.triggerPromiseReactions(promise, true)
+	if promise.trySettle(PromiseFulfilled, value) {
+		vm.triggerPromiseReactions(promise, true)
+	}
 }
 
-// rejectPromise rejects a promise with a reason
+// rejectPromise rejects a promise with a reason. Safe to call from any
+// goroutine (see PromiseObject's mu doc comment).
 func (vm *VM) rejectPromise(promise *PromiseObject, reason Value) {
-	if promise.State != PromisePending {
-		return // Already settled
+	if promise.trySettle(PromiseRejected, reason) {
+		vm.triggerPromiseReactions(promise, false)
 	}
-
-	promise.State = PromiseRejected
-	promise.Result = reason
-	vm.triggerPromiseReactions(promise, false)
 }
 
-// triggerPromiseReactions schedules all reactions for a settled promise
+// triggerPromiseReactions schedules all reactions for a settled promise.
+// Must only be called after the promise has actually settled (State is
+// Fulfilled/Rejected, checked via trySettle/addReaction's return value by
+// every caller) - it reads Result via GetResult() rather than trySettle's
+// return so it works equally when called for reactions added after
+// settlement (addReaction/PromiseThen's "already settled, trigger
+// immediately" paths), not just right after the settling trySettle call.
 func (vm *VM) triggerPromiseReactions(promise *PromiseObject, isFulfilled bool) {
-	var reactions []PromiseReaction
-	if isFulfilled {
-		reactions = promise.FulfillReactions
-		promise.FulfillReactions = nil
-	} else {
-		reactions = promise.RejectReactions
-		promise.RejectReactions = nil
+	reactions := promise.takeReactions(isFulfilled)
+	if len(reactions) == 0 {
+		return
 	}
+	value := promise.GetResult()
 
 	rt := vm.GetAsyncRuntime()
 	for _, reaction := range reactions {
 		reaction := reaction // Capture for closure
-		value := promise.Result
 
 		rt.ScheduleMicrotask(func() {
 			if reaction.Handler.Type() == 0 || reaction.Handler.Type() == TypeUndefined {
@@ -276,16 +403,15 @@ func (vm *VM) addPromiseReaction(promiseVal Value, isFulfilled bool, callback fu
 		Reject:  callback,
 	}
 
+	// addReaction appends and reports the current state in one atomic step -
+	// see its doc comment for why checking State separately afterward would
+	// be racy against a concurrent settle.
 	if isFulfilled {
-		promise.FulfillReactions = append(promise.FulfillReactions, reaction)
-		// If already fulfilled, trigger immediately
-		if promise.State == PromiseFulfilled {
+		if promise.addReaction(true, reaction) == PromiseFulfilled {
 			vm.triggerPromiseReactions(promise, true)
 		}
 	} else {
-		promise.RejectReactions = append(promise.RejectReactions, reaction)
-		// If already rejected, trigger immediately
-		if promise.State == PromiseRejected {
+		if promise.addReaction(false, reaction) == PromiseRejected {
 			vm.triggerPromiseReactions(promise, false)
 		}
 	}
@@ -319,10 +445,10 @@ func (vm *VM) PromiseThen(thisPromise Value, onFulfilled, onRejected Value) (Val
 					_, _ = vm.Call(reject, Undefined, []Value{r})
 				},
 			}
-			promise.FulfillReactions = append(promise.FulfillReactions, reaction)
-
-			// If already fulfilled, trigger immediately
-			if promise.State == PromiseFulfilled {
+			// addReaction appends and reports the current state atomically -
+			// see its doc comment for why a separate State check afterward
+			// would be racy against a concurrent settle.
+			if promise.addReaction(true, reaction) == PromiseFulfilled {
 				vm.triggerPromiseReactions(promise, true)
 			}
 		}
@@ -343,10 +469,7 @@ func (vm *VM) PromiseThen(thisPromise Value, onFulfilled, onRejected Value) (Val
 					_, _ = vm.Call(reject, Undefined, []Value{r})
 				},
 			}
-			promise.RejectReactions = append(promise.RejectReactions, reaction)
-
-			// If already rejected, trigger immediately
-			if promise.State == PromiseRejected {
+			if promise.addReaction(false, reaction) == PromiseRejected {
 				vm.triggerPromiseReactions(promise, false)
 			}
 		}

--- a/pkg/vm/promise_goroutine_race_test.go
+++ b/pkg/vm/promise_goroutine_race_test.go
@@ -1,0 +1,138 @@
+package vm
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPromiseGoroutineResolveRace is the minimal repro for the data race
+// this fix closes: settling a Promise from a goroutine other than the one
+// reading its state/result (exactly what fetch() does today via
+// doFetchRequestWithContext calling vm.ResolvePromise from its own request
+// goroutine) used to race unsynchronized against any direct read of
+// PromiseObject.State/Result - most notably the `await` opcode's own
+// `switch awaitedPromise.State` (vm.go), but reproducible with nothing more
+// than this: no fetch(), no ReadableStream, no other feature involved.
+// See pkg/driver/promise_goroutine_race_test.go for the same race exercised
+// through the real `await` opcode end to end.
+func TestPromiseGoroutineResolveRace(t *testing.T) {
+	vmInstance := NewVM()
+	p := vmInstance.NewPendingPromise()
+	promise := p.AsPromise()
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		vmInstance.ResolvePromise(promise, NumberValue(42))
+	}()
+
+	// GetState()/GetResult() are the thread-safe accessors PromiseObject's
+	// mu backs - this is deliberately the exact same "poll from the calling
+	// goroutine" shape the original bug report used, just going through the
+	// now-locked methods instead of direct field access.
+	deadline := time.Now().Add(2 * time.Second)
+	for promise.GetState() == PromisePending {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for goroutine to resolve promise")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if state := promise.GetState(); state != PromiseFulfilled {
+		t.Fatalf("expected PromiseFulfilled, got %v", state)
+	}
+	if result := promise.GetResult(); result.ToFloat() != 42 {
+		t.Fatalf("expected 42, got %v", result.Inspect())
+	}
+}
+
+// TestPromiseGoroutineRejectRace mirrors the above for rejection.
+func TestPromiseGoroutineRejectRace(t *testing.T) {
+	vmInstance := NewVM()
+	p := vmInstance.NewPendingPromise()
+	promise := p.AsPromise()
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		vmInstance.RejectPromise(promise, NewString("boom"))
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for promise.GetState() == PromisePending {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for goroutine to reject promise")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if state := promise.GetState(); state != PromiseRejected {
+		t.Fatalf("expected PromiseRejected, got %v", state)
+	}
+	if result := promise.GetResult(); result.ToString() != "boom" {
+		t.Fatalf("expected %q, got %v", "boom", result.Inspect())
+	}
+}
+
+// TestAddAwaitReactionsDoesNotLeakOnSettledPromise is a regression test for
+// a leak the first version of this fix introduced: awaiting an
+// already-settled promise repeatedly (e.g. `for (;;) { await
+// cachedResolvedPromise }`, a perfectly ordinary pattern) used to append one
+// dead reaction of the *opposite*, permanently-unreachable disposition per
+// call - since a settled promise's disposition never changes, a fulfilled
+// promise's RejectReactions (or a rejected promise's FulfillReactions) can
+// never fire, but an earlier version of this fix appended one there anyway
+// on every await, retaining its closure forever. addAwaitReactions must
+// register only the reaction that can actually still fire once a promise is
+// already settled - see its doc comment - so both lists must stay at
+// exactly the one live reaction actually needed, not grow with each call.
+func TestAddAwaitReactionsDoesNotLeakOnSettledPromise(t *testing.T) {
+	noop := PromiseReaction{Resolve: func(Value) {}, Reject: func(Value) {}}
+
+	t.Run("fulfilled", func(t *testing.T) {
+		p := NewVM().NewPendingPromise().AsPromise()
+		if !p.trySettle(PromiseFulfilled, Undefined) {
+			t.Fatal("trySettle failed on a fresh pending promise")
+		}
+		for i := range 1000 {
+			if state := p.addAwaitReactions(noop, noop); state != PromiseFulfilled {
+				t.Fatalf("iteration %d: expected PromiseFulfilled, got %v", i, state)
+			}
+		}
+		if got := len(p.FulfillReactions); got != 1000 {
+			t.Errorf("FulfillReactions: expected 1000 (one per await, each still reachable via the immutable Fulfilled state), got %d", got)
+		}
+		if got := len(p.RejectReactions); got != 0 {
+			t.Errorf("RejectReactions: expected 0 (a fulfilled promise can never reject, so none of these should have been registered), got %d", got)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		p := NewVM().NewPendingPromise().AsPromise()
+		if !p.trySettle(PromiseRejected, Undefined) {
+			t.Fatal("trySettle failed on a fresh pending promise")
+		}
+		for i := range 1000 {
+			if state := p.addAwaitReactions(noop, noop); state != PromiseRejected {
+				t.Fatalf("iteration %d: expected PromiseRejected, got %v", i, state)
+			}
+		}
+		if got := len(p.RejectReactions); got != 1000 {
+			t.Errorf("RejectReactions: expected 1000 (one per await, each still reachable via the immutable Rejected state), got %d", got)
+		}
+		if got := len(p.FulfillReactions); got != 0 {
+			t.Errorf("FulfillReactions: expected 0 (a rejected promise can never fulfill, so none of these should have been registered), got %d", got)
+		}
+	})
+
+	t.Run("pending registers both", func(t *testing.T) {
+		p := NewVM().NewPendingPromise().AsPromise()
+		if state := p.addAwaitReactions(noop, noop); state != PromisePending {
+			t.Fatalf("expected PromisePending, got %v", state)
+		}
+		if got := len(p.FulfillReactions); got != 1 {
+			t.Errorf("FulfillReactions: expected 1 (disposition still unknown, either could fire), got %d", got)
+		}
+		if got := len(p.RejectReactions); got != 1 {
+			t.Errorf("RejectReactions: expected 1 (disposition still unknown, either could fire), got %d", got)
+		}
+	})
+}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -1777,13 +1777,19 @@ func (v Value) inspectWithDepth(nested bool, depth int, maxDepth int) string {
 	case TypePromise:
 		promise := v.AsPromise()
 		if promise != nil {
-			switch promise.State {
+			// snapshot(), not direct field access: the promise may be
+			// settled from a goroutine other than this one (e.g. an
+			// in-flight fetch()), and inspecting it - for a console.log,
+			// say - is a perfectly ordinary thing to do concurrently with
+			// that.
+			state, result := promise.snapshot()
+			switch state {
 			case PromisePending:
 				return "Promise { <pending> }"
 			case PromiseFulfilled:
-				return fmt.Sprintf("Promise { %s }", promise.Result.inspectWithDepth(false, depth+1, maxDepth))
+				return fmt.Sprintf("Promise { %s }", result.inspectWithDepth(false, depth+1, maxDepth))
 			case PromiseRejected:
-				return fmt.Sprintf("Promise { <rejected> %s }", promise.Result.inspectWithDepth(false, depth+1, maxDepth))
+				return fmt.Sprintf("Promise { <rejected> %s }", result.inspectWithDepth(false, depth+1, maxDepth))
 			default:
 				return "Promise { <unknown state> }"
 			}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -15375,10 +15375,23 @@ startExecution:
 
 			// Check if we're in top-level await (no async function context)
 			if frame.promiseObj == nil {
-				// Top-level await - drain microtasks until settled for pending promises
-				if awaitedPromise.State == PromisePending {
+				// Top-level await - drain microtasks until settled for pending
+				// promises. Every check of the promise's disposition below
+				// goes through snapshot() rather than direct field access:
+				// awaitedPromise may be settled from a goroutine other than
+				// this one (e.g. fetch()'s own request goroutine calling
+				// vm.ResolvePromise once its HTTP round-trip completes), and
+				// a raw `awaitedPromise.State` read here is exactly the
+				// unsynchronized access `go test -race` catches racing
+				// against that goroutine's write.
+				tlaState, tlaResult := awaitedPromise.snapshot()
+				if tlaState == PromisePending {
 					rt := vm.GetAsyncRuntime()
-					for awaitedPromise.State == PromisePending {
+					for {
+						tlaState, tlaResult = awaitedPromise.snapshot()
+						if tlaState != PromisePending {
+							break
+						}
 						progress := false
 						if rt.RunNextTicks() {
 							progress = true
@@ -15403,8 +15416,8 @@ startExecution:
 					}
 				}
 				// Promise has settled - return result or throw
-				if awaitedPromise.State == PromiseFulfilled {
-					registers[resultReg] = awaitedPromise.Result
+				if tlaState == PromiseFulfilled {
+					registers[resultReg] = tlaResult
 					continue
 				} else {
 					// A rejected top-level await must behave like a thrown exception:
@@ -15421,7 +15434,7 @@ startExecution:
 					// this itself once consumed, and if a handler DOES exist it's simply
 					// never read (see handleUncaughtException).
 					vm.unhandledRejectionPrefix = "Uncaught (in promise)"
-					vm.throwException(awaitedPromise.Result)
+					vm.throwException(tlaResult)
 
 					if vm.frameCount == 0 || vm.unwindingCrossedNative {
 						// No handler anywhere - genuinely uncaught. throwException already
@@ -15469,73 +15482,42 @@ startExecution:
 			frame.promiseObj.Frame.openUpvalues = frame.openUpvalues
 
 			asyncPromise := frame.promiseObj
-			rt := vm.GetAsyncRuntime()
 
-			// Check promise state and schedule appropriate resumption
-			switch awaitedPromise.State {
-			case PromiseFulfilled:
-				// Promise already fulfilled - schedule resumption with value as microtask
-				fulfilledValue := awaitedPromise.Result
-				if debugAsyncAwait {
-					funcName := "?"
-					if frame.closure != nil && frame.closure.Fn != nil {
-						funcName = frame.closure.Fn.Name
-					}
-					fmt.Printf("[AWAIT-DEBUG] func=%s FULFILLED: scheduling resume with value=%s, outputReg=%d\n",
-						funcName, fulfilledValue.Inspect(), resultReg)
-				}
-				rt.ScheduleMicrotask(func() {
-					result, err := vm.resumeAsyncFunction(asyncPromise, fulfilledValue)
-					if err != nil {
-						// Reject with the real thrown value (an Error object,
-						// etc.), not a stringified Go error - exceptionError's
-						// Error() method is a fixed literal ("VM exception"),
-						// so a plain NewString(err.Error()) here would hand
-						// the .catch()/reject handler a bare string with no
-						// .message, .stack, etc. Mirrors the identical
-						// ExceptionError handling in promise.go's executor
-						// rejection path.
-						var reason Value
-						if ee, ok := err.(ExceptionError); ok {
-							reason = ee.GetExceptionValue()
-						} else {
-							reason = NewString(err.Error())
-						}
-						vm.rejectPromise(asyncPromise, reason)
-					} else if asyncPromise.Frame != nil {
-						// Async function hit another await and suspended again
-						// Don't resolve - the new await's handlers will take over
-					} else {
-						// Async function completed - resolve with final value
-						vm.resolvePromise(asyncPromise, result)
-					}
-				})
-				return InterpretOK, Undefined
-
-			case PromiseRejected:
-				// Promise already rejected - schedule resumption with throw as microtask
-				rejectedReason := awaitedPromise.Result
-				rt.ScheduleMicrotask(func() {
-					result, err := vm.resumeAsyncFunctionWithException(asyncPromise, rejectedReason)
-					if err != nil {
-						// Exception wasn't caught - reject the async promise
-						vm.rejectPromise(asyncPromise, rejectedReason)
-					} else if asyncPromise.Frame != nil {
-						// Async function hit another await and suspended again
-						// Don't resolve - the new await's handlers will take over
-					} else {
-						// Async function completed - resolve with final value
-						vm.resolvePromise(asyncPromise, result)
-					}
-				})
-				return InterpretOK, Undefined
-
-			case PromisePending:
-				// Promise is pending - attach handlers for when it settles
-				// Frame state already saved above
-
-				// Register fulfillment handler
-				awaitedPromise.FulfillReactions = append(awaitedPromise.FulfillReactions, PromiseReaction{
+			// addAwaitReactions atomically determines awaitedPromise's
+			// disposition and registers only the reaction(s) that can
+			// actually still fire for it, then we trigger dispatch
+			// ourselves if it turns out to already be settled.
+			//
+			// This unifies what used to be three separate branches (a
+			// `switch awaitedPromise.State` reading Fulfilled/Rejected/
+			// Pending, with the two "already settled" cases each hand-
+			// rolling their own rt.ScheduleMicrotask(...) call around the
+			// exact same resume logic the Pending case's reactions used)
+			// into one race-free path: the old `switch awaitedPromise.State`
+			// here was exactly the unsynchronized read `go test -race`
+			// flags racing against a concurrent settle (e.g. fetch()'s own
+			// request goroutine calling vm.ResolvePromise) - determining
+			// disposition and registering interest atomically under
+			// PromiseObject's own lock closes that gap, and doing so via
+			// addAwaitReactions specifically (rather than two separate
+			// addReaction calls) also avoids leaving a permanently-dead
+			// reaction of the opposite disposition attached to an
+			// already-settled promise forever (see its doc comment - that
+			// matters because a promise's disposition never changes once
+			// settled, so e.g. `for (;;) { await cachedResolvedPromise }`
+			// would otherwise leak one dead reaction per iteration).
+			// triggerPromiseReactions is itself idempotent (it atomically
+			// takes-and-clears the reaction list), so calling it here never
+			// risks double-firing the same reaction if the promise happens
+			// to settle and dispatch its reactions via resolvePromise/
+			// rejectPromise's own call to it at the same moment.
+			//
+			// Per ECMAScript spec, await always suspends and resumes via a
+			// microtask even for an already-settled promise;
+			// triggerPromiseReactions always defers through
+			// rt.ScheduleMicrotask, so that guarantee still holds here.
+			awaitState := awaitedPromise.addAwaitReactions(
+				PromiseReaction{
 					Handler: Undefined, // No user handler - internal resumption
 					Resolve: func(value Value) {
 						// Resume async function with fulfilled value
@@ -15543,8 +15525,12 @@ startExecution:
 						if err != nil {
 							// Resume failed - reject the async promise with the
 							// real thrown value, not a stringified Go error -
-							// see the identical fix/comment on the
-							// PromiseFulfilled case above.
+							// exceptionError's Error() method is a fixed literal
+							// ("VM exception"), so a plain NewString(err.Error())
+							// here would hand the .catch()/reject handler a bare
+							// string with no .message/.stack. Mirrors the
+							// identical ExceptionError handling in promise.go's
+							// executor rejection path.
 							var reason Value
 							if ee, ok := err.(ExceptionError); ok {
 								reason = ee.GetExceptionValue()
@@ -15564,11 +15550,9 @@ startExecution:
 						// This is called if the Resolve handler throws
 						vm.rejectPromise(asyncPromise, reason)
 					},
-				})
-
-				// Register rejection handler
+				},
 				// Note: For no-handler pass-through, triggerPromiseReactions calls Reject, not Resolve
-				awaitedPromise.RejectReactions = append(awaitedPromise.RejectReactions, PromiseReaction{
+				PromiseReaction{
 					Handler: Undefined, // No user handler - internal resumption
 					Resolve: func(reason Value) {
 						// Not called for rejection pass-through
@@ -15587,13 +15571,28 @@ startExecution:
 							vm.resolvePromise(asyncPromise, result)
 						}
 					},
-				})
+				},
+			)
 
-				// Suspend execution - return to caller
-				// The async function's promise remains pending
-				return InterpretOK, Undefined
+			if debugAsyncAwait {
+				funcName := "?"
+				if frame.closure != nil && frame.closure.Fn != nil {
+					funcName = frame.closure.Fn.Name
+				}
+				fmt.Printf("[AWAIT-DEBUG] func=%s registered reaction(s), state=%v outputReg=%d\n",
+					funcName, awaitState, resultReg)
 			}
-			continue
+
+			switch awaitState {
+			case PromiseFulfilled:
+				vm.triggerPromiseReactions(awaitedPromise, true)
+			case PromiseRejected:
+				vm.triggerPromiseReactions(awaitedPromise, false)
+			}
+
+			// Suspend execution - return to caller
+			// The async function's promise remains pending
+			return InterpretOK, Undefined
 
 		case OpDeleteProp:
 			destReg := code[ip]


### PR DESCRIPTION
## Summary

Fixes a real, reproducible data race in the VM's core Promise machinery, flagged as a follow-up while scoping [#205](https://github.com/nooga/paserati/issues/205) (see [nooga/paserati#207](https://github.com/nooga/paserati/pull/207)).

`PromiseObject`'s `State`/`Result`/`FulfillReactions`/`RejectReactions` fields were read and written with **zero synchronization**, even though a Promise created via `NewPendingPromise` (`new Promise(executor)`, `fetch()`, etc.) can legitimately be settled from a goroutine other than the one executing VM bytecode — `fetch()`'s own `doFetchRequestWithContext` (`pkg/builtins/fetch_init.go`) already calls `vm.ResolvePromise`/`vm.RejectPromise` from its own request goroutine once the HTTP round-trip completes.

**Confirmed reproducible independent of fetch or any other feature**: a bare `NewPendingPromise()` + a goroutine calling `ResolvePromise()` + a naive polling read races under `go test -race`. In shipped behavior this hits the `await` opcode directly — `const p = fetch(url); doWork(); await p` races the opcode's own `switch awaitedPromise.State` (`vm.go`) against the fetch goroutine's write the moment the response arrives while `doWork()` is still running.

## Fix

- Added a mutex to `PromiseObject` guarding `State`/`Result`/`FulfillReactions`/`RejectReactions` specifically (`Frame`/`Function`/`ThisValue` and `Properties`/`prototype` are untouched — those are only ever read/written from the VM's own execution goroutine).
- Added `snapshot`/`trySettle`/`takeReactions`/`addReaction`/`addAwaitReactions` methods as the only sanctioned way to touch those fields.
- Rewrote `resolvePromise`/`rejectPromise`/`triggerPromiseReactions`/`addPromiseReaction`/`PromiseThen` to go through them. `takeReactions` being idempotent (atomically take-and-clear) is what makes "register a reaction, then trigger dispatch yourself if it turns out the promise already settled" race-free without ever double-firing, regardless of interleaving.
- Rewrote the `await` opcode to register reactions and check disposition atomically via `addAwaitReactions`, unifying three previously-separate branches into one path. `addAwaitReactions` only registers the reaction that can still fire once a promise is already settled — a promise's disposition is immutable once settled, so registering both unconditionally (an earlier version of this fix did) would leak one permanently-dead reaction, and its captured closure, per await in a loop like `for (;;) { await cachedResolvedPromise }`.
- Rewrote the top-level-await drain loop similarly.
- Fixed the identical unsynchronized access in `pkg/builtins/array_init.go`'s `Array.fromAsync` implementation, found via a grep sweep for direct field access — missed by an earlier, narrower search that only looked for the literal type name `PromiseObject` (this file never spells it out, always using `:=` type inference off `.AsPromise()`).
- Fixed `value.go`'s Promise `Inspect()` the same way.

## Verification

- `go test -race ./pkg/vm/... ./pkg/builtins/... ./pkg/driver/...` clean, repeatedly
- `go test -race ./tests -run TestScripts` clean — the **entire smoke-test corpus** (every await/`.then`/`Promise.all`/async-generator/TLA script) under the race detector
- New regression tests exercise the exact original repro shape, including through the real `await` opcode end-to-end (both in-async-function and top-level-await paths) via a native module function that hands back a promise a background goroutine resolves. **Confirmed these tests actually catch the bug**: copied verbatim into a worktree checked out at the pre-fix commit, `go test -race` fails there (caught the exact race on the first run) and passes reliably (30/30) on this fix
- New regression test covers the reaction-leak fix
- test262 `language/*` and `built-ins/*` (including `built-ins/Array/fromAsync` specifically) show **zero diff** against main
- `go vet` clean (no copylock issues — confirmed `PromiseObject` is used exclusively via pointer everywhere)
- Smoke tests (`TestScripts`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)