### PR TITLE
fix: arrow this-capture, const self-reference, function prototype accessors, and two regex property-escape gaps (#222-#226)

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -1891,6 +1891,38 @@ func (c *Checker) visit(node parser.Node) {
 			}
 			c.checkDefiniteAssignmentAssertionInitializer(declarator)
 
+			// --- FIX for self-referencing const arrow/function expressions nested in a
+			// function body: temporarily define the name (mirroring what LetStatement
+			// and VarStatement already do) BEFORE visiting the initializer, so a
+			// self-reference inside the initializer's own body (e.g. a memoized/lazy
+			// builder pattern: `const builder = () => { return builder.level; }`)
+			// resolves instead of reporting "Cannot find name". At module/program
+			// scope this is already handled by Pass 2 hoisting; nested const
+			// declarations have no such pre-pass, so it must happen here too. ---
+			var preliminaryInitializerType types.Type = nil
+			if funcLit, ok := declarator.Value.(*parser.FunctionLiteral); ok {
+				prelimSig := c.resolveFunctionLiteralSignature(funcLit, c.env)
+				if prelimSig == nil {
+					prelimSig = &types.Signature{
+						ParameterTypes: make([]types.Type, len(funcLit.Parameters)),
+						ReturnType:     types.Any,
+					}
+					for i := range prelimSig.ParameterTypes {
+						prelimSig.ParameterTypes[i] = types.Any
+					}
+				}
+				preliminaryInitializerType = types.NewFunctionType(prelimSig)
+			}
+			tempType := preliminaryInitializerType
+			if tempType == nil {
+				tempType = declaredType // Use annotation if no prelim func type
+			}
+			if tempType == nil {
+				tempType = types.Any // Fallback to Any (covers arrow functions, etc.)
+			}
+			preDefined := declarator.Value != nil && c.env.Define(declarator.Name.Value, tempType, true)
+			debugPrintf("// [Checker ConstStmt] Temp Define '%s' as: %s (ok=%v)\n", declarator.Name.Value, tempType.String(), preDefined)
+
 			// 2. Handle Initializer (Must be present for const)
 			var computedInitializerType types.Type
 			if declarator.Value != nil {
@@ -1953,8 +1985,13 @@ func (c *Checker) visit(node parser.Node) {
 				}
 			}
 
-			// 4. Define variable in the current environment
-			if !c.env.Define(declarator.Name.Value, finalType, true) {
+			// 4. Define (or, if pre-defined above for self-reference support, update)
+			// the variable's final type in the current environment.
+			if preDefined {
+				if !c.env.Update(declarator.Name.Value, finalType) {
+					debugPrintf("// [Checker ConstStmt] WARNING: Update failed unexpectedly for '%s'\n", declarator.Name.Value)
+				}
+			} else if !c.env.Define(declarator.Name.Value, finalType, true) {
 				c.addError(declarator.Name, fmt.Sprintf("constant '%s' already declared in this scope", declarator.Name.Value))
 			}
 			// Set computed type on the Name Identifier node itself and the declarator

--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -943,7 +943,7 @@ func (c *Compiler) compileObjectLiteral(node *parser.ObjectLiteral, hint Registe
 							freePropertyRegs()
 							return BadRegister, compileErr
 						}
-						c.emitClosureGeneric(valueReg, funcConstIndex, arrowFunc.Token.Line, &parser.Identifier{Token: arrowFunc.Token, Value: propName}, freeSymbols)
+						c.emitClosureGeneric(valueReg, funcConstIndex, arrowFunc.Token.Line, &parser.Identifier{Token: arrowFunc.Token, Value: propName}, freeSymbols, true)
 						valueCompiled = true
 					} else if funcLit, ok := prop.Value.(*parser.FunctionLiteral); ok {
 						if funcLit.Name == nil || funcLit.Name.Value == "" {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1515,8 +1515,8 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 		if hint == NoHint || hint == BadRegister {
 			hint = c.regAlloc.Alloc()
 		}
-		// Emit OpClosure using the generic emitter
-		c.emitClosureGeneric(hint, funcConstIndex, node.Token.Line, node.Name, freeSymbols)
+		// Emit OpClosure using the generic emitter (shorthand methods are not arrow functions)
+		c.emitClosureGeneric(hint, funcConstIndex, node.Token.Line, node.Name, freeSymbols, false)
 
 		return hint, nil
 
@@ -4033,9 +4033,14 @@ func (c *Compiler) emitClosure(destReg Register, funcConstIndex uint16, node *pa
 // emitClosureGeneric is a generic version of emitClosure that works with any node type
 // that has Token.Line and Name fields (like ShorthandMethod)
 // OPTIMIZATION: If there are no upvalues, just load the function constant directly.
-func (c *Compiler) emitClosureGeneric(destReg Register, funcConstIndex uint16, line int, nameNode *parser.Identifier, freeSymbols []*Symbol) Register {
+// This optimization is unsafe for arrow functions: they always need their own
+// Closure wrapper so CapturedThis (and new.target/arguments inheritance) is
+// populated, even when they capture zero named free variables (e.g. an arrow
+// whose only free reference is `this`). Callers must pass isArrowFunction=true
+// for arrow functions so this path always goes through OpClosure instead.
+func (c *Compiler) emitClosureGeneric(destReg Register, funcConstIndex uint16, line int, nameNode *parser.Identifier, freeSymbols []*Symbol, isArrowFunction bool) Register {
 	// OPTIMIZATION: If no upvalues, just load the function constant
-	if len(freeSymbols) == 0 {
+	if len(freeSymbols) == 0 && !isArrowFunction {
 		debugPrintf("// [emitClosureGeneric OPTIMIZED] No upvalues, using OpLoadConstant instead of OpClosure\n")
 		c.emitLoadConstant(destReg, funcConstIndex, line)
 		return destReg

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -282,6 +282,14 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			}
 			return true, InterpretOK, *valueToSet
 		}
+		// Check the function's *custom* [[Prototype]] chain (set via
+		// Object.setPrototypeOf) for an inherited accessor setter — e.g.
+		// chalk's `level` setter defined on a Function-typed prototype.
+		if propName != "prototype" && fn.Prototype.Type() != TypeNull && fn.Prototype.Type() != TypeUndefined {
+			if handled, ok, status, val := vm.checkCustomProtoChainAccessorSetter(fn.Prototype, propName, objVal, valueToSet); handled {
+				return ok, status, val
+			}
+		}
 		// Check Function.prototype for inherited accessor properties (e.g., caller, arguments)
 		// Only for strict/arrow/generator/async functions; sloppy regular functions allow setting caller/arguments
 		if fn.IsArrowFunction || fn.IsGenerator || fn.IsAsync || (fn.Chunk != nil && fn.Chunk.IsStrict) {
@@ -365,6 +373,14 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 				return false, InterpretRuntimeError, Undefined
 			}
 			return true, InterpretOK, *valueToSet
+		}
+		// Check the closure's *custom* [[Prototype]] chain (set via
+		// Object.setPrototypeOf) for an inherited accessor setter — e.g.
+		// chalk's `level` setter defined on a Function-typed prototype.
+		if propName != "prototype" && closure.Fn.Prototype.Type() != TypeNull && closure.Fn.Prototype.Type() != TypeUndefined {
+			if handled, ok, status, val := vm.checkCustomProtoChainAccessorSetter(closure.Fn.Prototype, propName, objVal, valueToSet); handled {
+				return ok, status, val
+			}
 		}
 		// Check Function.prototype for inherited accessor properties (e.g., caller, arguments)
 		// Only for strict/arrow/generator/async functions; sloppy regular functions allow setting caller/arguments

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -122,6 +122,24 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 			case TypeClosure:
 				cl := proto.AsClosure()
 				if cl.Properties != nil {
+					// Check accessor properties (getters/setters) before plain data
+					// properties — e.g. chalk's `level` getter defined via
+					// Object.defineProperty on a Function-typed prototype.
+					if getter, _, _, _, exists := cl.Properties.GetOwnAccessor(propName); exists {
+						if getter.Type() != TypeUndefined {
+							res, err := vm.Call(getter, objVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.throwException(NewString(err.Error()))
+								}
+								return Undefined, false
+							}
+							return res, true
+						}
+						return Undefined, true
+					}
 					if prop, exists := cl.Properties.GetOwn(propName); exists {
 						return prop, true
 					}
@@ -130,6 +148,23 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 			case TypeFunction:
 				fn := proto.AsFunction()
 				if fn.Properties != nil {
+					// Check accessor properties (getters/setters) before plain data
+					// properties — see TypeClosure case above for rationale.
+					if getter, _, _, _, exists := fn.Properties.GetOwnAccessor(propName); exists {
+						if getter.Type() != TypeUndefined {
+							res, err := vm.Call(getter, objVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.throwException(NewString(err.Error()))
+								}
+								return Undefined, false
+							}
+							return res, true
+						}
+						return Undefined, true
+					}
 					if prop, exists := fn.Properties.GetOwn(propName); exists {
 						return prop, true
 					}
@@ -489,6 +524,102 @@ func (vm *VM) checkFunctionProtoAccessorSetter(propName string, objVal *Value, v
 				return true, false, InterpretRuntimeError, Undefined
 			}
 			return true, true, InterpretOK, *valueToSet
+		}
+	}
+	return false, false, InterpretOK, Undefined
+}
+
+// checkCustomProtoChainAccessorSetter walks a Closure/Function's *custom*
+// [[Prototype]] chain (set via Object.setPrototypeOf, e.g. chalk's
+// `Object.setPrototypeOf(builder, proto)` where proto is itself a Function)
+// looking for an inherited accessor property with a setter. This mirrors the
+// getter-side walk in handleCallableProperty: without it, `fn.level = v` where
+// `level` is a setter defined on a Function-typed prototype silently creates
+// a shadowing own data property on fn instead of invoking the inherited
+// setter, matching the getter bug's root cause (issue #223).
+func (vm *VM) checkCustomProtoChainAccessorSetter(startProto Value, propName string, objVal *Value, valueToSet *Value) (handled bool, ok bool, status InterpretResult, val Value) {
+	proto := startProto
+	for proto.Type() != TypeNull && proto.Type() != TypeUndefined {
+		switch proto.Type() {
+		case TypeClosure:
+			cl := proto.AsClosure()
+			if cl.Properties != nil {
+				if _, setter, _, _, exists := cl.Properties.GetOwnAccessor(propName); exists {
+					if setter.Type() == TypeUndefined {
+						// Accessor exists but has no setter: per spec this is a
+						// silent no-op in sloppy mode (throwing is handled by
+						// the caller's strict-mode logic elsewhere, if any).
+						return true, true, InterpretOK, *valueToSet
+					}
+					_, err := vm.Call(setter, *objVal, []Value{*valueToSet})
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							vm.throwException(ee.GetExceptionValue())
+						} else {
+							vm.throwException(NewString(err.Error()))
+						}
+						return true, false, InterpretRuntimeError, Undefined
+					}
+					return true, true, InterpretOK, *valueToSet
+				}
+				if _, exists := cl.Properties.GetOwn(propName); exists {
+					// Inherited plain data property: per spec, assignment
+					// creates a new own property on the receiver rather than
+					// mutating the inherited one, so stop walking and let the
+					// caller fall through to its normal own-property set path.
+					return false, false, InterpretOK, Undefined
+				}
+			}
+			proto = cl.Fn.Prototype
+		case TypeFunction:
+			fnProto := proto.AsFunction()
+			if fnProto.Properties != nil {
+				if _, setter, _, _, exists := fnProto.Properties.GetOwnAccessor(propName); exists {
+					if setter.Type() == TypeUndefined {
+						return true, true, InterpretOK, *valueToSet
+					}
+					_, err := vm.Call(setter, *objVal, []Value{*valueToSet})
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							vm.throwException(ee.GetExceptionValue())
+						} else {
+							vm.throwException(NewString(err.Error()))
+						}
+						return true, false, InterpretRuntimeError, Undefined
+					}
+					return true, true, InterpretOK, *valueToSet
+				}
+				if _, exists := fnProto.Properties.GetOwn(propName); exists {
+					return false, false, InterpretOK, Undefined
+				}
+			}
+			proto = fnProto.Prototype
+		case TypeObject:
+			po := proto.AsPlainObject()
+			if po == nil {
+				return false, false, InterpretOK, Undefined
+			}
+			if _, setter, _, _, exists := po.GetOwnAccessor(propName); exists {
+				if setter.Type() == TypeUndefined {
+					return true, true, InterpretOK, *valueToSet
+				}
+				_, err := vm.Call(setter, *objVal, []Value{*valueToSet})
+				if err != nil {
+					if ee, ok := err.(ExceptionError); ok {
+						vm.throwException(ee.GetExceptionValue())
+					} else {
+						vm.throwException(NewString(err.Error()))
+					}
+					return true, false, InterpretRuntimeError, Undefined
+				}
+				return true, true, InterpretOK, *valueToSet
+			}
+			if _, exists := po.GetOwn(propName); exists {
+				return false, false, InterpretOK, Undefined
+			}
+			proto = po.GetPrototype()
+		default:
+			return false, false, InterpretOK, Undefined
 		}
 	}
 	return false, false, InterpretOK, Undefined

--- a/pkg/vm/regex_emoji.go
+++ b/pkg/vm/regex_emoji.go
@@ -1,0 +1,185 @@
+package vm
+
+import (
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// Unicode's "properties of strings" (RGI_Emoji and friends, from the
+// emoji-sequence data files, not DerivedCoreProperties.txt) are a different
+// kind of gap than the properties expandDerivedUnicodeProperties handles
+// above: they match whole *sequences* of code points (a skin-toned emoji, a
+// flag, a family joined with ZWJ), valid only under the `v` flag, and are
+// fundamentally not expressible as a `[...]` character class - neither
+// engine has any notion of them at all (paserati#224). Go's unicode package
+// ships no equivalent data (no Emoji_Modifier_Base, no Extended_Pictographic,
+// no RGI_Emoji_ZWJ_Sequence list), so this file hand-assembles a real
+// (?:alternation) of sequence shapes from the pieces Unicode's emoji
+// specification defines structurally, rather than pass the name through for
+// the engines to reject.
+//
+// This is a best-effort approximation, not the literal curated data:
+//
+//   - Basic_Emoji is approximated as the five solid default-emoji-presentation
+//     blocks (Misc Symbols & Pictographs, Emoticons, Transport & Map Symbols,
+//     Supplemental Symbols & Pictographs, Symbols & Pictographs Extended-A)
+//     plus an optional trailing VS16. Older scattered single emoji that need
+//     an explicit VS16 outside those blocks (e.g. the original dingbats) are
+//     not covered.
+//   - RGI_Emoji_Flag_Sequence is any two Regional_Indicator symbols, not
+//     restricted to currently-assigned region codes (Go carries no such
+//     restriction list either).
+//   - RGI_Emoji_Modifier_Sequence uses a hand-maintained Emoji_Modifier_Base
+//     range list (Unicode has no single stable table for it; this one won't
+//     track future emoji releases automatically).
+//   - RGI_Emoji_ZWJ_Sequence is approximated as two or more of the above
+//     units joined by ZWJ, rather than the actual finite curated sequence
+//     list (~1500 entries) - this can accept a well-formed but not
+//     Unicode-recognized combination, but every real ZWJ emoji (family,
+//     couple, profession-with-skin-tone, ...) is built from exactly these
+//     parts and so still matches.
+//   - RGI_Emoji_Tag_Sequence is exact (the flag-tag-cancel grammar has no
+//     ambiguity to approximate).
+//   - Emoji_Keycap_Sequence is exact.
+//
+// Per ECMAScript, a property of strings can only be used as \p{Name} (never
+// negated with \P{Name} - that's a SyntaxError) and, in this implementation,
+// only outside a character class: splicing a multi-codepoint alternation
+// into a `[...]` class is a `v`-flag-only construct with no equivalent in
+// either underlying engine's class syntax.
+
+// Code points structural to the emoji-sequence grammar itself (not table
+// data - these are exact, stable parts of the Unicode emoji specification).
+const (
+	emojiVS16       rune = 0x0000FE0F // Variation Selector-16 (emoji presentation)
+	emojiZWJ        rune = 0x0000200D // Zero Width Joiner
+	emojiKeycapMark rune = 0x000020E3 // Combining Enclosing Keycap
+	emojiModifierLo rune = 0x0001F3FB // Skin tone modifiers (Emoji_Modifier)
+	emojiModifierHi rune = 0x0001F3FF
+	emojiTagBase    rune = 0x0001F3F4 // WAVING BLACK FLAG (RGI tag-sequence base)
+	emojiTagLo      rune = 0x000E0020 // Tag characters
+	emojiTagHi      rune = 0x000E007E
+	emojiTagCancel  rune = 0x000E007F // CANCEL TAG
+)
+
+// emojiModifierBaseRanges: a hand-maintained approximation of
+// Emoji_Modifier_Base (Unicode ships no single stable table for it; see the
+// package doc comment above).
+var emojiModifierBaseRanges = []runeRange{
+	{0x261D, 0x261D}, {0x26F9, 0x26F9}, {0x270A, 0x270D},
+	{0x1F385, 0x1F385}, {0x1F3C2, 0x1F3C4}, {0x1F3C7, 0x1F3C7},
+	{0x1F3CA, 0x1F3CC}, {0x1F442, 0x1F443}, {0x1F446, 0x1F450},
+	{0x1F466, 0x1F469}, {0x1F46E, 0x1F46E}, {0x1F470, 0x1F478},
+	{0x1F47C, 0x1F47C}, {0x1F481, 0x1F483}, {0x1F485, 0x1F487},
+	{0x1F48F, 0x1F48F}, {0x1F491, 0x1F491}, {0x1F4AA, 0x1F4AA},
+	{0x1F574, 0x1F575}, {0x1F57A, 0x1F57A}, {0x1F590, 0x1F590},
+	{0x1F595, 0x1F596}, {0x1F645, 0x1F647}, {0x1F64B, 0x1F64F},
+	{0x1F6A3, 0x1F6A3}, {0x1F6B4, 0x1F6B6}, {0x1F6C0, 0x1F6C0},
+	{0x1F6CC, 0x1F6CC}, {0x1F90C, 0x1F90C}, {0x1F90F, 0x1F90F},
+	{0x1F918, 0x1F91F}, {0x1F926, 0x1F926}, {0x1F930, 0x1F939},
+	{0x1F93D, 0x1F93E}, {0x1F9B5, 0x1F9B6}, {0x1F9B8, 0x1F9B9},
+	{0x1F9BB, 0x1F9BB}, {0x1F9CD, 0x1F9CF}, {0x1F9D1, 0x1F9DD},
+}
+
+// basicEmojiRanges: solid default-emoji-presentation blocks; see the package
+// doc comment above for what this deliberately does not cover.
+var basicEmojiRanges = []runeRange{
+	{0x1F300, 0x1F5FF}, // Miscellaneous Symbols and Pictographs
+	{0x1F600, 0x1F64F}, // Emoticons
+	{0x1F680, 0x1F6FF}, // Transport and Map Symbols
+	{0x1F900, 0x1F9FF}, // Supplemental Symbols and Pictographs
+	{0x1FA70, 0x1FAFF}, // Symbols and Pictographs Extended-A
+}
+
+// runeClass renders a `[...]` character class from a set of ranges, reusing
+// writeClassRanges/writeClassRune so astral code points are spelled the same
+// rune-literal way the rest of this package already relies on both engines
+// accepting in a class.
+func runeClass(ranges []runeRange) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	writeClassRanges(&b, ranges)
+	b.WriteByte(']')
+	return b.String()
+}
+
+func patternRune(r rune) string {
+	var b strings.Builder
+	writeClassRune(&b, r)
+	return b.String()
+}
+
+// regionalIndicatorRanges computes Regional_Indicator's ranges once, reusing
+// the same table this package already registers as a bare \p{} property.
+var regionalIndicatorRanges = &derivedProperty{build: func(set runeSet) {
+	set.include(unicode.Regional_Indicator)
+}}
+
+// emojiPatternPiece lazily builds and caches one regex pattern fragment.
+type emojiPatternPiece struct {
+	once    sync.Once
+	build   func() string
+	pattern string
+}
+
+func (p *emojiPatternPiece) get() string {
+	p.once.Do(func() { p.pattern = p.build() })
+	return p.pattern
+}
+
+var basicEmojiPattern = &emojiPatternPiece{build: func() string {
+	return runeClass(basicEmojiRanges) + patternRune(emojiVS16) + "?"
+}}
+
+var modifierSeqPattern = &emojiPatternPiece{build: func() string {
+	return runeClass(emojiModifierBaseRanges) + patternRune(emojiVS16) + "?" +
+		"[" + patternRune(emojiModifierLo) + "-" + patternRune(emojiModifierHi) + "]"
+}}
+
+var flagSeqPattern = &emojiPatternPiece{build: func() string {
+	cls := runeClass(regionalIndicatorRanges.get().ranges)
+	return cls + cls
+}}
+
+var tagSeqPattern = &emojiPatternPiece{build: func() string {
+	return patternRune(emojiTagBase) +
+		"[" + patternRune(emojiTagLo) + "-" + patternRune(emojiTagHi) + "]+" +
+		patternRune(emojiTagCancel)
+}}
+
+var keycapSeqPattern = &emojiPatternPiece{build: func() string {
+	return `[0-9#*]` + patternRune(emojiVS16) + "?" + patternRune(emojiKeycapMark)
+}}
+
+var emojiUnitPattern = &emojiPatternPiece{build: func() string {
+	return "(?:" + strings.Join([]string{
+		tagSeqPattern.get(),
+		keycapSeqPattern.get(),
+		flagSeqPattern.get(),
+		modifierSeqPattern.get(),
+		basicEmojiPattern.get(),
+	}, "|") + ")"
+}}
+
+var zwjSeqPattern = &emojiPatternPiece{build: func() string {
+	unit := emojiUnitPattern.get()
+	return unit + "(?:" + patternRune(emojiZWJ) + unit + ")+"
+}}
+
+var rgiEmojiPattern = &emojiPatternPiece{build: func() string {
+	return "(?:" + zwjSeqPattern.get() + "|" + emojiUnitPattern.get() + ")"
+}}
+
+// emojiStringProperties maps each "property of strings" name ECMAScript's
+// emoji-sequence data defines to the pattern piece it expands to. Every
+// value is wrapped in its own non-capturing group by the caller.
+var emojiStringProperties = map[string]*emojiPatternPiece{
+	"Basic_Emoji":                 basicEmojiPattern,
+	"Emoji_Keycap_Sequence":       keycapSeqPattern,
+	"RGI_Emoji_Flag_Sequence":     flagSeqPattern,
+	"RGI_Emoji_Modifier_Sequence": modifierSeqPattern,
+	"RGI_Emoji_Tag_Sequence":      tagSeqPattern,
+	"RGI_Emoji_ZWJ_Sequence":      zwjSeqPattern,
+	"RGI_Emoji":                   rgiEmojiPattern,
+}

--- a/pkg/vm/regex_properties.go
+++ b/pkg/vm/regex_properties.go
@@ -298,12 +298,110 @@ func writeClassRanges(b *strings.Builder, ranges []runeRange) {
 	}
 }
 
+// scriptValueAliases maps the standard short (ISO 15924-style) aliases that
+// ECMAScript's Script/Script_Extensions property values accept to Go's
+// unicode.Scripts canonical key. A value that already spells a Go Scripts
+// key exactly (e.g. "Han", "Hiragana", "Greek") needs no entry here at all -
+// this table exists only to bridge the abbreviated forms (paserati#225).
+// Not exhaustive over every obscure historic script Go carries, but covers
+// the scripts real-world patterns actually name.
+var scriptValueAliases = map[string]string{
+	"Latn": "Latin", "Grek": "Greek", "Cyrl": "Cyrillic", "Armn": "Armenian",
+	"Hebr": "Hebrew", "Arab": "Arabic", "Syrc": "Syriac", "Thaa": "Thaana",
+	"Deva": "Devanagari", "Beng": "Bengali", "Guru": "Gurmukhi", "Gujr": "Gujarati",
+	"Orya": "Oriya", "Taml": "Tamil", "Telu": "Telugu", "Knda": "Kannada",
+	"Mlym": "Malayalam", "Sinh": "Sinhala", "Thai": "Thai", "Laoo": "Lao",
+	"Tibt": "Tibetan", "Mymr": "Myanmar", "Geor": "Georgian", "Hang": "Hangul",
+	"Ethi": "Ethiopic", "Cher": "Cherokee", "Cans": "Canadian_Aboriginal",
+	"Ogam": "Ogham", "Runr": "Runic", "Khmr": "Khmer", "Mong": "Mongolian",
+	"Hira": "Hiragana", "Kana": "Katakana", "Bopo": "Bopomofo", "Hani": "Han",
+	"Yiii": "Yi", "Ital": "Old_Italic", "Goth": "Gothic", "Dsrt": "Deseret",
+	"Zyyy": "Common", "Zinh": "Inherited", "Copt": "Coptic", "Brai": "Braille",
+	"Nkoo": "Nko", "Tglg": "Tagalog", "Hano": "Hanunoo", "Buhd": "Buhid",
+	"Tagb": "Tagbanwa", "Limb": "Limbu", "Tale": "Tai_Le", "Talu": "New_Tai_Lue",
+	"Bugi": "Buginese", "Bali": "Balinese", "Java": "Javanese", "Sund": "Sundanese",
+	"Batk": "Batak", "Lepc": "Lepcha", "Olck": "Ol_Chiki", "Vaii": "Vai",
+	"Bamu": "Bamum", "Adlm": "Adlam", "Osge": "Osage", "Glag": "Glagolitic",
+	"Shaw": "Shavian", "Osma": "Osmanya", "Cprt": "Cypriot", "Linb": "Linear_B",
+	"Lina": "Linear_A", "Xsux": "Cuneiform", "Egyp": "Egyptian_Hieroglyphs",
+	"Phnx": "Phoenician", "Samr": "Samaritan", "Mand": "Mandaic", "Avst": "Avestan",
+	"Prti": "Inscriptional_Parthian", "Phli": "Inscriptional_Pahlavi",
+	"Xpeo": "Old_Persian", "Ugar": "Ugaritic", "Sarb": "Old_South_Arabian",
+	"Narb": "Old_North_Arabian", "Armi": "Imperial_Aramaic", "Palm": "Palmyrene",
+	"Nbat": "Nabataean", "Hatr": "Hatran", "Chrs": "Chorasmian", "Sogd": "Sogdian",
+	"Sogo": "Old_Sogdian", "Elym": "Elymaic", "Mani": "Manichaean",
+	"Merc": "Meroitic_Cursive", "Mero": "Meroitic_Hieroglyphs",
+}
+
+// generalCategoryValueAliases maps the long-form ECMAScript General_Category
+// values (and a few common short aliases like "digit"/"punct"/"cntrl") to
+// Go's unicode.Categories canonical key. A value already spelling a Go
+// Categories key exactly (e.g. "Lu", "Nd", "Cn", "LC") needs no lookup here.
+var generalCategoryValueAliases = map[string]string{
+	"Cased_Letter": "LC", "Uppercase_Letter": "Lu", "Lowercase_Letter": "Ll",
+	"Titlecase_Letter": "Lt", "Modifier_Letter": "Lm", "Other_Letter": "Lo",
+	"Letter":          "L",
+	"Nonspacing_Mark": "Mn", "Spacing_Mark": "Mc", "Enclosing_Mark": "Me",
+	"Mark": "M", "Combining_Mark": "M",
+	"Decimal_Number": "Nd", "Letter_Number": "Nl", "Other_Number": "No",
+	"Number": "N", "digit": "Nd",
+	"Connector_Punctuation": "Pc", "Dash_Punctuation": "Pd", "Open_Punctuation": "Ps",
+	"Close_Punctuation": "Pe", "Initial_Punctuation": "Pi", "Final_Punctuation": "Pf",
+	"Other_Punctuation": "Po", "Punctuation": "P", "punct": "P",
+	"Math_Symbol": "Sm", "Currency_Symbol": "Sc", "Modifier_Symbol": "Sk",
+	"Other_Symbol": "So", "Symbol": "S",
+	"Space_Separator": "Zs", "Line_Separator": "Zl", "Paragraph_Separator": "Zp",
+	"Separator": "Z",
+	"Control":   "Cc", "cntrl": "Cc", "Format": "Cf", "Surrogate": "Cs",
+	"Private_Use": "Co", "Unassigned": "Cn", "Other": "C",
+}
+
+// resolveUnicodePropertyValuePair resolves an ECMAScript \p{Name=Value} /
+// \P{Name=Value} property escape (Script, Script_Extensions, and
+// General_Category, plus their short aliases sc/scx/gc - the forms
+// ECMAScript defines) into a bare property name both RE2 and regexp2 already
+// recognize natively (paserati#225). Neither engine parses the Name=Value
+// grammar at all - not "unknown value", the syntax itself isn't recognized -
+// so this rewrite happens before either engine ever sees the pattern.
+//
+// Script_Extensions is approximated with the same per-codepoint Script data
+// (Go ships no separate ScriptExtensions.txt table); this covers the
+// overwhelming majority of real usage - the two properties differ only for
+// characters shared across multiple scripts (e.g. combining marks, some
+// punctuation).
+func resolveUnicodePropertyValuePair(content string) (string, bool) {
+	name, value, hasEq := strings.Cut(content, "=")
+	if !hasEq {
+		return "", false
+	}
+	switch name {
+	case "Script", "sc", "Script_Extensions", "scx":
+		if _, ok := unicode.Scripts[value]; ok {
+			return value, true
+		}
+		if canonical, ok := scriptValueAliases[value]; ok {
+			return canonical, true
+		}
+	case "General_Category", "gc":
+		if _, ok := unicode.Categories[value]; ok {
+			return value, true
+		}
+		if canonical, ok := generalCategoryValueAliases[value]; ok {
+			return canonical, true
+		}
+	}
+	return "", false
+}
+
 // expandDerivedUnicodeProperties rewrites every \p{Name} / \P{Name} whose
-// Name is in derivedUnicodeProperties into explicit ranges. Inside a
-// character class only the members are emitted; outside, they're wrapped in
-// a class of their own. Every other escape - including every other \p{...}
-// name, and the \p{Script=...} / \p{General_Category=...} forms - passes
-// through untouched for the engines to judge.
+// Name is in derivedUnicodeProperties into explicit ranges, and every
+// \p{Name=Value} / \P{Name=Value} pair that resolveUnicodePropertyValuePair
+// recognizes into the bare engine-native property name it resolves to (see
+// that function's doc comment - paserati#225). Inside a character class only
+// the members are emitted; outside, they're wrapped in a class of their own.
+// Every other escape - including every other \p{...} name, and an
+// unresolvable \p{Name=Value} pair - passes through untouched for the
+// engines to judge.
 //
 // Operates on bytes like rewriteECMAClasses: every construct inspected is
 // ASCII, so multi-byte runes copy through as-is.
@@ -319,7 +417,8 @@ func expandDerivedUnicodeProperties(pattern string) string {
 		if c == '\\' && i+1 < len(pattern) {
 			if e := pattern[i+1]; (e == 'p' || e == 'P') && i+2 < len(pattern) && pattern[i+2] == '{' {
 				if end := strings.IndexByte(pattern[i+3:], '}'); end >= 0 {
-					if prop, ok := derivedUnicodeProperties[pattern[i+3:i+3+end]]; ok {
+					content := pattern[i+3 : i+3+end]
+					if prop, ok := derivedUnicodeProperties[content]; ok {
 						prop.get()
 						ranges := prop.ranges
 						if e == 'P' {
@@ -332,6 +431,15 @@ func expandDerivedUnicodeProperties(pattern string) string {
 						if !inClass {
 							b.WriteByte(']')
 						}
+						i += 3 + end
+						continue
+					}
+					if resolved, ok := resolveUnicodePropertyValuePair(content); ok {
+						b.WriteByte('\\')
+						b.WriteByte(e)
+						b.WriteByte('{')
+						b.WriteString(resolved)
+						b.WriteByte('}')
 						i += 3 + end
 						continue
 					}

--- a/pkg/vm/regex_properties.go
+++ b/pkg/vm/regex_properties.go
@@ -394,13 +394,16 @@ func resolveUnicodePropertyValuePair(content string) (string, bool) {
 }
 
 // expandDerivedUnicodeProperties rewrites every \p{Name} / \P{Name} whose
-// Name is in derivedUnicodeProperties into explicit ranges, and every
+// Name is in derivedUnicodeProperties into explicit ranges, every
 // \p{Name=Value} / \P{Name=Value} pair that resolveUnicodePropertyValuePair
 // recognizes into the bare engine-native property name it resolves to (see
-// that function's doc comment - paserati#225). Inside a character class only
-// the members are emitted; outside, they're wrapped in a class of their own.
-// Every other escape - including every other \p{...} name, and an
-// unresolvable \p{Name=Value} pair - passes through untouched for the
+// that function's doc comment - paserati#225), and every standalone,
+// non-negated \p{Name} naming one of Unicode's "properties of strings" (see
+// regex_emoji.go - paserati#224) into its sequence-alternation expansion.
+// Inside a character class only the members are emitted; outside, they're
+// wrapped in a class of their own. Every other escape - including every
+// other \p{...} name, an unresolvable \p{Name=Value} pair, and a property of
+// strings used negated or inside a class - passes through untouched for the
 // engines to judge.
 //
 // Operates on bytes like rewriteECMAClasses: every construct inspected is
@@ -442,6 +445,23 @@ func expandDerivedUnicodeProperties(pattern string) string {
 						b.WriteByte('}')
 						i += 3 + end
 						continue
+					}
+					// Unicode "properties of strings" (RGI_Emoji and friends,
+					// paserati#224): only valid as \p{Name} (never \P{Name} -
+					// negating a property of strings is a SyntaxError per
+					// spec), and only outside a character class - a
+					// multi-codepoint alternation has no equivalent inside
+					// `[...]` in either underlying engine. Leave both of
+					// those cases unexpanded so they fall through to the
+					// engines' own (correct) rejection.
+					if e == 'p' && !inClass {
+						if piece, ok := emojiStringProperties[content]; ok {
+							b.WriteString("(?:")
+							b.WriteString(piece.get())
+							b.WriteString(")")
+							i += 3 + end
+							continue
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes five open bugs, each found via the `noderati`/`pi-tui` real-world compatibility work. One commit per issue.

## Fixes #222 — arrow function as object-literal property value loses lexical `this`

`emitClosureGeneric`'s zero-upvalue fast path skipped `OpClosure` (loading the bare function constant directly) whenever an arrow function captured no *named* free variables — but an arrow whose only free reference is `this` still needs a `Closure` wrapper for `CapturedThis` to be populated. Gated the fast path on a new `isArrowFunction` flag so arrow functions always get a real closure, matching what the always-correct `compileArrowFunctionLiteral` path already does.

## Fixes #226 — nested `const` arrow function can't reference itself

`ConstStatement` checking never pre-declared the binding before visiting its initializer, unlike `LetStatement`/`VarStatement` which already do this for exactly this reason (self-referencing recursive functions). Mirrored that pattern for `const`.

## Fixes #223 — getter/setter on a Function-typed prototype not found via inherited access

This is chalk's actual color-level-detection bug. The `[[Prototype]]`-chain walk in `handleCallableProperty` (used for `Object.setPrototypeOf(fn, otherFn)`) checked only plain data properties for `Closure`/`Function`-typed prototype links, never accessors — so an inherited getter/setter defined via `Object.defineProperty` on a function silently resolved to `undefined` / silently shadowed instead of invoking. Fixed both the getter side and the analogous setter-side gap.

## Fixes #225 — `\p{Script=Value}` / `\p{General_Category=Value}` regex syntax unsupported

Neither RE2 nor regexp2 parses the `\p{Name=Value}` grammar at all — not "unknown value", the syntax itself isn't recognized. Both engines *do* accept the equivalent bare property name natively (`\p{Han}`, `\p{L}`, `\p{Lu}`, ...), so `Script`/`sc`, `Script_Extensions`/`scx`, and `General_Category`/`gc` pairs are now resolved to that bare form before either engine sees the pattern, using Go's own `unicode.Scripts`/`unicode.Categories` tables plus alias maps for the standard short spellings.

## Fixes #224 — Unicode "properties of strings" (`\p{RGI_Emoji}` etc.) unsupported by either engine

Unlike single-codepoint property gaps, these match whole *sequences* of code points (a skin-toned emoji, a flag, a ZWJ family), valid only under the `v` flag, and have no character-class equivalent in either engine — regexp2's fallback can't rescue this since it doesn't know these names either. Added `regex_emoji.go`, which hand-assembles a real alternation of sequence shapes from the pieces Unicode's emoji specification defines structurally, since neither Go nor either engine carries the actual curated emoji-sequence data. Documented as a best-effort approximation, not the literal data — but every case from the original `pi-tui` repro now matches identically to real Node.

## Verification

- `go test ./tests -run TestScripts` (smoke suite) passes after every commit and at the tip.
- Test262's `built-ins/RegExp` subsuite: **+139 new passes, 0 regressions** (the #224/#225 commits together).
- Test262's `language` and `built-ins/Function` subsuites: 0 regressions from the compiler/checker/VM commits.
- Each fix additionally checked by hand against real Node output and against adjacent cases (class static accessor inheritance, const redeclaration errors, computed-key arrow properties) to confirm no existing behavior broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
