### PR TITLE
fix(vm): resolve bare Object.prototype methods as globals (#246)

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1606,6 +1606,19 @@ func initializeBuiltinsWithCustom(paserati *Paserati, initializers []builtins.Bu
 		}
 	}
 
+	// vmInstance.GlobalObject was created (in realm.InitializePrototypes) before
+	// this loop ran, chained to the placeholder Object.prototype that existed at
+	// that time. ObjectInitializer.InitRuntime above replaces vmInstance.ObjectPrototype
+	// wholesale with a brand-new object carrying the real methods (hasOwnProperty,
+	// toString, valueOf, ...) - GlobalObject's prototype link still points at the
+	// orphaned placeholder unless re-pointed here. Without this, bare references to
+	// Object.prototype methods (which fall back to a lookup on GlobalObject) report
+	// as absent even though `globalThis.hasOwnProperty` correctly resolves via a
+	// separate special case in property access. See #246.
+	if vmInstance.GlobalObject != nil && vmInstance.ObjectPrototype.IsObject() {
+		vmInstance.GlobalObject.SetPrototype(vmInstance.ObjectPrototype)
+	}
+
 	// Get builtin names and preallocate indices in the heap allocator
 	// IMPORTANT: Separate standard builtins from custom ones to ensure stable indices
 	// Standard builtins (from GetStandardInitializers) must have consistent indices
@@ -1681,6 +1694,20 @@ func (p *Paserati) InitializeRealmBuiltins(realm *vm.Realm, initializers []built
 				// Log error but continue - some initializers may fail in secondary realms
 				continue
 			}
+		}
+
+		// realm.GlobalObject was created (in realm.InitializePrototypes) chained to
+		// whatever placeholder Object.prototype existed at that time. The
+		// ObjectInitializer.InitRuntime call above replaces vmInstance.ObjectPrototype
+		// wholesale with a brand-new object carrying the real methods (hasOwnProperty,
+		// toString, valueOf, ...) - GlobalObject's prototype link still points at the
+		// orphaned placeholder unless re-pointed here, same root cause fixed for the
+		// main realm above in initializeBuiltinsWithCustom. Do this once, here,
+		// rather than in SyncPrototypesToRealm (called on every WithRealm exit),
+		// which would silently re-force the link over a legitimate later
+		// Object.setPrototypeOf(globalThis, ...) in this realm. See #246.
+		if realm.GlobalObject != nil && vmInstance.ObjectPrototype.IsObject() {
+			realm.GlobalObject.SetPrototype(vmInstance.ObjectPrototype)
 		}
 	})
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2144,10 +2144,23 @@ startExecution:
 
 			identifierName := AsString(constants[nameIdx])
 
-			// Try to resolve the identifier - check heap for global variables
-			// Use the heap's nameToIndex map if available
-			if heapIdx, exists := vm.heap.nameToIndex[identifierName]; exists {
-				val, _ := vm.heap.Get(heapIdx)
+			// Try to resolve the identifier - check heap for global variables.
+			// A name can appear in nameToIndex merely because some OTHER reference
+			// to it earlier in this same compile unit caused a heap slot to be
+			// allocated for it (GetOrAssignGlobalIndex) - that slot may never have
+			// actually been Set. Use the value-returning form of Get and only treat
+			// the identifier as heap-resolved when a value was really written there;
+			// otherwise fall through to the GlobalObject check below, same as
+			// OpGetGlobal (see #246 - this previously made bare Object.prototype
+			// methods report "undefined" whenever anything else in the script also
+			// referenced them by name).
+			heapIdx, nameExists := vm.heap.nameToIndex[identifierName]
+			heapVal, heapValExists := Undefined, false
+			if nameExists {
+				heapVal, heapValExists = vm.heap.Get(heapIdx)
+			}
+			if heapValExists {
+				val := heapVal
 				// A let/const/class binding still in its temporal dead zone throws
 				// on typeof like on any other read (spec: typeof evaluates the
 				// reference first). The name may carry a module prefix, see the
@@ -2166,8 +2179,10 @@ startExecution:
 				}
 				typeofStr := getTypeofString(val)
 				registers[destReg] = String(typeofStr)
-			} else if vm.GlobalObject != nil && vm.GlobalObject.HasOwn(identifierName) {
-				// Also check GlobalObject for properties set via Object.defineProperty(this, ...)
+			} else if vm.GlobalObject != nil && vm.GlobalObject.Has(identifierName) {
+				// Also check GlobalObject for properties set via Object.defineProperty(this, ...),
+				// or inherited from its prototype chain (e.g. bare Object.prototype methods like
+				// hasOwnProperty, toString, valueOf - see #246).
 				frame.ip = ip
 				vm.helperCallDepth++
 				propVal, err := vm.GetProperty(NewValueFromPlainObject(vm.GlobalObject), identifierName)
@@ -13617,8 +13632,10 @@ startExecution:
 			// If not in heap, also check GlobalObject (for properties set via Object.defineProperty(this, ...))
 			if !exists && vm.GlobalObject != nil {
 				varName := vm.heap.GetNameByIndex(int(globalIdx))
-				if varName != "" && vm.GlobalObject.HasOwn(varName) {
-					// Get from GlobalObject - use GetProperty to handle getters
+				if varName != "" && vm.GlobalObject.Has(varName) {
+					// Get from GlobalObject - use GetProperty to handle getters. This also
+					// covers properties inherited via the global object's prototype chain,
+					// e.g. bare Object.prototype methods like hasOwnProperty (#246).
 					frame.ip = ip
 					vm.helperCallDepth++
 					propVal, err := vm.GetProperty(NewValueFromPlainObject(vm.GlobalObject), varName)
@@ -13728,8 +13745,13 @@ startExecution:
 			if isStrict && !heapExists && vm.globalsFromGlobalObject[globalIdx] {
 				varName := vm.heap.GetNameByIndex(int(globalIdx))
 				if varName != "" && vm.GlobalObject != nil {
-					// Check if property exists on GlobalObject
-					if !vm.GlobalObject.HasOwn(varName) {
+					// Check if the binding still exists on GlobalObject. Per ECMAScript
+					// 9.1.1.2.1 HasBinding, an object environment record's binding test
+					// is [[HasProperty]] - prototype-chain inclusive, not own-properties-only -
+					// so an inherited-only binding (e.g. bare Object.prototype methods like
+					// hasOwnProperty, see #246) still counts as present here and a plain
+					// assignment should create an own property, not throw.
+					if !vm.GlobalObject.Has(varName) {
 						frame.ip = ip
 						vm.ThrowReferenceError(fmt.Sprintf("Cannot assign to deleted binding '%s' in strict mode", varName))
 						if vm.unwinding {

--- a/tests/scripts/bare_object_prototype_methods.ts
+++ b/tests/scripts/bare_object_prototype_methods.ts
@@ -1,0 +1,22 @@
+// expect: true
+// skip-typecheck
+// Bare (unqualified) references to Object.prototype methods must resolve via
+// the global object's prototype chain, same as `globalThis.hasOwnProperty`
+// does. See #246. Uses skip-typecheck (not no-typecheck) because that's the
+// code path real JS (paserati --no-typecheck / noderati) actually takes -
+// the checker's global environment happens to already know these names, so
+// no-typecheck alone would silently exercise a different path than the bug.
+
+let results: boolean[] = [];
+
+results.push(typeof hasOwnProperty === "function");
+results.push(typeof toString === "function");
+results.push(typeof valueOf === "function");
+results.push(typeof isPrototypeOf === "function");
+results.push(typeof propertyIsEnumerable === "function");
+results.push(typeof toLocaleString === "function");
+
+results.push(hasOwnProperty.call({ a: 1 }, "a") === true);
+results.push(hasOwnProperty.call({ a: 1 }, "b") === false);
+
+results.every((r) => r === true);


### PR DESCRIPTION
Fixes #246.

## Summary

`typeof hasOwnProperty` reported `"undefined"` and calling `hasOwnProperty` bare threw `ReferenceError`, even though `globalThis.hasOwnProperty` and `obj.hasOwnProperty` both worked correctly. Same for `toString`, `valueOf`, `isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString`.

## The issue's root-cause diagnosis was incomplete

The issue proposed swapping `GlobalObject.HasOwn` → `GlobalObject.Has` at two sites in `pkg/vm/vm.go`. That's necessary but **not sufficient** — the actual root cause is one level deeper, and applying just that swap does nothing observable on its own. Two more bugs had to be found and fixed:

1. **`GlobalObject`'s prototype link was orphaned.** `vm.GlobalObject` is created early (`realm.InitializePrototypes`) chained to a placeholder `Object.prototype`. `builtins.ObjectInitializer.InitRuntime` later replaces `vmInstance.ObjectPrototype` *wholesale* with a brand-new object carrying the real methods, without updating anyone who already captured the old pointer. Confirmed directly: `Object.getPrototypeOf(globalThis) === Object.prototype` was `false` on main. Property access (`globalThis.x`, `obj.x`) happened to work anyway only because `op_getprop.go` already has a separate special-cased workaround for this exact staleness — identifier resolution (`OpGetGlobal`/`OpTypeofIdentifier`) had no such workaround, so `GlobalObject.Has()` couldn't find anything via the (broken) chain regardless of `HasOwn` vs `Has`.

2. **`OpTypeofIdentifier` discarded `heap.Get`'s exists bool.** A heap slot gets allocated for a name as soon as *any* reference to it is compiled, whether or not it's ever actually `Set`. The old code took the "found in heap" branch whenever the name merely had an allocated slot, then treated the never-written `Undefined` value as if it were real. This is why the issue's own two-line repro (`typeof` read, then a bare call) exhibited the bug while a `typeof`-only one-liner did not — the second reference was enough to allocate the slot the first one's `typeof` check then misread.

## Fixes

- `driver.go`: after builtins finish initializing — both the main realm (`initializeBuiltinsWithCustom`) and secondary realms (`InitializeRealmBuiltins`, e.g. via `$262.createRealm()`) — re-point `GlobalObject`'s prototype at the now-finalized `Object.prototype`. Done once, at the initialization call site, *not* inside `SyncPrototypesToRealm` (called on every `WithRealm` exit) — that would silently re-force the link over a legitimate later `Object.setPrototypeOf(globalThis, ...)` in that realm (verified this stays correct with a custom test).
- `vm.go` `OpTypeofIdentifier`: use the value-returning form of `heap.Get` and only treat a name as heap-resolved when a value was actually written, matching `OpGetGlobal`'s existing (correct) structure.
- `vm.go` `OpGetGlobal`/`OpTypeofIdentifier`: `GlobalObject.HasOwn` → `Has` (the issue's original proposal), so the fallback lookup for a name not in the heap also finds properties inherited via `GlobalObject`'s prototype chain — with the two fixes above, this now actually fires.
- `vm.go` `OpSetGlobal`: same `HasOwn` → `Has` swap for the strict-mode "was this binding deleted" check. Per ECMAScript 9.1.1.2.1 `HasBinding`, an object environment record's binding test is `[[HasProperty]]` (prototype-chain inclusive), not own-properties-only. Note: no test exercises this path directly — a strict-mode assignment to a name unresolved at compile time is short-circuited by `emitStrictUnresolvableReferenceError` before this runtime code ever runs (confirmed pre-existing/unrelated behavior on main via a stashed build). This is spec alignment, not an observable behavior change under current compiler behavior.

## Testing

- `go test ./...` — green.
- Added [tests/scripts/bare_object_prototype_methods.ts](tests/scripts/bare_object_prototype_methods.ts) (`skip-typecheck`, matching the real `paserati --no-typecheck` code path the issue's repro used).
- Test262 `built-ins/` vs `baseline.txt`: **+2 / -0** net (one of the two new passes is a test known to be flaky in batch mode; passes individually).
- Test262 `language/` (23,523 tests): byte-identical results (23162 passed / 361 failed) against a stashed main-branch build.
- Manually verified two cross-realm scenarios via `$262.createRealm()` that aren't covered by the existing Test262 corpus: `typeof hasOwnProperty` resolves correctly in a secondary realm, and a legitimate `Object.setPrototypeOf(globalThis, null)` in a realm survives subsequent `evalScript` calls (i.e. the fix doesn't silently re-force the prototype link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)