### PR TITLE
Fix regex literal misparsed as division after unbraced if/while/for/with body

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1901,6 +1901,12 @@ func (p *Parser) parseIfStatement() *IfStatement {
 	if !p.expectPeek(lexer.RPAREN) {
 		return nil
 	}
+	// An un-braced consequence starting with `/` is a regex literal, not
+	// division - RPAREN isn't in canBeRegexStart's set (correctly, since most
+	// of the time it closes a value-producing expression), so the peek ahead
+	// of it needs the same rescan every other statement-boundary token gets
+	// (#235).
+	p.rescanPeekAsRegex()
 
 	// --- MODIFIED: Handle both block statements and single statements ---
 	if p.peekTokenIs(lexer.LBRACE) {
@@ -6019,6 +6025,8 @@ func (p *Parser) parseWhileStatement() *WhileStatement {
 	if !p.expectPeek(lexer.RPAREN) {
 		return nil // Expected ')' after condition
 	}
+	// See parseIfStatement's identical rescan for why (#235).
+	p.rescanPeekAsRegex()
 
 	// --- MODIFIED: Handle both block statements and single statements ---
 	if p.peekTokenIs(lexer.LBRACE) {
@@ -6068,6 +6076,8 @@ func (p *Parser) parseWithStatement() *WithStatement {
 	if !p.expectPeek(lexer.RPAREN) {
 		return nil // Expected ')' after expression
 	}
+	// See parseIfStatement's identical rescan for why (#235).
+	p.rescanPeekAsRegex()
 
 	// Handle both block statements and single statements
 	if p.peekTokenIs(lexer.LBRACE) {
@@ -9534,6 +9544,11 @@ func (p *Parser) parseRegularForStatementWithVar(forToken *lexer.Token, varStmt 
 
 // parseForBody parses the body of any for loop
 func (p *Parser) parseForBody() *BlockStatement {
+	// curToken is the ')' closing the for-head (regular/for-of/for-in alike,
+	// every caller reaches here via expectPeek(RPAREN)). An un-braced body
+	// starting with `/` is a regex literal, not division - see
+	// parseIfStatement's identical rescan for why (#235).
+	p.rescanPeekAsRegex()
 	if p.peekTokenIs(lexer.LBRACE) {
 		if !p.expectPeek(lexer.LBRACE) {
 			return nil

--- a/tests/scripts/regex_after_unbraced_control_flow.ts
+++ b/tests/scripts/regex_after_unbraced_control_flow.ts
@@ -1,0 +1,32 @@
+// paserati#235: a regex literal right after an if/while/for/with header's
+// closing ')' - with no braces around the body - used to misparse as
+// division, since RPAREN isn't in the lexer's canBeRegexStart set (correctly,
+// for the common case where ')' closes a value-producing expression) and the
+// parser never re-lexed the peeked token in regex context for this specific
+// boundary, unlike every other statement-boundary token it handles.
+// expect: true
+
+let hits = 0;
+
+// if with un-braced body
+if (true) /x/.test("x") && hits++;
+
+// while with un-braced body
+let n = 0;
+while (n++ < 1) /x/.test("x") && hits++;
+
+// for with un-braced body
+for (let i = 0; i < 1; i++) /x/.test("x") && hits++;
+
+// for-of / for-in with un-braced bodies
+for (const _ of [1]) /x/.test("x") && hits++;
+for (const _ in { a: 1 }) /x/.test("x") && hits++;
+
+// with with un-braced body (non-strict only - `with` throws in strict mode)
+with ({ a: 1 }) /x/.test("x") && hits++;
+
+// Division after a value-producing parenthesized expression must still work
+// (not misdetected as a regex start just because a `for`/`if`/etc. is nearby).
+let divided = (4 + 2) / 3;
+
+hits === 6 && divided === 2;


### PR DESCRIPTION
## Summary

Fixes #235. A regex literal right after an `if`/`while`/`for`/`with` header's closing `)` — with no braces around the body — misparsed as division:

```ts
for (let e = 0; e < 3; e++) /x/.test("x") && (hit = true);
//                          ^ TS1109 Expression expected.
```

`pkg/lexer/lexer.go`'s `canBeRegexStart(prevTokenType)` correctly excludes `RPAREN` in general — most of the time `)` closes a value-producing expression and a following `/` is division (`(4 + 2) / 3` already worked). But the parser never re-lexed the peeked token in regex context for this one specific statement boundary, unlike every other one it already handles (block/class/function/switch/try's closing `}`, statement-ending `;`, etc., all via the existing `rescanPeekAsRegex()` escape hatch).

## Fix

Added the same `p.rescanPeekAsRegex()` call, right after each header's `expectPeek(RPAREN)`, to `parseIfStatement`, `parseWhileStatement`, `parseWithStatement`, and `parseForBody` (the single helper already shared by regular `for`, `for-of`, and `for-in`'s un-braced-body parsing — one call there covers all three). `if`'s `else` branch didn't need the fix — `ELSE` is already in `canBeRegexStart`'s set, so `else /x/.test(...)` already worked.

## Testing
- Added `tests/scripts/regex_after_unbraced_control_flow.ts` covering all four statement kinds plus the not-a-regex division case; verified it fails with the exact reported `TS1109` on the unpatched parser.
- `go test ./tests -run TestScripts` and `go test ./pkg/...` — all green.
- Test262 before/after diffs for `language/statements/{if,while,for,for-of,for-in,with}`, `language/literals/regexp`, and `annexB/language/statements` — identical pass/fail counts, no regressions.

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)