### PR TITLE
fix(vm): restore a suspended generator/async frame's spill slots on resume

### DIFF
--- a/pkg/driver/host_suspended_upvalue_test.go
+++ b/pkg/driver/host_suspended_upvalue_test.go
@@ -1,6 +1,8 @@
 package driver
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/nooga/paserati/pkg/vm"
@@ -444,5 +446,113 @@ func TestConcurrentGeneratorInstancesDontCrossContaminate(t *testing.T) {
 		if got != w {
 			t.Errorf("snapshot %d: got %v, want %v", i, got, w)
 		}
+	}
+}
+
+// spillPadding returns n throwaway `let` declarations that are never freed
+// (all live in the same top-level function scope for its whole body), to
+// push the compiler's register allocator for that function past
+// VariableRegisterThreshold (200, see pkg/compiler/regalloc.go) so that
+// whatever local is declared after them lands in a spill slot
+// (frame.spillSlots) rather than a register.
+func spillPadding(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("let pad")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(" = 0;\n")
+	}
+	return b.String()
+}
+
+// TestAsyncClosureMutationAfterResumeStaysCoherentWithSpilledLocal is the
+// spill-slot counterpart of TestAsyncClosureMutationAfterResumeStaysCoherent:
+// the captured local `n` is forced into a spill slot (not a register) by 250
+// throwaway padding declarations ahead of it, then mutated both directly and
+// via a closure after resume. Note this alone does not reproduce the
+// frame.spillSlots restore bug (with nothing else running between suspend
+// and resume, the same CallFrame slot happens to still hold this call's own
+// spillSlots array even without an explicit restore) - it's a coherence
+// check, kept alongside the true discriminator below
+// (TestConcurrentAsyncFunctionsWithSpilledLocalsDontCrossContaminate, which
+// forces the reused-slot collision and does fail without the fix).
+func TestAsyncClosureMutationAfterResumeStaysCoherentWithSpilledLocal(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		async function f() {
+			` + spillPadding(250) + `
+			let n = 1; // forced into a spill slot by the 250 padding locals above
+			const get = () => n;
+			const inc = () => { n++; };
+			await new Promise((r) => setTimeout(r, 0));
+			inc();
+			n = n + 10;
+			return [n, get()];
+		}
+		let result = null;
+		f().then((r) => { result = r; });
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	result, ok := p.GetVM().GetGlobal("result")
+	if !ok || !result.IsArray() {
+		t.Fatalf("expected array result, got %v", result)
+	}
+	arr := result.AsArray()
+	if arr.Length() != 2 || arr.Get(0).ToString() != "12" || arr.Get(1).ToString() != "12" {
+		t.Errorf("expected [12, 12] (direct write and closure read of the spilled local must agree), got %s", result.Inspect())
+	}
+}
+
+// TestConcurrentAsyncFunctionsWithSpilledLocalsDontCrossContaminate runs two
+// concurrently-suspended instances of the same async function, each with a
+// spilled captured local, resumed together off the same timer tick - each
+// instance's closure must keep observing its own spill array, never the
+// other instance's.
+//
+// (Deliberately uses the *same* delay for both: an earlier version of this
+// test gave the two instances different delays and hit an unrelated,
+// pre-existing timer-ordering bug where the earlier-scheduled instance's
+// post-await continuation silently never ran its own body - confirmed with
+// no spilling involved at all, so out of scope here. Same delay sidesteps it
+// without weakening what this test is actually checking.)
+func TestConcurrentAsyncFunctionsWithSpilledLocalsDontCrossContaminate(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		async function f(tag) {
+			` + spillPadding(250) + `
+			let n = 1; // forced into a spill slot
+			const get = () => n;
+			await new Promise((r) => setTimeout(r, 1));
+			n = n + 100;
+			return { tag, value: get() };
+		}
+		let results = [];
+		Promise.all([f("a"), f("b")]).then((rs) => { results = rs; });
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	results, ok := p.GetVM().GetGlobal("results")
+	if !ok || !results.IsArray() || results.AsArray().Length() != 2 {
+		t.Fatalf("expected a 2-element results array, got %v", results)
+	}
+	arr := results.AsArray()
+	seen := map[string]string{}
+	for i := 0; i < 2; i++ {
+		entry := arr.Get(i).AsPlainObject()
+		tag, _ := entry.GetOwn("tag")
+		value, _ := entry.GetOwn("value")
+		seen[tag.ToString()] = value.ToString()
+	}
+	if seen["a"] != "101" || seen["b"] != "101" {
+		t.Errorf("expected both instances' spilled local to independently reach 101, got %v", seen)
 	}
 }

--- a/pkg/driver/host_suspended_upvalue_test.go
+++ b/pkg/driver/host_suspended_upvalue_test.go
@@ -1,0 +1,448 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// These tests cover #247: a local captured by a nested closure inside an
+// async function or generator must keep its correct value across a
+// suspend/resume (await/yield), even while other code runs concurrently and
+// reuses the register-stack slice the suspended frame's own registers were
+// carved from.
+//
+// Root cause: a generator/async frame's `openUpvalues` are deliberately kept
+// open (not closed) across a yield/await, because a suspended closure over a
+// `let`/`const` must keep observing the binding once the function resumes.
+// But `frame.registers` is a slice of the single shared vm.registerStack,
+// and suspending immediately hands that exact stack region back for reuse by
+// whatever unrelated code runs next - so an open upvalue whose Location
+// still points into it silently starts aliasing that unrelated code's data
+// the moment anything else reuses the slot. See vm.relocateOpenUpvalues's own
+// doc comment for the fix.
+
+// TestAsyncClosureSurvivesAwaitUnderConcurrentStackReuse is a from-scratch
+// isolation of the issue with plain async functions only (no generators, no
+// $262) - simpler to reproduce than the issue's own repro and a better
+// regression test for it.
+func TestAsyncClosureSurvivesAwaitUnderConcurrentStackReuse(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		function pollute(n) {
+			// Recurse to build up a register-heavy call chain that occupies
+			// whatever register-stack region gets freed up while producer() is
+			// suspended at its await.
+			if (n <= 0) return 0;
+			let a = "junk-A-" + n;
+			let b = "junk-B-" + n;
+			let c = { tag: "junk-C-" + n };
+			let d = [n, n, n];
+			let sym = Symbol("junk-sym-" + n);
+			return pollute(n - 1) + (a.length - a.length) + (b.length - b.length) +
+				(c ? 0 : 0) + d.length - d.length + (sym ? 0 : 0) + 1;
+		}
+
+		async function producer() {
+			let obj = { tag: "original-obj" };
+			const getObj = () => obj; // arrow captures 'obj' via a register upvalue
+			await new Promise((r) => setTimeout(r, 0)); // suspend here
+			return getObj();
+		}
+
+		let result = null;
+		async function main() {
+			const p = producer();
+			for (let i = 0; i < 20; i++) {
+				pollute(30);
+			}
+			result = await p;
+		}
+		main();
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	result, ok := p.GetVM().GetGlobal("result")
+	if !ok {
+		t.Fatal("global result not found")
+	}
+	if !result.IsObject() {
+		t.Fatalf("expected the original object back, got %s (%s) - the closure's captured local was corrupted across the await", result.Inspect(), result.TypeName())
+	}
+	tag, exists := result.AsPlainObject().GetOwn("tag")
+	if !exists || tag.ToString() != "original-obj" {
+		t.Errorf("expected tag %q, got %s", "original-obj", tag.Inspect())
+	}
+}
+
+// TestAsyncClosureMutationAfterResumeStaysCoherent guards against a *wrong*
+// fix for the above: naively closing a suspending frame's open upvalues
+// (rather than re-homing them) would make a captured local mutated again
+// after resume desync between a direct register write and a closure's view
+// of the same binding, since paserati's compiler keeps writing captured
+// locals directly to the register for the rest of the enclosing function
+// (only outer closures go through the upvalue) - see
+// freeScopeRegisters/captureUpvalue's doc comments.
+func TestAsyncClosureMutationAfterResumeStaysCoherent(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		async function f() {
+			let n = 1;
+			const get = () => n;
+			const inc = () => { n++; };
+			await new Promise((r) => setTimeout(r, 0));
+			inc();
+			n = n + 10;
+			return [n, get()];
+		}
+		let result = null;
+		f().then((r) => { result = r; });
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	result, ok := p.GetVM().GetGlobal("result")
+	if !ok || !result.IsArray() {
+		t.Fatalf("expected array result, got %v", result)
+	}
+	arr := result.AsArray()
+	if arr.Length() != 2 || arr.Get(0).ToString() != "12" || arr.Get(1).ToString() != "12" {
+		t.Errorf("expected [12, 12] (direct write and closure read must agree), got %s", result.Inspect())
+	}
+}
+
+// TestGeneratorClosureMutationAcrossYieldsStaysCoherent is the generator
+// equivalent of the above: a captured local mutated between two yields, read
+// via the same closure after each.
+func TestGeneratorClosureMutationAcrossYieldsStaysCoherent(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		function* g() {
+			let n = 1;
+			const get = () => n;
+			yield get();
+			n = n + 10;
+			yield get();
+			n = n + 100;
+			yield get();
+		}
+		let it = g();
+		[it.next().value, it.next().value, it.next().value]
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsArray() {
+		t.Fatalf("expected array result, got %s", result.Inspect())
+	}
+	arr := result.AsArray()
+	got := [3]string{arr.Get(0).ToString(), arr.Get(1).ToString(), arr.Get(2).ToString()}
+	want := [3]string{"1", "11", "111"}
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestIssue247Repro is the issue's own minimal repro: a `const` captured by
+// a closure in a concurrently-running async IIFE must not lose its value
+// across an await while a separately-driven async generator (with its own
+// internal await, consumed via `for await`) is live at the same time.
+func TestIssue247Repro(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		class EventStream {
+			queue = [];
+			waiting = [];
+			done = false;
+			push(event) {
+				const waiter = this.waiting.shift();
+				if (waiter) { waiter({ value: event, done: false }); }
+				else { this.queue.push(event); }
+			}
+			end() {
+				this.done = true;
+				while (this.waiting.length > 0) {
+					this.waiting.shift()({ value: undefined, done: true });
+				}
+			}
+			async *[Symbol.asyncIterator]() {
+				while (true) {
+					if (this.queue.length > 0) { yield this.queue.shift(); }
+					else if (this.done) { return; }
+					else {
+						const result = await new Promise((resolve) => this.waiting.push(resolve));
+						if (result.done) return;
+						yield result.value;
+					}
+				}
+			}
+		}
+
+		var typeofBlocks = null;
+		var isArrayBlocks = null;
+		function startStreaming() {
+			const stream = new EventStream();
+			(async () => {
+				const output = { content: [] };
+				const blocks = output.content;
+				const getContentIndex = (block) => {
+					typeofBlocks = typeof blocks;
+					isArrayBlocks = Array.isArray(blocks);
+					return -1;
+				};
+				await new Promise((r) => setTimeout(r, 0));
+				const block = {};
+				getContentIndex(block);
+				stream.push({ type: "done" });
+				stream.end();
+			})();
+			return stream;
+		}
+
+		let doneFlag = false;
+		async function main() {
+			const stream = startStreaming();
+			for await (const event of stream) {}
+			doneFlag = true;
+		}
+		main();
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	done, ok := p.GetVM().GetGlobal("doneFlag")
+	if !ok || !done.IsTruthy() {
+		t.Fatalf("expected doneFlag to be true (for-await loop must complete), got %v", done)
+	}
+	typeofBlocks, ok := p.GetVM().GetGlobal("typeofBlocks")
+	if !ok || typeofBlocks.Type() == vm.TypeNull {
+		t.Fatal("typeofBlocks never set - getContentIndex never ran")
+	}
+	if typeofBlocks.ToString() != "object" {
+		t.Errorf("expected typeof blocks === \"object\" (real Node behavior), got %q", typeofBlocks.ToString())
+	}
+	isArrayBlocks, ok := p.GetVM().GetGlobal("isArrayBlocks")
+	if !ok || !isArrayBlocks.IsTruthy() {
+		t.Errorf("expected Array.isArray(blocks) === true, got %v", isArrayBlocks)
+	}
+}
+
+// TestIssue247ReproLarger is the larger, closer-to-production repro from a
+// follow-up comment on #247 (~80 simulated SSE chunks via an async generator,
+// a producer IIFE mutating a captured `thinkingBlock`/`blocks` across many
+// awaits). Where the minimal repro above lost the binding to `undefined`,
+// this shape corrupted it to a live but *unrelated* value from elsewhere in
+// the runtime (observed as a Symbol) - a stronger signal that some other
+// frame's data was aliased in, not just a dropped write.
+func TestIssue247ReproLarger(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	js := `
+		class EventStream {
+			queue = [];
+			waiting = [];
+			done = false;
+			push(event) {
+				if (this.done) return;
+				const waiter = this.waiting.shift();
+				if (waiter) {
+					waiter({ value: event, done: false });
+				} else {
+					this.queue.push(event);
+				}
+			}
+			end() {
+				this.done = true;
+				while (this.waiting.length > 0) {
+					const waiter = this.waiting.shift();
+					waiter({ value: undefined, done: true });
+				}
+			}
+			async *[Symbol.asyncIterator]() {
+				while (true) {
+					if (this.queue.length > 0) {
+						yield this.queue.shift();
+					} else if (this.done) {
+						return;
+					} else {
+						const result = await new Promise((resolve) => this.waiting.push(resolve));
+						if (result.done) return;
+						yield result.value;
+					}
+				}
+			}
+		}
+
+		async function* fakeChunks(n) {
+			for (let i = 0; i < n; i++) {
+				await new Promise((r) => setTimeout(r, 0));
+				yield { delta: { reasoning_content: "x" + i } };
+			}
+		}
+
+		var brokenCount = 0;
+		function startStreaming(n) {
+			const stream = new EventStream();
+			(async () => {
+				const output = { content: [] };
+				let thinkingBlock = null;
+				const blocks = output.content;
+				const getContentIndex = (block) => {
+					if (!Array.isArray(blocks) || typeof blocks.indexOf !== "function") {
+						brokenCount++;
+						return -999;
+					}
+					return blocks.indexOf(block);
+				};
+				for await (const chunk of fakeChunks(n)) {
+					if (chunk.delta.reasoning_content) {
+						if (!thinkingBlock) {
+							thinkingBlock = { type: "thinking", thinking: "" };
+							blocks.push(thinkingBlock);
+						}
+						thinkingBlock.thinking += chunk.delta.reasoning_content;
+						const idx = getContentIndex(thinkingBlock);
+						stream.push({ type: "thinking_delta", contentIndex: idx, partial: output });
+					}
+				}
+				stream.push({ type: "done", message: output });
+				stream.end();
+			})();
+			return stream;
+		}
+
+		var eventCount = 0;
+		async function main() {
+			const stream = startStreaming(80);
+			for await (const event of stream) eventCount++;
+		}
+		main();
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+
+	broken, ok := p.GetVM().GetGlobal("brokenCount")
+	if !ok {
+		t.Fatal("brokenCount not found")
+	}
+	if broken.ToFloat() != 0 {
+		t.Errorf("expected brokenCount === 0 (blocks must stay the live array throughout), got %s", broken.Inspect())
+	}
+	eventCount, ok := p.GetVM().GetGlobal("eventCount")
+	if !ok {
+		t.Fatal("eventCount not found")
+	}
+	if eventCount.ToFloat() != 81 {
+		t.Errorf("expected 81 events processed (80 chunks + done), got %s", eventCount.Inspect())
+	}
+}
+
+// TestAsyncClosureWritableWhileParked exercises the *suspend-side* half of
+// the fix specifically: every other test above only reads/writes the
+// captured binding after the suspended function resumes. This one calls the
+// escaped closure while the async function is still parked at its await -
+// the write must land in the save buffer relocateOpenUpvalues points the
+// upvalue at, and resume must pick it up via its own copy+relocate.
+func TestAsyncClosureWritableWhileParked(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		let probe = null;
+		let result = null;
+		async function f() {
+			let n = 1;
+			probe = () => { n++; };
+			await Promise.resolve(); // always suspends per spec, even for a settled promise
+			return n;
+		}
+		f().then((r) => { result = r; });
+		// f is parked here - probe() must mutate the paused function's own binding,
+		// not a stale copy or (if the bug were still present) some unrelated
+		// register-stack slot.
+		probe();
+		probe();
+	`
+	_, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	result, ok := p.GetVM().GetGlobal("result")
+	if !ok {
+		t.Fatal("result not found")
+	}
+	if result.ToFloat() != 3 {
+		t.Errorf("expected 3 (1 + two probe() calls while parked), got %s", result.Inspect())
+	}
+}
+
+// TestConcurrentGeneratorInstancesDontCrossContaminate covers the
+// "concurrency" the issue's title actually names: two independently
+// suspended instances of the *same* generator function, resumed in an
+// interleaved order, must each keep their own closure's view of their own
+// captured local - relocateOpenUpvalues must never point one instance's
+// upvalue at another instance's save buffer.
+func TestConcurrentGeneratorInstancesDontCrossContaminate(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		function* g() {
+			let n = 1;
+			const get = () => n;
+			yield get;
+			n = 100;
+			yield null;
+			n = n + 1;
+			yield null;
+		}
+		let a = g();
+		let b = g();
+		const getA = a.next().value;
+		const getB = b.next().value;
+		a.next(); // a: n=100, b untouched
+		let snap1 = [getA(), getB()];
+		b.next(); // b: n=100
+		let snap2 = [getA(), getB()];
+		a.next(); // a: n=101
+		let snap3 = [getA(), getB()];
+		[snap1, snap2, snap3]
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsArray() {
+		t.Fatalf("expected array result, got %s", result.Inspect())
+	}
+	arr := result.AsArray()
+	if arr.Length() != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", arr.Length())
+	}
+	want := [3][2]string{{"100", "1"}, {"100", "100"}, {"101", "100"}}
+	for i, w := range want {
+		snap := arr.Get(i)
+		if !snap.IsArray() || snap.AsArray().Length() != 2 {
+			t.Fatalf("snapshot %d: expected a 2-element array, got %s", i, snap.Inspect())
+		}
+		got := [2]string{snap.AsArray().Get(0).ToString(), snap.AsArray().Get(1).ToString()}
+		if got != w {
+			t.Errorf("snapshot %d: got %v, want %v", i, got, w)
+		}
+	}
+}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -338,6 +338,17 @@ type SuspendedFrame struct {
 	// must survive the suspend and be restored on resume, then closed when the
 	// function finally completes.
 	openUpvalues *Upvalue
+	// spillSlots preserves this frame's overflow locals (used once a function
+	// has more than 255 live registers) across a suspend. Without this, a
+	// resumed frame keeps whatever spillSlots array the reused CallFrame slot
+	// last had (from some unrelated prior call) instead of this instance's
+	// own, so its own direct spill-slot reads/writes after resume would
+	// diverge from a closure's still-correctly-aliased view of the original
+	// array. This mirrors the register-stack aliasing bug #247's
+	// relocateOpenUpvalues fixed - see that function's doc comment, which
+	// flagged this exact gap as pre-existing and out of scope there. nil when
+	// the function never spills, which is the common case.
+	spillSlots []Value
 }
 
 // GeneratorFrame is an alias for backwards compatibility

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -15324,6 +15324,16 @@ startExecution:
 			// which persists for the generator's lifetime - `registers` itself is
 			// about to be handed back to vm.registerStack for reuse (#247).
 			relocateOpenUpvalues(genObj.Frame.openUpvalues, registers, genObj.Frame.registers)
+			// Carry the frame's spill-slot array itself across the suspend. No
+			// relocation is needed here (unlike registers above): frame.spillSlots
+			// is already a private per-call array, not part of vm.registerStack,
+			// so it isn't about to be reused by anyone else. Sharing the array
+			// (not copying it) is load-bearing, not an optimization - any open
+			// upvalue captured via CaptureFromSpill points directly at a slot in
+			// this array, so the resume side must re-attach the SAME backing
+			// array rather than a copy, or a closure's writes would silently
+			// diverge from what .next()/await sees, same class of bug as #247.
+			genObj.Frame.spillSlots = frame.spillSlots
 
 			// Create iterator result { value: yieldedValue, done: false }
 			result := NewObject(vm.ObjectPrototype).AsPlainObject()
@@ -15374,6 +15384,7 @@ startExecution:
 				copy(genObj.Frame.registers, registers)
 				genObj.Frame.openUpvalues = frame.openUpvalues
 				relocateOpenUpvalues(genObj.Frame.openUpvalues, registers, genObj.Frame.registers)
+				genObj.Frame.spillSlots = frame.spillSlots
 
 				// Transition to SuspendedStart state
 				logGeneratorStateTransition(genObj, GeneratorSuspendedStart, "OpInitYield")
@@ -15441,6 +15452,7 @@ startExecution:
 			copy(genObj.Frame.registers, registers)
 			genObj.Frame.openUpvalues = frame.openUpvalues
 			relocateOpenUpvalues(genObj.Frame.openUpvalues, registers, genObj.Frame.registers)
+			genObj.Frame.spillSlots = frame.spillSlots
 
 			// Return the iterator result as-is (don't wrap it)
 			return InterpretOK, iterResult
@@ -15624,6 +15636,9 @@ startExecution:
 			// which persists for the async function's lifetime - `registers`
 			// itself is about to be handed back to vm.registerStack for reuse (#247).
 			relocateOpenUpvalues(frame.promiseObj.Frame.openUpvalues, registers, frame.promiseObj.Frame.registers)
+			// Carry the frame's spill-slot array itself across the suspend - see
+			// the identical comment on the generator suspend sites above.
+			frame.promiseObj.Frame.spillSlots = frame.spillSlots
 
 			asyncPromise := frame.promiseObj
 
@@ -17060,16 +17075,12 @@ func (vm *VM) closeFrameUpvalues(frame *CallFrame) {
 // writing that unrelated code's data instead of the paused function's own
 // variable the moment anything else reuses the slot, without the paused
 // function ever being touched again. (A spill-slot capture's Location
-// pointer itself stays valid the same way - frame.spillSlots is a separate
-// make([]Value, n) per call, kept alive by the pointer via the Go GC even
-// after the CallFrame struct slot that made it is reused by an unrelated
-// call - but that's a narrower guarantee than "no such problem": resume does
-// not currently restore frame.spillSlots from anything saved at suspend, so
-// a spilled local's own direct reads/writes after resume run against
-// whatever spill array the reused CallFrame slot happened to have last,
-// which can desync from a closure's still-correctly-aliased view of the
-// pre-suspend array. Pre-existing, out of scope for #247, and orthogonal to
-// this function - not touched here.)
+// pointer needs no such relocation: frame.spillSlots is a separate
+// make([]Value, n) per call, not part of vm.registerStack, so the pointer
+// stays valid via the Go GC even after the CallFrame struct slot that made
+// it is reused by an unrelated call - the same array just has to be
+// re-attached to frame.spillSlots on resume, which every suspend/resume site
+// below does right alongside its openUpvalues save/restore.)
 //
 // The fix relocates each register-backed upvalue's Location in lockstep with
 // the register VALUES already being copied at every suspend/resume boundary:
@@ -18964,6 +18975,10 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	// register window, so this run's direct register reads/writes stay
 	// coherent with anything closed over the same binding (#247).
 	relocateOpenUpvalues(frame.openUpvalues, genObj.Frame.registers, frame.registers)
+	// Re-attach this generator's own spill-slot array (saved at suspend) -
+	// without this, frame.spillSlots would be whatever the reused CallFrame
+	// slot last held from an unrelated call.
+	frame.spillSlots = genObj.Frame.spillSlots
 
 	if debugGeneratorStates {
 		fmt.Printf("[GEN STATE] resumeGenerator: AFTER restore, frame.registers values:\n")
@@ -19227,6 +19242,8 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	// Re-home any register-backed upvalue into this freshly allocated live
 	// register window (#247 - see relocateOpenUpvalues doc comment).
 	relocateOpenUpvalues(frame.openUpvalues, genObj.Frame.registers, frame.registers)
+	// Re-attach this generator's own spill-slot array (saved at suspend).
+	frame.spillSlots = genObj.Frame.spillSlots
 
 	// Update VM state
 	vm.frameCount++
@@ -19407,6 +19424,8 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 	// Re-home any register-backed upvalue into this freshly allocated live
 	// register window (#247 - see relocateOpenUpvalues doc comment).
 	relocateOpenUpvalues(frame.openUpvalues, genObj.Frame.registers, frame.registers)
+	// Re-attach this generator's own spill-slot array (saved at suspend).
+	frame.spillSlots = genObj.Frame.spillSlots
 
 	// Update VM state
 	vm.frameCount++
@@ -19588,6 +19607,8 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 	// Re-home any register-backed upvalue into this freshly allocated live
 	// register window (#247 - see relocateOpenUpvalues doc comment).
 	relocateOpenUpvalues(frame.openUpvalues, promiseObj.Frame.registers, frame.registers)
+	// Re-attach this async function's own spill-slot array (saved at suspend).
+	frame.spillSlots = promiseObj.Frame.spillSlots
 
 	// Store the resolved value in the register specified by the await instruction
 	if promiseObj.Frame != nil && int(promiseObj.Frame.outputReg) < len(frame.registers) {
@@ -19739,6 +19760,8 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 	// Re-home any register-backed upvalue into this freshly allocated live
 	// register window (#247 - see relocateOpenUpvalues doc comment).
 	relocateOpenUpvalues(frame.openUpvalues, promiseObj.Frame.registers, frame.registers)
+	// Re-attach this async function's own spill-slot array (saved at suspend).
+	frame.spillSlots = promiseObj.Frame.spillSlots
 
 	// Update VM state
 	vm.frameCount++

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -15320,6 +15320,10 @@ startExecution:
 			copy(genObj.Frame.registers, registers)
 			// Carry the frame's open-upvalue list across the suspend (not closed on yield)
 			genObj.Frame.openUpvalues = frame.openUpvalues
+			// Re-home any register-backed upvalue into the copy just made above,
+			// which persists for the generator's lifetime - `registers` itself is
+			// about to be handed back to vm.registerStack for reuse (#247).
+			relocateOpenUpvalues(genObj.Frame.openUpvalues, registers, genObj.Frame.registers)
 
 			// Create iterator result { value: yieldedValue, done: false }
 			result := NewObject(vm.ObjectPrototype).AsPlainObject()
@@ -15369,6 +15373,7 @@ startExecution:
 				}
 				copy(genObj.Frame.registers, registers)
 				genObj.Frame.openUpvalues = frame.openUpvalues
+				relocateOpenUpvalues(genObj.Frame.openUpvalues, registers, genObj.Frame.registers)
 
 				// Transition to SuspendedStart state
 				logGeneratorStateTransition(genObj, GeneratorSuspendedStart, "OpInitYield")
@@ -15435,6 +15440,7 @@ startExecution:
 			// Copy register state to generator frame
 			copy(genObj.Frame.registers, registers)
 			genObj.Frame.openUpvalues = frame.openUpvalues
+			relocateOpenUpvalues(genObj.Frame.openUpvalues, registers, genObj.Frame.registers)
 
 			// Return the iterator result as-is (don't wrap it)
 			return InterpretOK, iterResult
@@ -15614,6 +15620,10 @@ startExecution:
 			copy(frame.promiseObj.Frame.registers, registers)
 			// Carry the frame's open-upvalue list across the await (not closed on suspend)
 			frame.promiseObj.Frame.openUpvalues = frame.openUpvalues
+			// Re-home any register-backed upvalue into the copy just made above,
+			// which persists for the async function's lifetime - `registers`
+			// itself is about to be handed back to vm.registerStack for reuse (#247).
+			relocateOpenUpvalues(frame.promiseObj.Frame.openUpvalues, registers, frame.promiseObj.Frame.registers)
 
 			asyncPromise := frame.promiseObj
 
@@ -17030,6 +17040,84 @@ func (vm *VM) closeFrameUpvalues(frame *CallFrame) {
 		uv = next
 	}
 	frame.openUpvalues = nil
+}
+
+// relocateOpenUpvalues redirects every open upvalue in the list that
+// currently points somewhere inside `from` to the corresponding index inside
+// `to`, leaving everything else (closed upvalues, and upvalues captured from
+// a spill slot rather than a register - captureUpvalue's callers only ever
+// pass a register or a spill-slot location) untouched.
+//
+// Why this is needed (#247): a generator/async frame's open upvalues are
+// deliberately NOT closed across a yield/await - a suspended closure over a
+// `let` must keep observing later writes to that binding once the function
+// resumes, so closeFrameUpvalues (which permanently detaches Location) is
+// wrong here. But `frame.registers` is a slice of the single shared
+// vm.registerStack, and suspending immediately hands that exact stack region
+// back for reuse by whatever unrelated code runs next (see
+// executeAsyncFunctionBody/resumeGenerator's savedNextRegSlot restore) - an
+// upvalue whose Location still points into it silently starts reading and
+// writing that unrelated code's data instead of the paused function's own
+// variable the moment anything else reuses the slot, without the paused
+// function ever being touched again. (A spill-slot capture's Location
+// pointer itself stays valid the same way - frame.spillSlots is a separate
+// make([]Value, n) per call, kept alive by the pointer via the Go GC even
+// after the CallFrame struct slot that made it is reused by an unrelated
+// call - but that's a narrower guarantee than "no such problem": resume does
+// not currently restore frame.spillSlots from anything saved at suspend, so
+// a spilled local's own direct reads/writes after resume run against
+// whatever spill array the reused CallFrame slot happened to have last,
+// which can desync from a closure's still-correctly-aliased view of the
+// pre-suspend array. Pre-existing, out of scope for #247, and orthogonal to
+// this function - not touched here.)
+//
+// The fix relocates each register-backed upvalue's Location in lockstep with
+// the register VALUES already being copied at every suspend/resume boundary:
+// on suspend, from the live (about-to-be-reclaimed) registers into the
+// GeneratorFrame/SuspendedFrame's own persistently-owned save buffer (stable
+// for the lifetime of the generator/promise object, so nothing else can ever
+// reuse it); on resume, back out of that save buffer into the freshly
+// allocated live register window, so this run's direct register reads/writes
+// stay coherent with anything closed over the same binding.
+func relocateOpenUpvalues(openUpvalues *Upvalue, from, to []Value) {
+	if openUpvalues == nil || len(from) == 0 {
+		return
+	}
+	// Everything here converts an already-valid pointer (&from[0], or an open
+	// upvalue's own live Location) to a uintptr for pure arithmetic and back;
+	// it never materializes an unsafe.Pointer to an address that isn't itself
+	// a real element of an existing allocation (in particular, never a
+	// one-past-the-end sentinel) - `go test -race`'s checkptr instrumentation
+	// flags that pattern even though the resulting pointer is never
+	// dereferenced.
+	baseAddr := uintptr(unsafe.Pointer(&from[0]))
+	span := uintptr(len(from)) * unsafe.Sizeof(Value{})
+	for uv := openUpvalues; uv != nil; uv = uv.next {
+		if uv.Location == nil {
+			continue // already closed (shouldn't normally appear in an open list)
+		}
+		locAddr := uintptr(unsafe.Pointer(uv.Location))
+		// Unsigned subtraction: if locAddr < baseAddr, this wraps around to a
+		// huge value, which the >= span check below rejects the same as any
+		// other out-of-range offset - no separate "before base" check needed.
+		offset := locAddr - baseAddr
+		if offset >= span {
+			continue // not inside `from` - e.g. a spill-slot capture
+		}
+		idx := offset / unsafe.Sizeof(Value{})
+		// `to` should always be at least as long as `from`: both the save
+		// buffer and the live register window for a given generator/async
+		// call are sized to funcObj.RegisterSize (TCO, the one thing that can
+		// give a frame a different allocatedRegSize, is unconditionally
+		// disabled for generator and async functions - see the
+		// canPerformTCO checks in OpTailCall/OpTailCallMethod). This bounds
+		// check is defensive only; if it is ever false the relocation is
+		// silently skipped and the upvalue is left pointing at `from`; letting
+		// its lifetime run out that way is preferable to a panic here.
+		if int(idx) < len(to) {
+			uv.Location = &to[idx]
+		}
+	}
 }
 
 // hasFunctionPrototypeProperty checks if FunctionPrototype has a property.
@@ -18871,6 +18959,11 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 
 	// Restore register state from saved frame
 	copy(frame.registers, genObj.Frame.registers)
+	// Re-home any register-backed upvalue (relocated to the save buffer by the
+	// suspend that parked this generator) into this freshly allocated live
+	// register window, so this run's direct register reads/writes stay
+	// coherent with anything closed over the same binding (#247).
+	relocateOpenUpvalues(frame.openUpvalues, genObj.Frame.registers, frame.registers)
 
 	if debugGeneratorStates {
 		fmt.Printf("[GEN STATE] resumeGenerator: AFTER restore, frame.registers values:\n")
@@ -19131,6 +19224,9 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 
 	// Restore register state from saved frame
 	copy(frame.registers, genObj.Frame.registers)
+	// Re-home any register-backed upvalue into this freshly allocated live
+	// register window (#247 - see relocateOpenUpvalues doc comment).
+	relocateOpenUpvalues(frame.openUpvalues, genObj.Frame.registers, frame.registers)
 
 	// Update VM state
 	vm.frameCount++
@@ -19308,6 +19404,9 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 
 	// Restore register state from saved frame
 	copy(frame.registers, genObj.Frame.registers)
+	// Re-home any register-backed upvalue into this freshly allocated live
+	// register window (#247 - see relocateOpenUpvalues doc comment).
+	relocateOpenUpvalues(frame.openUpvalues, genObj.Frame.registers, frame.registers)
 
 	// Update VM state
 	vm.frameCount++
@@ -19486,6 +19585,9 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 
 	// Restore register state from saved frame
 	copy(frame.registers, promiseObj.Frame.registers)
+	// Re-home any register-backed upvalue into this freshly allocated live
+	// register window (#247 - see relocateOpenUpvalues doc comment).
+	relocateOpenUpvalues(frame.openUpvalues, promiseObj.Frame.registers, frame.registers)
 
 	// Store the resolved value in the register specified by the await instruction
 	if promiseObj.Frame != nil && int(promiseObj.Frame.outputReg) < len(frame.registers) {
@@ -19634,6 +19736,9 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 
 	// Restore register state from saved frame
 	copy(frame.registers, promiseObj.Frame.registers)
+	// Re-home any register-backed upvalue into this freshly allocated live
+	// register window (#247 - see relocateOpenUpvalues doc comment).
+	relocateOpenUpvalues(frame.openUpvalues, promiseObj.Frame.registers, frame.registers)
 
 	// Update VM state
 	vm.frameCount++


### PR DESCRIPTION
## Summary

Follow-up to #247 (PR #249, still unmerged — this branch is stacked directly on that commit, `09d8a508`). While fixing #247, the PR description explicitly flagged spill slots as a related but out-of-scope gap. This closes it.

`SuspendedFrame` (aka `GeneratorFrame`, `pkg/vm/value.go`) had no `spillSlots` field, and none of the five resume paths (`resumeGenerator`, `resumeGeneratorWithException`, `resumeGeneratorWithReturn`, `resumeAsyncFunction`, `resumeAsyncFunctionWithException`) saved or restored `frame.spillSlots` across a suspend. A resumed `CallFrame`'s `spillSlots` was whatever some unrelated prior call last left in that reused `vm.frames[N]` slot — not the actual pre-suspend spill array for this generator/async instance.

Any local forced into a spill slot would silently read/write the wrong backing array after a `yield` or `await`. This isn't only a >255-live-locals edge case: **it's reachable in ordinary generator code**, because class declarations unconditionally spill their name binding (`compile_class.go`). The Test262 evidence below confirms this — all 4 newly-passing tests are `class { [yield] ... }` computed-property-name tests, none of which have anywhere near 255 locals.

## Fix

Unlike register-backed upvalues (#247's fix), a spill-backed upvalue's `Location` pointer needs **no relocation**: `frame.spillSlots` is a private per-call `make([]Value, n)`, not a slice of the shared `vm.registerStack`, so the array itself stays valid via the GC even after the `CallFrame` struct slot that referenced it is reused for something else. The fix just carries that same array across the suspend/resume boundary **by reference**:

- `pkg/vm/value.go`: add `spillSlots []Value` to `SuspendedFrame`.
- `pkg/vm/vm.go`: save `frame.spillSlots` into the generator/promise frame at all four suspend sites (`OpYield`, `OpInitYield`'s first-suspend branch, `OpYieldDelegated`, `OpAwait`), and restore it at all five resume sites, alongside each site's existing `relocateOpenUpvalues` call from #247.

Copying the array instead of sharing it would silently reintroduce the exact divergence this fixes — a closure's `Location` must keep pointing at the live array, not a snapshot, or a direct write and a closure read of the same spilled local would diverge after resume.

## Testing

- `go test ./...` and `go test -race ./pkg/driver ./pkg/vm` — clean.
- Two new regression tests in `pkg/driver/host_suspended_upvalue_test.go`:
  - `TestAsyncClosureMutationAfterResumeStaysCoherentWithSpilledLocal` — coherence check for a single spilled-and-captured local across an `await`. (Confirmed via `git stash` A/B testing that this one alone does *not* discriminate the bug — a single instance has no frame-slot contention — so it's documented as a coherence check, not the regression test.)
  - `TestConcurrentAsyncFunctionsWithSpilledLocalsDontCrossContaminate` — the actual discriminator: two concurrent async instances, each with a spilled local, confirmed via stash-testing to genuinely **fail without this fix** (cross-contaminated at `{a:1, b:201}` instead of independently reaching `{a:101, b:101}`), and pass with it.
- Test262 `language/` subsuite, diffed against this branch's parent commit (#247): **+4 net new passes, 0 regressions** — all four are generator/class computed-property-name tests (e.g. `accessor-name-inst-computed-yield-expr.js`).
- Test262 `built-ins/` subsuite: byte-identical before/after (16314 passed / 6980 failed both sides, 0 diff lines).

## Note

While testing this, I found what looks like a separate, pre-existing bug in the `setTimeout`/async resume path: two concurrent async functions awaiting `setTimeout` with *different* delays can lose a post-await mutation on the earlier-scheduled instance. It reproduces with zero spilling and without `Promise.all`, so it's unrelated to this fix — spun off as its own follow-up rather than folded in here.
