### PR TITLE
fix(fetch): forward real Headers data and stop false top-level-await deadlocks

### DIFF
--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -553,7 +553,8 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Perform HTTP request asynchronously in a goroutine. On a response
 		// that streams (the common case, #205), cancel/rt outlive this
 		// goroutine and are discharged later by the body-drain goroutine
-		// doFetchRequestWithContext starts instead; on an early-return
+		// doFetchRequestWithContext starts instead, *after* doFetchRequestWithContext
+		// has already resolved promiseObj itself (#238); on an early-return
 		// error, *this* goroutine owns them, and must discharge them only
 		// after settling the promise below (#213 - see the doc comment on
 		// doFetchRequestWithContext for why the order matters: cancel()/
@@ -561,7 +562,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// that before the rejection is scheduled can make the drain exit
 		// with the promise settled but its continuation never resumed).
 		go func() {
-			response, err := doFetchRequestWithContext(ctx, cancel, rt, vmInstance, url, init)
+			err := doFetchRequestWithContext(ctx, cancel, rt, vmInstance, promiseObj, url, init)
 
 			if err != nil {
 				// Classify by the error type doFetchRequestWithContext
@@ -588,9 +589,9 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 				// Settled above; safe to wake the driver's drain loop now.
 				cancel()
 				rt.EndExternalOp()
-			} else {
-				vmInstance.ResolvePromise(promiseObj, response)
 			}
+			// Success: doFetchRequestWithContext already resolved promiseObj
+			// and handed cancel/rt off to its own body-drain goroutine.
 		}()
 
 		return promise, nil
@@ -1109,21 +1110,31 @@ func bytesToValue(data []byte) vm.Value {
 
 // doFetchRequestWithContext performs the HTTP request with context support
 // for cancellation. On any early return (parse error, network error, no
-// response) it leaves cancel/rt untouched - the caller must discharge them
-// itself, and must do so *after* settling the fetch() promise with the
-// returned error: cancel()/rt.EndExternalOp() wake the driver's event-loop
-// drain immediately, and if that happened before the promise reaction is
-// scheduled, the drain can see nothing pending and return, leaving the
-// promise settled but its `await`/`.then()` continuation never resumed
-// (previously masked by #213, which made this path effectively dead code -
-// see the fetchFn caller for where settlement now happens first). On
+// response) it leaves cancel/rt untouched and the promise unsettled - the
+// caller must reject the promise with the returned error and only then
+// discharge cancel/rt itself: cancel()/rt.EndExternalOp() wake the driver's
+// event-loop drain immediately, and if that happened before the promise
+// reaction is scheduled, the drain can see nothing pending and return,
+// leaving the promise settled but its `await`/`.then()` continuation never
+// resumed (previously masked by #213, which made this path effectively dead
+// code - see the fetchFn caller for where settlement happens first). On
 // success (#205) the response resolves as soon as headers arrive - real
 // fetch()/spec semantics, and required so an SSE body that never EOFs
-// doesn't block the fetch() promise forever - and a goroutine started here
-// streams the body into a ReadableStream, discharging cancel/rt itself only
-// once that finishes (EOF, read error, or the request being aborted
-// mid-body); the caller must NOT discharge them again in that case.
-func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, rt runtime.AsyncRuntime, vmInstance *vm.VM, url string, init vm.Value) (vm.Value, error) {
+// doesn't block the fetch() promise forever - and this function resolves
+// promiseObj itself, synchronously, *before* spawning the goroutine that
+// streams the body into a ReadableStream and only then discharges cancel/rt.
+// That ordering is required, not cosmetic (#238): the body-drain goroutine
+// can finish arbitrarily fast (an empty or already-buffered body EOFs
+// immediately) and its rt.EndExternalOp() can otherwise race the promise
+// settlement on a completely unsynchronized goroutine - if the external-op
+// count reaches zero before the promise is actually resolved, a top-level
+// await polling in the gap between those two events sees no pending
+// microtasks, no pending external ops, and a still-pending promise, and
+// falsely reports deadlock even though the promise was about to settle.
+// Resolving here, strictly before the `go func(){...}()` below even starts,
+// makes that ordering impossible instead of merely unlikely. The caller
+// must NOT resolve/reject promiseObj again in the success case.
+func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, rt runtime.AsyncRuntime, vmInstance *vm.VM, promiseObj *vm.PromiseObject, url string, init vm.Value) error {
 	// Default options
 	method := "GET"
 	headers := &FetchHeaders{headers: make(http.Header)}
@@ -1166,14 +1177,14 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 						// Auto-stringify objects for JSON content type
 						jsonBytes, err := b.MarshalJSON()
 						if err != nil {
-							return vm.Undefined, newTypeError(vmInstance, "failed to serialize body to JSON: "+err.Error())
+							return newTypeError(vmInstance, "failed to serialize body to JSON: "+err.Error())
 						}
 						body = bytes.NewReader(jsonBytes)
 					} else if b.Type() == vm.TypeObject || b.Type() == vm.TypeDictObject {
 						// Default to JSON for objects
 						jsonBytes, err := b.MarshalJSON()
 						if err != nil {
-							return vm.Undefined, newTypeError(vmInstance, "failed to serialize body to JSON: "+err.Error())
+							return newTypeError(vmInstance, "failed to serialize body to JSON: "+err.Error())
 						}
 						body = bytes.NewReader(jsonBytes)
 					} else {
@@ -1192,7 +1203,7 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 						if r, exists := signalObj.GetOwn("reason"); exists && r.Type() != vm.TypeUndefined {
 							reason = r
 						}
-						return vm.Undefined, &AbortError{Message: reason.ToString()}
+						return &AbortError{Message: reason.ToString()}
 					}
 				}
 				// Store reference for potential future abort (would need more infrastructure)
@@ -1239,7 +1250,7 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 	// Create request with context for cancellation support
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return vm.Undefined, err
+		return err
 	}
 
 	// Set headers
@@ -1254,9 +1265,9 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 		// before returning - see the doc comment above, #213) - so this
 		// correctly distinguishes a real abort from a plain network error.
 		if ctx.Err() == context.Canceled {
-			return vm.Undefined, &AbortError{Message: "The operation was aborted"}
+			return &AbortError{Message: "The operation was aborted"}
 		}
-		return vm.Undefined, err
+		return err
 	}
 
 	// Create response headers
@@ -1289,6 +1300,13 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 		Type:       responseType,
 	}
 
+	// Resolve the promise now, strictly before spawning the body-drain
+	// goroutine below - see the doc comment above (#238) for why the order
+	// matters: this must happen-before that goroutine's rt.EndExternalOp()
+	// can possibly run, which is only guaranteed if it has not even been
+	// spawned yet.
+	vmInstance.ResolvePromise(promiseObj, createResponseObject(vmInstance, response))
+
 	// Stream the body in off the VM goroutine: enqueue each chunk on the
 	// ReadableStream as it arrives (for consumers reading response.body
 	// directly) and accumulate it in bodyState (for text()/json()/etc,
@@ -1320,7 +1338,7 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 		}
 	}()
 
-	return createResponseObject(vmInstance, response), nil
+	return nil
 }
 
 // FetchRequest represents the Request object

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -160,23 +160,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Initialize with headers if provided
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined && args[0].Type() != vm.TypeNull {
-			if args[0].Type() == vm.TypeObject {
-				obj := args[0].AsPlainObject()
-				keys := obj.OwnKeys()
-				for _, key := range keys {
-					if val, exists := obj.GetOwn(key); exists {
-						headers.headers.Set(key, val.ToString())
-					}
-				}
-			} else if args[0].Type() == vm.TypeDictObject {
-				dictObj := args[0].AsDictObject()
-				keys := dictObj.OwnKeys()
-				for _, key := range keys {
-					if val, exists := dictObj.GetOwn(key); exists {
-						headers.headers.Set(key, val.ToString())
-					}
-				}
-			}
+			mergeHeadersFrom(headers, args[0])
 		}
 
 		return createHeadersObject(vmInstance, headers), nil
@@ -722,6 +706,14 @@ func boolToValue(b bool) vm.Value {
 func createHeadersObject(vmInstance *vm.VM, h *FetchHeaders) vm.Value {
 	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 
+	// Brand the object with its backing FetchHeaders so code that reads a
+	// Headers-shaped value (fetch()'s request builder, parseHeaders, the
+	// Headers constructor itself) can recover the actual header data. Every
+	// accessor below is installed non-enumerable, so OwnKeys() on this
+	// object is always empty - reading headers via OwnKeys() alone silently
+	// drops everything set through .set()/.append()/new Headers(...) (#237).
+	obj.SetInternalSlots(h)
+
 	obj.SetOwnNonEnumerable("get", vm.NewNativeFunction(1, false, "get", func(args []vm.Value) (vm.Value, error) {
 		if len(args) < 1 {
 			return vm.NewString(""), nil
@@ -1159,21 +1151,7 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 
 			// Headers
 			if h, exists := initObj.GetOwn("headers"); exists && h.Type() != vm.TypeUndefined {
-				if h.Type() == vm.TypeObject {
-					hObj := h.AsPlainObject()
-					for _, key := range hObj.OwnKeys() {
-						if val, exists := hObj.GetOwn(key); exists {
-							headers.headers.Set(key, val.ToString())
-						}
-					}
-				} else if h.Type() == vm.TypeDictObject {
-					hDictObj := h.AsDictObject()
-					for _, key := range hDictObj.OwnKeys() {
-						if val, exists := hDictObj.GetOwn(key); exists {
-							headers.headers.Set(key, val.ToString())
-						}
-					}
-				}
+				mergeHeadersFrom(headers, h)
 			}
 
 			// Body
@@ -1398,22 +1376,45 @@ func valueToBytes(v vm.Value) []byte {
 // parseHeaders parses a value into FetchHeaders
 func parseHeaders(v vm.Value) *FetchHeaders {
 	headers := &FetchHeaders{headers: make(http.Header)}
+	mergeHeadersFrom(headers, v)
+	return headers
+}
+
+// mergeHeadersFrom reads header entries out of v - which may be a real
+// Headers instance, or a plain object/dict literal such as
+// { "Content-Type": "application/json" } - into dst.
+//
+// A Headers instance's own data lives behind SetInternalSlots (see
+// createHeadersObject): every one of its get/set/append/etc. accessors is
+// installed non-enumerable, so OwnKeys() on it is always empty. Reading
+// headers via OwnKeys() alone therefore silently drops everything set
+// through a real Headers object's .set()/.append(), or passed as
+// new Headers(anotherHeadersInstance) - #237. Check for that internal state
+// first and only fall back to OwnKeys() for genuine object/dict literals.
+func mergeHeadersFrom(dst *FetchHeaders, v vm.Value) {
 	if v.Type() == vm.TypeObject {
 		obj := v.AsPlainObject()
+		if h, ok := obj.InternalSlots().(*FetchHeaders); ok && h != nil {
+			for name, values := range h.headers {
+				for _, value := range values {
+					dst.headers.Add(name, value)
+				}
+			}
+			return
+		}
 		for _, key := range obj.OwnKeys() {
 			if val, exists := obj.GetOwn(key); exists {
-				headers.headers.Set(key, val.ToString())
+				dst.headers.Set(key, val.ToString())
 			}
 		}
 	} else if v.Type() == vm.TypeDictObject {
 		dictObj := v.AsDictObject()
 		for _, key := range dictObj.OwnKeys() {
 			if val, exists := dictObj.GetOwn(key); exists {
-				headers.headers.Set(key, val.ToString())
+				dst.headers.Set(key, val.ToString())
 			}
 		}
 	}
-	return headers
 }
 
 // parseRequestInit parses RequestInit options from a PlainObject

--- a/pkg/driver/fetch_headers_test.go
+++ b/pkg/driver/fetch_headers_test.go
@@ -1,0 +1,76 @@
+package driver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFetchForwardsRealHeadersInstance is a regression test for #237: a
+// real Headers object's data lives behind every accessor (.get/.set/
+// .append/etc) installed non-enumerable via SetOwnNonEnumerable (see
+// createHeadersObject in pkg/builtins/fetch_init.go), so Object.keys()/
+// OwnKeys() on it is always empty. fetch()'s request builder used to read
+// init.headers purely via OwnKeys(), which works for a plain object
+// literal like { "X-Foo": "bar" } but silently drops every header set
+// through the real Headers API - new Headers(), .set(), .append() - so
+// fetch(url, { headers: new Headers() }) sent none of them, and the server
+// saw only Go's own http.Client defaults.
+func TestFetchForwardsRealHeadersInstance(t *testing.T) {
+	var gotAuth, gotCustom string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotCustom = r.Header.Get("X-Custom")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	script := `
+		async function run() {
+			const h = new Headers();
+			h.set("Authorization", "Bearer secret123");
+			h.append("X-Custom", "hello");
+			await fetch("` + server.URL + `", { headers: h });
+		}
+		await run();
+	`
+
+	_, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed: %v", errs[0])
+	}
+
+	if gotAuth != "Bearer secret123" {
+		t.Fatalf("Authorization header = %q, want %q (a real Headers instance's data was dropped)", gotAuth, "Bearer secret123")
+	}
+	if gotCustom != "hello" {
+		t.Fatalf("X-Custom header = %q, want %q (a real Headers instance's data was dropped)", gotCustom, "hello")
+	}
+}
+
+// TestHeadersConstructorAcceptsExistingHeadersInstance covers the same
+// OwnKeys()-blindness bug (#237) in the Headers constructor itself:
+// new Headers(anotherHeadersInstance) must copy the source's entries, not
+// silently produce an empty Headers object.
+func TestHeadersConstructorAcceptsExistingHeadersInstance(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	script := `
+		const src = new Headers();
+		src.set("X-Test", "abc");
+		const copy = new Headers(src);
+		copy.get("X-Test");
+	`
+
+	result, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed: %v", errs[0])
+	}
+	if result.ToString() != "abc" {
+		t.Fatalf("copy.get(\"X-Test\") = %q, want %q", result.ToString(), "abc")
+	}
+}

--- a/pkg/driver/fetch_tla_deadlock_race_test.go
+++ b/pkg/driver/fetch_tla_deadlock_race_test.go
@@ -1,0 +1,62 @@
+package driver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestTopLevelAwaitFetchTextDoesNotFalselyDeadlock is a regression test for
+// #238: `for (...) { await one(); }` at the top level, where `one()` does
+// `const res = await fetch(url); await res.text();`, used to falsely throw
+// "Top-level await: promise remains pending with no microtasks to process"
+// roughly one iteration in ~15, even though nothing was actually deadlocked.
+//
+// fetch() and Response.text() each track their own external async
+// operation (rt.BeginExternalOp/EndExternalOp) so the driver's event loop
+// knows to keep waiting for them. The top-level-await drain loop
+// (pkg/vm/vm.go, OpAwait) polls several independent signals in sequence -
+// RunNextTicks, RunUntilIdle (microtasks), RunDueTimers, RunMacrotasks,
+// HasPendingExternalOps - each under its *own* separate lock/unlock cycle
+// rather than one atomic snapshot. That leaves a gap: a background
+// goroutine (fetch()'s body-drain goroutine, or Response.text()'s own
+// drainBody goroutine) can schedule the microtask that resumes this very
+// await *and* end its external op in the window between this loop's
+// RunUntilIdle() check (too early - the microtask isn't scheduled yet) and
+// its HasPendingExternalOps() check (too late - the op has already ended).
+// Every individual check then reports nothing pending, even though a
+// microtask is sitting right there in the queue, and the loop wrongly
+// declares deadlock.
+//
+// This runs enough iterations against a real (loopback) HTTP server for
+// that race to reproduce reliably before the fix (a `HasPendingWork()`
+// atomic-snapshot fallback before giving up, mirroring the identical guard
+// already present in VM.DrainUntilIdle).
+func TestTopLevelAwaitFetchTextDoesNotFalselyDeadlock(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	script := `
+		async function one() {
+			const res = await fetch("` + server.URL + `");
+			await res.text();
+		}
+		for (let i = 0; i < 300; i++) {
+			await one();
+		}
+		"done";
+	`
+
+	result, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed (a \"Top-level await\" message here is the #238 false deadlock): %v", errs[0])
+	}
+	if result.ToString() != "done" {
+		t.Fatalf("expected %q, got %v", "done", result.Inspect())
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -15471,6 +15471,7 @@ startExecution:
 				tlaState, tlaResult := awaitedPromise.snapshot()
 				if tlaState == PromisePending {
 					rt := vm.GetAsyncRuntime()
+					deadlockRetries := 0
 					for {
 						tlaState, tlaResult = awaitedPromise.snapshot()
 						if tlaState != PromisePending {
@@ -15493,6 +15494,33 @@ startExecution:
 							progress = true
 						}
 						if !progress {
+							// Each check above locks/unlocks the runtime's
+							// mutex separately, rather than deciding "nothing
+							// is pending" from one atomic snapshot. That
+							// leaves a gap a background goroutine can land
+							// in: e.g. fetch()'s body-drain goroutine (or a
+							// Response.text()/.json()/etc drainBody
+							// goroutine) can schedule the microtask that
+							// resumes this very await *and* end its external
+							// op in the window between this loop's
+							// RunUntilIdle() call (too early to see that
+							// microtask - not scheduled yet) and its
+							// HasPendingExternalOps() call (too late - the
+							// op has already ended) - so every check above
+							// reports nothing pending even though real work
+							// is sitting in the microtask queue (#238).
+							// HasPendingWork() takes a single snapshot under
+							// the runtime's own lock, so it can't be fooled
+							// by that same race - if it says something is
+							// pending, retry instead of wrongly declaring
+							// deadlock (mirrors the identical guard in
+							// VM.DrainUntilIdle, async_runtime.go). Capped
+							// the same way, in case something really is
+							// stuck forever.
+							if rt.HasPendingWork() && deadlockRetries < 1_000_000 {
+								deadlockRetries++
+								continue
+							}
 							frame.ip = ip
 							status := vm.runtimeError("Top-level await: promise remains pending with no microtasks to process")
 							return status, Undefined


### PR DESCRIPTION
## Summary

Fixes two bugs reported for `fetch()`, kept as separate commits.

### #237 — `fetch()` silently drops headers set through the real Headers API
`createHeadersObject` installs every accessor (`get`/`set`/`append`/etc.) as a **non-enumerable** own property, so `Object.keys()`/`OwnKeys()` on a `Headers` instance is always empty — the actual header data lives only in the closure-captured `*FetchHeaders`. `fetch()`'s request builder, the shared `parseHeaders()` helper (used by `Response`/`Request` and `Response.json()`), and the `Headers` constructor itself all read a headers-shaped value purely via `OwnKeys()`. That works for a plain object literal (`{ "Content-Type": "..." }`) but silently drops everything set via `new Headers()`, `.set()`, `.append()`, or `new Headers(existing)`.

Fix: brand each `Headers` object with its backing `*FetchHeaders` via `PlainObject.SetInternalSlots` (the existing mechanism for builtins with no dedicated VM object type), and check for that first in a new shared `mergeHeadersFrom()`, falling back to `OwnKeys()` only for genuine object/dict literals.

Verified against a raw HTTP server: `fetch(url, { headers: h })` with a real `Headers` instance now forwards `Authorization`/custom headers instead of only Go's `http.Client` defaults.

### #238 — intermittent false "Top-level await" deadlock after `fetch()`
`for (...) { await one(); }` where `one()` does `const res = await fetch(url); await res.text();` intermittently (~1 in 15–25 against a real server) threw `Top-level await: promise remains pending with no microtasks to process` even though nothing was stuck. Two independent bugs combined:

1. `doFetchRequestWithContext` resolved `fetch()`'s promise from the *caller*, after already spawning its body-drain goroutine (which owns the external-op count). A fast-EOF body's `rt.EndExternalOp()` could fire before the promise was ever resolved — fixed by resolving the promise **inside** `doFetchRequestWithContext`, synchronously, strictly before spawning that goroutine.
2. The top-level-await drain loop polls several signals (`RunNextTicks`/`RunUntilIdle`/.../`HasPendingExternalOps`) each under its own separate lock, not one atomic snapshot. A background goroutine (fetch's body-drain, or `Response.text()`'s own `drainBody`) can schedule the resuming microtask *and* end its external op in the gap between two of these checks, so every individual check reports nothing pending — fixed by falling back to `rt.HasPendingWork()` (one atomic snapshot) before declaring deadlock, mirroring the identical guard already in `VM.DrainUntilIdle`.

Each root cause was confirmed independently by reverting one fix at a time and reproducing reliably (25/25 and 10/10 failures) under `-race`; both pass reliably with both fixes applied.

## Testing
- `go test ./...` — all green
- `go build -race` stress runs of the real repro scripts: 0/40+ failures after the fix (reliably 10-25/25 failures before)
- New regression tests: `TestFetchForwardsRealHeadersInstance`, `TestHeadersConstructorAcceptsExistingHeadersInstance`, `TestTopLevelAwaitFetchTextDoesNotFalselyDeadlock` — all confirmed to fail reliably against the pre-fix code and pass against the fix

## Note
While investigating, I found a separate, pre-existing, out-of-scope bug: `fetch(new Request(url, {...}))` doesn't work at all — `url := args[0].ToString()` never extracts the URL from a `Request` object, so it isn't just a headers issue for that call shape. Not fixed here to keep this PR focused; flagging for a follow-up.