### PR TITLE
fix(driver): stop native-module numeric params panicking on IntegerNumber values

### DIFF
--- a/pkg/driver/issue_252_test.go
+++ b/pkg/driver/issue_252_test.go
@@ -1,0 +1,77 @@
+package driver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestNativeFunctionAcceptsIntegerRepresentedNumber covers paserati#252:
+// vmValueToReflectValue converted a JS number argument into a Go numeric
+// parameter (float64/float32/int/int64) via the raw Value.AsFloat()
+// accessor, which panics ("value is not a float") whenever the argument
+// happens to be TypeIntegerNumber-represented internally rather than
+// TypeFloatNumber - a distinction invisible at the JS level (typeof is
+// "number" either way; e.g. "hello".length is IntegerValue-represented).
+// The fix swaps in the safe, representation-agnostic Value.ToFloat().
+func TestNativeFunctionAcceptsIntegerRepresentedNumber(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue252mod", func(m *ModuleBuilder) {
+		m.Function("takesFloat64", func(n float64) float64 { return n })
+		m.Function("takesFloat32", func(n float32) float32 { return n })
+		m.Function("takesInt", func(n int) int { return n })
+		m.Function("takesInt64", func(n int64) int64 { return n })
+	})
+
+	res, errs := p.RunString(`
+		import { takesFloat64, takesFloat32, takesInt, takesInt64 } from "issue252mod";
+		// "hello".length is internally an IntegerValue-represented number,
+		// indistinguishable from a "float" one at the JS level.
+		const n = "hello".length;
+		JSON.stringify([
+			takesFloat64(n),
+			takesFloat32(n),
+			takesInt(n),
+			takesInt64(n),
+		]);
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := res.ToString()
+	want := `[5,5,5,5]`
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+// TestVMValueToReflectValueHandlesIntegerNumber constructs a
+// TypeIntegerNumber vm.Value directly (via vm.IntegerValue) and passes it
+// through the reflection conversion helper, guarding against a regression
+// back to the panicking Value.AsFloat() accessor.
+func TestVMValueToReflectValueHandlesIntegerNumber(t *testing.T) {
+	iv := vm.IntegerValue(42)
+	if !iv.IsNumber() {
+		t.Fatalf("expected IntegerValue to report IsNumber() == true")
+	}
+
+	cases := []struct {
+		name string
+		typ  reflect.Type
+		want interface{}
+	}{
+		{"float64", reflect.TypeOf(float64(0)), float64(42)},
+		{"float32", reflect.TypeOf(float32(0)), float32(42)},
+		{"int", reflect.TypeOf(int(0)), int(42)},
+		{"int64", reflect.TypeOf(int64(0)), int64(42)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := vmValueToReflectValue(iv, c.typ).Interface()
+			if got != c.want {
+				t.Fatalf("expected %v (%T), got %v (%T)", c.want, c.want, got, got)
+			}
+		})
+	}
+}

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -775,19 +775,19 @@ func vmValueToReflectValue(vmVal vm.Value, targetType reflect.Type) reflect.Valu
 		return reflect.ValueOf(vmVal.ToString())
 	case reflect.Float64:
 		if vmVal.IsNumber() {
-			return reflect.ValueOf(vmVal.AsFloat())
+			return reflect.ValueOf(vmVal.ToFloat())
 		}
 		return reflect.ValueOf(0.0)
 	case reflect.Float32:
 		if vmVal.IsNumber() {
-			return reflect.ValueOf(float32(vmVal.AsFloat()))
+			return reflect.ValueOf(float32(vmVal.ToFloat()))
 		}
 		return reflect.ValueOf(float32(0.0))
 	case reflect.Int, reflect.Int64:
 		if vmVal.IsNumber() {
-			return reflect.ValueOf(int64(vmVal.AsFloat()))
+			return reflect.ValueOf(int64(vmVal.ToFloat())).Convert(targetType)
 		}
-		return reflect.ValueOf(int64(0))
+		return reflect.Zero(targetType)
 	case reflect.Bool:
 		if vmVal.IsBoolean() {
 			return reflect.ValueOf(vmVal.AsBoolean())
@@ -836,7 +836,7 @@ func vmValueToReflectValue(vmVal vm.Value, targetType reflect.Type) reflect.Valu
 		case vmVal.IsString():
 			return reflect.ValueOf(vmVal.AsString())
 		case vmVal.IsNumber():
-			return reflect.ValueOf(vmVal.AsFloat())
+			return reflect.ValueOf(vmVal.ToFloat())
 		case vmVal.IsBoolean():
 			return reflect.ValueOf(vmVal.AsBoolean())
 		case vmVal.Type() == vm.TypeNull:
@@ -879,7 +879,7 @@ func vmValueToInterface(vmVal vm.Value) interface{} {
 	case vmVal.IsString():
 		return vmVal.AsString()
 	case vmVal.IsNumber():
-		return vmVal.AsFloat()
+		return vmVal.ToFloat()
 	case vmVal.IsBoolean():
 		return vmVal.AsBoolean()
 	case vmVal.Type() == vm.TypeNull:
@@ -1071,19 +1071,19 @@ func (vc *ValueConverter) convertVMValueToReflectValue(vmVal vm.Value, targetTyp
 		return reflect.ValueOf(vmVal.ToString())
 	case reflect.Float64:
 		if vmVal.IsNumber() {
-			return reflect.ValueOf(vmVal.AsFloat())
+			return reflect.ValueOf(vmVal.ToFloat())
 		}
 		return reflect.ValueOf(0.0)
 	case reflect.Float32:
 		if vmVal.IsNumber() {
-			return reflect.ValueOf(float32(vmVal.AsFloat()))
+			return reflect.ValueOf(float32(vmVal.ToFloat()))
 		}
 		return reflect.ValueOf(float32(0.0))
 	case reflect.Int, reflect.Int64:
 		if vmVal.IsNumber() {
-			return reflect.ValueOf(int64(vmVal.AsFloat()))
+			return reflect.ValueOf(int64(vmVal.ToFloat())).Convert(targetType)
 		}
-		return reflect.ValueOf(int64(0))
+		return reflect.Zero(targetType)
 	case reflect.Bool:
 		if vmVal.IsBoolean() {
 			return reflect.ValueOf(vmVal.AsBoolean())


### PR DESCRIPTION
## Summary

Fixes #252.

`vmValueToReflectValue` (and its duplicate implementation on `ValueConverter`) converted a JS number argument for a Go `float64`/`float32`/`int`/`int64` native-module parameter via the raw `Value.AsFloat()` accessor. That accessor only handles `TypeFloatNumber` and panics (`"value is not a float"`) for `TypeIntegerNumber`-represented numbers.

The two internal representations are indistinguishable at the JS level (`typeof` is `"number"` either way — e.g. `"hello".length` is `IntegerValue`-represented), so any Go native-module function with such a parameter was a latent panic waiting for an ordinary integer-shaped JS number, as described in the issue (`tty.isatty(process.stderr.fd)`).

## Fix

- Swapped in the representation-agnostic `Value.ToFloat()` (already used elsewhere, e.g. `VM.ToNumber`) everywhere `AsFloat()` was used in a `IsNumber()`-guarded conversion path in `pkg/driver/native_module.go`, including the duplicated `ValueConverter` implementation and the `vmValueToInterface()` helper, which had the identical bug.
- While reproducing the issue end-to-end, found and fixed an adjacent, independent bug in the same `reflect.Int, reflect.Int64` case: it always built an `int64`-kind `reflect.Value` regardless of whether the Go parameter was `int` or `int64`, which panics with `"reflect: Call using int64 as type int"` for any native function declaring a plain `int` parameter — reproducible with any number, not just `TypeIntegerNumber`-represented ones. Fixed with `.Convert(targetType)`.

## Testing

- Added `pkg/driver/issue_252_test.go`:
  - `TestNativeFunctionAcceptsIntegerRepresentedNumber`: end-to-end module call passing `"hello".length` (an `IntegerValue`-represented number) into native functions with `float64`/`float32`/`int`/`int64` parameters.
  - `TestVMValueToReflectValueHandlesIntegerNumber`: direct unit test of `vmValueToReflectValue` against a `vm.IntegerValue`-constructed value for all four numeric kinds.
- `go test ./pkg/driver/...` — pass
- `go test ./tests -run TestScripts` — pass (smoke suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)