### PR TITLE
Add Intl.Segmenter (#210) and make VM strings canonical WTF-8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/dlclark/regexp2 v1.11.5
+	github.com/rivo/uniseg v0.4.7
 	golang.org/x/perf v0.0.0-20260615155930-9e4b9ddef5b6
 	golang.org/x/text v0.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTN
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/perf v0.0.0-20260615155930-9e4b9ddef5b6 h1:YTGOochus7nQXtT5KnsVfJ3/1yslyOyP3m9vMG1qMuQ=
 golang.org/x/perf v0.0.0-20260615155930-9e4b9ddef5b6/go.mod h1:FisaKCtzcRx02gCop3DILSnoD7CMnqwmde2yVxo4meM=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -3,6 +3,7 @@ package builtins
 import (
 	"errors"
 	"fmt"
+	"github.com/nooga/paserati/pkg/wtf8"
 
 	"github.com/nooga/paserati/pkg/types"
 	"github.com/nooga/paserati/pkg/vm"
@@ -695,7 +696,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 			result += separator + v.ToString()
 		}
-		return vm.NewString(result), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("toString", vm.NewNativeFunction(0, false, "toString", func(args []vm.Value) (vm.Value, error) {
@@ -723,7 +724,7 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 			result += "," + v.ToString()
 		}
-		return vm.NewString(result), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))
 
 	arrayProto.SetOwnNonEnumerable("reverse", vm.NewNativeFunction(0, false, "reverse", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/intl_init.go
+++ b/pkg/builtins/intl_init.go
@@ -1,0 +1,102 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// PriorityIntl: Intl only needs Object, Symbol and %Iterator.prototype%,
+// all of which are in place well before the Date/Temporal tier.
+const PriorityIntl = PriorityDate + 5
+
+// IntlInitializer installs the ECMA-402 Intl namespace object. Scope (#210):
+// Intl.Segmenter (grapheme/word/sentence, UAX #29 default rules) plus the
+// namespace's own Intl.getCanonicalLocales and @@toStringTag. The other
+// ECMA-402 constructors (Collator, DateTimeFormat, NumberFormat, ...) are
+// not implemented and are absent rather than stubbed, so feature detection
+// (`"DateTimeFormat" in Intl`) stays truthful.
+type IntlInitializer struct{}
+
+func (i *IntlInitializer) Name() string  { return "Intl" }
+func (i *IntlInitializer) Priority() int { return PriorityIntl }
+
+func (i *IntlInitializer) InitTypes(ctx *TypeContext) error {
+	stringArray := &types.ArrayType{ElementType: types.String}
+
+	// interface Intl.SegmentData { segment: string; index: number; input: string; isWordLike?: boolean }
+	segmentDataType := types.NewObjectType().
+		WithProperty("segment", types.String).
+		WithProperty("index", types.Number).
+		WithProperty("input", types.String).
+		WithOptionalProperty("isWordLike", types.Boolean)
+
+	segmentIteratorResultType := types.NewObjectType().
+		WithProperty("value", segmentDataType).
+		WithProperty("done", types.Boolean)
+	segmentIteratorType := types.NewObjectType().
+		WithProperty("next", types.NewSimpleFunction([]types.Type{}, segmentIteratorResultType))
+	// [Symbol.iterator] on the iterator itself, so it is iterable too.
+	segmentIteratorType.WithProperty("__COMPUTED_PROPERTY__", types.NewSimpleFunction([]types.Type{}, segmentIteratorType))
+
+	// interface Intl.Segments { containing(index?: number): SegmentData | undefined; [Symbol.iterator](): Iterator<SegmentData> }
+	segmentsType := types.NewObjectType().
+		WithProperty("containing", types.NewOptionalFunction([]types.Type{types.Number},
+			types.NewUnionType(segmentDataType, types.Undefined), []bool{true})).
+		WithProperty("__COMPUTED_PROPERTY__", types.NewSimpleFunction([]types.Type{}, segmentIteratorType))
+
+	resolvedOptionsType := types.NewObjectType().
+		WithProperty("locale", types.String).
+		WithProperty("granularity", types.String)
+
+	// interface Intl.Segmenter { segment(input: string): Segments; resolvedOptions(): ResolvedSegmenterOptions }
+	segmenterType := types.NewObjectType().
+		WithProperty("segment", types.NewSimpleFunction([]types.Type{types.String}, segmentsType)).
+		WithProperty("resolvedOptions", types.NewSimpleFunction([]types.Type{}, resolvedOptionsType))
+
+	// new Intl.Segmenter(locales?: string | string[], options?: { localeMatcher?, granularity? })
+	segmenterCtorType := types.NewObjectType().
+		WithConstructSignature(&types.Signature{
+			ParameterTypes: []types.Type{types.Any, types.Any},
+			ReturnType:     segmenterType,
+			OptionalParams: []bool{true, true},
+		}).
+		WithProperty("supportedLocalesOf", types.NewOptionalFunction([]types.Type{types.Any, types.Any}, stringArray, []bool{false, true})).
+		WithProperty("prototype", segmenterType)
+
+	intlNamespace := types.NewNamespaceType("Intl")
+	intlNamespace.ValueShape.
+		WithProperty("Segmenter", segmenterCtorType).
+		WithProperty("getCanonicalLocales", types.NewOptionalFunction([]types.Type{types.Any}, stringArray, []bool{true}))
+	intlNamespace.TypeMembers["Segmenter"] = segmenterType
+	intlNamespace.TypeMembers["Segments"] = segmentsType
+	intlNamespace.TypeMembers["SegmentData"] = segmentDataType
+	intlNamespace.TypeMembers["ResolvedSegmenterOptions"] = resolvedOptionsType
+
+	// The value binding is the namespace object's shape (so `Intl.Segmenter`
+	// resolves as an ordinary property); the type binding is the namespace
+	// itself (so `Intl.Segmenter` also resolves in type position).
+	if err := ctx.DefineGlobal("Intl", intlNamespace.ValueShape); err != nil {
+		return err
+	}
+	return ctx.DefineTypeAlias("Intl", intlNamespace)
+}
+
+func (i *IntlInitializer) InitRuntime(ctx *RuntimeContext) error {
+	vmInstance := ctx.VM
+
+	intlObj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	intlDefineToStringTag(vmInstance, intlObj, "Intl")
+
+	// Intl.getCanonicalLocales(locales)
+	intlObj.SetOwnNonEnumerable("getCanonicalLocales", vm.NewNativeFunction(1, false, "getCanonicalLocales", func(args []vm.Value) (vm.Value, error) {
+		list, err := intlCanonicalizeLocaleList(vmInstance, intlArg(args, 0))
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		return intlStringList(vmInstance, list), nil
+	}))
+
+	installIntlSegmenter(vmInstance, intlObj)
+
+	return ctx.DefineGlobal("Intl", vm.NewValueFromPlainObject(intlObj))
+}

--- a/pkg/builtins/intl_locale.go
+++ b/pkg/builtins/intl_locale.go
@@ -1,0 +1,743 @@
+package builtins
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"golang.org/x/text/language"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// ECMA-402 locale plumbing shared by the Intl constructors: language-tag
+// structural validation (UTS #35 unicode_locale_id), canonicalization,
+// CanonicalizeLocaleList, the default locale, and the lookup matcher.
+//
+// Paserati ships no CLDR locale data - the only Intl consumer so far is
+// Intl.Segmenter (#210), whose default-locale segmentation is
+// locale-independent (UAX #29). So "available locale" here means "a
+// structurally valid tag whose language subtag is a known ISO 639 code"
+// (x/text's tables stand in for the language list), and canonicalization
+// covers casing, subtag ordering and the handful of deprecated ISO 639-1
+// codes below rather than the full CLDR alias data. Intl.getCanonicalLocales
+// is therefore best-effort where CLDR aliases are concerned.
+
+// ---- UTS #35 unicode_locale_id grammar ----
+
+func intlIsAlpha(c byte) bool { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
+func intlIsDigit(c byte) bool { return c >= '0' && c <= '9' }
+func intlIsAlnum(c byte) bool { return intlIsAlpha(c) || intlIsDigit(c) }
+
+func intlAll(s string, pred func(byte) bool) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !pred(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// unicode_language_subtag = alpha{2,3} | alpha{5,8}
+func intlIsLanguageSubtag(s string) bool {
+	n := len(s)
+	return (n == 2 || n == 3 || (n >= 5 && n <= 8)) && intlAll(s, intlIsAlpha)
+}
+
+// unicode_script_subtag = alpha{4}
+func intlIsScriptSubtag(s string) bool { return len(s) == 4 && intlAll(s, intlIsAlpha) }
+
+// unicode_region_subtag = alpha{2} | digit{3}
+func intlIsRegionSubtag(s string) bool {
+	return (len(s) == 2 && intlAll(s, intlIsAlpha)) || (len(s) == 3 && intlAll(s, intlIsDigit))
+}
+
+// unicode_variant_subtag = alphanum{5,8} | digit alphanum{3}
+func intlIsVariantSubtag(s string) bool {
+	n := len(s)
+	return (n >= 5 && n <= 8 && intlAll(s, intlIsAlnum)) ||
+		(n == 4 && intlIsDigit(s[0]) && intlAll(s, intlIsAlnum))
+}
+
+func intlIsAlnumRange(s string, lo, hi int) bool {
+	return len(s) >= lo && len(s) <= hi && intlAll(s, intlIsAlnum)
+}
+
+// intlParseLanguageID consumes a unicode_language_id starting at parts[i]
+// (language, optional script, optional region, variants) and returns the
+// index just past it. Fails on a missing/ill-formed language subtag or a
+// duplicate variant (ECMA-402 IsStructurallyValidLanguageTag step 4).
+func intlParseLanguageID(parts []string, i int) (int, bool) {
+	if i >= len(parts) || !intlIsLanguageSubtag(parts[i]) {
+		return i, false
+	}
+	i++
+	if i < len(parts) && intlIsScriptSubtag(parts[i]) {
+		i++
+	}
+	if i < len(parts) && intlIsRegionSubtag(parts[i]) {
+		i++
+	}
+	var seen []string
+	for i < len(parts) && intlIsVariantSubtag(parts[i]) {
+		v := strings.ToLower(parts[i])
+		for _, s := range seen {
+			if s == v {
+				return i, false
+			}
+		}
+		seen = append(seen, v)
+		i++
+	}
+	return i, true
+}
+
+// intlIsStructurallyValidLanguageTag implements ECMA-402
+// IsStructurallyValidLanguageTag: the tag matches the UTS #35
+// unicode_locale_id production (BCP 47 syntax, hyphen separators only, no
+// grandfathered or extlang forms), has no duplicate variant subtags and no
+// duplicate extension singletons.
+func intlIsStructurallyValidLanguageTag(tag string) bool {
+	if tag == "" {
+		return false
+	}
+	for i := 0; i < len(tag); i++ {
+		if c := tag[i]; !intlIsAlnum(c) && c != '-' {
+			return false
+		}
+	}
+	parts := strings.Split(tag, "-")
+	for _, p := range parts {
+		if p == "" { // leading/trailing/double separator
+			return false
+		}
+	}
+	i, ok := intlParseLanguageID(parts, 0)
+	if !ok {
+		return false
+	}
+	var seen [128]bool
+	for i < len(parts) {
+		p := parts[i]
+		if len(p) != 1 {
+			return false
+		}
+		s := p[0] | 0x20 // fold letters to lowercase; digits are unaffected
+		if seen[s] {
+			return false
+		}
+		seen[s] = true
+		i++
+		switch s {
+		case 'x':
+			// pu_extensions = sep [xX] (sep alphanum{1,8})+ ; always last
+			if i >= len(parts) {
+				return false
+			}
+			for ; i < len(parts); i++ {
+				if !intlIsAlnumRange(parts[i], 1, 8) {
+					return false
+				}
+			}
+			return true
+		case 'u':
+			// unicode_locale_extensions = [uU] ((sep keyword)+ | (sep attribute)+ (sep keyword)*)
+			// attribute = alphanum{3,8}; keyword = key (sep type)?; key = alphanum alpha; type = alphanum{3,8}+
+			start := i
+			for i < len(parts) && intlIsAlnumRange(parts[i], 3, 8) {
+				i++
+			}
+			for i < len(parts) && len(parts[i]) == 2 && intlIsAlnum(parts[i][0]) && intlIsAlpha(parts[i][1]) {
+				i++
+				for i < len(parts) && intlIsAlnumRange(parts[i], 3, 8) {
+					i++
+				}
+			}
+			if i == start {
+				return false
+			}
+		case 't':
+			// transformed_extensions = [tT] ((sep tlang (sep tfield)*) | (sep tfield)+)
+			// tfield = tkey tvalue; tkey = alpha digit; tvalue = (sep alphanum{3,8})+
+			start := i
+			if i < len(parts) && intlIsLanguageSubtag(parts[i]) {
+				n, ok := intlParseLanguageID(parts, i)
+				if !ok {
+					return false
+				}
+				i = n
+			}
+			for i < len(parts) && len(parts[i]) == 2 && intlIsAlpha(parts[i][0]) && intlIsDigit(parts[i][1]) {
+				i++
+				vs := i
+				for i < len(parts) && intlIsAlnumRange(parts[i], 3, 8) {
+					i++
+				}
+				if i == vs {
+					return false
+				}
+			}
+			if i == start {
+				return false
+			}
+		default:
+			// other_extensions = [alphanum-[tTuUxX]] (sep alphanum{2,8})+
+			start := i
+			for i < len(parts) && intlIsAlnumRange(parts[i], 2, 8) {
+				i++
+			}
+			if i == start {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ---- Canonicalization ----
+
+// Deprecated ISO 639-1 codes and their CLDR replacements - the aliases real
+// code and the ECMA-402 tests most commonly exercise. Not the full CLDR
+// languageAlias table (see the file comment).
+var intlLanguageAliases = map[string]string{
+	"iw":  "he",
+	"in":  "id",
+	"ji":  "yi",
+	"jw":  "jv",
+	"mo":  "ro",
+	"tl":  "fil",
+	"sh":  "sr-Latn",
+	"cmn": "zh",
+}
+
+// Regular grandfathered BCP 47 tags that are structurally valid unicode_locale_ids
+// (language + variant) and have a CLDR replacement.
+var intlGrandfatheredAliases = map[string]string{
+	"art-lojban":  "jbo",
+	"cel-gaulish": "xtg",
+	"zh-guoyu":    "zh",
+	"zh-hakka":    "hak",
+	"zh-xiang":    "hsn",
+}
+
+func intlTitleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + strings.ToLower(s[1:])
+}
+
+// intlCanonicalizeUnicodeLocaleID implements the casing/ordering part of UTS
+// #35's canonical Unicode locale identifier: lowercase language, titlecase
+// script, uppercase region, variants sorted, extensions ordered by
+// singleton with private use last, -u- attributes/keywords sorted and "true"
+// types dropped, -t- fields sorted by key, plus the language aliases above.
+// The tag must already be structurally valid.
+func intlCanonicalizeUnicodeLocaleID(tag string) string {
+	parts := strings.Split(strings.ToLower(tag), "-")
+	n := len(parts)
+	i := 0
+
+	lang := parts[i]
+	i++
+	script, region := "", ""
+	if i < n && intlIsScriptSubtag(parts[i]) {
+		script = intlTitleCase(parts[i])
+		i++
+	}
+	if i < n && intlIsRegionSubtag(parts[i]) {
+		region = strings.ToUpper(parts[i])
+		i++
+	}
+	var variants []string
+	for i < n && intlIsVariantSubtag(parts[i]) {
+		variants = append(variants, parts[i])
+		i++
+	}
+	sort.Strings(variants)
+
+	// Regular grandfathered tags (language + variant) that CLDR maps to a
+	// plain language subtag, e.g. art-lojban -> jbo.
+	if len(variants) == 1 {
+		if alias, ok := intlGrandfatheredAliases[lang+"-"+variants[0]]; ok {
+			lang = alias
+			variants = nil
+		}
+	}
+	// ISO 639-2/3 codes whose language has an ISO 639-1 code canonicalize to
+	// the two-letter form (heb -> he, ces -> cs); x/text's tables know these.
+	if len(lang) == 3 {
+		if base, err := language.ParseBase(lang); err == nil {
+			if short := base.String(); len(short) == 2 {
+				lang = short
+			}
+		}
+	}
+	if alias, ok := intlLanguageAliases[lang]; ok {
+		ap := strings.Split(alias, "-")
+		lang = ap[0]
+		if len(ap) > 1 && script == "" {
+			script = ap[1]
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(lang)
+	if script != "" {
+		sb.WriteByte('-')
+		sb.WriteString(script)
+	}
+	if region != "" {
+		sb.WriteByte('-')
+		sb.WriteString(region)
+	}
+	for _, v := range variants {
+		sb.WriteByte('-')
+		sb.WriteString(v)
+	}
+
+	type extension struct {
+		singleton byte
+		body      []string
+	}
+	var exts []extension
+	var privateUse []string
+	for i < n {
+		s := parts[i][0]
+		i++
+		if s == 'x' {
+			privateUse = parts[i:]
+			break
+		}
+		start := i
+		for i < n && len(parts[i]) != 1 {
+			i++
+		}
+		exts = append(exts, extension{singleton: s, body: parts[start:i]})
+	}
+	sort.SliceStable(exts, func(a, b int) bool { return exts[a].singleton < exts[b].singleton })
+	for _, e := range exts {
+		body := e.body
+		switch e.singleton {
+		case 'u':
+			body = intlCanonicalizeUnicodeExtension(body)
+		case 't':
+			body = intlCanonicalizeTransformedExtension(body)
+		}
+		sb.WriteByte('-')
+		sb.WriteByte(e.singleton)
+		for _, b := range body {
+			sb.WriteByte('-')
+			sb.WriteString(b)
+		}
+	}
+	if privateUse != nil {
+		sb.WriteString("-x")
+		for _, b := range privateUse {
+			sb.WriteByte('-')
+			sb.WriteString(b)
+		}
+	}
+	return sb.String()
+}
+
+// intlCanonicalizeUnicodeExtension sorts and dedupes the attributes, sorts
+// the keywords by key keeping the first occurrence of a duplicate key, and
+// drops the type "true" (UTS #35: a keyword with type "true" is canonically
+// just the key).
+func intlCanonicalizeUnicodeExtension(body []string) []string {
+	i := 0
+	var attrs []string
+	for i < len(body) && len(body[i]) != 2 {
+		attrs = append(attrs, body[i])
+		i++
+	}
+	sort.Strings(attrs)
+	attrs = intlDedupeSorted(attrs)
+
+	type keyword struct {
+		key   string
+		types []string
+	}
+	var keywords []keyword
+	seenKey := map[string]bool{}
+	for i < len(body) {
+		kw := keyword{key: body[i]}
+		i++
+		for i < len(body) && len(body[i]) != 2 {
+			kw.types = append(kw.types, body[i])
+			i++
+		}
+		if seenKey[kw.key] {
+			continue
+		}
+		seenKey[kw.key] = true
+		if len(kw.types) == 1 && kw.types[0] == "true" {
+			kw.types = nil
+		}
+		keywords = append(keywords, kw)
+	}
+	sort.SliceStable(keywords, func(a, b int) bool { return keywords[a].key < keywords[b].key })
+
+	out := attrs
+	for _, kw := range keywords {
+		out = append(out, kw.key)
+		out = append(out, kw.types...)
+	}
+	return out
+}
+
+// intlCanonicalizeTransformedExtension keeps the tlang (already lowercase,
+// which is its canonical form) and sorts the tfields by tkey.
+func intlCanonicalizeTransformedExtension(body []string) []string {
+	i := 0
+	var out []string
+	if i < len(body) && intlIsLanguageSubtag(body[i]) {
+		n, _ := intlParseLanguageID(body, i)
+		tlang := body[i:n]
+		variants := []string(nil)
+		// Sort the tlang's variants like the main language id's.
+		j := 1
+		if j < len(tlang) && intlIsScriptSubtag(tlang[j]) {
+			j++
+		}
+		if j < len(tlang) && intlIsRegionSubtag(tlang[j]) {
+			j++
+		}
+		variants = append(variants, tlang[j:]...)
+		sort.Strings(variants)
+		out = append(out, tlang[:j]...)
+		out = append(out, variants...)
+		i = n
+	}
+	type field struct {
+		key    string
+		values []string
+	}
+	var fields []field
+	for i < len(body) {
+		f := field{key: body[i]}
+		i++
+		for i < len(body) && len(body[i]) != 2 {
+			f.values = append(f.values, body[i])
+			i++
+		}
+		fields = append(fields, f)
+	}
+	sort.SliceStable(fields, func(a, b int) bool { return fields[a].key < fields[b].key })
+	for _, f := range fields {
+		out = append(out, f.key)
+		out = append(out, f.values...)
+	}
+	return out
+}
+
+func intlDedupeSorted(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	out := s[:1]
+	for _, v := range s[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// ---- Abstract operations over VM values ----
+
+// intlAbrupt is the tail of every Intl native's error path. The conversion
+// helpers (getStringValueWithVM, toNumberWithVM, toLengthWithVM, ...) report
+// a JS exception thrown inside ToPrimitive as ErrVMUnwinding: the VM is
+// already unwinding towards the handler, so the native must return normally
+// rather than surface the sentinel as a second, bogus "VM unwinding" Error.
+// Every other error (TypeError/RangeError values, errors from Call/GetProperty)
+// is returned as-is.
+func intlAbrupt(err error) (vm.Value, error) {
+	if err == ErrVMUnwinding {
+		return vm.Undefined, nil
+	}
+	return vm.Undefined, err
+}
+
+// intlArg returns args[i] or undefined.
+func intlArg(args []vm.Value, i int) vm.Value {
+	if i < len(args) {
+		return args[i]
+	}
+	return vm.Undefined
+}
+
+// intlCanonicalizeLocaleList implements ECMA-402 CanonicalizeLocaleList:
+// undefined -> empty; a string -> a one-element list; otherwise ToObject the
+// argument and walk it array-like, requiring each present element to be a
+// String or Object, structurally valid, and canonicalizing + deduplicating.
+// (Intl.Locale objects are not implemented, so objects go through ToString.)
+func intlCanonicalizeLocaleList(vmInstance *vm.VM, locales vm.Value) ([]string, error) {
+	if locales.Type() == vm.TypeUndefined {
+		return nil, nil
+	}
+	var obj vm.Value
+	if locales.Type() == vm.TypeString {
+		obj = vm.NewArrayWithArgs([]vm.Value{locales})
+	} else {
+		o, err := vmInstance.ToObject(locales)
+		if err != nil {
+			return nil, err
+		}
+		obj = o
+	}
+	lenVal, err := vmInstance.GetProperty(obj, "length")
+	if err != nil {
+		return nil, err
+	}
+	length, err := toLengthWithVM(vmInstance, lenVal)
+	if err != nil {
+		return nil, err
+	}
+	var seen []string
+	for k := 0; k < length; k++ {
+		kValue, present, err := arrayLikeGet(vmInstance, obj, k)
+		if err != nil {
+			return nil, err
+		}
+		if !present {
+			continue
+		}
+		if kValue.Type() != vm.TypeString && !kValue.IsObject() && !kValue.IsCallable() {
+			return nil, vmInstance.NewTypeError("Language ID should be string or object.")
+		}
+		tag, err := getStringValueWithVM(vmInstance, kValue)
+		if err != nil {
+			return nil, err
+		}
+		if !intlIsStructurallyValidLanguageTag(tag) {
+			return nil, vmInstance.NewRangeError(fmt.Sprintf("Incorrect locale information provided: %q", tag))
+		}
+		canonical := intlCanonicalizeUnicodeLocaleID(tag)
+		dup := false
+		for _, s := range seen {
+			if s == canonical {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			seen = append(seen, canonical)
+		}
+	}
+	return seen, nil
+}
+
+// intlStringList turns a Go string slice into a fresh, mutable JS Array -
+// CreateArrayFromList.
+func intlStringList(vmInstance *vm.VM, list []string) vm.Value {
+	elems := make([]vm.Value, len(list))
+	for i, s := range list {
+		elems[i] = vm.NewString(s)
+	}
+	return vmInstance.NewArrayFromSlice(elems)
+}
+
+// intlGetOptionsObject implements ECMA-402 GetOptionsObject (used by the
+// constructors): undefined -> a null-prototype object, an Object -> itself,
+// anything else -> TypeError.
+func intlGetOptionsObject(vmInstance *vm.VM, options vm.Value) (vm.Value, error) {
+	if options.Type() == vm.TypeUndefined {
+		return vm.NewObject(vm.Null), nil
+	}
+	if options.IsObject() || options.IsCallable() {
+		return options, nil
+	}
+	return vm.Undefined, vmInstance.NewTypeError("Options must be an object or undefined")
+}
+
+// intlCoerceOptionsToObject implements ECMA-402 CoerceOptionsToObject (used
+// by supportedLocalesOf): undefined -> a null-prototype object, otherwise
+// ToObject.
+func intlCoerceOptionsToObject(vmInstance *vm.VM, options vm.Value) (vm.Value, error) {
+	if options.Type() == vm.TypeUndefined {
+		return vm.NewObject(vm.Null), nil
+	}
+	return vmInstance.ToObject(options)
+}
+
+// intlGetStringOption implements ECMA-402 GetOption for a "string" option:
+// Get the property, fall back when undefined, ToString it (an abrupt
+// toString or a Symbol propagates as the error it is), and range-check it
+// against allowed when allowed is non-nil.
+func intlGetStringOption(vmInstance *vm.VM, options vm.Value, property, owner string, allowed []string, fallback string) (string, error) {
+	value, err := vmInstance.GetProperty(options, property)
+	if err != nil {
+		return "", err
+	}
+	if value.Type() == vm.TypeUndefined {
+		return fallback, nil
+	}
+	s, err := getStringValueWithVM(vmInstance, value)
+	if err != nil {
+		return "", err
+	}
+	if allowed != nil {
+		ok := false
+		for _, a := range allowed {
+			if a == s {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return "", vmInstance.NewRangeError(fmt.Sprintf("Value %s out of range for %s options property %s", s, owner, property))
+		}
+	}
+	return s, nil
+}
+
+var intlLocaleMatchers = []string{"lookup", "best fit"}
+
+// ---- Default locale and lookup matching ----
+
+var (
+	intlDefaultLocaleOnce  sync.Once
+	intlDefaultLocaleValue string
+)
+
+// intlDefaultLocale implements DefaultLocale: the host's preferred locale,
+// taken from the POSIX locale environment (LC_ALL, LC_MESSAGES, LANG - e.g.
+// "en_US.UTF-8" -> "en-US") when it names an available locale, and "en-US"
+// otherwise (including the "C"/"POSIX" locales). Computed once per process.
+func intlDefaultLocale() string {
+	intlDefaultLocaleOnce.Do(func() {
+		intlDefaultLocaleValue = "en-US"
+		for _, key := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+			v := os.Getenv(key)
+			if v == "" {
+				continue
+			}
+			if i := strings.IndexAny(v, ".@"); i >= 0 {
+				v = v[:i]
+			}
+			v = strings.ReplaceAll(v, "_", "-")
+			if intlIsStructurallyValidLanguageTag(v) {
+				canonical := intlCanonicalizeUnicodeLocaleID(v)
+				if available, ok := intlBestAvailableLocale(intlRemoveUnicodeExtensions(canonical)); ok {
+					intlDefaultLocaleValue = available
+				}
+			}
+			break
+		}
+	})
+	return intlDefaultLocaleValue
+}
+
+// intlIsAvailableLocale is the stand-in for an Intl constructor's
+// [[AvailableLocales]]: a canonical language(-Script)?(-REGION)? tag whose
+// language subtag is a known ISO 639 code other than the "no language"
+// placeholders. Variants, extensions and private use never match, so the
+// lookup matcher truncates them off exactly as an ICU-backed engine would.
+func intlIsAvailableLocale(locale string) bool {
+	parts := strings.Split(locale, "-")
+	if len(parts) > 3 {
+		return false
+	}
+	switch parts[0] {
+	case "und", "zxx", "mul", "mis":
+		return false
+	}
+	if _, err := language.ParseBase(parts[0]); err != nil {
+		return false
+	}
+	i := 1
+	if i < len(parts) && intlIsScriptSubtag(parts[i]) {
+		i++
+	}
+	if i < len(parts) && intlIsRegionSubtag(parts[i]) {
+		i++
+	}
+	return i == len(parts)
+}
+
+// intlBestAvailableLocale implements BestAvailableLocale: try the locale,
+// then successively drop its trailing subtag (skipping over a lone
+// singleton) until an available locale is found.
+func intlBestAvailableLocale(locale string) (string, bool) {
+	candidate := locale
+	for {
+		if intlIsAvailableLocale(candidate) {
+			return candidate, true
+		}
+		pos := strings.LastIndexByte(candidate, '-')
+		if pos < 0 {
+			return "", false
+		}
+		if pos >= 2 && candidate[pos-2] == '-' {
+			pos -= 2
+		}
+		candidate = candidate[:pos]
+	}
+}
+
+// intlRemoveUnicodeExtensions strips the -u- extension sequence from a
+// canonical tag (the "noExtensionsLocale" of LookupMatcher).
+func intlRemoveUnicodeExtensions(locale string) string {
+	parts := strings.Split(locale, "-")
+	out := make([]string, 0, len(parts))
+	skipping := false
+	for _, p := range parts {
+		if len(p) == 1 {
+			skipping = p == "u"
+		}
+		if !skipping {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, "-")
+}
+
+// intlLookupMatcher implements LookupMatcher for a constructor with no
+// relevant extension keys: the first requested locale (minus extensions)
+// that has an available prefix wins, else the default locale. (BestFitMatcher
+// is implementation-defined; this engine uses the same algorithm.)
+func intlLookupMatcher(requested []string) string {
+	for _, locale := range requested {
+		if available, ok := intlBestAvailableLocale(intlRemoveUnicodeExtensions(locale)); ok {
+			return available
+		}
+	}
+	return intlDefaultLocale()
+}
+
+// intlLookupSupportedLocales implements LookupSupportedLocales: the
+// requested locales (extensions intact) that have an available prefix.
+func intlLookupSupportedLocales(requested []string) []string {
+	var out []string
+	for _, locale := range requested {
+		if _, ok := intlBestAvailableLocale(intlRemoveUnicodeExtensions(locale)); ok {
+			out = append(out, locale)
+		}
+	}
+	return out
+}
+
+// intlSupportedLocalesOf implements the shared body of every
+// Intl.<Constructor>.supportedLocalesOf(locales, options).
+func intlSupportedLocalesOf(vmInstance *vm.VM, owner string, locales, options vm.Value) (vm.Value, error) {
+	requested, err := intlCanonicalizeLocaleList(vmInstance, locales)
+	if err != nil {
+		return vm.Undefined, err
+	}
+	optionsObj, err := intlCoerceOptionsToObject(vmInstance, options)
+	if err != nil {
+		return vm.Undefined, err
+	}
+	if _, err := intlGetStringOption(vmInstance, optionsObj, "localeMatcher", owner, intlLocaleMatchers, "best fit"); err != nil {
+		return vm.Undefined, err
+	}
+	return intlStringList(vmInstance, intlLookupSupportedLocales(requested)), nil
+}

--- a/pkg/builtins/intl_locale_test.go
+++ b/pkg/builtins/intl_locale_test.go
@@ -1,0 +1,126 @@
+package builtins
+
+import "testing"
+
+// The invalid tags are test262/harness/testIntl.js's getInvalidLanguageTags
+// list; each must be rejected by IsStructurallyValidLanguageTag.
+func TestIntlStructurallyInvalidLanguageTags(t *testing.T) {
+	invalid := []string{
+		"", "i", "x", "u", "419", "u-nu-latn-cu-bob", "hans-cmn-cn", "abcdefghi",
+		"cmn-hans-cn-u-u", "cmn-hans-cn-t-u-ca-u", "de-gregory-gregory", "*", "de-*",
+		"中文", "en-ß", "ıd", "es-Latn-latn", "pl-PL-pl", "u-ca-gregory", "de-1996-1996",
+		"pt-u-ca-gregory-u-nu-latn",
+		"no-nyn", "i-klingon", "zh-hak-CN", "sgn-ils", "x-foo", "x-en-US-12345",
+		"x-12345-12345-en-US", "x-en-US-12345-12345", "x-en-u-foo", "x-en-u-foo-u-bar", "x-u-foo",
+		"de_DE", "DE_de", "cmn_Hans", "cmn-hans_cn", "es_419", "es-419-u-nu-latn-cu_bob",
+		"i_klingon", "cmn-hans-cn-t-ca-u-ca-x_t-u", "enochian_enochian", "de-gregory_u-ca-gregory",
+		"en\x00", " en", "en ", "it-IT-Latn", "de-u", "de-u-", "de-u-ca-", "de-u-ca-gregory-",
+		"si-x", "x-", "x-y-", "en-GB-oed", "x-private", "root",
+	}
+	for _, tag := range invalid {
+		if intlIsStructurallyValidLanguageTag(tag) {
+			t.Errorf("%q should be structurally invalid", tag)
+		}
+	}
+}
+
+func TestIntlStructurallyValidLanguageTags(t *testing.T) {
+	valid := []string{
+		"en", "EN", "en-US", "en-us", "sr-Thai-RS", "zh-CN", "und", "zxx", "xyz",
+		"en-u-ca-gregory", "en-US-u-nu-latn", "cmn-Hans-CN", "sl-rozaj-biske-1994",
+		"en-a-bbb-x-a-ccc", "de-x-abc", "en-Latn", "zh-hans-cn-t-zh-hant-tw",
+		"en-u-foo-bar-nu-thai-ca-buddhist-kk-true", "de-DE-u-co-phonebk", "en-US-x-twain",
+		"en-t-k0-dvorak", "en-u-attr", "de-1996", "es-419", "abcdefgh", "en-0-abc", "en-u-nu",
+	}
+	for _, tag := range valid {
+		if !intlIsStructurallyValidLanguageTag(tag) {
+			t.Errorf("%q should be structurally valid", tag)
+		}
+	}
+}
+
+func TestIntlCanonicalizeUnicodeLocaleID(t *testing.T) {
+	cases := map[string]string{
+		"EN":                                "en",
+		"en-us":                             "en-US",
+		"EN-LATN-us":                        "en-Latn-US",
+		"sr-thai-rs":                        "sr-Thai-RS",
+		"iw":                                "he",
+		"in-ID":                             "id-ID",
+		"sh":                                "sr-Latn",
+		"sh-Cyrl":                           "sr-Cyrl",
+		"sl-1994-rozaj-biske":               "sl-1994-biske-rozaj",
+		"en-u-foo-bar-nu-thai-ca-buddhist":  "en-u-bar-foo-ca-buddhist-nu-thai",
+		"en-u-kk-true":                      "en-u-kk",
+		"en-u-ca-gregory-ca-islamic":        "en-u-ca-gregory",
+		"en-x-Twain-U":                      "en-x-twain-u",
+		"en-t-k0-dvorak-h0-hybrid":          "en-t-h0-hybrid-k0-dvorak",
+		"en-t-ZH-HANT-TW":                   "en-t-zh-hant-tw",
+		"en-Z-abc-A-def-U-ca-gregory-x-foo": "en-a-def-u-ca-gregory-z-abc-x-foo",
+		"de-u-co-phonebk-x-PRIV":            "de-u-co-phonebk-x-priv",
+	}
+	for in, want := range cases {
+		if !intlIsStructurallyValidLanguageTag(in) {
+			t.Errorf("%q unexpectedly invalid", in)
+			continue
+		}
+		if got := intlCanonicalizeUnicodeLocaleID(in); got != want {
+			t.Errorf("canonicalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIntlLookupMatcher(t *testing.T) {
+	cases := []struct {
+		requested []string
+		want      string
+	}{
+		{[]string{"en-US"}, "en-US"},
+		{[]string{"xyz", "ar"}, "ar"},
+		{[]string{"en-US-u-nu-latn"}, "en-US"},
+		{[]string{"en-US-x-twain"}, "en-US"},
+		{[]string{"sl-rozaj-biske-1994"}, "sl"},
+		{[]string{"sr-Thai-RS"}, "sr-Thai-RS"},
+		{[]string{"zxx"}, intlDefaultLocale()},
+		{nil, intlDefaultLocale()},
+	}
+	for _, c := range cases {
+		if got := intlLookupMatcher(c.requested); got != c.want {
+			t.Errorf("lookup(%v) = %q, want %q", c.requested, got, c.want)
+		}
+	}
+	if got := intlLookupSupportedLocales([]string{"sr-Thai-RS", "zxx", "de", "en-u-nu-latn", "xyz"}); len(got) != 3 ||
+		got[0] != "sr-Thai-RS" || got[1] != "de" || got[2] != "en-u-nu-latn" {
+		t.Errorf("supported = %v", got)
+	}
+}
+
+func TestIntlNormalizeWTF8(t *testing.T) {
+	// A surrogate pair spelled as two WTF-8 surrogates (ED A0 80 ED B0 80)
+	// is joined into the 4-byte UTF-8 form of U+10000; a lone surrogate stays.
+	if got := intlNormalizeWTF8("\xed\xa0\x80\xed\xb0\x80"); got != "\U00010000" {
+		t.Errorf("normalize(pair) = %q", got)
+	}
+	if got := intlNormalizeWTF8("a\xed\xa0\x80b"); got != "a\xed\xa0\x80b" {
+		t.Errorf("normalize(lone) = %q", got)
+	}
+	if s := "plain 😀 ퟿"; intlNormalizeWTF8(s) != s {
+		t.Errorf("normalize changed valid UTF-8")
+	}
+}
+
+func TestIntlSanitizeWTF8(t *testing.T) {
+	// U+D800 lone lead surrogate in WTF-8 is ED A0 80.
+	in := "a\xed\xa0\x80b"
+	got := intlSanitizeWTF8(in, intlSurrogateStandInOther)
+	if got != "a�b" || len(got) != len(in) {
+		t.Errorf("sanitize = %q", got)
+	}
+	// Valid UTF-8 (including U+D7FF = ED 9F BF, the last pre-surrogate code
+	// point, and 4-byte astral characters) is returned untouched.
+	for _, s := range []string{"plain", "퟿", "😀", "é"} {
+		if intlSanitizeWTF8(s, intlSurrogateStandInOther) != s {
+			t.Errorf("sanitize(%q) changed valid UTF-8", s)
+		}
+	}
+}

--- a/pkg/builtins/intl_segmenter.go
+++ b/pkg/builtins/intl_segmenter.go
@@ -1,0 +1,383 @@
+package builtins
+
+import (
+	"math"
+	"sort"
+	"unicode"
+
+	"github.com/rivo/uniseg"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// Intl.Segmenter (ECMA-402 §18) over UAX #29 default text segmentation, via
+// rivo/uniseg. This is what #210's real consumer (pi-tui's terminal string
+// measuring/wrapping) needs: default-locale grapheme and word boundaries,
+// walked through segment(str) / for-of / containing(index).
+//
+// Segmentation is locale-independent here - UAX #29's default rules with no
+// locale tailoring and no dictionary-based word breaking (Thai, Lao, Khmer
+// and CJK text therefore break per character for "word", where ICU would
+// consult a dictionary). isWordLike is "the segment contains a letter or a
+// number", the observable effect of ICU's rule-status classes.
+//
+// Strings are canonical WTF-8 in the VM (see pkg/wtf8: a surrogate pair is
+// always one 4-byte sequence), but a lone surrogate is a 3-byte sequence
+// uniseg would split byte-by-byte. So the input is normalized once more as a
+// cheap safety net (a no-op for canonical strings), then each lone surrogate
+// is swapped for a same-width stand-in with the surrogate's break properties
+// (see intlSanitizeWTF8). Byte offsets from uniseg therefore map 1:1 onto the
+// normalized text, which is what segments are sliced from.
+
+type intlGranularity uint8
+
+const (
+	intlGranularityGrapheme intlGranularity = iota
+	intlGranularityWord
+	intlGranularitySentence
+)
+
+func (g intlGranularity) String() string {
+	switch g {
+	case intlGranularityWord:
+		return "word"
+	case intlGranularitySentence:
+		return "sentence"
+	default:
+		return "grapheme"
+	}
+}
+
+var intlGranularityNames = []string{"grapheme", "word", "sentence"}
+
+// intlSegmenter is an Intl.Segmenter instance's internal slots
+// ([[Locale]], [[SegmenterGranularity]]).
+type intlSegmenter struct {
+	locale      string
+	granularity intlGranularity
+}
+
+// intlSegmentRun is one segment: byte offsets into the original string plus
+// its UTF-16 start index (what JS observes) and, for "word", word-likeness.
+type intlSegmentRun struct {
+	start, end int
+	u16Start   int
+	wordLike   bool
+}
+
+// intlSegments is a Segments instance's internal slots ([[SegmentsSegmenter]],
+// [[SegmentsString]]). The string is immutable, so its full segmentation is
+// computed once, lazily, and shared by every iterator and containing() call -
+// equivalent to the spec's FindBoundary-from-the-start on every step, minus
+// the quadratic cost.
+type intlSegments struct {
+	segmenter *intlSegmenter
+	input     string // as passed to segment(): the `input` property of every segment
+	text      string // input with WTF-8 surrogate pairs joined; runs index into this
+	runs      []intlSegmentRun
+	computed  bool
+}
+
+// intlSegmentIterator is a Segment Iterator's internal slots
+// ([[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]]).
+type intlSegmentIterator struct {
+	segments *intlSegments
+	pos      int
+}
+
+// Same-width stand-ins for WTF-8 lone surrogates (both 3 bytes, like the
+// surrogate encoding). Surrogates have Grapheme_Cluster_Break=Control (so a
+// following mark does not attach), and Word_Break / Sentence_Break = Other.
+const (
+	intlSurrogateStandInGrapheme = "​" // ZERO WIDTH SPACE: GCB=Control
+	intlSurrogateStandInOther    = "�" // REPLACEMENT CHARACTER: WB=Other, SB=Other
+)
+
+// intlHasWTF8Surrogate reports whether s contains a WTF-8 encoded surrogate
+// (ED A0..BF xx - a byte pattern valid UTF-8 never produces).
+func intlHasWTF8Surrogate(s string) bool {
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] == 0xED && s[i+1] >= 0xA0 && s[i+1] <= 0xBF {
+			return true
+		}
+	}
+	return false
+}
+
+// intlNormalizeWTF8 joins adjacent WTF-8 lead+trail surrogates into the
+// 4-byte UTF-8 character they denote, leaving lone surrogates as WTF-8. The
+// UTF-16 view is unchanged, so the result is the same JS string. Returns s
+// itself when it holds no surrogate bytes at all.
+func intlNormalizeWTF8(s string) string {
+	if !intlHasWTF8Surrogate(s) {
+		return s
+	}
+	return vm.UTF16ToString(vm.StringToUTF16(s))
+}
+
+// intlSanitizeWTF8 replaces every WTF-8 encoded lone surrogate with
+// replacement, which must be exactly three bytes so offsets are preserved.
+// Returns s itself when there is nothing to replace.
+func intlSanitizeWTF8(s string, replacement string) string {
+	var b []byte
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] == 0xED && s[i+1] >= 0xA0 && s[i+1] <= 0xBF && s[i+2] >= 0x80 && s[i+2] <= 0xBF {
+			if b == nil {
+				b = []byte(s)
+			}
+			copy(b[i:i+3], replacement)
+			i += 2
+		}
+	}
+	if b == nil {
+		return s
+	}
+	return string(b)
+}
+
+func intlIsWordLike(segment string) bool {
+	for _, r := range segment {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *intlSegments) ensureRuns() {
+	if s.computed {
+		return
+	}
+	s.computed = true
+	granularity := s.segmenter.granularity
+	standIn := intlSurrogateStandInOther
+	if granularity == intlGranularityGrapheme {
+		standIn = intlSurrogateStandInGrapheme
+	}
+	s.text = intlNormalizeWTF8(s.input)
+	text := intlSanitizeWTF8(s.text, standIn)
+
+	state := -1
+	offset := 0
+	rest := text
+	for len(rest) > 0 {
+		var segment string
+		switch granularity {
+		case intlGranularityWord:
+			segment, rest, state = uniseg.FirstWordInString(rest, state)
+		case intlGranularitySentence:
+			segment, rest, state = uniseg.FirstSentenceInString(rest, state)
+		default:
+			segment, rest, _, state = uniseg.FirstGraphemeClusterInString(rest, state)
+		}
+		if len(segment) == 0 { // defensive: never spin on a zero-width step
+			break
+		}
+		end := offset + len(segment)
+		run := intlSegmentRun{start: offset, end: end, u16Start: vm.ByteToUTF16Offset(s.text, offset)}
+		if granularity == intlGranularityWord {
+			run.wordLike = intlIsWordLike(s.text[offset:end])
+		}
+		s.runs = append(s.runs, run)
+		offset = end
+	}
+}
+
+// dataObject implements CreateSegmentDataObject for run i: a fresh ordinary
+// object with segment, index, input and - for word granularity - isWordLike,
+// in that order.
+func (s *intlSegments) dataObject(vmInstance *vm.VM, i int) vm.Value {
+	run := s.runs[i]
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	obj.SetOwn("segment", vm.NewString(s.text[run.start:run.end]))
+	obj.SetOwn("index", vm.NumberValue(float64(run.u16Start)))
+	obj.SetOwn("input", vm.NewString(s.input))
+	if s.segmenter.granularity == intlGranularityWord {
+		obj.SetOwn("isWordLike", vm.BooleanValue(run.wordLike))
+	}
+	return vm.NewValueFromPlainObject(obj)
+}
+
+// containing implements the core of %SegmentsPrototype%.containing: the
+// segment whose UTF-16 span covers code unit index n, or undefined when n is
+// out of range.
+func (s *intlSegments) containing(vmInstance *vm.VM, n float64) vm.Value {
+	if n < 0 || n >= float64(vm.UTF16Length(s.input)) {
+		return vm.Undefined
+	}
+	s.ensureRuns()
+	idx := int(n)
+	i := sort.Search(len(s.runs), func(i int) bool { return s.runs[i].u16Start > idx }) - 1
+	if i < 0 {
+		return vm.Undefined
+	}
+	return s.dataObject(vmInstance, i)
+}
+
+func intlSlotsOf(v vm.Value) any {
+	if v.Type() != vm.TypeObject {
+		return nil
+	}
+	return v.AsPlainObject().InternalSlots()
+}
+
+func intlIterResult(vmInstance *vm.VM, value vm.Value, done bool) vm.Value {
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	obj.SetOwn("value", value)
+	obj.SetOwn("done", vm.BooleanValue(done))
+	return vm.NewValueFromPlainObject(obj)
+}
+
+func intlDefineToStringTag(vmInstance *vm.VM, obj *vm.PlainObject, tag string) {
+	if vmInstance.SymbolToStringTag.Type() != vm.TypeSymbol {
+		return
+	}
+	writable, enumerable, configurable := false, false, true
+	obj.DefineOwnPropertyByKey(vm.NewSymbolKey(vmInstance.SymbolToStringTag), vm.NewString(tag),
+		&writable, &enumerable, &configurable)
+}
+
+// installIntlSegmenter builds Intl.Segmenter, %Segmenter.prototype%,
+// %SegmentsPrototype% and %SegmentIteratorPrototype% and installs the
+// constructor on the Intl object.
+func installIntlSegmenter(vmInstance *vm.VM, intlObj *vm.PlainObject) {
+	segmenterProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	segmenterProtoVal := vm.NewValueFromPlainObject(segmenterProto)
+	segmentsProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	segmentsProtoVal := vm.NewValueFromPlainObject(segmentsProto)
+	iteratorProto := vm.NewObject(vmInstance.IteratorPrototype).AsPlainObject()
+	iteratorProtoVal := vm.NewValueFromPlainObject(iteratorProto)
+
+	// Register the realm intrinsic so GetPrototypeFromConstructor can fall
+	// back to the *constructor's* realm's prototype for cross-realm
+	// Reflect.construct, like every other builtin prototype.
+	vmInstance.IntlSegmenterPrototype = segmenterProtoVal
+
+	// ---- Intl.Segmenter(locales, options) ----
+	ctor := vm.NewConstructorWithProps(0, false, "Segmenter", func(args []vm.Value) (vm.Value, error) {
+		newTarget := vmInstance.GetNewTarget()
+		if newTarget.IsUndefined() {
+			return vm.Undefined, vmInstance.NewTypeError("Constructor Intl.Segmenter requires 'new'")
+		}
+		requested, err := intlCanonicalizeLocaleList(vmInstance, intlArg(args, 0))
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		options, err := intlGetOptionsObject(vmInstance, intlArg(args, 1))
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		// Options are read in spec order: localeMatcher, then (after
+		// ResolveLocale) granularity. lineBreakStyle is not an option.
+		if _, err := intlGetStringOption(vmInstance, options, "localeMatcher", "Intl.Segmenter", intlLocaleMatchers, "best fit"); err != nil {
+			return intlAbrupt(err)
+		}
+		locale := intlLookupMatcher(requested)
+		granularityName, err := intlGetStringOption(vmInstance, options, "granularity", "Intl.Segmenter", intlGranularityNames, "grapheme")
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		granularity := intlGranularityGrapheme
+		for i, name := range intlGranularityNames {
+			if name == granularityName {
+				granularity = intlGranularity(i)
+			}
+		}
+
+		// OrdinaryCreateFromConstructor(NewTarget, "%Intl.Segmenter.prototype%"):
+		// a throwing "prototype" getter propagates; a non-object falls back
+		// to newTarget's realm's %Intl.Segmenter.prototype%.
+		proto, err := vmInstance.GetPrototypeFromConstructor(newTarget, "%Intl.Segmenter.prototype%")
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		obj := vm.NewObject(proto).AsPlainObject()
+		obj.SetInternalSlots(&intlSegmenter{locale: locale, granularity: granularity})
+		return vm.NewValueFromPlainObject(obj), nil
+	})
+	ctorProps := ctor.AsNativeFunctionWithProps().Properties
+	ctorProps.DefineFixedProperty("prototype", segmenterProtoVal)
+	ctorProps.SetOwnNonEnumerable("supportedLocalesOf", vm.NewNativeFunction(1, false, "supportedLocalesOf", func(args []vm.Value) (vm.Value, error) {
+		return intlSupportedLocalesOf(vmInstance, "Intl.Segmenter", intlArg(args, 0), intlArg(args, 1))
+	}))
+
+	// ---- %Segmenter.prototype% ----
+	segmenterProto.SetOwnNonEnumerable("constructor", ctor)
+	intlDefineToStringTag(vmInstance, segmenterProto, "Intl.Segmenter")
+
+	segmenterProto.SetOwnNonEnumerable("segment", vm.NewNativeFunction(1, false, "segment", func(args []vm.Value) (vm.Value, error) {
+		segmenter, ok := intlSlotsOf(vmInstance.GetThis()).(*intlSegmenter)
+		if !ok {
+			return vm.Undefined, vmInstance.NewTypeError("Method Intl.Segmenter.prototype.segment called on incompatible receiver")
+		}
+		input, err := getStringValueWithVM(vmInstance, intlArg(args, 0))
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		obj := vm.NewObject(segmentsProtoVal).AsPlainObject()
+		obj.SetInternalSlots(&intlSegments{segmenter: segmenter, input: input})
+		return vm.NewValueFromPlainObject(obj), nil
+	}))
+
+	segmenterProto.SetOwnNonEnumerable("resolvedOptions", vm.NewNativeFunction(0, false, "resolvedOptions", func(args []vm.Value) (vm.Value, error) {
+		segmenter, ok := intlSlotsOf(vmInstance.GetThis()).(*intlSegmenter)
+		if !ok {
+			return vm.Undefined, vmInstance.NewTypeError("Method Intl.Segmenter.prototype.resolvedOptions called on incompatible receiver")
+		}
+		obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+		obj.SetOwn("locale", vm.NewString(segmenter.locale))
+		obj.SetOwn("granularity", vm.NewString(segmenter.granularity.String()))
+		return vm.NewValueFromPlainObject(obj), nil
+	}))
+
+	// ---- %SegmentsPrototype% ----
+	segmentsProto.SetOwnNonEnumerable("containing", vm.NewNativeFunction(1, false, "containing", func(args []vm.Value) (vm.Value, error) {
+		segments, ok := intlSlotsOf(vmInstance.GetThis()).(*intlSegments)
+		if !ok {
+			return vm.Undefined, vmInstance.NewTypeError("Method %Segments.prototype%.containing called on incompatible receiver")
+		}
+		// ToIntegerOrInfinity(index): Symbols and BigInts throw, objects go
+		// through ToPrimitive, NaN is 0, and the fraction is truncated.
+		f, err := toNumberWithVM(vmInstance, intlArg(args, 0))
+		if err != nil {
+			return intlAbrupt(err)
+		}
+		if math.IsNaN(f) {
+			f = 0
+		} else if !math.IsInf(f, 0) {
+			f = math.Trunc(f)
+		}
+		return segments.containing(vmInstance, f), nil
+	}))
+
+	writable, enumerable, configurable := true, false, true
+	segmentsProto.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolIterator),
+		vm.NewNativeFunction(0, false, "[Symbol.iterator]", func(args []vm.Value) (vm.Value, error) {
+			segments, ok := intlSlotsOf(vmInstance.GetThis()).(*intlSegments)
+			if !ok {
+				return vm.Undefined, vmInstance.NewTypeError("Method %Segments.prototype%[Symbol.iterator] called on incompatible receiver")
+			}
+			it := vm.NewObject(iteratorProtoVal).AsPlainObject()
+			it.SetInternalSlots(&intlSegmentIterator{segments: segments})
+			return vm.NewValueFromPlainObject(it), nil
+		}), &writable, &enumerable, &configurable)
+
+	// ---- %SegmentIteratorPrototype% ----
+	intlDefineToStringTag(vmInstance, iteratorProto, "Segmenter String Iterator")
+	iteratorProto.SetOwnNonEnumerable("next", vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
+		it, ok := intlSlotsOf(vmInstance.GetThis()).(*intlSegmentIterator)
+		if !ok {
+			return vm.Undefined, vmInstance.NewTypeError("Method %SegmentIterator.prototype%.next called on incompatible receiver")
+		}
+		segments := it.segments
+		segments.ensureRuns()
+		if it.pos >= len(segments.runs) {
+			return intlIterResult(vmInstance, vm.Undefined, true), nil
+		}
+		value := segments.dataObject(vmInstance, it.pos)
+		it.pos++
+		return intlIterResult(vmInstance, value, false), nil
+	}))
+
+	intlObj.SetOwnNonEnumerable("Segmenter", ctor)
+}

--- a/pkg/builtins/json_init.go
+++ b/pkg/builtins/json_init.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nooga/paserati/pkg/wtf8"
 	"math"
 	"sort"
 	"strconv"
@@ -103,8 +104,16 @@ func (j *JSONInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return internalizeJSONProperty(vmInstance, rootVal, "", reviver, sourceMap, "")
 		}
 
-		// No reviver - use standard parser (faster)
-		val, err := parseJSONToValueWithPrototypes(vmInstance, text)
+		// No reviver - use the standard parser (faster). Go's decoder turns a lone
+		// surrogate escape into U+FFFD, so text that may hold one goes through the
+		// WTF-8-preserving manual parser instead.
+		var val vm.Value
+		var err error
+		if jsonMayContainSurrogateEscape(text) || wtf8.HasSurrogate(text) {
+			val, _, err = parseJSONWithSource(vmInstance, text)
+		} else {
+			val, err = parseJSONToValueWithPrototypes(vmInstance, text)
+		}
 		if err != nil {
 			// Wrap parse error as SyntaxError exception
 			ctor, _ := ctx.VM.GetGlobal("SyntaxError")
@@ -618,7 +627,7 @@ func parseJSONString(text string) (string, int, error) {
 	i := 1 // Skip opening quote
 	for i < len(text) {
 		if text[i] == '"' {
-			return result.String(), i + 1, nil
+			return wtf8.JoinSurrogatePairs(result.String()), i + 1, nil
 		}
 		if text[i] == '\\' {
 			if i+1 >= len(text) {
@@ -646,7 +655,9 @@ func parseJSONString(text string) (string, int, error) {
 				if err != nil {
 					return "", 0, errors.New("invalid unicode escape")
 				}
-				result.WriteRune(rune(code))
+				// \uXXXX names a UTF-16 code unit: surrogates must survive as WTF-8
+				// (WriteRune would emit U+FFFD) and pairs are joined on return.
+				wtf8.WriteCodeUnit(&result, uint16(code))
 				i += 4
 			default:
 				return "", 0, errors.New("invalid escape sequence")
@@ -1601,4 +1612,23 @@ func stringifyValueToJSONWithVisited(vmInstance *vm.VM, value vm.Value, visited 
 	default:
 		return "null", nil
 	}
+}
+
+// jsonMayContainSurrogateEscape reports whether text contains a \uXXXX escape
+// that could name a UTF-16 surrogate (\uD800..\uDFFF, any hex case). It is a
+// cheap over-approximation (퀀..퟿ also match) used, together with a
+// check for raw WTF-8 surrogate bytes in the text, only to pick the parser
+// that preserves lone surrogates (encoding/json would emit U+FFFD).
+func jsonMayContainSurrogateEscape(text string) bool {
+	for i := strings.Index(text, "\\u"); i >= 0; {
+		if i+2 < len(text) && (text[i+2] == 'd' || text[i+2] == 'D') {
+			return true
+		}
+		j := strings.Index(text[i+2:], "\\u")
+		if j < 0 {
+			return false
+		}
+		i += 2 + j
+	}
+	return false
 }

--- a/pkg/builtins/regexp_init.go
+++ b/pkg/builtins/regexp_init.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"fmt"
+	"github.com/nooga/paserati/pkg/wtf8"
 	"math"
 	"strconv"
 	"strings"
@@ -81,7 +82,8 @@ func regexpUnicodeEscape(c rune) string {
 // $n -> nth capture group (1-9)
 // $nn -> nth capture group (01-99)
 // $<name> -> named capture group (names is the pattern's GroupNames; nil
-//            when it has none, in which case "$<" is literal text)
+//
+//	when it has none, in which case "$<" is literal text)
 func processReplacementPattern(str string, match []int, names []string, replacement string) string {
 	var result strings.Builder
 	i := 0
@@ -978,7 +980,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 					replaceStr := replaceValue.ToString()
 					if !strings.Contains(replaceStr, "$") {
 						if isGlobal {
-							return vm.NewString(regex.ReplaceAllLiteralString(str, replaceStr)), nil
+							return vm.NewString(wtf8.JoinSurrogatePairs(regex.ReplaceAllLiteralString(str, replaceStr))), nil
 						}
 						// Non-global: replace first match only
 						match := regex.FindStringSubmatchIndex(str)
@@ -989,7 +991,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 						result.WriteString(str[:match[0]])
 						result.WriteString(replaceStr)
 						result.WriteString(str[match[1]:])
-						return vm.NewString(result.String()), nil
+						return vm.NewString(wtf8.JoinSurrogatePairs(result.String())), nil
 					}
 				}
 
@@ -1064,7 +1066,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 					}
 				}
 				result.WriteString(str[lastIndex:])
-				return vm.NewString(result.String()), nil
+				return vm.NewString(wtf8.JoinSurrogatePairs(result.String())), nil
 			}
 		}
 
@@ -1204,7 +1206,7 @@ func (r *RegExpInitializer) InitRuntime(ctx *RuntimeContext) error {
 			accumulatedResult += str[nextSourcePosition:]
 		}
 
-		return vm.NewString(accumulatedResult), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(accumulatedResult)), nil
 	})
 	regexpProto.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolReplace), replaceFunc, &w, &e, &c)
 

--- a/pkg/builtins/standard.go
+++ b/pkg/builtins/standard.go
@@ -62,6 +62,7 @@ func GetStandardInitializers() []BuiltinInitializer {
 	initializers = append(initializers, &FetchInitializer{})
 	initializers = append(initializers, &DateInitializer{})
 	initializers = append(initializers, &TemporalInitializer{})
+	initializers = append(initializers, &IntlInitializer{})
 	initializers = append(initializers, &PerformanceInitializer{})
 	initializers = append(initializers, &ArrayBufferInitializer{})
 	initializers = append(initializers, &SharedArrayBufferInitializer{})

--- a/pkg/builtins/string_init.go
+++ b/pkg/builtins/string_init.go
@@ -3,6 +3,7 @@ package builtins
 import (
 	"errors"
 	"fmt"
+	"github.com/nooga/paserati/pkg/wtf8"
 	"math"
 	"strings"
 
@@ -346,7 +347,7 @@ func (s *StringInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("repeat", types.NewSimpleFunction([]types.Type{types.Number}, types.String)).
 		WithProperty("padStart", types.NewOptionalFunction([]types.Type{types.Number, types.String}, types.String, []bool{false, true})).
 		WithProperty("padEnd", types.NewOptionalFunction([]types.Type{types.Number, types.String}, types.String, []bool{false, true})).
-		WithProperty("concat", types.NewVariadicFunction([]types.Type{}, types.String, types.String)).
+		WithProperty("concat", types.NewVariadicFunction([]types.Type{}, types.String, &types.ArrayType{ElementType: types.String})).
 		WithProperty("split", types.NewOptionalFunction([]types.Type{types.NewUnionType(types.String, types.RegExp), types.Number}, &types.ArrayType{ElementType: types.String}, []bool{true, true})).
 		WithProperty("replace", types.NewSimpleFunction([]types.Type{
 			types.NewUnionType(types.String, types.RegExp),
@@ -638,7 +639,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if start >= end {
 			return vm.NewString(""), nil
 		}
-		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
+		return vm.NewString(vm.UTF16Substring(thisStr, start, end)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("substring", vm.NewNativeFunction(2, false, "substring", func(args []vm.Value) (vm.Value, error) {
@@ -674,7 +675,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if start > end {
 			start, end = end, start
 		}
-		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
+		return vm.NewString(vm.UTF16Substring(thisStr, start, end)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("substr", vm.NewNativeFunction(2, false, "substr", func(args []vm.Value) (vm.Value, error) {
@@ -738,7 +739,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if end < start {
 			end = start
 		}
-		return vm.NewString(thisStr[utf16ToByteOffset(thisStr, start):utf16ToByteOffset(thisStr, end)]), nil
+		return vm.NewString(vm.UTF16Substring(thisStr, start, end)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("indexOf", vm.NewNativeFunction(1, false, "indexOf", func(args []vm.Value) (vm.Value, error) {
@@ -786,6 +787,11 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		// Search over bytes, report in code units: strings.Index is the fast path
 		// and the offsets it speaks are not the ones the caller asked in.
+		// A needle holding a lone surrogate can match half of a 4-byte character,
+		// which a byte search cannot see: compare code units instead.
+		if wtf8.HasSurrogate(searchStr) {
+			return vm.NumberValue(float64(vm.UTF16IndexOf(thisStr, searchStr, position))), nil
+		}
 		startByte := utf16ToByteOffset(thisStr, position)
 		index := strings.Index(thisStr[startByte:], searchStr)
 		if index == -1 {
@@ -828,6 +834,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			} else if position > utf16Len(thisStr) {
 				position = utf16Len(thisStr)
 			}
+		}
+		if wtf8.HasSurrogate(searchStr) {
+			return vm.NumberValue(float64(vm.UTF16LastIndexOf(thisStr, searchStr, position))), nil
 		}
 		// Ensure we don't go past the end of the string
 		endPos := utf16ToByteOffset(thisStr, position) + len(searchStr)
@@ -883,6 +892,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if position >= utf16Len(thisStr) {
 			return vm.BooleanValue(false), nil
 		}
+		if wtf8.HasSurrogate(searchStr) {
+			return vm.BooleanValue(vm.UTF16IndexOf(thisStr, searchStr, position) >= 0), nil
+		}
 		return vm.BooleanValue(strings.Contains(thisStr[utf16ToByteOffset(thisStr, position):], searchStr)), nil
 	}))
 
@@ -924,6 +936,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if position >= utf16Len(thisStr) {
 			return vm.BooleanValue(false), nil
 		}
+		if wtf8.HasSurrogate(searchStr) {
+			return vm.BooleanValue(vm.UTF16HasPrefixAt(thisStr, searchStr, position)), nil
+		}
 		return vm.BooleanValue(strings.HasPrefix(thisStr[utf16ToByteOffset(thisStr, position):], searchStr)), nil
 	}))
 
@@ -963,6 +978,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			} else if length > utf16Len(thisStr) {
 				length = utf16Len(thisStr)
 			}
+		}
+		if wtf8.HasSurrogate(searchStr) {
+			return vm.BooleanValue(vm.UTF16HasSuffixAt(thisStr, searchStr, length)), nil
 		}
 		// endPos is where the caller's `length` lands in bytes; the comparison
 		// below is byte-wise because searchStr is measured the same way.
@@ -1225,7 +1243,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if count == 0 || thisStr == "" {
 			return vm.NewString(""), nil
 		}
-		return vm.NewString(strings.Repeat(thisStr, count)), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(strings.Repeat(thisStr, count))), nil
 	}))
 
 	// String.prototype.padStart - pads string at the start to reach target length
@@ -1272,24 +1290,19 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		fillLength := targetLength - stringLength
 		padUtf16 := vm.StringToUTF16(padString)
 
-		// Build the padding
-		var result strings.Builder
-		for result.Len() < fillLength {
+		// Build the padding in UTF-16 code units (fillLength counts units), then
+		// encode: a fill string's surrogates survive and are paired where adjacent.
+		padUnits := make([]uint16, 0, fillLength)
+		for len(padUnits) < fillLength && len(padUtf16) > 0 {
 			for _, unit := range padUtf16 {
-				if result.Len() >= fillLength {
+				if len(padUnits) >= fillLength {
 					break
 				}
-				result.WriteRune(rune(unit))
+				padUnits = append(padUnits, unit)
 			}
 		}
-		// Truncate if necessary and append original string
-		padding := result.String()
-		if len(vm.StringToUTF16(padding)) > fillLength {
-			// Truncate to exact fill length
-			padRunes := []rune(padding)
-			padding = string(padRunes[:fillLength])
-		}
-		return vm.NewString(padding + thisStr), nil
+		padding := vm.UTF16ToString(padUnits)
+		return vm.NewString(wtf8.Concat(padding, thisStr)), nil
 	}))
 
 	// String.prototype.padEnd - pads string at the end to reach target length
@@ -1336,24 +1349,19 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		fillLength := targetLength - stringLength
 		padUtf16 := vm.StringToUTF16(padString)
 
-		// Build the padding
-		var result strings.Builder
-		for result.Len() < fillLength {
+		// Build the padding in UTF-16 code units (fillLength counts units), then
+		// encode: a fill string's surrogates survive and are paired where adjacent.
+		padUnits := make([]uint16, 0, fillLength)
+		for len(padUnits) < fillLength && len(padUtf16) > 0 {
 			for _, unit := range padUtf16 {
-				if result.Len() >= fillLength {
+				if len(padUnits) >= fillLength {
 					break
 				}
-				result.WriteRune(rune(unit))
+				padUnits = append(padUnits, unit)
 			}
 		}
-		// Truncate if necessary and prepend original string
-		padding := result.String()
-		if len(vm.StringToUTF16(padding)) > fillLength {
-			// Truncate to exact fill length
-			padRunes := []rune(padding)
-			padding = string(padRunes[:fillLength])
-		}
-		return vm.NewString(thisStr + padding), nil
+		padding := vm.UTF16ToString(padUnits)
+		return vm.NewString(wtf8.Concat(thisStr, padding)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("concat", vm.NewNativeFunction(1, true, "concat", func(args []vm.Value) (vm.Value, error) {
@@ -1377,7 +1385,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 			result += argStr
 		}
-		return vm.NewString(result), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("split", vm.NewNativeFunction(2, false, "split", func(args []vm.Value) (vm.Value, error) {
@@ -1558,16 +1566,31 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.NewArrayWithArgs(elements), nil
 		} else {
 			// String separator
-			if separator == "" {
-				// Split into individual characters
-				runes := []rune(thisStr)
-				count := uint32(len(runes))
-				if limit < count {
-					count = limit
+			if separator == "" || wtf8.HasSurrogate(separator) {
+				// Code-unit based split. "" yields one element per UTF-16 code unit (a
+				// surrogate pair becomes its two lone halves, as in JS), and a separator
+				// holding a lone surrogate can match half of a 4-byte character, which a
+				// byte-level strings.Split cannot see.
+				elements := []vm.Value{}
+				strLen := vm.UTF16Length(thisStr)
+				if separator == "" {
+					for i := 0; i < strLen && uint32(len(elements)) < limit; i++ {
+						elements = append(elements, vm.NewString(vm.UTF16Substring(thisStr, i, i+1)))
+					}
+					return vm.NewArrayWithArgs(elements), nil
 				}
-				elements := make([]vm.Value, count)
-				for i := uint32(0); i < count; i++ {
-					elements[i] = vm.NewString(string(runes[i]))
+				sepLen := vm.UTF16Length(separator)
+				p := 0
+				for uint32(len(elements)) < limit {
+					q := vm.UTF16IndexOf(thisStr, separator, p)
+					if q < 0 {
+						break
+					}
+					elements = append(elements, vm.NewString(vm.UTF16Substring(thisStr, p, q)))
+					p = q + sepLen
+				}
+				if uint32(len(elements)) < limit {
+					elements = append(elements, vm.NewString(vm.UTF16Substring(thisStr, p, strLen)))
 				}
 				return vm.NewArrayWithArgs(elements), nil
 			}
@@ -1677,7 +1700,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		result := thisStr[:idx] + replacement + thisStr[idx+len(searchValue):]
-		return vm.NewString(result), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))
 
 	// String.prototype.replaceAll - replaces all occurrences of a search string/pattern
@@ -1779,7 +1802,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 					result.WriteRune(runes[i])
 				}
 			}
-			return vm.NewString(result.String()), nil
+			return vm.NewString(wtf8.JoinSurrogatePairs(result.String())), nil
 		}
 
 		// Find all occurrences and replace
@@ -1819,7 +1842,7 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Add the rest of the string
 		result.WriteString(thisStr[lastIndex:])
-		return vm.NewString(result.String()), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(result.String())), nil
 	}))
 
 	stringProto.SetOwnNonEnumerable("match", vm.NewNativeFunction(1, false, "match", func(args []vm.Value) (vm.Value, error) {
@@ -2220,8 +2243,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if len(args) == 0 {
 			return vm.NewString(""), nil
 		}
-		// Use runes to properly handle Unicode code points
-		result := make([]rune, len(args))
+		// Collect UTF-16 code units; UTF16ToString pairs adjacent surrogates and
+		// keeps lone ones as WTF-8 (string(rune) would turn them into U+FFFD).
+		units := make([]uint16, len(args))
 		for i, arg := range args {
 			// BigInt to Number throws TypeError per ECMAScript
 			if arg.Type() == vm.TypeBigInt {
@@ -2242,9 +2266,9 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Truncate to integer and mask to 16 bits
 				code = int(math.Trunc(num)) & 0xFFFF
 			}
-			result[i] = rune(code)
+			units[i] = uint16(code)
 		}
-		return vm.NewString(string(result)), nil
+		return vm.NewString(vm.UTF16ToString(units)), nil
 	}))
 
 	// String.fromCodePoint - creates string from code points (supports full Unicode range)
@@ -2277,10 +2301,15 @@ func (s *StringInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if codePoint < 0 || codePoint > 0x10FFFF {
 				return vm.Undefined, vmInstance.NewRangeError("Invalid code point " + fmt.Sprintf("%d", codePoint))
 			}
-			// Convert code point to string (handles surrogate pairs automatically)
-			result.WriteRune(rune(codePoint))
+			// Surrogate code points are legal here and must survive as WTF-8 (WriteRune
+			// would emit U+FFFD); an adjacent lead+trail pair is joined below.
+			if codePoint >= 0xD800 && codePoint <= 0xDFFF {
+				wtf8.WriteCodeUnit(&result, uint16(codePoint))
+			} else {
+				result.WriteRune(rune(codePoint))
+			}
 		}
-		return vm.NewString(result.String()), nil
+		return vm.NewString(wtf8.JoinSurrogatePairs(result.String())), nil
 	}))
 
 	// String.raw - template tag function for raw string literals (21.1.2.4)

--- a/pkg/builtins/symbol_init.go
+++ b/pkg/builtins/symbol_init.go
@@ -90,6 +90,10 @@ func (s *SymbolInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Use the VM's Symbol.prototype
 	symbolProto := vmInstance.SymbolPrototype.AsPlainObject()
+	// The VM allocates %Symbol.prototype% before ObjectInitializer installs the
+	// real %Object.prototype%, so re-parent it now; otherwise Symbol wrapper
+	// objects never see Object.prototype (getters, hasOwnProperty, ...).
+	symbolProto.SetPrototype(vmInstance.ObjectPrototype)
 
 	// thisSymbolValue extracts the symbol from `this`:
 	// - If `this` is a Symbol primitive, return it directly

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3365,12 +3365,12 @@ func (c *Checker) checkArrayDestructuringDeclaration(node *parser.ArrayDestructu
 		for range node.Elements {
 			elementTypes = append(elementTypes, types.Any)
 		}
-	} else if _, ok := destructureType.(*types.ObjectType); ok {
-		// Object types might implement Symbol.iterator (iterable protocol)
-		// At runtime, we'll check and use iterator protocol
-		// For type checking, assume elements are Any since we can't statically determine iterator element type
+	} else if c.isSpreadableIterableType(destructureType) {
+		// Iterable protocol values (objects with Symbol.iterator, strings, etc.)
+		// destructure element-wise using the iterator's declared value type.
+		elemType := types.DeeplyWidenType(c.getSpreadElementType(destructureType))
 		for range node.Elements {
-			elementTypes = append(elementTypes, types.Any)
+			elementTypes = append(elementTypes, elemType)
 		}
 	} else {
 		// Not an array-like or iterable type

--- a/pkg/checker/expressions.go
+++ b/pkg/checker/expressions.go
@@ -3053,12 +3053,6 @@ func (c *Checker) isSpreadableIterableType(t types.Type) bool {
 	if t == nil {
 		return false
 	}
-	if t == types.String {
-		return false
-	}
-	if literalType, ok := t.(*types.LiteralType); ok && literalType.Value.Type() == vm.TypeString {
-		return false
-	}
 	if genericType, ok := t.(*types.GenericType); ok {
 		if genericType.Name == "Iterable" || genericType.Name == "Iterator" {
 			return true
@@ -3120,7 +3114,18 @@ func (c *Checker) getSpreadElementType(t types.Type) types.Type {
 		}
 	}
 
-	nextType := c.getPropertyTypeFromType(t, "next", false)
+	// If t isn't already iterator-shaped (no .next of its own), it's an iterable:
+	// resolve its [Symbol.iterator]() return type and look for .next on that instead.
+	iteratorType := t
+	if !c.hasIteratorNext(t) {
+		if methodType := c.getPropertyTypeFromType(t, "__COMPUTED_PROPERTY__", false); methodType != nil && methodType != types.Never {
+			if methodReturn := callableReturnType(methodType); methodReturn != nil && methodReturn != types.Any {
+				iteratorType = methodReturn
+			}
+		}
+	}
+
+	nextType := c.getPropertyTypeFromType(iteratorType, "next", false)
 	nextReturnType := callableReturnType(nextType)
 	if nextReturnType == nil || nextReturnType == types.Any || nextReturnType == types.Never {
 		return types.Any

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -2,6 +2,7 @@ package lexer
 
 import (
 	"fmt"
+	"github.com/nooga/paserati/pkg/wtf8"
 	"strconv" // Added for ParseInt
 	"strings" // Added for strings.Builder
 	"unicode"
@@ -889,7 +890,7 @@ func PreprocessUnicodeEscapesContextAware(input string) string {
 		}
 	}
 
-	return result.String()
+	return wtf8.JoinSurrogatePairs(result.String())
 }
 
 // isWhitespaceUnicodeEscape checks if the current position contains a Unicode escape
@@ -1811,7 +1812,7 @@ func (l *Lexer) readIdentifierWithUnicode() (string, bool) {
 		}
 	}
 
-	return result.String(), hasEscape
+	return wtf8.JoinSurrogatePairs(result.String()), hasEscape
 }
 
 // readNumber reads a number literal (integer or float, various bases) and advances the lexer's position.
@@ -1992,6 +1993,11 @@ func (l *Lexer) readString(quote byte) (string, bool, bool) {
 		// Check for termination conditions *before* processing the character
 		if l.ch == quote {
 			l.readChar() // Consume the closing quote
+			if hasEscape {
+				// Escapes are decoded per \uXXXX unit, so a lead+trail pair written
+				// as two escapes must be joined into the one character it denotes.
+				return wtf8.JoinSurrogatePairs(builder.String()), true, true
+			}
 			return builder.String(), hasEscape, true
 		}
 		if l.isEOF() { // EOF - use isEOF() to distinguish from literal null bytes
@@ -3152,7 +3158,7 @@ func (l *Lexer) readTemplateString(startLine, startCol, startPos int) Token {
 	// If there was an invalid escape, the cooked value should be undefined (for tagged templates)
 	return Token{
 		Type:              TEMPLATE_STRING,
-		Literal:           cooked.String(),
+		Literal:           wtf8.JoinSurrogatePairs(cooked.String()),
 		RawLiteral:        raw.String(),
 		CookedIsUndefined: hasInvalidEscape,
 		Line:              startLine,

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -287,6 +287,25 @@ type PlainObject struct {
 	// Nil for ordinary objects; non-nil doubles as the brand check that
 	// RequireInternalSlot performs on every DisposableStack.prototype method.
 	disposableState *DisposableStackState
+	// Internal state for builtins implemented outside pkg/vm that have no
+	// dedicated object type (currently Intl.Segmenter and its Segments /
+	// Segment Iterator objects). Nil for ordinary objects; the builtin's own
+	// type assertion on the stored value is the spec's internal-slot brand
+	// check, so a plain object or another builtin's instance never passes.
+	internalSlots any
+}
+
+// InternalSlots returns the opaque builtin-specific internal state attached
+// with SetInternalSlots, or nil for ordinary objects. Kept off the property
+// storage so it is invisible to user code, like spec internal slots.
+func (o *PlainObject) InternalSlots() any {
+	return o.internalSlots
+}
+
+// SetInternalSlots attaches builtin-specific internal state; called once when
+// a builtin constructs a new instance.
+func (o *PlainObject) SetInternalSlots(state any) {
+	o.internalSlots = state
 }
 
 // InternalIterState returns the Map/Set iterator internal state, or nil for

--- a/pkg/vm/realm.go
+++ b/pkg/vm/realm.go
@@ -27,6 +27,7 @@ type Realm struct {
 	WeakSetPrototype              Value
 	WeakRefPrototype              Value
 	FinalizationRegistryPrototype Value
+	IntlSegmenterPrototype        Value // %Intl.Segmenter.prototype%
 	GeneratorPrototype            Value
 	AsyncGeneratorPrototype       Value
 	IteratorPrototype             Value // %Iterator.prototype% - base for all iterators
@@ -161,6 +162,7 @@ func (r *Realm) InitializePrototypes() {
 	r.WeakSetPrototype = NewObject(r.ObjectPrototype)
 	r.WeakRefPrototype = NewObject(r.ObjectPrototype)
 	r.FinalizationRegistryPrototype = NewObject(r.ObjectPrototype)
+	r.IntlSegmenterPrototype = NewObject(r.ObjectPrototype)
 	r.PromisePrototype = NewObject(r.ObjectPrototype)
 	r.ArrayBufferPrototype = NewObject(r.ObjectPrototype)
 	r.SharedArrayBufferPrototype = NewObject(r.ObjectPrototype)

--- a/pkg/vm/string_utf16.go
+++ b/pkg/vm/string_utf16.go
@@ -378,3 +378,88 @@ func stringToUTF16WithOffsets(s string, wantOffsets bool) ([]uint16, []int32) {
 	}
 	return result, offs
 }
+
+// splitsSurrogatePair reports whether UTF-16 offset i falls between the two
+// halves of a surrogate pair in s - the one place where a code unit offset
+// has no byte offset of its own.
+func splitsSurrogatePair(s string, i int) bool {
+	e := stringInfo(s)
+	if e.ascii || i <= 0 || i >= e.n {
+		return false
+	}
+	prev, cur := e.units[i-1], e.units[i]
+	return prev >= 0xD800 && prev <= 0xDBFF && cur >= 0xDC00 && cur <= 0xDFFF
+}
+
+// UTF16Substring returns the JS substring of s between UTF-16 offsets start
+// and end (0 <= start <= end <= UTF16Length(s), the caller's job). When both
+// offsets sit on character boundaries this is a zero-copy byte slice. When one
+// splits a surrogate pair - "😀".slice(1) - the result cannot be a byte slice
+// of the UTF-8 character, so it is re-encoded from the code units, which
+// yields the lone half as WTF-8 exactly as charAt would.
+func UTF16Substring(s string, start, end int) string {
+	if start >= end {
+		return ""
+	}
+	if splitsSurrogatePair(s, start) || splitsSurrogatePair(s, end) {
+		return UTF16ToString(stringInfo(s).units[start:end])
+	}
+	return s[UTF16ToByteOffset(s, start):UTF16ToByteOffset(s, end)]
+}
+
+// UTF16IndexOf is String.prototype.indexOf over code units: the first
+// position >= from where needle occurs in s, or -1. The byte-level
+// strings.Index is the fast path for well-formed needles; this is the slow
+// path for needles holding a lone surrogate, which can match half of a
+// 4-byte character and so is invisible to a byte search.
+func UTF16IndexOf(s, needle string, from int) int {
+	su, nu := StringToUTF16(s), StringToUTF16(needle)
+	if from < 0 {
+		from = 0
+	}
+	for i := from; i+len(nu) <= len(su); i++ {
+		if utf16Match(su, nu, i) {
+			return i
+		}
+	}
+	return -1
+}
+
+// UTF16LastIndexOf is String.prototype.lastIndexOf over code units: the last
+// position <= from where needle occurs in s, or -1.
+func UTF16LastIndexOf(s, needle string, from int) int {
+	su, nu := StringToUTF16(s), StringToUTF16(needle)
+	if from > len(su)-len(nu) {
+		from = len(su) - len(nu)
+	}
+	for i := from; i >= 0; i-- {
+		if utf16Match(su, nu, i) {
+			return i
+		}
+	}
+	return -1
+}
+
+// UTF16HasPrefixAt reports whether needle occurs in s exactly at code unit
+// offset at (String.prototype.startsWith with a position).
+func UTF16HasPrefixAt(s, needle string, at int) bool {
+	su, nu := StringToUTF16(s), StringToUTF16(needle)
+	return at >= 0 && at+len(nu) <= len(su) && utf16Match(su, nu, at)
+}
+
+// UTF16HasSuffixAt reports whether needle ends exactly at code unit offset
+// end in s (String.prototype.endsWith with an endPosition).
+func UTF16HasSuffixAt(s, needle string, end int) bool {
+	su, nu := StringToUTF16(s), StringToUTF16(needle)
+	start := end - len(nu)
+	return start >= 0 && end <= len(su) && utf16Match(su, nu, start)
+}
+
+func utf16Match(su, nu []uint16, at int) bool {
+	for j, u := range nu {
+		if su[at+j] != u {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/vm/string_utf16_wtf8_test.go
+++ b/pkg/vm/string_utf16_wtf8_test.go
@@ -1,0 +1,64 @@
+package vm
+
+import "testing"
+
+// Half-character operations on a 4-byte UTF-8 character must yield WTF-8 lone
+// surrogates, and needles holding lone surrogates must be found inside 4-byte
+// characters - the cases a byte-level slice/search cannot express.
+func TestUTF16SubstringSplitsSurrogatePairs(t *testing.T) {
+	const grin = "😀" // U+1F600: D83D DE00
+	lead, trail := "\xed\xa0\xbd", "\xed\xb8\x80"
+	cases := []struct {
+		s          string
+		start, end int
+		want       string
+	}{
+		{grin, 0, 2, grin},
+		{grin, 0, 1, lead},
+		{grin, 1, 2, trail},
+		{grin, 1, 1, ""},
+		{"a" + grin + "b", 1, 3, grin},
+		{"a" + grin + "b", 2, 4, trail + "b"},
+		{"a" + grin + "b", 0, 2, "a" + lead},
+		{"plain", 1, 3, "la"},
+		{"ünïcode", 1, 3, "nï"},
+	}
+	for _, c := range cases {
+		if got := UTF16Substring(c.s, c.start, c.end); got != c.want {
+			t.Errorf("UTF16Substring(%q, %d, %d) = %q, want %q", c.s, c.start, c.end, got, c.want)
+		}
+	}
+	// Re-joining the halves reproduces the character's UTF-16 view.
+	if UTF16ToString(StringToUTF16(UTF16Substring(grin, 0, 1)+UTF16Substring(grin, 1, 2))) != grin {
+		t.Errorf("halves do not recombine")
+	}
+}
+
+func TestUTF16SearchWithLoneSurrogates(t *testing.T) {
+	const s = "a😀b😀"
+	lead, trail := "\xed\xa0\xbd", "\xed\xb8\x80"
+	if got := UTF16IndexOf(s, trail, 0); got != 2 {
+		t.Errorf("IndexOf trail = %d, want 2", got)
+	}
+	if got := UTF16IndexOf(s, lead, 2); got != 4 {
+		t.Errorf("IndexOf lead from 2 = %d, want 4", got)
+	}
+	if got := UTF16IndexOf(s, "😀b", 0); got != 1 {
+		t.Errorf("IndexOf pair = %d, want 1", got)
+	}
+	if got := UTF16IndexOf(s, trail+"x", 0); got != -1 {
+		t.Errorf("IndexOf missing = %d, want -1", got)
+	}
+	if got := UTF16LastIndexOf(s, lead, 10); got != 4 {
+		t.Errorf("LastIndexOf lead = %d, want 4", got)
+	}
+	if got := UTF16LastIndexOf(s, lead, 3); got != 1 {
+		t.Errorf("LastIndexOf lead from 3 = %d, want 1", got)
+	}
+	if !UTF16HasPrefixAt(s, lead, 1) || UTF16HasPrefixAt(s, lead, 2) {
+		t.Errorf("HasPrefixAt wrong")
+	}
+	if !UTF16HasSuffixAt(s, trail, 6) || UTF16HasSuffixAt(s, trail, 5) {
+		t.Errorf("HasSuffixAt wrong")
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/nooga/paserati/pkg/wtf8"
 	"math"
 	"math/big"
 	"os"
@@ -2414,7 +2415,7 @@ startExecution:
 			// Now convert primitives to strings
 			leftStr := leftVal.ToString()
 			rightStr := rightVal.ToString()
-			registers[destReg] = String(leftStr + rightStr)
+			registers[destReg] = String(wtf8.Concat(leftStr, rightStr))
 
 		case OpAdd, OpSubtract, OpMultiply, OpDivide,
 			OpEqual, OpNotEqual, OpStrictEqual, OpStrictNotEqual,
@@ -2584,7 +2585,7 @@ startExecution:
 						ip = frame.ip
 						continue
 					}
-					registers[destReg] = String(leftPrim.ToString() + rightPrim.ToString())
+					registers[destReg] = String(wtf8.Concat(leftPrim.ToString(), rightPrim.ToString()))
 				} else if leftPrim.IsBigInt() && rightPrim.IsBigInt() {
 					// Both are BigInt: do BigInt addition
 					result := new(big.Int).Add(leftPrim.AsBigInt(), rightPrim.AsBigInt())
@@ -17390,11 +17391,18 @@ func (vm *VM) extractSpreadArguments(iterableVal Value) ([]Value, error) {
 		return args, nil
 
 	case TypeString:
-		// Strings are iterable - spread into individual characters
-		str := AsString(iterableVal)
-		args := make([]Value, 0, len(str))
-		for _, char := range str {
-			args = append(args, NewString(string(char)))
+		// Strings are iterable by code point over their UTF-16 view (the same
+		// elements String.prototype[Symbol.iterator] yields): a surrogate pair is
+		// one element, a lone surrogate is one element kept as WTF-8.
+		units := StringToUTF16(AsString(iterableVal))
+		args := make([]Value, 0, len(units))
+		for i := 0; i < len(units); i++ {
+			n := 1
+			if units[i] >= 0xD800 && units[i] <= 0xDBFF && i+1 < len(units) && units[i+1] >= 0xDC00 && units[i+1] <= 0xDFFF {
+				n = 2
+			}
+			args = append(args, NewString(UTF16ToString(units[i:i+n])))
+			i += n - 1
 		}
 		return args, nil
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -266,6 +266,7 @@ type VM struct {
 	WeakSetPrototype              Value
 	WeakRefPrototype              Value
 	FinalizationRegistryPrototype Value
+	IntlSegmenterPrototype        Value // %Intl.Segmenter.prototype%
 	GeneratorPrototype            Value
 	AsyncGeneratorPrototype       Value
 	IteratorPrototype             Value // %Iterator.prototype% - base for all iterators
@@ -717,6 +718,8 @@ func (vm *VM) GetPrototypeFromConstructor(constructor Value, intrinsicDefault st
 		return realm.WeakRefPrototype, nil
 	case "%FinalizationRegistryPrototype%":
 		return realm.FinalizationRegistryPrototype, nil
+	case "%Intl.Segmenter.prototype%":
+		return realm.IntlSegmenterPrototype, nil
 	case "%ErrorPrototype%":
 		return realm.ErrorPrototype, nil
 	case "%TypeErrorPrototype%":
@@ -800,6 +803,7 @@ func (vm *VM) syncPrototypesFromRealm() {
 	vm.WeakSetPrototype = r.WeakSetPrototype
 	vm.WeakRefPrototype = r.WeakRefPrototype
 	vm.FinalizationRegistryPrototype = r.FinalizationRegistryPrototype
+	vm.IntlSegmenterPrototype = r.IntlSegmenterPrototype
 	vm.PromisePrototype = r.PromisePrototype
 	vm.SymbolPrototype = r.SymbolPrototype
 	vm.DatePrototype = r.DatePrototype
@@ -897,6 +901,7 @@ func (vm *VM) SyncPrototypesToRealm() {
 	r.WeakSetPrototype = vm.WeakSetPrototype
 	r.WeakRefPrototype = vm.WeakRefPrototype
 	r.FinalizationRegistryPrototype = vm.FinalizationRegistryPrototype
+	r.IntlSegmenterPrototype = vm.IntlSegmenterPrototype
 	r.PromisePrototype = vm.PromisePrototype
 	r.SymbolPrototype = vm.SymbolPrototype
 	r.DatePrototype = vm.DatePrototype
@@ -18117,7 +18122,9 @@ func (vm *VM) toPrimitive(val Value, hint string) Value {
 	}
 
 	for _, methodName := range methods {
-		// Try to get the method
+		// Try to get the method. A throwing accessor for valueOf/toString
+		// propagates: the exception is already set, so stop here (mirrors the
+		// @@toPrimitive lookup above).
 		var methodVal Value
 		ok, status, _ := vm.opGetProp(nil, 0, &val, methodName, &methodVal)
 		// A throwing accessor (e.g. `{ get toString() { throw ... } }`) leaves an

--- a/pkg/wtf8/wtf8.go
+++ b/pkg/wtf8/wtf8.go
@@ -1,0 +1,130 @@
+// Package wtf8 holds the byte-level helpers that keep Paserati's WTF-8
+// strings canonical.
+//
+// The VM stores JavaScript strings as Go strings in WTF-8: well-formed UTF-8,
+// except that a lone UTF-16 surrogate (which UTF-8 cannot express) is kept as
+// its generalized 3-byte form ED A0..BF xx. That gives one representation for
+// every JS string - as long as two lone surrogates that together form a valid
+// pair never sit next to each other, because then the same JS string (one
+// supplementary character, two UTF-16 code units) would have two byte forms:
+// the 4-byte UTF-8 sequence or the 6-byte surrogate pair. Equality and the
+// UTF-16 view hide the difference, but every builtin that slices or scans Go
+// bytes (TextEncoder, encodeURIComponent, regexps, spread, Intl.Segmenter,
+// ...) would observe it.
+//
+// The WTF-8 spec therefore requires producers to re-pair: whenever a string
+// is built from pieces (escape sequences in the lexer, concatenation, code
+// unit sequences from fromCharCode/JSON.parse), an adjacent lead+trail pair
+// must be encoded as the single code point it denotes. These helpers do that
+// for the lexer and the VM, which cannot import each other.
+package wtf8
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// isLead reports whether s[i:i+3] is a WTF-8 lead surrogate (U+D800..U+DBFF).
+func isLead(s string, i int) bool {
+	return i+2 < len(s) && s[i] == 0xED && s[i+1] >= 0xA0 && s[i+1] <= 0xAF && s[i+2] >= 0x80 && s[i+2] <= 0xBF
+}
+
+// isTrail reports whether s[i:i+3] is a WTF-8 trail surrogate (U+DC00..U+DFFF).
+func isTrail(s string, i int) bool {
+	return i+2 < len(s) && s[i] == 0xED && s[i+1] >= 0xB0 && s[i+1] <= 0xBF && s[i+2] >= 0x80 && s[i+2] <= 0xBF
+}
+
+// codeUnit decodes the 3-byte generalized UTF-8 sequence at s[i:i+3].
+func codeUnit(s string, i int) uint16 {
+	return uint16(s[i]&0x0F)<<12 | uint16(s[i+1]&0x3F)<<6 | uint16(s[i+2]&0x3F)
+}
+
+func pairToRune(lead, trail uint16) rune {
+	return 0x10000 + (rune(lead)-0xD800)<<10 + (rune(trail) - 0xDC00)
+}
+
+// JoinSurrogatePairs returns s with every adjacent lead+trail surrogate pair
+// re-encoded as the 4-byte UTF-8 sequence of the supplementary character it
+// denotes. Lone surrogates that do not pair stay as they are. When there is
+// nothing to join, s itself is returned without allocating; strings with no
+// 0xED byte (all ASCII, most text) take that path after one IndexByte.
+func JoinSurrogatePairs(s string) string {
+	i := strings.IndexByte(s, 0xED)
+	if i < 0 {
+		return s
+	}
+	var out []byte
+	last := 0
+	for i >= 0 && i+6 <= len(s) {
+		if isLead(s, i) && isTrail(s, i+3) {
+			if out == nil {
+				out = make([]byte, 0, len(s))
+			}
+			out = append(out, s[last:i]...)
+			out = utf8.AppendRune(out, pairToRune(codeUnit(s, i), codeUnit(s, i+3)))
+			i += 6
+			last = i
+			if j := strings.IndexByte(s[i:], 0xED); j >= 0 {
+				i += j
+			} else {
+				i = -1
+			}
+			continue
+		}
+		if j := strings.IndexByte(s[i+1:], 0xED); j >= 0 {
+			i += 1 + j
+		} else {
+			i = -1
+		}
+	}
+	if out == nil {
+		return s
+	}
+	return string(append(out, s[last:]...))
+}
+
+// Concat returns a+b, re-pairing a lead surrogate at the end of a with a
+// trail surrogate at the start of b. Both inputs are assumed canonical (as
+// every VM string is), so only the seam needs checking - this is the
+// constant-time helper for the hot concatenation paths.
+func Concat(a, b string) string {
+	if len(a) >= 3 && len(b) >= 3 && isLead(a, len(a)-3) && isTrail(b, 0) {
+		var buf [4]byte
+		n := utf8.EncodeRune(buf[:], pairToRune(codeUnit(a, len(a)-3), codeUnit(b, 0)))
+		return a[:len(a)-3] + string(buf[:n]) + b[3:]
+	}
+	return a + b
+}
+
+// AppendCodeUnit appends one UTF-16 code unit to buf: BMP characters as
+// UTF-8, surrogates in their 3-byte WTF-8 form. A sequence built this way
+// must be passed through JoinSurrogatePairs once complete (or, when the
+// units are all at hand, encoded with the VM's UTF16ToString instead).
+func AppendCodeUnit(buf []byte, u uint16) []byte {
+	if u >= 0xD800 && u <= 0xDFFF {
+		return append(buf, 0xE0|byte(u>>12), 0x80|byte((u>>6)&0x3F), 0x80|byte(u&0x3F))
+	}
+	return utf8.AppendRune(buf, rune(u))
+}
+
+// WriteCodeUnit is AppendCodeUnit for a strings.Builder.
+func WriteCodeUnit(sb *strings.Builder, u uint16) {
+	var buf [3]byte
+	sb.Write(AppendCodeUnit(buf[:0], u))
+}
+
+// HasSurrogate reports whether s contains a WTF-8 encoded surrogate (a lone
+// one, in a canonical string). Cheap: one IndexByte for the common case.
+func HasSurrogate(s string) bool {
+	for i := strings.IndexByte(s, 0xED); i >= 0; {
+		if i+1 < len(s) && s[i+1] >= 0xA0 {
+			return true
+		}
+		j := strings.IndexByte(s[i+1:], 0xED)
+		if j < 0 {
+			return false
+		}
+		i += 1 + j
+	}
+	return false
+}

--- a/pkg/wtf8/wtf8_test.go
+++ b/pkg/wtf8/wtf8_test.go
@@ -1,0 +1,71 @@
+package wtf8
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	lead  = "\xed\xa0\x80" // U+D800
+	trail = "\xed\xb0\x80" // U+DC00
+	pair  = "\U00010000"   // what lead+trail denote
+	// U+D7FF is the last code point before the surrogate block: ED 9F BF,
+	// the closest well-formed neighbour of the lead pattern.
+	preSurrogate = "퟿"
+)
+
+func TestJoinSurrogatePairs(t *testing.T) {
+	cases := map[string]string{
+		"":                          "",
+		"plain ascii":               "plain ascii",
+		lead + trail:                pair,
+		"a" + lead + trail + "b":    "a" + pair + "b",
+		lead:                        lead,
+		trail:                       trail,
+		trail + lead:                trail + lead,
+		lead + lead + trail:         lead + pair,
+		lead + trail + lead + trail: pair + pair,
+		preSurrogate + trail:        preSurrogate + trail,
+		"한글" + lead + trail:         "한글" + pair, // Hangul also uses 0xED lead bytes
+		pair:                        pair,
+		lead + "x" + trail:          lead + "x" + trail,
+	}
+	for in, want := range cases {
+		if got := JoinSurrogatePairs(in); got != want {
+			t.Errorf("JoinSurrogatePairs(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// No allocation / identical string when nothing changes.
+	s := "already canonical " + pair + lead
+	if got := JoinSurrogatePairs(s); got != s {
+		t.Errorf("canonical input changed: %q", got)
+	}
+}
+
+func TestConcat(t *testing.T) {
+	if got := Concat(lead, trail); got != pair {
+		t.Errorf("Concat(lead, trail) = %q", got)
+	}
+	if got := Concat("ab"+lead, trail+"cd"); got != "ab"+pair+"cd" {
+		t.Errorf("Concat with context = %q", got)
+	}
+	for _, c := range [][2]string{{"a", "b"}, {lead, "x"}, {"x", trail}, {trail, lead}, {"", trail}, {lead, ""}, {preSurrogate, trail}} {
+		if got := Concat(c[0], c[1]); got != c[0]+c[1] {
+			t.Errorf("Concat(%q, %q) = %q, want plain concatenation", c[0], c[1], got)
+		}
+	}
+}
+
+func TestAppendCodeUnit(t *testing.T) {
+	var sb strings.Builder
+	for _, u := range []uint16{'a', 0xD800, 0xDC00, 0xD7FF, 0xFFFD} {
+		WriteCodeUnit(&sb, u)
+	}
+	want := "a" + lead + trail + preSurrogate + "�"
+	if sb.String() != want {
+		t.Errorf("WriteCodeUnit sequence = %q, want %q", sb.String(), want)
+	}
+	if got := JoinSurrogatePairs(sb.String()); got != "a"+pair+preSurrogate+"�" {
+		t.Errorf("joined sequence = %q", got)
+	}
+}

--- a/tests/scripts/intl_segmenter_basic.ts
+++ b/tests/scripts/intl_segmenter_basic.ts
@@ -1,0 +1,89 @@
+// expect: ok
+// Intl.Segmenter (#210): default-locale grapheme/word/sentence segmentation,
+// Segments iteration + containing(), resolvedOptions, supportedLocalesOf,
+// and the Intl namespace object itself.
+
+const results: string[] = [];
+function check(name: string, cond: boolean) {
+  if (!cond) results.push(name);
+}
+
+check("typeof Intl", typeof Intl === "object");
+check("Intl toStringTag", Object.prototype.toString.call(Intl) === "[object Intl]");
+check("Segmenter is function", typeof Intl.Segmenter === "function");
+
+// Graphemes: combining marks, ZWJ emoji sequences and flags are single
+// segments; indices are UTF-16 code units.
+const graphemes: Intl.Segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+const text = "éa👨‍👩‍👧‍👦🇵🇱b";
+const gs: Intl.SegmentData[] = [...graphemes.segment(text)];
+check("grapheme count", gs.length === 5);
+check("grapheme[0]", gs[0].segment === "é" && gs[0].index === 0);
+check("grapheme[1]", gs[1].segment === "a" && gs[1].index === 2);
+check("grapheme[2] family", gs[2].segment === "👨‍👩‍👧‍👦" && gs[2].index === 3);
+check("grapheme[3] flag", gs[3].segment === "🇵🇱" && gs[3].index === 14);
+check("grapheme[4]", gs[4].segment === "b" && gs[4].index === 18);
+check("grapheme isWordLike absent", !("isWordLike" in gs[0]));
+check("grapheme input", gs[0].input === text);
+check("grapheme roundtrip", gs.map((g) => g.segment).join("") === text);
+
+// Lone surrogates are their own segments; a pair built by concatenation is
+// the same JS string as the literal and segments identically.
+const lone = [...graphemes.segment("\ud800 \udc00")];
+check("lone surrogates", lone.length === 3 && lone[0].segment === "\ud800" && lone[2].segment === "\udc00" && lone[2].index === 2);
+const joined = "\ud800" + "\udc00";
+const pairSegs = [...graphemes.segment(joined + "x")];
+check("concatenated pair", pairSegs.length === 2 && pairSegs[0].segment === "𐀀" && pairSegs[1].index === 2);
+check("containing trail surrogate", graphemes.segment(joined).containing(1)!.segment === joined);
+
+// Words: isWordLike marks letter/number runs; punctuation and spaces are not.
+const words = new Intl.Segmenter("en", { granularity: "word" });
+const ws = [...words.segment("Hello, wörld! It's 3.14")];
+check("word segments", ws.map((w) => w.segment).join("|") === "Hello|,| |wörld|!| |It's| |3.14");
+check("word isWordLike", ws.map((w) => (w.isWordLike ? "1" : "0")).join("") === "100100101");
+check("word index", ws[3].index === 7 && ws[3].input === "Hello, wörld! It's 3.14");
+
+// Sentences.
+const sentences = new Intl.Segmenter("en", { granularity: "sentence" });
+const ss = [...sentences.segment("Hello world! How are you? Fine.")];
+check("sentence segments", ss.map((s) => s.segment).join("|") === "Hello world! |How are you? |Fine.");
+
+// containing(): by UTF-16 index, undefined when out of range; the Segments
+// object can be iterated repeatedly and independently of containing().
+const segs: Intl.Segments = words.segment("ab cd");
+check("containing(1)", segs.containing(1)!.segment === "ab" && segs.containing(1)!.index === 0);
+check("containing(2)", segs.containing(2)!.segment === " ");
+check("containing(4)", segs.containing(4)!.segment === "cd" && segs.containing(4)!.index === 3);
+check("containing(-1)", segs.containing(-1) === undefined);
+check("containing(5)", segs.containing(5) === undefined);
+check("containing default", segs.containing()!.index === 0);
+check("re-iterable", [...segs].length === 3 && [...segs].length === 3);
+
+// Iterator protocol details.
+const it = segs[Symbol.iterator]();
+check("iterator toStringTag", Object.prototype.toString.call(it) === "[object Segmenter String Iterator]");
+check("iterator next", it.next().value.segment === "ab" && it.next().value.segment === " " && it.next().value.segment === "cd" && it.next().done === true);
+
+// Options and locales.
+check("default granularity", new Intl.Segmenter().resolvedOptions().granularity === "grapheme");
+check("locale canonicalized", new Intl.Segmenter("en-us").resolvedOptions().locale === "en-US");
+check("unsupported falls through", new Intl.Segmenter(["xyz", "de"]).resolvedOptions().locale === "de");
+check("extensions dropped", new Intl.Segmenter("pl-PL-u-nu-latn").resolvedOptions().locale === "pl-PL");
+check("supportedLocalesOf", Intl.Segmenter.supportedLocalesOf(["sr-Thai-RS", "zxx", "de"]).join(",") === "sr-Thai-RS,de");
+check("getCanonicalLocales", Intl.getCanonicalLocales(["EN-us", "en-US", "iw", "zh-hans-cn-u-nu-latn-ca-gregory"]).join(",") === "en-US,he,zh-Hans-CN-u-ca-gregory-nu-latn");
+check("prototype toStringTag", Object.prototype.toString.call(words) === "[object Intl.Segmenter]");
+
+let threw = "";
+try { (Intl.Segmenter as any)(); } catch (e) { threw = (e as Error).constructor.name; }
+check("requires new", threw === "TypeError");
+threw = "";
+try { new Intl.Segmenter("en-GB-oed"); } catch (e) { threw = (e as Error).constructor.name; }
+check("invalid tag RangeError", threw === "RangeError");
+threw = "";
+try { new Intl.Segmenter(undefined, { granularity: "line" }); } catch (e) { threw = (e as Error).constructor.name; }
+check("invalid granularity RangeError", threw === "RangeError");
+threw = "";
+try { Intl.Segmenter.prototype.segment.call({}, "x"); } catch (e) { threw = (e as Error).constructor.name; }
+check("branding TypeError", threw === "TypeError");
+
+results.length === 0 ? "ok" : "failed: " + results.join(", ");

--- a/tests/scripts/spread_type_error_array.ts
+++ b/tests/scripts/spread_type_error_array.ts
@@ -1,4 +1,5 @@
-// Test spread type error with non-array
-let notArray = "string";
+// Test spread type error with a non-iterable value.
+// Strings are iterable (Symbol.iterator) so [...str] is legal; numbers are not.
+let notArray = 42;
 [...notArray];
 // expect_compile_error: spread syntax can only be applied to arrays

--- a/tests/scripts/wtf8_surrogate_pairs.ts
+++ b/tests/scripts/wtf8_surrogate_pairs.ts
@@ -33,8 +33,8 @@ check("fromCharCode", String.fromCharCode(0xd800, 0xdc00) === lit && bytes(Strin
 check("fromCodePoint surrogates", String.fromCodePoint(0xd800, 0xdc00) === lit && bytes(String.fromCodePoint(0xdc00)) === 3);
 check("JSON.parse", JSON.parse("\"\\ud800\\udc00\"") === lit && bytes(JSON.parse("\"\\ud800\"")) === 3 && JSON.parse("\"\\ud800\"").charCodeAt(0) === 0xd800);
 check("JSON roundtrip", JSON.stringify(lead + trail) === JSON.stringify(lit) && JSON.stringify(lead) === "\"\\ud800\"");
-check("spread pair", [...((lead + trail) as any)].length === 1 && [...(("a" + lit + "b") as any)].length === 3);
-check("spread lone", [...(lead as any)].length === 1 && [...(lead as any)][0] === lead && [...((trail + lead) as any)].length === 2);
+check("spread pair", [...(lead + trail)].length === 1 && [...("a" + lit + "b")].length === 3);
+check("spread lone", [...lead].length === 1 && [...lead][0] === lead && [...(trail + lead)].length === 2);
 check("encodeURIComponent", encodeURIComponent(lead + trail) === "%F0%90%80%80");
 check("regex /u", /^.$/u.test(lead + trail) && /^\p{Any}$/u.test(lead + trail));
 check("iterator", Array.from(lead + trail).length === 1);

--- a/tests/scripts/wtf8_surrogate_pairs.ts
+++ b/tests/scripts/wtf8_surrogate_pairs.ts
@@ -1,0 +1,44 @@
+// expect: ok
+// WTF-8 canonical form: the same JS string must have one byte representation
+// whether a supplementary character was written as one literal character, as
+// two \uXXXX escapes, or assembled from lone surrogates by concatenation and
+// friends. Byte-sensitive builtins (TextEncoder, encodeURIComponent, /u
+// regexes, spread) are how the difference would show.
+
+const results: string[] = [];
+function check(name: string, cond: boolean) { if (!cond) results.push(name); }
+function bytes(s: string): number { return new TextEncoder().encode(s).length; }
+function units(s: string): string { const out: string[] = []; for (let i = 0; i < s.length; i++) out.push(s.charCodeAt(i).toString(16)); return out.join(" "); }
+
+const lit = String.fromCodePoint(0x10000);
+check("fromCodePoint bytes", bytes(lit) === 4 && units(lit) === "d800 dc00");
+const esc = "\ud800\udc00";
+check("escaped literal", esc === lit && bytes(esc) === 4);
+check("escaped literal in array", bytes(["\ud800\udc00"][0]) === 4);
+check("template literal", bytes(`\ud800\udc00`) === 4 && bytes(`x${"\ud800"}${"\udc00"}`) === 5);
+const lead = "\ud800", trail = "\udc00";
+check("lone surrogates stay", bytes(lead) === 3 && bytes(trail) === 3 && units(lead) === "d800");
+check("concat", bytes(lead + trail) === 4 && lead + trail === lit);
+let acc = "a" + lead; acc += trail; acc += "b";
+check("compound concat", bytes(acc) === 6 && acc === "a" + lit + "b");
+check("reverse order not joined", bytes(trail + lead) === 6 && units(trail + lead) === "dc00 d800");
+check("String.prototype.concat", bytes(lead.concat(trail)) === 4);
+check("Array.prototype.join", bytes([lead, trail].join("")) === 4 && bytes([lead, trail].join("-")) === 7);
+check("padStart", bytes(trail.padStart(2, lead)) === 4 && trail.padStart(2, lead) === lit);
+check("padEnd", bytes(lead.padEnd(2, trail)) === 4 && "ab".padEnd(5, lit) === "ab" + lit + lead);
+check("repeat", bytes((trail + lead).repeat(2)) === 10 && units((trail + lead).repeat(2)) === "dc00 d800 dc00 d800");
+check("replace", bytes(("a" + trail).replace("a", lead)) === 4 && bytes(("a" + trail).replaceAll("a", lead)) === 4);
+check("regex replace", bytes(("a" + trail).replace(/a/, lead)) === 4 && bytes(("a" + trail).replace(/a/g, "$&" + lead)) === 5);
+check("fromCharCode", String.fromCharCode(0xd800, 0xdc00) === lit && bytes(String.fromCharCode(0xd800, 0xdc00)) === 4 && bytes(String.fromCharCode(0xd800)) === 3);
+check("fromCodePoint surrogates", String.fromCodePoint(0xd800, 0xdc00) === lit && bytes(String.fromCodePoint(0xdc00)) === 3);
+check("JSON.parse", JSON.parse("\"\\ud800\\udc00\"") === lit && bytes(JSON.parse("\"\\ud800\"")) === 3 && JSON.parse("\"\\ud800\"").charCodeAt(0) === 0xd800);
+check("JSON roundtrip", JSON.stringify(lead + trail) === JSON.stringify(lit) && JSON.stringify(lead) === "\"\\ud800\"");
+check("spread pair", [...((lead + trail) as any)].length === 1 && [...(("a" + lit + "b") as any)].length === 3);
+check("spread lone", [...(lead as any)].length === 1 && [...(lead as any)][0] === lead && [...((trail + lead) as any)].length === 2);
+check("encodeURIComponent", encodeURIComponent(lead + trail) === "%F0%90%80%80");
+check("regex /u", /^.$/u.test(lead + trail) && /^\p{Any}$/u.test(lead + trail));
+check("iterator", Array.from(lead + trail).length === 1);
+check("length/indexing", (lead + trail).length === 2 && (lead + trail)[0] === lead && (lead + trail).slice(1) === trail);
+check("eval", bytes(eval("\"\\ud800\\udc00\"")) === 4);
+
+results.length === 0 ? "ok" : "failed: " + results.join(", ");


### PR DESCRIPTION
## Summary

Closes #210: `Intl` did not exist, and pi-tui's real bundle constructs `Intl.Segmenter` at module load. While testing it, a second, older problem surfaced: the same JS string could have two byte representations in the VM, which every byte-slicing builtin could observe. This PR fixes both, in two commits.

### 1. `Intl` namespace with `Intl.Segmenter`

- `Intl` object with `@@toStringTag` and `Intl.getCanonicalLocales`.
- `Intl.Segmenter` over UAX #29 default segmentation via `rivo/uniseg` (new dependency, MIT, no transitive deps): grapheme, word and sentence granularity, `segment()`, `containing()`, for-of iteration, `isWordLike`, `resolvedOptions()`, `supportedLocalesOf`, subclassing, and cross-realm prototype resolution through a new `%Intl.Segmenter.prototype%` realm intrinsic.
- Locale plumbing in `intl_locale.go`: UTS #35 structural validation, canonicalization, `CanonicalizeLocaleList`, default locale from the POSIX environment, lookup matcher. There is no CLDR data; "available locale" means a known ISO 639 language, which is enough because default segmentation is locale-independent.
- Prototype methods brand-check through a new generic `InternalSlots` field on `PlainObject`. TypeScript types expose `Intl.Segmenter`, `Intl.Segments`, `Intl.SegmentData` in type position.
- Two pre-existing VM bugs the test262 suite exposed, fixed alongside: `toPrimitive` ignored an exception thrown by a `valueOf`/`toString`/`@@toPrimitive` accessor when a catch handler existed and then threw a second TypeError that escaped `try/catch`; `Symbol.prototype` was parented to a placeholder object, so Symbol wrappers never saw `Object.prototype`.

### 2. Canonical WTF-8 strings

The lexer decoded each `\uXXXX` escape on its own and never joined a lead+trail pair, so `"𐀀"` was 6 bytes while the literal character was 4. Concatenation, `concat`, `join`, `padStart`/`padEnd`, `repeat`, `replace`/`replaceAll` and RegExp replace results did the same; `fromCharCode`, `fromCodePoint`, `padStart`/`padEnd` and `JSON.parse` turned lone surrogates into U+FFFD; spreading a string iterated Go runes.

- New `pkg/wtf8` (shared by lexer and VM): `JoinSurrogatePairs`, an O(1) seam-check `Concat` for the `OpAdd`/`OpStringConcat` hot paths, `WriteCodeUnit`, `HasSurrogate`. Canonicalization happens at the producers; `NewString` stays O(1) so `s = s.slice(pos)` loops do not become quadratic.
- With pairs always 4 bytes, half-character operations needed fixing too: `"😀".slice(0,1)` returned the whole character and `indexOf("\ude00")` could not see inside it. New `vm.UTF16Substring` and UTF-16 search helpers back `slice`/`substring`/`substr`, `split("")`, and the `indexOf` family whenever a needle holds a lone surrogate.
- `JSON.parse` routes text with surrogate escapes or raw surrogate bytes through the WTF-8-preserving parser. `String.prototype.concat`'s type declared a `string` rest parameter, which made any two-argument call a checker error.

## Known limitations

- No dictionary-based word breaking: Thai and CJK text break per character under `"word"`, where ICU consults a dictionary.
- `Intl.getCanonicalLocales` is best-effort on CLDR aliases (small table plus ISO 639-2/3 to 639-1 mapping).
- The remaining Segmenter failure, `Reflect.construct` with a Proxy newTarget, is a known engine-wide gap (`Map` fails identically).
- The type checker still rejects `[...str]`; the smoke test casts through `any`.

## Verification

| Check | Result |
|---|---|
| test262 intl402/Segmenter | 78 / 79 (was 0) |
| test262 built-ins vs baseline | +24 passes, 0 regressions |
| test262 language, main build vs this build | 0 regressions, 3 new passes |
| `go test ./tests -run TestScripts` | green, new `intl_segmenter_basic.ts` and `wtf8_surrogate_pairs.ts` |
| Go unit tests (wtf8, vm string helpers, Intl locale helpers) | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
