### PR TITLE
Fix #220 (contextual keyword function names) and #221 (bound method error swallowing)

### DIFF
--- a/pkg/driver/issue_221_test.go
+++ b/pkg/driver/issue_221_test.go
@@ -1,0 +1,83 @@
+package driver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+type issue221Thing struct{ Value string }
+
+func newIssue221Thing(input string) (*issue221Thing, error) {
+	return &issue221Thing{Value: input}, nil
+}
+
+// DoThing returns an error when its argument is empty - the shape
+// createBoundMethod is supposed to special-case, just like
+// createClassConstructor already does for constructors (paserati#167).
+func (t *issue221Thing) DoThing(input string) (vm.Value, error) {
+	if input == "" {
+		return vm.Undefined, errors.New("input required")
+	}
+	return vm.NewString(t.Value + input), nil
+}
+
+// TestBoundMethodErrorReturnThrows covers paserati#221:
+// ModuleBuilder.createBoundMethod only ever looked at results[0] from a
+// bound Go method call, silently discarding a second (error) return value -
+// unlike goFunctionToVM (module-level Function) and createClassConstructor
+// (Class constructor), both of which already special-case the idiomatic Go
+// (T, error) return shape. A bound instance method returning a non-nil
+// error made the call evaluate to a value instead of throwing.
+func TestBoundMethodErrorReturnThrows(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue221mod", func(m *ModuleBuilder) {
+		m.Class("Thing", &issue221Thing{}, newIssue221Thing)
+	})
+
+	res, errs := p.RunString(`
+		import { Thing } from "issue221mod";
+		let threw = false;
+		let message = "";
+		const t = new Thing("hello");
+		try {
+			t.doThing("");
+		} catch (e) {
+			threw = true;
+			message = e.message;
+		}
+		JSON.stringify({ threw, message });
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := res.ToString()
+	want := `{"threw":true,"message":"input required"}`
+	if got != want {
+		t.Fatalf("expected bound method error to throw: got %s, want %s", got, want)
+	}
+}
+
+// TestBoundMethodErrorReturnSucceedsWithoutError guards against a
+// regression: the (value, error) success case - error is nil - must still
+// return the method's value, not treat every two-value method as an error
+// path.
+func TestBoundMethodErrorReturnSucceedsWithoutError(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue221mod2", func(m *ModuleBuilder) {
+		m.Class("Thing", &issue221Thing{}, newIssue221Thing)
+	})
+
+	res, errs := p.RunString(`
+		import { Thing } from "issue221mod2";
+		const t = new Thing("hello ");
+		t.doThing("world");
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if res.ToString() != "hello world" {
+		t.Fatalf("expected 'hello world', got %s", res.ToString())
+	}
+}

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -460,6 +460,17 @@ func (m *ModuleBuilder) createBoundMethod(methodFunc reflect.Value) vm.Value {
 		// Call the Go method
 		results := methodFunc.Call(goArgs)
 
+		// Handle the common (value, error) method shape (paserati#221):
+		// mirrors createClassConstructor's own len(results) == 2 error check -
+		// without this, a non-nil error here was silently discarded and the
+		// call evaluated to a value instead of throwing.
+		if len(results) == 2 && results[1].Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+			if !results[1].IsNil() {
+				errVal := results[1].Interface().(error)
+				return vm.Undefined, errVal
+			}
+		}
+
 		// Convert result back to VM value
 		if len(results) > 0 {
 			return reflectValueToVM(results[0]), nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -269,6 +269,8 @@ func NewParser(l *lexer.Lexer) *Parser {
 	p.registerPrefix(lexer.IS, p.parseIdentifier)        // IS is a contextual keyword (type predicates), can be used as identifier in JS
 	p.registerPrefix(lexer.SATISFIES, p.parseIdentifier) // SATISFIES is a TS operator, but also a valid binding name (e.g. semver)
 	p.registerPrefix(lexer.AS, p.parseIdentifier)        // AS is a TS operator (type assertions), but also a valid binding name
+	p.registerPrefix(lexer.KEYOF, p.parseIdentifier)     // KEYOF is a TS type operator, but also a valid binding name in JS
+	p.registerPrefix(lexer.INFER, p.parseIdentifier)     // INFER is a TS type operator, but also a valid binding name in JS
 	p.registerPrefix(lexer.FUNCTION, func() Expression { return p.parseFunctionLiteral(false) })
 	p.registerPrefix(lexer.ASYNC, p.parseAsyncExpression) // Added for async functions and async arrows
 	p.registerPrefix(lexer.CLASS, p.parseClassExpression)
@@ -2606,7 +2608,10 @@ func (p *Parser) parseFunctionLiteral(isAsync bool) Expression {
 		p.peekTokenIs(lexer.TYPE) || p.peekTokenIs(lexer.FROM) ||
 		p.peekTokenIs(lexer.OF) || p.peekTokenIs(lexer.AS) ||
 		p.peekTokenIs(lexer.ASYNC) || p.peekTokenIs(lexer.STATIC) ||
-		p.peekTokenIs(lexer.WITH) {
+		p.peekTokenIs(lexer.WITH) || p.peekTokenIs(lexer.SATISFIES) ||
+		p.peekTokenIs(lexer.IS) || p.peekTokenIs(lexer.INFER) ||
+		p.peekTokenIs(lexer.READONLY) || p.peekTokenIs(lexer.OVERRIDE) ||
+		p.peekTokenIs(lexer.ABSTRACT) || p.peekTokenIs(lexer.KEYOF) {
 		p.nextToken() // Consume name identifier/keyword
 		// Create identifier from token (works for both IDENT and keywords)
 		lit.Name = &Identifier{Token: p.curToken, Value: p.curToken.Literal}

--- a/tests/scripts/contextual_keyword_function_name.ts
+++ b/tests/scripts/contextual_keyword_function_name.ts
@@ -1,0 +1,29 @@
+// expect: 28
+// paserati#220: function declarations named after a TS contextual keyword
+// (satisfies, is, infer, readonly, override, abstract, keyof) failed to
+// parse with "'(' expected" - parseFunctionLiteral's hand-maintained list
+// of tokens allowed as a function name was missing all seven. Real Node
+// accepts all of them as ordinary function names/identifiers since none of
+// these are reserved words at the JS runtime level.
+function satisfies(e: number): number {
+  return e;
+}
+function is(e: number): number {
+  return e;
+}
+function infer(e: number): number {
+  return e;
+}
+function readonly(e: number): number {
+  return e;
+}
+function override(e: number): number {
+  return e;
+}
+function abstract(e: number): number {
+  return e;
+}
+function keyof(e: number): number {
+  return e;
+}
+satisfies(1) + is(2) + infer(3) + readonly(4) + override(5) + abstract(6) + keyof(7);


### PR DESCRIPTION
Two independent parser/driver fixes, one commit each.

## fix(parser): accept satisfies/is/infer/readonly/override/abstract/keyof as function names — fixes #220

`parseFunctionLiteral`'s hand-maintained list of tokens allowed as a function declaration/expression name was missing these seven TypeScript contextual keywords, so e.g. `function satisfies(e) {...}` failed to parse with `'(' expected`, even though none of them are reserved words at the JS runtime level (real Node accepts all seven).

Also registers `KEYOF` and `INFER` as value-expression prefix parsers (aliased to `parseIdentifier`, matching the existing pattern for `satisfies`/`is`/`readonly`/`override`/`abstract`/`as`) — they were only wired up as type-expression prefix operators, so referencing a function named `keyof` or `infer` from a value position still failed even after the declaration itself parsed correctly. This was needed to make the issue's own repro (declare + call) actually work end-to-end.

Added `tests/scripts/contextual_keyword_function_name.ts` covering all seven names.

## fix(driver): propagate (T, error) returns from bound Class instance methods — fixes #221

`createBoundMethod` (used by `bindStructMethods` for every `Class` instance) only ever looked at `results[0]` from a bound Go method call, silently discarding a non-nil second (error) return value. The same idiomatic Go `(T, error)` shape is already handled correctly for module-level `Function`s (`goFunctionToVM`) and for `Class` constructors themselves (`createClassConstructor`, #167) — only the bound instance-method path was missing the check, so a method that returned an error evaluated as if it had succeeded instead of throwing.

Added `pkg/driver/issue_221_test.go`, mirroring the existing `issue_167_test.go` pattern, covering both the error-throws and success-without-error cases.

## Testing
- `go build ./...`
- `go test ./tests -run TestScripts` (smoke suite, all green)
- `go test ./pkg/...` (all green)