### PR TITLE
Fix uncatchable crashes on globalThis.TypeError reassignment, console.error/warn stderr routing, and absolute-path module resolution

### DIFF
--- a/pkg/builtins/console_init.go
+++ b/pkg/builtins/console_init.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/nooga/paserati/pkg/types"
@@ -70,17 +71,20 @@ func (c *ConsoleInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}))
 
 	consoleObj.SetOwnNonEnumerable("error", vm.NewNativeFunction(0, true, "error", func(args []vm.Value) (vm.Value, error) {
-		fmt.Printf("ERROR: %s\n", formatArgs(args))
+		fmt.Fprintln(os.Stderr, formatArgs(args))
 		return vm.Undefined, nil
 	}))
 
 	consoleObj.SetOwnNonEnumerable("warn", vm.NewNativeFunction(0, true, "warn", func(args []vm.Value) (vm.Value, error) {
-		fmt.Printf("WARN: %s\n", formatArgs(args))
+		fmt.Fprintln(os.Stderr, formatArgs(args))
 		return vm.Undefined, nil
 	}))
 
 	consoleObj.SetOwnNonEnumerable("info", vm.NewNativeFunction(0, true, "info", func(args []vm.Value) (vm.Value, error) {
-		fmt.Printf("INFO: %s\n", formatArgs(args))
+		// info's destination (stdout) was already correct - only the
+		// non-standard "INFO: " prefix needed to go, matching log's plain
+		// formatting (#230's issue body called this out alongside error/warn).
+		fmt.Println(formatArgs(args))
 		return vm.Undefined, nil
 	}))
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -184,8 +184,15 @@ func NewPaseratiWithInitializersAndBaseDir(customInitializers []builtins.Builtin
 	// Create module loader first
 	config := modules.DefaultLoaderConfig()
 
-	// Create file system resolver for the specified base directory
-	fsResolver := modules.NewFileSystemResolver(os.DirFS(baseDir), baseDir)
+	// Create file system resolver for the specified base directory. Uses the
+	// real OS filesystem directly (not an fs.FS wrapping os.DirFS(baseDir))
+	// so that an entry file passed by absolute path - and any relative
+	// import resolved against it - can be found: fs.FS's contract rejects
+	// any absolute path outright, which surfaced as "no resolver could
+	// handle specifier" for a relative import from an absolute-path entry
+	// module (#232, misreported as top-level await not working, since that's
+	// what the failing import happened to sit next to).
+	fsResolver := modules.NewOSFileSystemResolver(baseDir)
 
 	// Create module loader with file system resolver
 	moduleLoader := modules.NewModuleLoader(config, fsResolver)
@@ -274,8 +281,15 @@ func NewPaseratiWithBaseDir(baseDir string) *Paserati {
 	// Create module loader first
 	config := modules.DefaultLoaderConfig()
 
-	// Create file system resolver for the specified base directory
-	fsResolver := modules.NewFileSystemResolver(os.DirFS(baseDir), baseDir)
+	// Create file system resolver for the specified base directory. Uses the
+	// real OS filesystem directly (not an fs.FS wrapping os.DirFS(baseDir))
+	// so that an entry file passed by absolute path - and any relative
+	// import resolved against it - can be found: fs.FS's contract rejects
+	// any absolute path outright, which surfaced as "no resolver could
+	// handle specifier" for a relative import from an absolute-path entry
+	// module (#232, misreported as top-level await not working, since that's
+	// what the failing import happened to sit next to).
+	fsResolver := modules.NewOSFileSystemResolver(baseDir)
 
 	// Create module loader with file system resolver
 	moduleLoader := modules.NewModuleLoader(config, fsResolver)

--- a/pkg/driver/issue_232_test.go
+++ b/pkg/driver/issue_232_test.go
@@ -1,0 +1,55 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAbsolutePathEntryResolvesRelativeImport covers paserati#232, filed as
+// "top-level await unsupported in .mjs entry files" - the reporter's actual
+// script was `const mod = await import("./helper.js")` at module top level,
+// and the failure ("no resolver could handle specifier: ./helper.js") sat
+// right next to the `await`, but had nothing to do with it.
+//
+// The real cause: cmd/paserati's runFileWithTypes passes the CLI's filename
+// argument through verbatim as both RunOptions.ModuleName and .Filename,
+// which becomes the "fromPath" a relative import is resolved against. When
+// that argument is an absolute path (as it commonly is - many shells and
+// wrapper scripts invoke tools by absolute path), the module resolver's
+// os.DirFS-backed filesystem rejected it outright: fs.FS's contract forbids
+// any path starting with "/", including ones arrived at by joining a
+// relative specifier onto an absolute fromPath's directory. Switching to
+// modules.NewOSFileSystemResolver (real OS file access, no fs.FS path
+// restrictions) fixes it - this test locks that in without needing await or
+// dynamic import at all, since neither was ever the actual defect.
+func TestAbsolutePathEntryResolvesRelativeImport(t *testing.T) {
+	dir := t.TempDir()
+
+	helperPath := filepath.Join(dir, "helper.mjs")
+	if err := os.WriteFile(helperPath, []byte(`export const value = 42;`), 0644); err != nil {
+		t.Fatalf("failed to write helper file: %v", err)
+	}
+
+	entryPath := filepath.Join(dir, "entry.mjs")
+	entrySource := `
+		import { value } from "./helper.mjs";
+		value;
+	`
+	if err := os.WriteFile(entryPath, []byte(entrySource), 0644); err != nil {
+		t.Fatalf("failed to write entry file: %v", err)
+	}
+
+	if !filepath.IsAbs(entryPath) {
+		t.Fatalf("test setup bug: expected entryPath to be absolute, got %q", entryPath)
+	}
+
+	p := NewPaserati()
+	res, errs := p.RunCode(entrySource, RunOptions{ModuleName: entryPath, Filename: entryPath})
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors resolving a relative import from an absolute-path entry module: %v", errs)
+	}
+	if got := res.ToFloat(); got != 42 {
+		t.Fatalf("expected the imported value 42, got %v", res.Inspect())
+	}
+}

--- a/pkg/modules/resolver_fs.go
+++ b/pkg/modules/resolver_fs.go
@@ -121,6 +121,21 @@ func (r *FileSystemResolver) calculateTargetPath(specifier string, fromPath stri
 			return "", fmt.Errorf("relative import %s requires fromPath", specifier)
 		}
 
+		if filepath.IsAbs(fromPath) {
+			// fromPath is a real OS filesystem path here (e.g. the CLI's
+			// entry file, given by absolute path - #232), not a "/"-
+			// separated module specifier. On Windows that means backslashes
+			// and a drive letter, which pathpkg (forward-slash only) can't
+			// parse: pathpkg.Dir on "C:\Users\...\entry.mjs" sees no "/" at
+			// all and returns ".", silently losing the entry file's real
+			// directory - the exact same "no resolver could handle
+			// specifier" failure #232 already had, just Windows-only and
+			// unfixed by switching resolvers alone. filepath.Join also
+			// accepts (and correctly normalizes) a forward-slash specifier
+			// like "./helper.mjs" here, so this only needs to swap which
+			// path package does the joining, not touch the specifier.
+			return filepath.Join(filepath.Dir(fromPath), specifier), nil
+		}
 		fromDir := pathpkg.Dir(fromPath)
 		return pathpkg.Join(fromDir, specifier), nil
 	}
@@ -240,24 +255,35 @@ type osFS struct {
 	baseDir string
 }
 
+// resolveOSPath joins name onto baseDir, unless name is already an absolute
+// OS path (#232) - e.g. a relative import ("./helper.mjs") resolved against
+// an entry module whose own path is absolute, which calculateTargetPath's
+// relative-import branch (pathpkg.Join(pathpkg.Dir(fromPath), specifier))
+// correctly leaves absolute. filepath.Join doesn't special-case an absolute
+// later argument - Join(baseDir, "/tmp/helper.mjs") would come out as
+// ".../baseDir/tmp/helper.mjs", silently wrong rather than erroring - so an
+// already-absolute name must bypass baseDir entirely and be used as-is.
+func (osfs *osFS) resolveOSPath(name string) string {
+	if filepath.IsAbs(name) {
+		return name
+	}
+	return filepath.Join(osfs.baseDir, name)
+}
+
 func (osfs *osFS) Open(name string) (fs.File, error) {
-	fullPath := filepath.Join(osfs.baseDir, name)
-	return os.Open(fullPath)
+	return os.Open(osfs.resolveOSPath(name))
 }
 
 func (osfs *osFS) ReadFile(name string) ([]byte, error) {
-	fullPath := filepath.Join(osfs.baseDir, name)
-	return os.ReadFile(fullPath)
+	return os.ReadFile(osfs.resolveOSPath(name))
 }
 
 func (osfs *osFS) Stat(name string) (fs.FileInfo, error) {
-	fullPath := filepath.Join(osfs.baseDir, name)
-	return os.Stat(fullPath)
+	return os.Stat(osfs.resolveOSPath(name))
 }
 
 func (osfs *osFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	fullPath := filepath.Join(osfs.baseDir, name)
-	return os.ReadDir(fullPath)
+	return os.ReadDir(osfs.resolveOSPath(name))
 }
 
 // Glob implements fs.GlobFS

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -525,20 +525,46 @@ type Value struct {
 // newErrorHelper constructs an error exception, clearing currentNewTarget to prevent
 // interference from outer ConstructWithNewTarget contexts (e.g., a custom newTarget
 // with a throwing prototype getter would prevent the error object from being created).
+//
+// Guards against unbounded recursion via constructingIntrinsicError (#231):
+// if constructing this error's instance is itself what needs the engine to
+// raise another intrinsic error (e.g. a reassigned constructor that isn't
+// callable as a plain function, or a revoked Proxy's apply trap), that
+// nested attempt must not call back out to (possibly the very same) ctor
+// again - see constructingIntrinsicError's doc comment on the VM struct.
 func (vm *VM) newErrorHelper(name string, message string) error {
 	ctor, _ := vm.GetGlobal(name)
-	if ctor != Undefined {
-		prevNewTarget := vm.currentNewTarget
-		vm.currentNewTarget = Undefined
-		errObj, _ := vm.Call(ctor, Undefined, []Value{NewString(message)})
-		vm.currentNewTarget = prevNewTarget
-		return exceptionError{exception: errObj}
+	if ctor != Undefined && !vm.constructingIntrinsicError {
+		if exc, ok := vm.callIntrinsicErrorCtor(ctor, message); ok {
+			return exc
+		}
 	}
 	// Fallback generic error object
 	obj := NewObject(Null).AsPlainObject()
 	obj.SetOwn("name", NewString(name))
 	obj.SetOwn("message", NewString(message))
 	return exceptionError{exception: NewValueFromPlainObject(obj)}
+}
+
+// callIntrinsicErrorCtor calls ctor(message) to build an intrinsic error's
+// instance, guarding constructingIntrinsicError for the duration via defer -
+// not a plain assignment before and after the call - so that even a panic
+// inside vm.Call (recovered higher up, in vm.run()'s top-level recover())
+// can't leave the guard stuck true. Left stuck, every subsequent internal
+// error for the rest of the VM's lifetime would silently degrade to the
+// prototype-less fallback object below instead of a real error instance.
+func (vm *VM) callIntrinsicErrorCtor(ctor Value, message string) (error, bool) {
+	vm.constructingIntrinsicError = true
+	defer func() { vm.constructingIntrinsicError = false }()
+
+	prevNewTarget := vm.currentNewTarget
+	vm.currentNewTarget = Undefined
+	errObj, callErr := vm.Call(ctor, Undefined, []Value{NewString(message)})
+	vm.currentNewTarget = prevNewTarget
+	if callErr != nil {
+		return nil, false
+	}
+	return exceptionError{exception: errObj}, true
 }
 
 // NewTypeError constructs a TypeError exception error for builtin helpers to return
@@ -556,14 +582,13 @@ func (vm *VM) NewTypeErrorInRealm(realm *Realm, message string) error {
 }
 
 // newErrorHelperInRealm constructs an error exception using a constructor from the specified realm.
+// See newErrorHelper's doc comment for the constructingIntrinsicError guard (#231).
 func (vm *VM) newErrorHelperInRealm(realm *Realm, name string, message string) error {
 	ctor, ok := realm.GetGlobal(name)
-	if ok && ctor != Undefined {
-		prevNewTarget := vm.currentNewTarget
-		vm.currentNewTarget = Undefined
-		errObj, _ := vm.Call(ctor, Undefined, []Value{NewString(message)})
-		vm.currentNewTarget = prevNewTarget
-		return exceptionError{exception: errObj}
+	if ok && ctor != Undefined && !vm.constructingIntrinsicError {
+		if exc, ok := vm.callIntrinsicErrorCtor(ctor, message); ok {
+			return exc
+		}
 	}
 	// Fallback to current realm
 	return vm.newErrorHelper(name, message)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -362,8 +362,35 @@ type VM struct {
 	// Flag to track if we're in a builtin calling a user function
 	inBuiltinCall bool
 
-	// Flag to prevent infinite recursion when throwing ReferenceError
-	throwingReferenceError bool
+	// constructingIntrinsicError guards against unbounded recursion when a
+	// script has reassigned one of the intrinsic error constructors
+	// (TypeError, RangeError, ReferenceError, SyntaxError, ...) to a value
+	// whose own invocation itself needs the engine to raise that same kind
+	// of error again - e.g. a class constructor called without `new`, or a
+	// revoked Proxy's apply trap, both confirmed live loops (#231). Set for
+	// the duration of any vm.Call that invokes a (possibly-reassigned)
+	// intrinsic error constructor, by every helper below that does one;
+	// while set, those helpers build a plain fallback error object directly
+	// instead of calling out again.
+	//
+	// One flag shared by every error kind, not one per kind: replaces the
+	// narrower, TypeError/RangeError/SyntaxError-less throwingReferenceError
+	// this guard used to be. Every self-recursion actually reproduced so far
+	// is same-kind (TypeError constructing TypeError, both confirmed loops
+	// above), so a per-kind flag would already stop them; sharing is a
+	// deliberate belt-and-suspenders choice against a *hypothetical*
+	// cross-kind loop (e.g. a reassigned TypeError whose construction
+	// legitimately needs a ReferenceError - say, a TDZ access inside a
+	// getter it calls) that hasn't been demonstrated, not a fix for one that
+	// has. The cost: constructing one kind now also suppresses the *normal*,
+	// non-recursive construction of a different kind if the first is somehow
+	// still in flight when the second is needed (e.g. a real ReferenceError
+	// legitimately raised while a TypeError instance is being built loses
+	// its realm-correct constructor and stack, falling back to a bare
+	// prototype-less object) - narrow, currently unexercised by any test,
+	// but real. If that trade-off ever bites, split back into per-kind
+	// flags for the pairs that need to stay independent.
+	constructingIntrinsicError bool
 
 	// Instance-specific initialization callbacks
 	//initCallbacks []VMInitCallback
@@ -20574,7 +20601,11 @@ func (vm *VM) ThrowTypeError(message string) {
 	// Per ECMAScript spec, the TypeError should come from the realm of the
 	// running execution context's function. Check the current frame's HomeRealm.
 	typeErrorCtor, exists := vm.getRealmAwareGlobal("TypeError")
-	if !exists || typeErrorCtor.Type() == TypeUndefined {
+	// See constructingIntrinsicError's doc comment (#231): if we're already
+	// in the middle of constructing some intrinsic error's instance, don't
+	// call back out to a (possibly reassigned) constructor again - build the
+	// fallback directly, unconditionally.
+	if !exists || typeErrorCtor.Type() == TypeUndefined || vm.constructingIntrinsicError {
 		// Fallback: create a basic error object
 		errObj := NewObject(vm.TypeErrorPrototype).AsPlainObject()
 		errObj.SetOwn("name", NewString("TypeError"))
@@ -20583,6 +20614,9 @@ func (vm *VM) ThrowTypeError(message string) {
 		vm.throwException(NewValueFromPlainObject(errObj))
 		return
 	}
+
+	vm.constructingIntrinsicError = true
+	defer func() { vm.constructingIntrinsicError = false }()
 
 	// Call the TypeError constructor to create a proper instance
 	errorInstance, err := vm.Call(typeErrorCtor, Undefined, []Value{NewString(message)})
@@ -20618,11 +20652,15 @@ func (vm *VM) getRealmAwareGlobal(name string) (Value, bool) {
 
 // ThrowReferenceError creates and throws a proper ReferenceError instance
 func (vm *VM) ThrowReferenceError(message string) {
-	// Guard against infinite recursion when throwing ReferenceError for uninitialized globals
-	// This can happen if accessing ReferenceError constructor or its dependencies triggers another ReferenceError
-	if vm.throwingReferenceError {
-		// Already in the process of throwing a ReferenceError, create minimal error to avoid recursion
-		// Use Undefined as prototype to avoid any potential issues with prototype access
+	// Guard against infinite recursion when throwing ReferenceError for
+	// uninitialized globals, or when constructing the instance itself needs
+	// the engine to raise another intrinsic error - see
+	// constructingIntrinsicError's doc comment (#231).
+	refErrorCtor, exists := vm.GetGlobal("ReferenceError")
+	if vm.constructingIntrinsicError {
+		// Already constructing some intrinsic error, create minimal error to
+		// avoid recursion. Use Undefined as prototype to avoid any potential
+		// issues with prototype access.
 		errObj := NewObject(Undefined).AsPlainObject()
 		errObj.SetOwn("name", NewString("ReferenceError"))
 		errObj.SetOwn("message", NewString(message))
@@ -20630,11 +20668,10 @@ func (vm *VM) ThrowReferenceError(message string) {
 		return
 	}
 
-	vm.throwingReferenceError = true
-	defer func() { vm.throwingReferenceError = false }()
+	vm.constructingIntrinsicError = true
+	defer func() { vm.constructingIntrinsicError = false }()
 
 	// Get the ReferenceError constructor from globals
-	refErrorCtor, exists := vm.GetGlobal("ReferenceError")
 	if !exists || refErrorCtor.Type() == TypeUndefined {
 		// Fallback: create a basic error object
 		errObj := NewObject(vm.ReferenceErrorPrototype).AsPlainObject()
@@ -20664,7 +20701,8 @@ func (vm *VM) ThrowReferenceError(message string) {
 func (vm *VM) ThrowSyntaxError(message string) {
 	// Get the SyntaxError constructor from globals
 	syntaxErrorCtor, exists := vm.GetGlobal("SyntaxError")
-	if !exists || syntaxErrorCtor.Type() == TypeUndefined {
+	// See constructingIntrinsicError's doc comment (#231).
+	if !exists || syntaxErrorCtor.Type() == TypeUndefined || vm.constructingIntrinsicError {
 		// Fallback: create a basic error object
 		errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
 		errObj.SetOwn("name", NewString("SyntaxError"))
@@ -20673,6 +20711,9 @@ func (vm *VM) ThrowSyntaxError(message string) {
 		vm.throwException(NewValueFromPlainObject(errObj))
 		return
 	}
+
+	vm.constructingIntrinsicError = true
+	defer func() { vm.constructingIntrinsicError = false }()
 
 	// Call the SyntaxError constructor to create a proper instance
 	errorInstance, err := vm.Call(syntaxErrorCtor, Undefined, []Value{NewString(message)})
@@ -20689,11 +20730,27 @@ func (vm *VM) ThrowSyntaxError(message string) {
 	vm.throwException(errorInstance)
 }
 
+// newStackOverflowError builds a RangeError-shaped exception value directly,
+// without calling any constructor (built-in or user-reassigned). Used by
+// executeUserFunctionSafe's call-stack-full guard (#231): at that point
+// vm.frames has no room for another frame, so going through vm.Call - as
+// ThrowRangeError's own constructor lookup would - risks hitting that exact
+// same guard again. See ThrowRangeError below for the normal, constructor-
+// backed path used everywhere the stack has room.
+func (vm *VM) newStackOverflowError() Value {
+	errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+	errObj.SetOwn("name", NewString("RangeError"))
+	errObj.SetOwn("message", NewString("Maximum call stack size exceeded"))
+	errObj.SetOwn("stack", NewString(vm.CaptureStackTrace()))
+	return NewValueFromPlainObject(errObj)
+}
+
 // ThrowRangeError creates and throws a proper RangeError instance
 func (vm *VM) ThrowRangeError(message string) {
 	// Get the RangeError constructor from globals
 	rangeErrorCtor, exists := vm.GetGlobal("RangeError")
-	if !exists || rangeErrorCtor.Type() == TypeUndefined {
+	// See constructingIntrinsicError's doc comment (#231).
+	if !exists || rangeErrorCtor.Type() == TypeUndefined || vm.constructingIntrinsicError {
 		// Fallback: create a basic error object
 		errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
 		errObj.SetOwn("name", NewString("RangeError"))
@@ -20702,6 +20759,9 @@ func (vm *VM) ThrowRangeError(message string) {
 		vm.throwException(NewValueFromPlainObject(errObj))
 		return
 	}
+
+	vm.constructingIntrinsicError = true
+	defer func() { vm.constructingIntrinsicError = false }()
 
 	// Call the RangeError constructor to create a proper instance
 	errorInstance, err := vm.Call(rangeErrorCtor, Undefined, []Value{NewString(message)})

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1953,11 +1953,42 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 	// sequence, each via its own executeUserFunctionSafe call).
 	frameCountAtEntry := vm.frameCount
 
+	// Remember whether we were already unwinding *with* a live exception at
+	// entry (the cleanup just above only scrubs the currentException==Null
+	// case, deliberately leaving this one alone - a native caller mid-
+	// unwind, forwarding or absorbing an exception, is expected to be able
+	// to make further vm.Call calls). The shouldSwitch=false branch below
+	// must only treat vm.unwinding as *this* call's own doing if it became
+	// true during it - otherwise a prepareCall that runs a native function
+	// to completion, perfectly successfully, while an unrelated exception
+	// from before this call is still sitting on the VM, would get its
+	// legitimate result thrown away and replaced with that stale exception.
+	unwindingAtEntry := vm.unwinding && vm.currentException != Null
+
 	// Set up the caller context first (pooled 1-element result holder)
 	callerRegisters := vm.getSentinelReg()
 	defer vm.putSentinelReg(callerRegisters)
 	destReg := byte(0)
 	callerIP := 0
+
+	// Bail out before touching vm.frames if the call stack is already full.
+	// This path is reentrant - a native Go call into JS, e.g. vm.Call from
+	// ThrowTypeError/ThrowRangeError/etc. constructing an exception instance,
+	// or any other builtin invoking a callback - and unlike the bytecode-level
+	// call sites (OpCall/OpSpreadNew), which already guard against
+	// overflowing vm.frames before pushing a new frame, this one used to
+	// index straight past the end of the fixed-size frames array once
+	// frameCount reached len(vm.frames), panicking with a raw "index out of
+	// range" instead of raising a catchable exception (#231 - reassigning
+	// globalThis.TypeError to a class made every internal ThrowTypeError call
+	// recurse into itself indefinitely through exactly this path). Build the
+	// exception directly rather than going through vm.ThrowRangeError/vm.Call
+	// - the stack is exactly as full as it was a moment ago, so calling back
+	// into a (possibly user-reassigned) RangeError constructor here would hit
+	// this very guard again.
+	if vm.frameCount >= len(vm.frames) {
+		return Undefined, exceptionError{exception: vm.newStackOverflowError()}
+	}
 
 	// Add a sentinel frame that will cause vm.run() to return when it hits this frame
 	sentinelFrame := &vm.frames[vm.frameCount]
@@ -1976,6 +2007,37 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 	}
 
 	if !shouldSwitch {
+		// prepareCall executed synchronously without switching frames - either
+		// a native function ran directly, or an exception (e.g. ThrowTypeError
+		// for a class constructor called without `new`, see call.go's
+		// IsClassConstructor check) was raised inline. The interpreter's own
+		// dispatch loop handles the latter case implicitly, by checking
+		// vm.unwinding after every instruction it executes - but this is a
+		// native Go call into JS with no such loop watching it, so it must
+		// check for a pending exception itself before reporting success. Left
+		// unchecked, this silently discarded the real exception and reported
+		// success with a stale/undefined "result" instead - which is how
+		// reassigning globalThis.TypeError to a class went from an unbounded-
+		// recursion panic (#231, fixed by the stack-depth guard above) to an
+		// "Uncaught exception: undefined" instead of the catchable TypeError
+		// real engines produce: the reassigned class's own construction hit
+		// this exact "called without new" check, and its resulting exception
+		// was getting swallowed right here before ThrowTypeError even saw it.
+		//
+		// Gated on the transition (!unwindingAtEntry), not just the current
+		// state: a native caller can legitimately already be mid-unwind with
+		// a live exception when it makes this call (e.g. IteratorClose
+		// forwarding a throw completion while it runs cleanup) and have
+		// prepareCall's native function complete normally - that must return
+		// its real result, not get it discarded in favor of the pre-existing,
+		// unrelated exception.
+		if !unwindingAtEntry && vm.unwinding && vm.currentException != Null {
+			ex := vm.currentException
+			vm.currentException = Null
+			vm.unwinding = false
+			vm.truncateFramesTo(frameCountAtEntry)
+			return Undefined, exceptionError{exception: ex}
+		}
 		// Native function was executed directly
 		// Remove sentinel frame
 		vm.frameCount--


### PR DESCRIPTION
## Summary

Three unrelated bugs, one PR per the triage discussion, each landed as its own commit:

### #231 — reassigning `globalThis.TypeError` crashes the process (the big one)
Reassigning `globalThis.TypeError` to an ordinary JS class, then triggering any internally-raised `TypeError`, crashed the whole process with a raw Go panic (`index out of range [4096] with length 4096`) instead of a catchable exception. A revoked `Proxy` assigned the same way was worse — an unrecoverable `fatal error: stack overflow` that not even `panic`/`recover` can catch.

Three separate bugs combined to cause this — see the commit message for the full trace, but briefly:
1. `executeUserFunctionSafe` (the `vm.Call` path used by all native-Go-to-JS reentrancy) pushed its sentinel frame without the same frame-depth guard every bytecode-level call site already has, so the reentrant recursion this triggers (`ThrowTypeError` re-resolving the reassigned global and calling it again) walked straight past the end of the fixed-size frames array. Added the same "Maximum call stack size exceeded" guard used elsewhere.
2. Fixing that panic exposed a second bug: the resulting exception surfaced as `undefined` instead of a real `TypeError`, because `executeUserFunctionSafe`'s `shouldSwitch=false` branch discarded a pending exception the bytecode interpreter's own dispatch loop would normally have caught. Fixed, gated on the exception actually happening *during* this call (not one already in flight when the call started, e.g. `IteratorClose` mid-cleanup) so a legitimately-succeeding native call can't have its real result thrown away.
3. A revoked-`Proxy`-shaped failure never touches `vm.frames` at all, so bug #1's guard didn't help — it recursed purely on the Go call stack via `NewTypeError → newErrorHelper → vm.Call → NewTypeError → ...`. Added `constructingIntrinsicError`, a reentrancy guard shared by all four `Throw*Error` functions and `newErrorHelper`, replacing the narrower `throwingReferenceError` flag that only covered `ReferenceError`'s own self-recursion.

**Honest trade-off**, noted in the commit and worth flagging in review: sharing one guard across all error kinds (rather than one per kind) is a deliberate belt-and-suspenders choice against a *hypothetical* cross-kind loop that hasn't actually been demonstrated — both reproduced loops are same-kind. The cost is narrow: a real `ReferenceError` legitimately raised while some other kind's instance is still under construction now also gets a degraded, prototype-less fallback object instead of a proper instance. Currently unexercised by any test.

**Also**, fixing bug #2 surfaces 11 previously-masked, genuine pre-existing bugs in `Promise.all`/`race`/`allSettled`/`any`/`try`: they invoke a species constructor via plain `[[Call]]` instead of `[[Construct]]`, which used to silently continue on a swallowed exception and now correctly throws `"cannot be invoked without new"`. Confirmed via the discriminator check in commit 2 that these are real (not an artifact of the exception-loss fix over-firing) and spawned as a separate follow-up rather than fixed here — out of scope for this PR.

### #230 — `console.error`/`console.warn` write to stdout with a non-standard prefix
Wrote to stdout via `fmt.Printf` with an `"ERROR: "`/`"WARN: "` prefix instead of stderr with no prefix, mixing diagnostic output into a program's clean stdout stream. Also fixed `console.info`'s prefix (destination was already correct) per the issue body's callout. `console.debug`/`console.trace` are out of scope — not mentioned by the issue, and `trace`'s real Node behavior needs a stack trace this doesn't add.

### #232 — top-level await "unsupported" in `.mjs` entry files
Top-level await itself works fine (verified across every file extension, with and without type checking) — the issue was misdiagnosed. The reporter's actual script used `await import("./helper.js")`, and the *import* failed to resolve, not the await: `cmd/paserati` passes the CLI's filename argument straight through as the module resolution "from path", and when that argument is an absolute path (common for shells/wrapper scripts), resolving a relative import against it produced another absolute path that the `os.DirFS`-backed resolver rejected outright (`fs.FS`'s contract forbids any path starting with `/`). Switched to `NewOSFileSystemResolver`, which talks to the real OS filesystem directly — there was no sandboxing need here since the driver already reads the entry file itself unsandboxed.

## Testing
- `go test ./tests -run TestScripts` (smoke suite) and `go test ./pkg/...` — all green throughout.
- Targeted Test262 before/after diffs (`language/statements/class`, `expressions/call`, `statements/try`, `built-ins/Array/prototype/map`, `built-ins/Error`, `built-ins/NativeErrors`, `built-ins/ThrowTypeError`, `language/module-code`, `expressions/dynamic-import`, `import.meta`, and a full `built-ins` sweep): no regressions from any of the three fixes (one net *improvement*: `expressions/call/tco-non-eval-global.js` now passes). The 11 newly-surfaced Promise failures are tracked separately (see above), not a regression from this PR.
- New regression test: `pkg/driver/issue_232_test.go` (`TestAbsolutePathEntryResolvesRelativeImport`), verified to fail with the exact reported error message on the unpatched resolver and pass after the fix.

Fixes #230, fixes #231, fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)