### PR TITLE
fix: async-named object-literal methods (#229) + generator spread typecheck gap

### DIFF
--- a/pkg/checker/expressions.go
+++ b/pkg/checker/expressions.go
@@ -3054,22 +3054,22 @@ func (c *Checker) isSpreadableIterableType(t types.Type) bool {
 		return false
 	}
 	if genericType, ok := t.(*types.GenericType); ok {
-		if genericType.Name == "Iterable" || genericType.Name == "Iterator" {
+		if genericType.Name == "Iterable" || genericType.Name == "Iterator" || genericType.Name == "Generator" {
 			return true
 		}
 	}
 	if genericRef, ok := t.(*types.GenericTypeAliasForwardReference); ok {
-		if genericRef.AliasName == "Iterable" || genericRef.AliasName == "Iterator" {
+		if genericRef.AliasName == "Iterable" || genericRef.AliasName == "Iterator" || genericRef.AliasName == "Generator" {
 			return true
 		}
 	}
 	if parameterizedRef, ok := t.(*types.ParameterizedForwardReferenceType); ok {
-		if parameterizedRef.ClassName == "Iterable" || parameterizedRef.ClassName == "Iterator" {
+		if parameterizedRef.ClassName == "Iterable" || parameterizedRef.ClassName == "Iterator" || parameterizedRef.ClassName == "Generator" {
 			return true
 		}
 	}
 	if instantiatedType, ok := t.(*types.InstantiatedType); ok {
-		if instantiatedType.Generic != nil && (instantiatedType.Generic.Name == "Iterable" || instantiatedType.Generic.Name == "Iterator") {
+		if instantiatedType.Generic != nil && (instantiatedType.Generic.Name == "Iterable" || instantiatedType.Generic.Name == "Iterator" || instantiatedType.Generic.Name == "Generator") {
 			return true
 		}
 	}
@@ -3109,7 +3109,7 @@ func (c *Checker) getSpreadElementType(t types.Type) types.Type {
 	}
 	if instantiatedType, ok := t.(*types.InstantiatedType); ok {
 		if instantiatedType.Generic != nil && len(instantiatedType.TypeArguments) > 0 &&
-			(instantiatedType.Generic.Name == "Iterable" || instantiatedType.Generic.Name == "Iterator") {
+			(instantiatedType.Generic.Name == "Iterable" || instantiatedType.Generic.Name == "Iterator" || instantiatedType.Generic.Name == "Generator") {
 			return instantiatedType.TypeArguments[0]
 		}
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -7146,8 +7146,12 @@ func (p *Parser) parseObjectLiteral() Expression {
 			}
 		} else {
 			// --- NEW: Check for async methods/generators (async foo() or async *foo()) ---
-			// But first check if 'async' is just a property name (async: value, { async }, etc.)
-			if p.curTokenIs(lexer.ASYNC) && !p.peekTokenIs(lexer.COLON) && !p.peekTokenIs(lexer.COMMA) && !p.peekTokenIs(lexer.RBRACE) {
+			// But first check if 'async' is just a property name (async: value, { async },
+			// { async, other }, or a plain shorthand method literally named 'async' -
+			// { async(...) {} } - #229). Per the grammar, AsyncMethod requires a
+			// PropertyName between 'async' and '(', so 'async' immediately followed by
+			// '(' can't be the async-modifier form at all.
+			if p.curTokenIs(lexer.ASYNC) && !p.peekTokenIs(lexer.COLON) && !p.peekTokenIs(lexer.COMMA) && !p.peekTokenIs(lexer.RBRACE) && !p.peekTokenIs(lexer.LPAREN) {
 				asyncToken := p.curToken
 				p.nextToken() // Consume 'async' to see what's next
 

--- a/tests/scripts/generator_spread_typecheck.ts
+++ b/tests/scripts/generator_spread_typecheck.ts
@@ -1,0 +1,27 @@
+// expect: 23
+// isSpreadableIterableType()/getSpreadElementType() only recognized
+// Iterable<T>/Iterator<T> generic types, not Generator<T, TReturn, TNext> -
+// a Generator implements Iterable<T> too, so spreading one in an array
+// literal, a rest/variadic call, or a destructuring pattern is valid JS
+// (confirmed against real tsc) but the type checker rejected all three with
+// "spread syntax can only be applied to arrays". Noticed while verifying
+// #204 ({ *static(e) { yield e } } - an object-literal generator method).
+function* gen(n: number) {
+  yield n;
+  yield n + 1;
+  yield n + 2;
+}
+
+// array literal spread
+const arr = [...gen(1)]; // [1, 2, 3]
+
+// spread into a rest/variadic parameter
+function sumAll(...nums: number[]) {
+  return nums.reduce((a, b) => a + b, 0);
+}
+const variadicSum = sumAll(...gen(4)); // 4+5+6 = 15
+
+// array-destructuring (including rest) from a generator
+const [first, ...rest] = gen(0); // first=0, rest=[1,2]
+
+arr.reduce((a, b) => a + b, 0) + variadicSum + first + rest.length; // 6 + 15 + 0 + 2

--- a/tests/scripts/object_method_named_async.ts
+++ b/tests/scripts/object_method_named_async.ts
@@ -1,0 +1,32 @@
+// expect: 10
+// #229: a shorthand method literally named 'async' - { async(...) {} } - was
+// always parsed as the async-modifier form, which requires a *separate*
+// PropertyName before '(' and so failed whenever 'async' was immediately
+// followed by '('. Per the grammar, AsyncMethod is
+// `async [no LineTerminator here] PropertyName (` - 'async' directly
+// followed by '(' can't be that production at all, so it must be a plain
+// method named 'async' instead (confirmed against real Node).
+const o = {
+  async(...args: number[]) { return args.reduce((a, b) => a + b, 0); },
+};
+const total = o.async(1, 2, 3, 4); // 10
+
+// Sibling forms that must keep working alongside the fix above.
+const p = {
+  async async() { return 5; }, // async method literally named 'async'
+  async *gen() { yield 1; yield 2; }, // async generator - regression trap
+};
+p.async().then((v: number) => {
+  if (v !== 5) throw new Error("async-named-async method returned " + v);
+});
+(async () => {
+  let genTotal = 0;
+  for await (const v of p.gen()) genTotal += v;
+  if (genTotal !== 3) throw new Error("async generator returned wrong total: " + genTotal);
+})();
+
+const g = { get async() { return 7; }, set async(v: number) { /* noop */ } };
+if (g.async !== 7) throw new Error("getter named async failed: " + g.async);
+g.async = 9;
+
+total;


### PR DESCRIPTION
## Summary

Two independent fixes, done together in one session:

1. **Fixes #229** — parser: an object-literal shorthand method literally named `async` (`{ async(...args) { ... } }`) always parsed as the async-modifier form and failed, because the disambiguation between "`async` as modifier" and "`async` as a literal name" checked for `:`, `,`, `}` after `async` but not `(`. Per the grammar, `AsyncMethod` requires a separate `PropertyName` between `async` and `(`, so `async` immediately followed by `(` can't be that production — it's unambiguously a plain method named `async`. Added the missing `(` disambiguator.

2. **Typechecker gap found while verifying #204** — `isSpreadableIterableType`/`getSpreadElementType` in the checker only recognized `Iterable<T>`/`Iterator<T>` generic types, not `Generator<T, TReturn, TNext>`. A `Generator` implements `Iterable<T>` too, so spreading one in an array literal, a rest/variadic call argument, or a destructuring pattern is valid JS (confirmed against real `tsc`) but the checker rejected all three with "spread syntax can only be applied to arrays", even though the same code ran fine with `--no-typecheck`. `AsyncGenerator` is deliberately *not* included — it's `AsyncIterable`, not sync `Iterable`, and spreading one with plain `...` still correctly errors, matching real JS's runtime `TypeError`.

## Verification

- Matrix-tested against real Node/tsc for both fixes (async-named methods in plain/async/generator/getter-setter forms; generator spread in array-literal, rest/variadic call, and destructuring contexts; confirmed fixed-arity call spread and AsyncGenerator sync spread still correctly error, matching tsc's TS2556 and real JS's TypeError respectively).
- `go test ./tests -run TestScripts` green, with new regression tests added (`object_method_named_async.ts`, `generator_spread_typecheck.ts`).
- test262 `language/expressions` (parser fix) and `language/` (checker fix) show zero diff against main — no regressions; the checker fix has no test262-visible effect since Test262 runs with type checking disabled (per project convention), so the smoke tests are the real coverage for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)