### PR TITLE
fix(vm): propagate a throwing toString/valueOf accessor out of string coercion

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2374,19 +2374,35 @@ startExecution:
 				return InterpretRuntimeError, Undefined
 			}
 
-			// For objects, call ToPrimitive with "string" hint to invoke toString()
+			// For objects, call ToPrimitive with "string" hint to invoke toString().
+			// frame.ip is published first so a throwing toString/valueOf can find
+			// this frame's handler table, and helperCallDepth is raised so that a
+			// handler in *this* frame reports itself via vm.handlerFound rather
+			// than silently swallowing the throw (see exceptionPending).
 			if leftVal.IsObject() || leftVal.IsCallable() {
+				frame.ip = ip
+				vm.helperCallDepth++
 				leftVal = vm.toPrimitive(leftVal, "string")
+				vm.helperCallDepth--
 				if vm.unwinding {
-					frame.ip = ip
-					return InterpretRuntimeError, vm.currentException
+					return InterpretRuntimeError, Undefined
+				}
+				if vm.handlerFound {
+					vm.handlerFound = false
+					goto reloadFrame
 				}
 			}
 			if rightVal.IsObject() || rightVal.IsCallable() {
+				frame.ip = ip
+				vm.helperCallDepth++
 				rightVal = vm.toPrimitive(rightVal, "string")
+				vm.helperCallDepth--
 				if vm.unwinding {
-					frame.ip = ip
-					return InterpretRuntimeError, vm.currentException
+					return InterpretRuntimeError, Undefined
+				}
+				if vm.handlerFound {
+					vm.handlerFound = false
+					goto reloadFrame
 				}
 			}
 
@@ -4279,6 +4295,29 @@ startExecution:
 					fmt.Printf("[DEBUG vm.go] OpCall: Reloaded frame state, ip=%d (frame.ip=%d), unwinding=%v\n", ip, frame.ip, vm.unwinding)
 				}
 				continue
+			}
+
+			// An exception was thrown during the call AND a handler claimed it
+			// (handleCatchBlock cleared unwinding and set handlerFound). prepareCall
+			// returned without storing a result, so the only thing left to do is
+			// resume at the handler.
+			//
+			// The frame.ip != frameIPBeforeCall check above cannot cover this: it is
+			// guarded on frameCount being unchanged, and a handler in an *outer*
+			// frame only becomes reachable after unwinding popped frames to get
+			// there. Without this, the loop kept running with code/registers/ip
+			// still cached from the popped frame and delivered garbage to the catch
+			// clause. OpCallMethod has carried the same check for this reason.
+			//
+			// No frameCount/unwindingCrossedNative guard: handleCatchBlock is the
+			// only setter of handlerFound, and it runs against a live frame and
+			// clears unwindingCrossedNative, so neither can hold here.
+			if vm.handlerFound {
+				if debugExceptions {
+					fmt.Printf("[DEBUG vm.go] OpCall: Handler found during native call, reloading frame\n")
+				}
+				vm.handlerFound = false
+				goto reloadFrame
 			}
 
 			// DISABLED: This logic was incorrectly detecting exception handling
@@ -17976,6 +18015,17 @@ func (vm *VM) stringToBigInt(str string) (*big.Int, bool) {
 	return result, true
 }
 
+// exceptionPending reports whether a helper-context property lookup left an
+// exception in flight. opGetProp/opGetPropSymbol signal a throw three different
+// ways depending on where the handler lives: InterpretRuntimeError when nothing
+// caught it, vm.unwinding while it is still propagating outward, and
+// vm.handlerFound (with status InterpretOK and unwinding already cleared) when a
+// catch block in the *current* frame claimed it. Only the last one is easy to
+// miss, and it is exactly the shape a throwing getter inside a try block takes.
+func (vm *VM) exceptionPending(status InterpretResult) bool {
+	return status == InterpretRuntimeError || vm.unwinding || vm.handlerFound
+}
+
 // toPrimitive implements JavaScript ToPrimitive abstract operation
 // hint can be "string", "number", or "default"
 func (vm *VM) toPrimitive(val Value, hint string) Value {
@@ -17994,7 +18044,13 @@ func (vm *VM) toPrimitive(val Value, hint string) Value {
 	if hint == "default" {
 		// Check if this is a Date object by looking for getTime method
 		var getTimeMethod Value
-		if ok, _, _ := vm.opGetProp(nil, 0, &val, "getTime", &getTimeMethod); ok {
+		ok, status, _ := vm.opGetProp(nil, 0, &val, "getTime", &getTimeMethod)
+		// A "getTime" accessor that throws leaves an exception pending; report it
+		// to the caller instead of probing on. See exceptionPending below.
+		if vm.exceptionPending(status) {
+			return Undefined
+		}
+		if ok {
 			if getTimeMethod.Type() == TypeNativeFunction || getTimeMethod.Type() == TypeNativeFunctionWithProps {
 				// This looks like a Date object - use "string" hint
 				hint = "string"
@@ -18007,8 +18063,8 @@ func (vm *VM) toPrimitive(val Value, hint string) Value {
 	var toPrimMethod Value
 	if vm.SymbolToPrimitive.Type() != TypeUndefined {
 		ok, status, _ := vm.opGetPropSymbol(nil, 0, &val, vm.SymbolToPrimitive, &toPrimMethod)
-		// If getter threw an error, return undefined (exception is already set)
-		if status == InterpretRuntimeError {
+		// If the lookup threw, return undefined (the exception is already pending).
+		if vm.exceptionPending(status) {
 			return Undefined
 		}
 		if ok {
@@ -18063,7 +18119,15 @@ func (vm *VM) toPrimitive(val Value, hint string) Value {
 	for _, methodName := range methods {
 		// Try to get the method
 		var methodVal Value
-		if ok, _, _ := vm.opGetProp(nil, 0, &val, methodName, &methodVal); ok {
+		ok, status, _ := vm.opGetProp(nil, 0, &val, methodName, &methodVal)
+		// A throwing accessor (e.g. `{ get toString() { throw ... } }`) leaves an
+		// exception pending and reports ok == false. Without this check the loop
+		// would treat it as "no such method", fall through to step 6 and throw a
+		// bogus "Cannot convert object to primitive value" over the real error.
+		if vm.exceptionPending(status) {
+			return Undefined
+		}
+		if ok {
 			// Check if it's a function
 			if methodVal.Type() == TypeFunction || methodVal.Type() == TypeClosure ||
 				methodVal.Type() == TypeNativeFunction || methodVal.Type() == TypeNativeFunctionWithProps {

--- a/tests/scripts/template_literal_tostring_throw.ts
+++ b/tests/scripts/template_literal_tostring_throw.ts
@@ -1,0 +1,61 @@
+// expect: boom|boom|boom|boom|[object Object]|TypeError
+// A throwing toString/valueOf accessor must propagate its own exception out of
+// every string-coercion path, instead of being masked by a second
+// "Cannot convert object to primitive value" TypeError that escaped try/catch.
+
+function caught(fn: () => void): string {
+  try {
+    fn();
+    return "no-throw";
+  } catch (e) {
+    return e.message;
+  }
+}
+
+// The `return` after each `throw` is unreachable on purpose. Paserati's checker
+// raises TS2378 ("A 'get' accessor must return a value") for a getter body that
+// only throws, which real TypeScript does not. Removing these makes the file
+// stop compiling; drop them once TS2378 accounts for throw-only bodies.
+const throwingToString = {
+  get toString() {
+    throw new Error("boom");
+    return "unreachable";
+  },
+};
+
+const throwingValueOf = {
+  get valueOf() {
+    throw new Error("boom");
+    return 0;
+  },
+  toString() {
+    return "unused";
+  },
+};
+
+const results: string[] = [];
+
+// Template literal substitution (OpStringConcat with a "string" hint).
+results.push(caught(() => { `${throwingToString}`; }));
+// Explicit ToString.
+results.push(caught(() => { String(throwingToString); }));
+// String concatenation via OpAdd.
+results.push(caught(() => { "" + throwingToString; }));
+// Numeric coercion prefers valueOf, so its getter throws first.
+results.push(caught(() => { +throwingValueOf; }));
+
+// A non-throwing object still stringifies normally inside a template.
+const plain = { a: 1 };
+results.push(`${plain}`);
+
+// An object with no usable primitive conversion still reports the real
+// TypeError rather than a stale/incorrect exception.
+const unconvertible = { valueOf: null, toString: null };
+try {
+  `${unconvertible}`;
+  results.push("no-throw");
+} catch (e) {
+  results.push(e.name);
+}
+
+results.join("|");


### PR DESCRIPTION
A template literal over an object whose `toString` is a throwing getter reported the wrong error and escaped the surrounding `try`/`catch`:

```bash
./paserati --no-typecheck -e 'try { `${({ get toString() { throw new Error("boom"); } })}`; } catch (e) { console.log("caught", e.message); }'
```

Before: `Uncaught exception: TypeError: Cannot convert object to primitive value`. After: `caught boom`.

## Root cause

The defect is in `toPrimitive`, not in the template literal path, and it was never specific to template literals. `String(obj)` and `"" + obj` were broken the same way. `+obj` only appeared to work by accident: its `valueOf` getter throw was misread as "no such method", the fallback to `Object.prototype.toString` succeeded, and the pending exception surfaced later on its own.

A property lookup signals a throw three different ways depending on where the handler lives:

| Signal | When |
| --- | --- |
| `InterpretRuntimeError` status | nothing caught it |
| `vm.unwinding` | still propagating outward |
| `vm.handlerFound`, status `InterpretOK` | a catch block in the *current* frame claimed it |

`toPrimitive` only ever checked the first. A getter that throws inside a `try` takes the third shape, so the lookup read as "no such method". The `valueOf`/`toString` loop fell through to OrdinaryToPrimitive step 6 and threw a fresh `TypeError` on top of the real pending exception, which is what the user saw and what escaped the handler.

## Changes

All three are in `pkg/vm/vm.go`.

- **`toPrimitive`.** New `exceptionPending` predicate covering all three signals, checked after every lookup: the `Symbol.toPrimitive` probe, the Date `getTime` probe, and the `valueOf`/`toString` loop.
- **`OpStringConcat`.** Publishes `frame.ip` and raises `helperCallDepth` around the `toPrimitive` call. That is what lets an in-frame handler announce itself at all, since `handleCatchBlock` only sets `handlerFound` when `helperCallDepth > 0`. It now reloads the frame when one does.
- **`OpCall`.** Gained the `handlerFound` check `OpCallMethod` already had. `call.go` deliberately returns without storing a result when a handler claims the exception, but `OpCall` only noticed via a `frame.ip` comparison guarded on an unchanged frame count. A handler in an *outer* frame is reachable only after unwinding pops frames, so that guard never held. The loop kept running with `code`, `registers` and `ip` cached from the popped frame and delivered a garbage value to the catch clause. This one is a pre-existing gap that became reachable only once the first two fixes landed.

## Testing

`tests/scripts/template_literal_tostring_throw.ts` covers all four coercion paths plus two controls: a plain object still stringifies normally, and an object with no usable conversion still reports a real `TypeError`.

| Suite | Result |
| --- | --- |
| test262 `built-ins` vs `baseline.txt` | +5 passes, 0 new failures |
| test262 `language` | 23158 passed, dump byte-identical to `main` |
| test262 `language/expressions/template-literal` | 57/57, dump byte-identical to `main` |
| `go test ./...` | pass |

The five new `built-ins` passes are the `String.prototype.trimStart`/`trimEnd` `tostring-call-err` and `valueof-call-err` cases plus `Object.prototype.hasOwnProperty/topropertykey_before_toobject.js`.

## Notes for review

- `-diff baseline.txt` on the template-literal subpath is a null comparison, because that baseline covers only `built-ins` and holds no template-literal rows. I captured a pre-edit dump and diffed against it instead, and ran the `built-ins` diff separately where the baseline does have signal.
- The test file has two `return` statements after `throw` that are unreachable on purpose. Paserati's checker raises TS2378 for a getter body that only throws, which real TypeScript does not. There is an inline comment saying so, since otherwise they read as dead code and deleting them stops the file compiling.
- The `getTime` probe in `toPrimitive` is a non-spec Date-detection hack. I added the pending-exception check to it for consistency, but its behavior for a throwing `getTime` accessor is unchanged. It remains a pre-existing deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
