### PR TITLE
fix(builtins): TextDecoder decode Uint8Array, fetch abort/error rejection

### DIFF
--- a/pkg/builtins/fetch_error_construction_test.go
+++ b/pkg/builtins/fetch_error_construction_test.go
@@ -1,0 +1,87 @@
+package builtins
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestFetchErrorConstructionIsGoroutineSafe is the regression test for the
+// vm.Call-from-background-goroutine hazard flagged after #212/#213/#214:
+// vmInstance.NewTypeError(...) builds its Error instance by calling the
+// TypeError constructor via vm.Call, which mutates the VM's shared
+// currentThis/currentNewTarget fields with no synchronization against the
+// main interpreter loop - unsafe from any goroutine but the one driving the
+// VM. fetch()'s two body-JSON-serialization error paths run inside
+// doFetchRequestWithContext, which executes entirely on its own background
+// goroutine (see fetch_init.go), so they can't safely use
+// vmInstance.NewTypeError. newTypeError/newTypeErrorValue/
+// newErrorValueWithPrototype build the instance by hand instead, touching
+// only data freshly allocated for the call.
+//
+// This drives that exact mechanism concurrently: one goroutine repeatedly
+// calls a native function through vm.Call (mutating currentThis/
+// currentNewTarget, mirroring the main interpreter loop's own native calls)
+// while several others repeatedly build TypeError/AbortError values via the
+// new helpers. Run with -race; a regression back to vm.Call-based
+// construction here reliably trips the race detector.
+func TestFetchErrorConstructionIsGoroutineSafe(t *testing.T) {
+	vmInstance := vm.NewVM()
+
+	// A trivial native function whose call convention is exactly what
+	// vm.Call exercises for Error/TypeError: entering via
+	// enterOrdinaryNativeCall, which sets currentThis (see vm.Call's
+	// TypeNativeFunctionWithProps case).
+	fn := vm.NewNativeFunction(0, false, "noop", func(args []vm.Value) (vm.Value, error) {
+		return vm.Undefined, nil
+	})
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+
+	// "Main" goroutine: repeatedly calls into the VM the way the
+	// interpreter loop does for any native call.
+	wg.Go(func() {
+		for range iterations {
+			if _, err := vmInstance.Call(fn, vm.Undefined, nil); err != nil {
+				t.Errorf("vm.Call(noop) failed: %v", err)
+				return
+			}
+		}
+	})
+
+	// Several background goroutines building fetch()'s error values
+	// concurrently - the exact shape of doFetchRequestWithContext's own
+	// goroutine racing the interpreter loop.
+	for range 4 {
+		wg.Go(func() {
+			for range iterations {
+				err := newTypeError(vmInstance, "failed to serialize body to JSON: boom")
+				exc, ok := err.(vm.ExceptionError)
+				if !ok {
+					t.Errorf("newTypeError did not return a vm.ExceptionError: %T", err)
+					return
+				}
+				val := exc.GetExceptionValue()
+				if val.Type() != vm.TypeObject {
+					t.Errorf("exception value is not an object: %v", val.Type())
+					return
+				}
+				obj := val.AsPlainObject()
+				if nameVal, _ := obj.GetOwn("name"); nameVal.ToString() != "TypeError" {
+					t.Errorf("name = %q, want %q", nameVal.ToString(), "TypeError")
+					return
+				}
+				if obj.GetPrototype() != vmInstance.TypeErrorPrototype {
+					t.Errorf("prototype is not vmInstance.TypeErrorPrototype")
+					return
+				}
+
+				_ = newAbortErrorValue(vmInstance, "aborted")
+			}
+		})
+	}
+
+	wg.Wait()
+}

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -599,7 +599,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 					}
 					vmInstance.RejectPromise(promiseObj, newAbortErrorValue(vmInstance, reason))
 				} else {
-					vmInstance.RejectPromise(promiseObj, newFetchNetworkErrorValue(vmInstance, err.Error()))
+					vmInstance.RejectPromise(promiseObj, newTypeErrorValue(vmInstance, err.Error()))
 				}
 				// Settled above; safe to wake the driver's drain loop now.
 				cancel()
@@ -1087,10 +1087,23 @@ func newAbortErrorValue(vmInstance *vm.VM, message string) vm.Value {
 	return newErrorValueWithPrototype(vmInstance.ErrorPrototype, "AbortError", message)
 }
 
-// newFetchNetworkErrorValue builds a real TypeError - what a network failure
-// rejects fetch() with per spec - instead of a bare string (#214).
-func newFetchNetworkErrorValue(vmInstance *vm.VM, message string) vm.Value {
+// newTypeErrorValue builds a real TypeError instance - what a network
+// failure rejects fetch() with per spec - instead of a bare string (#214).
+// Safe to call from any goroutine; see newErrorValueWithPrototype.
+func newTypeErrorValue(vmInstance *vm.VM, message string) vm.Value {
 	return newErrorValueWithPrototype(vmInstance.TypeErrorPrototype, "TypeError", message)
+}
+
+// newTypeError is newTypeErrorValue wrapped as a Go error via
+// vmInstance.NewExceptionError, for call sites inside doFetchRequestWithContext
+// that return (vm.Value, error) directly rather than settling a promise -
+// they too run on fetch()'s background goroutine, so they need the same
+// goroutine-safe construction (vmInstance.NewTypeError itself is not safe
+// here: it calls the TypeError constructor via vm.Call, which mutates
+// shared VM fields with no synchronization against the main interpreter
+// loop - see newErrorValueWithPrototype).
+func newTypeError(vmInstance *vm.VM, message string) error {
+	return vmInstance.NewExceptionError(newTypeErrorValue(vmInstance, message))
 }
 
 // bytesToValue wraps raw bytes as a Uint8Array, the representation blob()/
@@ -1175,14 +1188,14 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 						// Auto-stringify objects for JSON content type
 						jsonBytes, err := b.MarshalJSON()
 						if err != nil {
-							return vm.Undefined, vmInstance.NewTypeError("failed to serialize body to JSON: " + err.Error())
+							return vm.Undefined, newTypeError(vmInstance, "failed to serialize body to JSON: "+err.Error())
 						}
 						body = bytes.NewReader(jsonBytes)
 					} else if b.Type() == vm.TypeObject || b.Type() == vm.TypeDictObject {
 						// Default to JSON for objects
 						jsonBytes, err := b.MarshalJSON()
 						if err != nil {
-							return vm.Undefined, vmInstance.NewTypeError("failed to serialize body to JSON: " + err.Error())
+							return vm.Undefined, newTypeError(vmInstance, "failed to serialize body to JSON: "+err.Error())
 						}
 						body = bytes.NewReader(jsonBytes)
 					} else {

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -494,13 +494,13 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 					if aborted, exists := signalObj.GetOwn("aborted"); exists {
 						if aborted.IsBoolean() && aborted.AsBoolean() {
 							// Signal is already aborted - reject immediately without async
-							reason := "AbortError: signal is aborted without reason"
+							reason := "signal is aborted without reason"
 							if r, exists := signalObj.GetOwn("reason"); exists && r.Type() != vm.TypeUndefined {
-								reason = "AbortError: " + r.ToString()
+								reason = r.ToString()
 							}
 							promise := vmInstance.NewPendingPromise()
 							promiseObj := promise.AsPromise()
-							vmInstance.RejectPromise(promiseObj, vm.NewString(reason))
+							vmInstance.RejectPromise(promiseObj, newAbortErrorValue(vmInstance, reason))
 							return promise, nil
 						}
 					}
@@ -566,27 +566,44 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}()
 		}
 
-		// Perform HTTP request asynchronously in a goroutine. cancel and rt
-		// pass ownership of "clean up the context" / "the external op is
-		// over" into doFetchRequestWithContext: on a response that streams
-		// (the common case, #205), both outlive this goroutine and are
-		// discharged later by the body-drain goroutine it starts instead.
+		// Perform HTTP request asynchronously in a goroutine. On a response
+		// that streams (the common case, #205), cancel/rt outlive this
+		// goroutine and are discharged later by the body-drain goroutine
+		// doFetchRequestWithContext starts instead; on an early-return
+		// error, *this* goroutine owns them, and must discharge them only
+		// after settling the promise below (#213 - see the doc comment on
+		// doFetchRequestWithContext for why the order matters: cancel()/
+		// rt.EndExternalOp() wake the driver's event-loop drain, and doing
+		// that before the rejection is scheduled can make the drain exit
+		// with the promise settled but its continuation never resumed).
 		go func() {
 			response, err := doFetchRequestWithContext(ctx, cancel, rt, vmInstance, url, init)
 
 			if err != nil {
-				// Check if this was a context cancellation (abort)
-				if ctx.Err() == context.Canceled {
-					reason := "AbortError: The operation was aborted"
+				// Classify by the error type doFetchRequestWithContext
+				// returned, *not* ctx.Err(): a naive post-hoc ctx.Err() ==
+				// context.Canceled check can't tell a real abort from a
+				// plain network error once cleanup (which cancels ctx) has
+				// run - and per the above, cleanup must run before we reach
+				// this line for the case that actually reached this code -
+				// so this checks the error's own type instead (#213: this
+				// branch used to be checked via ctx.Err(), which was always
+				// true here, so every non-abort failure falsely rejected as
+				// AbortError instead of the real error).
+				if _, ok := errors.AsType[*AbortError](err); ok {
+					reason := "The operation was aborted"
 					if signalObj != nil {
 						if r, exists := signalObj.GetOwn("reason"); exists && r.Type() != vm.TypeUndefined {
-							reason = "AbortError: " + r.ToString()
+							reason = r.ToString()
 						}
 					}
-					vmInstance.RejectPromise(promiseObj, vm.NewString(reason))
+					vmInstance.RejectPromise(promiseObj, newAbortErrorValue(vmInstance, reason))
 				} else {
-					vmInstance.RejectPromise(promiseObj, vm.NewString(err.Error()))
+					vmInstance.RejectPromise(promiseObj, newFetchNetworkErrorValue(vmInstance, err.Error()))
 				}
+				// Settled above; safe to wake the driver's drain loop now.
+				cancel()
+				rt.EndExternalOp()
 			} else {
 				vmInstance.ResolvePromise(promiseObj, response)
 			}
@@ -1047,6 +1064,35 @@ func createResponseObject(vmInstance *vm.VM, r *FetchResponse) vm.Value {
 	return vm.NewValueFromPlainObject(obj)
 }
 
+// newErrorValueWithPrototype builds an Error-shaped instance directly as
+// data - NOT by calling the Error/TypeError constructor (vm.Call). fetch()'s
+// completion runs on its own goroutine, off the VM's own goroutine, and
+// vm.Call mutates shared VM fields (currentThis/currentNewTarget) around
+// the native call with no synchronization against the main interpreter
+// loop; building the instance by hand instead only touches data freshly
+// allocated for this call, which is safe from any goroutine.
+func newErrorValueWithPrototype(proto vm.Value, name, message string) vm.Value {
+	errVal := vm.NewObject(proto)
+	obj := errVal.AsPlainObject()
+	obj.SetOwnNonEnumerable("name", vm.NewString(name))
+	obj.SetOwnNonEnumerable("message", vm.NewString(message))
+	return errVal
+}
+
+// newAbortErrorValue builds a real Error instance (name "AbortError") so a
+// fetch() abort rejects with an actual Error object rather than a bare
+// string (#214) - there is no DOMException in this runtime to construct
+// instead.
+func newAbortErrorValue(vmInstance *vm.VM, message string) vm.Value {
+	return newErrorValueWithPrototype(vmInstance.ErrorPrototype, "AbortError", message)
+}
+
+// newFetchNetworkErrorValue builds a real TypeError - what a network failure
+// rejects fetch() with per spec - instead of a bare string (#214).
+func newFetchNetworkErrorValue(vmInstance *vm.VM, message string) vm.Value {
+	return newErrorValueWithPrototype(vmInstance.TypeErrorPrototype, "TypeError", message)
+}
+
 // bytesToValue wraps raw bytes as a Uint8Array, the representation blob()/
 // bytes() resolve to.
 func bytesToValue(data []byte) vm.Value {
@@ -1057,23 +1103,22 @@ func bytesToValue(data []byte) vm.Value {
 }
 
 // doFetchRequestWithContext performs the HTTP request with context support
-// for cancellation. It owns cancel and rt for the whole request: on any
-// early return (parse error, network error, no response) it calls both
-// itself before returning. On success (#205) the response resolves as soon
-// as headers arrive - real fetch()/spec semantics, and required so an SSE
-// body that never EOFs doesn't block the fetch() promise forever - and a
-// goroutine it starts streams the body into a ReadableStream, discharging
-// cancel/rt only once that finishes (EOF, read error, or the request being
-// aborted mid-body).
+// for cancellation. On any early return (parse error, network error, no
+// response) it leaves cancel/rt untouched - the caller must discharge them
+// itself, and must do so *after* settling the fetch() promise with the
+// returned error: cancel()/rt.EndExternalOp() wake the driver's event-loop
+// drain immediately, and if that happened before the promise reaction is
+// scheduled, the drain can see nothing pending and return, leaving the
+// promise settled but its `await`/`.then()` continuation never resumed
+// (previously masked by #213, which made this path effectively dead code -
+// see the fetchFn caller for where settlement now happens first). On
+// success (#205) the response resolves as soon as headers arrive - real
+// fetch()/spec semantics, and required so an SSE body that never EOFs
+// doesn't block the fetch() promise forever - and a goroutine started here
+// streams the body into a ReadableStream, discharging cancel/rt itself only
+// once that finishes (EOF, read error, or the request being aborted
+// mid-body); the caller must NOT discharge them again in that case.
 func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, rt runtime.AsyncRuntime, vmInstance *vm.VM, url string, init vm.Value) (vm.Value, error) {
-	streaming := false
-	defer func() {
-		if !streaming {
-			cancel()
-			rt.EndExternalOp()
-		}
-	}()
-
 	// Default options
 	method := "GET"
 	headers := &FetchHeaders{headers: make(http.Header)}
@@ -1213,6 +1258,13 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 	// fires), not until the body is fully read.
 	resp, err := client.Do(req)
 	if err != nil {
+		// A canceled ctx here means the abort-signal poller genuinely fired
+		// cancel() concurrently (this function no longer cancels ctx itself
+		// before returning - see the doc comment above, #213) - so this
+		// correctly distinguishes a real abort from a plain network error.
+		if ctx.Err() == context.Canceled {
+			return vm.Undefined, &AbortError{Message: "The operation was aborted"}
+		}
 		return vm.Undefined, err
 	}
 
@@ -1229,8 +1281,6 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 
 	// Headers are in hand: hand off cancel/rt to the body-drain goroutine
 	// below instead of discharging them when this function returns.
-	streaming = true
-
 	bodyStream, controller := NewHostFedReadableStream(vmInstance)
 	bodyState := newFetchBody()
 

--- a/pkg/builtins/text_codec_init.go
+++ b/pkg/builtins/text_codec_init.go
@@ -119,8 +119,33 @@ func (t *TextDecoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.NewString(""), nil
 		}
 		input := args[0]
-		// Handle ArrayObject (Uint8Array-like)
-		if input.Type() == vm.TypeArray {
+		switch input.Type() {
+		case vm.TypeTypedArray:
+			// A real Uint8Array (or any other TypedArray view) - the case that
+			// matters most, since every ReadableStream/fetch body chunk is one
+			// (#212). Per spec, decode() treats the input as a raw byte range:
+			// the view's byteOffset/byteLength window into its backing buffer,
+			// regardless of the view's element kind.
+			ta := input.AsTypedArray()
+			raw := ta.GetBufferData().GetData()
+			start := ta.GetByteOffset()
+			end := start + ta.GetByteLength()
+			if start > len(raw) {
+				start = len(raw)
+			}
+			if end > len(raw) {
+				end = len(raw)
+			}
+			if start > end {
+				start = end
+			}
+			return vm.NewString(string(raw[start:end])), nil
+		case vm.TypeArrayBuffer:
+			ab := input.AsArrayBuffer()
+			return vm.NewString(string(ab.GetData())), nil
+		case vm.TypeArray:
+			// Not a real BufferSource, but TextEncoder.encode() here still
+			// returns a plain array of byte values - keep decoding those.
 			arrObj := input.AsArray()
 			bytes := make([]byte, arrObj.Length())
 			for i := 0; i < arrObj.Length(); i++ {
@@ -128,8 +153,9 @@ func (t *TextDecoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 				bytes[i] = byte(val.ToFloat())
 			}
 			return vm.NewString(string(bytes)), nil
+		default:
+			return vm.NewString(input.ToString()), nil
 		}
-		return vm.NewString(input.ToString()), nil
 	}))
 
 	ctor := vm.NewNativeFunction(0, true, "TextDecoder", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/driver/fetch_errors_test.go
+++ b/pkg/driver/fetch_errors_test.go
@@ -1,0 +1,129 @@
+package driver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFetchPlainNetworkErrorIsNotAbortError is the discriminating regression
+// test for #213: a plain network failure with no AbortSignal involved at
+// all must reject with the real underlying error, not a false AbortError.
+// The bug was that doFetchRequestWithContext's own cleanup unconditionally
+// cancels the request's context on every early return, so by the time the
+// caller checked ctx.Err() == context.Canceled it was always true - turning
+// every non-abort failure into a bogus "AbortError: The operation was
+// aborted", masking the real cause. It also doubled as a regression test
+// for #214 (rejections must be real Error instances, not bare strings).
+func TestFetchPlainNetworkErrorIsNotAbortError(t *testing.T) {
+	// A server that's already closed gives a deterministic, hermetic
+	// connection-refused error - no reliance on external DNS/network.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	script := `
+		async function run() {
+			try {
+				await fetch("` + url + `");
+				return { ok: true };
+			} catch (e) {
+				return {
+					ok: false,
+					name: e.name,
+					isError: e instanceof Error,
+					hasMessage: typeof e.message === "string" && e.message.length > 0,
+				};
+			}
+		}
+		await run();
+	`
+
+	resultVal, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed: %v", errs[0])
+	}
+	if !resultVal.IsObject() {
+		t.Fatalf("script result is not an object: %#v", resultVal)
+	}
+	result := resultVal.AsPlainObject()
+
+	okVal, _ := result.GetOwn("ok")
+	if okVal.AsBoolean() {
+		t.Fatal("fetch() unexpectedly resolved; expected a connection-refused rejection")
+	}
+
+	nameVal, _ := result.GetOwn("name")
+	if got := nameVal.ToString(); got != "TypeError" {
+		t.Fatalf("rejection name = %q, want %q (the regression turned this into \"AbortError\")", got, "TypeError")
+	}
+
+	isErrorVal, _ := result.GetOwn("isError")
+	if !isErrorVal.AsBoolean() {
+		t.Fatal("rejection is not `instanceof Error` - fetch() must reject with a real Error object, not a bare string (#214)")
+	}
+
+	hasMessageVal, _ := result.GetOwn("hasMessage")
+	if !hasMessageVal.AsBoolean() {
+		t.Fatal("rejection has no non-empty string .message")
+	}
+}
+
+// TestFetchAbortIsStillAbortError is a companion to the above: an actual
+// AbortSignal-driven cancellation must still reject as a real AbortError
+// (name "AbortError", instanceof Error) after the #213 fix.
+func TestFetchAbortIsStillAbortError(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	script := `
+		async function run() {
+			try {
+				const controller = new AbortController();
+				controller.abort("stop");
+				await fetch("http://example.invalid/", { signal: controller.signal });
+				return { ok: true };
+			} catch (e) {
+				return {
+					ok: false,
+					name: e.name,
+					isError: e instanceof Error,
+					message: e.message,
+				};
+			}
+		}
+		await run();
+	`
+
+	resultVal, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed: %v", errs[0])
+	}
+	if !resultVal.IsObject() {
+		t.Fatalf("script result is not an object: %#v", resultVal)
+	}
+	result := resultVal.AsPlainObject()
+
+	okVal, _ := result.GetOwn("ok")
+	if okVal.AsBoolean() {
+		t.Fatal("fetch() unexpectedly resolved; expected a pre-aborted rejection")
+	}
+
+	nameVal, _ := result.GetOwn("name")
+	if got := nameVal.ToString(); got != "AbortError" {
+		t.Fatalf("rejection name = %q, want %q", got, "AbortError")
+	}
+
+	isErrorVal, _ := result.GetOwn("isError")
+	if !isErrorVal.AsBoolean() {
+		t.Fatal("rejection is not `instanceof Error` (#214)")
+	}
+
+	messageVal, _ := result.GetOwn("message")
+	if got := messageVal.ToString(); got != "stop" {
+		t.Fatalf("rejection message = %q, want %q", got, "stop")
+	}
+}

--- a/tests/scripts/textdecoder_uint8array.ts
+++ b/tests/scripts/textdecoder_uint8array.ts
@@ -1,0 +1,17 @@
+// TextDecoder.decode() must decode a real Uint8Array/ArrayBuffer, not just
+// a plain JS array - every fetch()/ReadableStream body chunk is one (#212).
+const decoder = new TextDecoder();
+
+const bytes = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+const fromTypedArray = decoder.decode(bytes);
+
+const fromArrayBuffer = decoder.decode(bytes.buffer);
+
+// A view over a slice of a larger buffer should decode only its own window.
+const buf = new Uint8Array([0, 0, 104, 105, 0, 0]).buffer;
+const view = new Uint8Array(buf, 2, 2); // "hi"
+const fromSlicedView = decoder.decode(view);
+
+`${fromTypedArray}|${fromArrayBuffer}|${fromSlicedView}`;
+
+// expect: hello|hello|hi


### PR DESCRIPTION
## Summary

Fixes three fetch()/TextDecoder bugs in one PR:

### #212 — TextDecoder.decode() never handled a real Uint8Array/ArrayBuffer
`decode()` only handled a plain JS array of byte values, falling through to stringifying any real `Uint8Array`/`ArrayBuffer` as `"[object Uint8Array]"` instead of decoding its bytes. Every `ReadableStream`/`fetch()` body chunk is a real `Uint8Array`, so this blocked real SSE text consumption. `decode()` now reads the raw byte window (`byteOffset`/`byteLength`) of any `TypedArray` view or `ArrayBuffer` directly, in addition to the existing plain-array fallback `TextEncoder.encode()` still produces.

### #213 — plain network failures falsely rejected as AbortError
[dbf6d62d](https://github.com/nooga/paserati/commit/dbf6d62d) moved `cancel()`/`rt.EndExternalOp()` ownership for a non-streaming `fetch()` failure into `doFetchRequestWithContext`'s own deferred cleanup, called unconditionally before returning to the caller. The caller then classified the failure by checking `ctx.Err() == context.Canceled` — which was now always true (that defer had just canceled it), so *every* plain network error falsely rejected as `"AbortError: The operation was aborted"` instead of the real error.

Fixed by:
- Classifying the failure by the returned error's own type (a real abort now returns `*AbortError`) instead of inspecting `ctx` post-hoc.
- Moving `cancel()`/`EndExternalOp()` to run only *after* the promise is settled — discharging them first wakes the driver's event-loop drain, and doing so before the rejection's continuation is scheduled let the drain exit with the promise settled but its `await`/`.then()` continuation never resumed. This was previously masked because the always-true `ctx.Err()` check made the real-error branch dead code.

### #214 — fetch() rejected with a bare string, never a real Error instance
Rejections now carry a real Error-shaped instance (`TypeError` for network failures, an `Error` named `"AbortError"` for aborts — there's no `DOMException` in this runtime) built directly as data rather than via the `Error`/`TypeError` constructor: fetch's completion runs on its own goroutine, and calling the constructor through `vm.Call` mutates shared VM fields (`currentThis`/`currentNewTarget`) with no synchronization against the main interpreter loop.

## Testing
- New smoke test: `tests/scripts/textdecoder_uint8array.ts`
- New driver-level regression tests: `pkg/driver/fetch_errors_test.go` (`TestFetchPlainNetworkErrorIsNotAbortError`, `TestFetchAbortIsStillAbortError`) — both run 10x clean, no flakiness
- `go build ./...`, `go vet ./...`, `go test ./...`, and the `TestScripts` smoke suite all pass
- Manually confirmed the pre-fix binary reproduces the exact `#213`/`#214` symptoms (bare-string `"AbortError: The operation was aborted"` for a genuine DNS failure) and the post-fix binary correctly reports a real `TypeError` instance with the underlying dial error

## Note
While reviewing this code I noticed a separate, narrower pre-existing issue (two JSON-body-serialization error paths in the same function also construct their `TypeError` via `vm.Call` from the background goroutine) — flagged separately rather than folded into this PR to keep it scoped to #212/#213/#214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes [#212](https://github.com/nooga/paserati/issues/212), closes [#213](https://github.com/nooga/paserati/issues/213), closes [#214](https://github.com/nooga/paserati/issues/214).

---

**Follow-up commit:** the same `vm.Call`-from-background-goroutine hazard this PR fixed for fetch()'s abort/error rejections was also present in two JSON-body-serialization error paths inside `doFetchRequestWithContext`. Fixed by generalizing `newFetchNetworkErrorValue` into `newTypeErrorValue`/`newTypeError` and using them there too. Added `TestFetchErrorConstructionIsGoroutineSafe` (run with `-race`); independently confirmed via a throwaway scratch test that concurrent `vm.Call` itself trips the race detector on the VM's shared call-state fields.