### PR TITLE
Fix Object.assign / enumeration dropping properties on function targets (#254)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1976,6 +1976,20 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 			}
 		}
+	case vm.TypeBoundFunction:
+		// A bound function's own properties (whether from direct assignment
+		// or Object.assign) live on its side table same as a plain
+		// function's - this case was missing entirely, so Object.keys on a
+		// bound function always came back empty even after `bound.x = 1`
+		// (paserati#254).
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			for _, key := range bf.Properties.OwnKeys() {
+				if _, _, en, _, ok := bf.Properties.GetOwnDescriptor(key); ok && en {
+					keysArray.Append(vm.NewString(key))
+				}
+			}
+		}
 	}
 
 	return keys, nil
@@ -2361,6 +2375,16 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 			}
 		}
+	case vm.TypeBoundFunction:
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			for _, key := range bf.Properties.OwnKeys() {
+				if _, _, en, _, ok := bf.Properties.GetOwnDescriptor(key); ok && en {
+					value, _ := bf.Properties.GetOwn(key)
+					valuesArray.Append(value)
+				}
+			}
+		}
 	}
 
 	return values, nil
@@ -2471,6 +2495,19 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			for _, key := range closure.Properties.OwnKeys() {
 				if _, _, en, _, ok := closure.Properties.GetOwnDescriptor(key); ok && en {
 					value, _ := closure.Properties.GetOwn(key)
+					entry := vm.NewArray()
+					entry.AsArray().Append(vm.NewString(key))
+					entry.AsArray().Append(value)
+					entriesArray.Append(entry)
+				}
+			}
+		}
+	case vm.TypeBoundFunction:
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			for _, key := range bf.Properties.OwnKeys() {
+				if _, _, en, _, ok := bf.Properties.GetOwnDescriptor(key); ok && en {
+					value, _ := bf.Properties.GetOwn(key)
 					entry := vm.NewArray()
 					entry.AsArray().Append(vm.NewString(key))
 					entry.AsArray().Append(value)
@@ -2793,6 +2830,20 @@ func setObjectAssignTargetProperty(target vm.Value, key string, value vm.Value) 
 			}
 		} else {
 			arr.SetOwn(key, value)
+		}
+	case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+		// Functions (plain, closures, natives, and bound functions) are
+		// ordinary callable objects to user code - Object.assign onto one
+		// used to match none of the branches above and silently drop every
+		// source property (paserati#254; the actual construction pattern
+		// @babel/template's public API uses: bind the callable, then
+		// Object.assign named sub-builders onto it). Their own properties
+		// live in a side table reached via EnsureOwnPropertiesTable, which
+		// allocates the table lazily the same way direct assignment
+		// (`fn.a = 1`) already does for these types - and lands the
+		// property enumerable, just like SetOwn does for TypeObject above.
+		if props := vm.EnsureOwnPropertiesTable(target); props != nil {
+			props.SetOwn(key, value)
 		}
 	}
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3425,8 +3425,20 @@ startExecution:
 					// Native functions don't have custom properties but inherit from FunctionPrototype
 					hasProperty = vm.hasFunctionPrototypeProperty(propKey)
 				case TypeBoundFunction:
-					// Bound functions inherit from FunctionPrototype
-					hasProperty = vm.hasFunctionPrototypeProperty(propKey)
+					// Bound functions can have their own properties (in
+					// bf.Properties, e.g. from direct assignment or
+					// Object.assign - paserati#254) before falling back to
+					// FunctionPrototype. This own-properties check was
+					// missing entirely, so for-in's per-key re-verification
+					// ("is this key still present?") always failed for a
+					// bound function and silently dropped every key that
+					// OpGetOwnKeys had just found.
+					bf := objVal.AsBoundFunction()
+					if bf.Properties != nil && bf.Properties.Has(propKey) {
+						hasProperty = true
+					} else {
+						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
+					}
 				case TypeSet:
 					// Set: check own property "size", then prototype chain
 					if propKey == "size" {
@@ -14192,6 +14204,32 @@ startExecution:
 				if closure.Properties != nil {
 					seen := make(map[string]bool)
 					cur := closure.Properties
+					for cur != nil {
+						for _, k := range cur.OwnKeys() {
+							if !seen[k] {
+								keys = append(keys, k)
+							}
+						}
+						for _, k := range cur.OwnPropertyNames() {
+							seen[k] = true
+						}
+						pv := cur.GetPrototype()
+						if !pv.IsObject() {
+							break
+						}
+						cur = pv.AsPlainObject()
+					}
+				}
+			case TypeBoundFunction:
+				// Enumerate own enumerable properties on the bound function's
+				// Properties object - this case was missing entirely, so
+				// `for (k in boundFn)` came back with nothing even after
+				// `boundFn.x = 1` (paserati#254), unlike the identical
+				// TypeFunction/TypeClosure cases just above.
+				bf := objValue.AsBoundFunction()
+				if bf.Properties != nil {
+					seen := make(map[string]bool)
+					cur := bf.Properties
 					for cur != nil {
 						for _, k := range cur.OwnKeys() {
 							if !seen[k] {

--- a/tests/scripts/issue254_bound_function_enumerable.ts
+++ b/tests/scripts/issue254_bound_function_enumerable.ts
@@ -1,0 +1,24 @@
+// expect: true
+// paserati#254: a bound function's own properties (set via direct assignment,
+// not just Object.assign) were readable via property access/hasOwnProperty
+// but invisible to Object.keys and for-in - OpGetOwnKeys had no TypeBoundFunction
+// case at all, and OpIn's TypeBoundFunction case never consulted the bound
+// function's own Properties table, so for-in's per-key re-check silently
+// dropped every key OpGetOwnKeys would otherwise have found.
+const checks: boolean[] = [];
+
+function base() {}
+const bound = base.bind(undefined);
+(bound as any).x = 1;
+
+checks.push(bound.hasOwnProperty("x"));
+checks.push((bound as any).x === 1);
+checks.push(JSON.stringify(Object.keys(bound)) === '["x"]');
+
+const seen: string[] = [];
+for (const k in bound) {
+  seen.push(k);
+}
+checks.push(JSON.stringify(seen) === '["x"]');
+
+checks.every((c) => c === true);

--- a/tests/scripts/issue254_object_assign_function_target.ts
+++ b/tests/scripts/issue254_object_assign_function_target.ts
@@ -1,0 +1,43 @@
+// expect: true
+// paserati#254: Object.assign onto a function target (plain, closure, or
+// Function.prototype.bind() result) matched none of setObjectAssignTargetProperty's
+// dispatch cases and silently dropped every source property - the exact
+// construction pattern @babel/template's public API uses (bind the callable,
+// then Object.assign named sub-builders onto it).
+const checks: boolean[] = [];
+
+function plain() {}
+Object.assign(plain as any, { a: 1 });
+checks.push((plain as any).a === 1);
+checks.push(plain.hasOwnProperty("a"));
+
+function base() {}
+const bound = base.bind(undefined);
+Object.assign(bound as any, { a: 1 });
+checks.push((bound as any).a === 1);
+checks.push(bound.hasOwnProperty("a"));
+
+let y = 10;
+const closureFn = () => y;
+Object.assign(closureFn as any, { c: 3 });
+checks.push((closureFn as any).c === 3);
+checks.push(closureFn.hasOwnProperty("c"));
+
+// Also verify Object.keys/values/entries see it, not just direct reads.
+Object.assign(bound as any, { b: 2 });
+checks.push(JSON.stringify(Object.keys(bound)) === '["a","b"]');
+checks.push(JSON.stringify(Object.values(bound)) === "[1,2]");
+checks.push(JSON.stringify(Object.entries(bound)) === '[["a",1],["b",2]]');
+
+// The actual reported scenario: @babel/template's public API binds a
+// callable and Object.assign's named sub-builders onto it, then calls one
+// of those sub-builders as a method (`n.template.statement(...)`).
+function tplBase() {}
+const tpl = Object.assign(tplBase.bind(undefined) as any, {
+  statement: (s: string) => "stmt:" + s,
+  ast: 1,
+});
+checks.push(tpl.statement("x") === "stmt:x");
+checks.push(tpl.ast === 1);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Fixes #254.

- **Repro 1 (the crash)**: `Object.assign` onto a function target (plain function, closure, or `Function.prototype.bind()` result) matched none of `setObjectAssignTargetProperty`'s dispatch cases in `pkg/builtins/object_init.go`, so it silently dropped every source property. This is the exact construction pattern `@babel/template`'s public API uses (`Object.assign(i.bind(void 0), { statement: o, ... })`), which was breaking `jiti`'s babel bundle bootstrap.
- **Repro 2 (related)**: a bound function's own properties (set via plain assignment, not just `Object.assign`) were readable via property access / `hasOwnProperty`, but invisible to `Object.keys`, `Object.values`, `Object.entries`, and `for...in`:
  - `OpGetOwnKeys` (the `for...in` key producer, `pkg/vm/vm.go`) had cases for `TypeFunction`/`TypeClosure` but none for `TypeBoundFunction`.
  - `OpIn`'s `TypeBoundFunction` case never consulted the bound function's own `Properties` table (only `Function.prototype`), so `for...in`'s per-key existence re-check silently dropped every key `OpGetOwnKeys` had just found.
  - The three `Object.keys`/`values`/`entries` switches in `object_init.go` were likewise missing a `TypeBoundFunction` case.

## Fix

- Added a callable-types case (`TypeFunction`, `TypeClosure`, `TypeNativeFunction`, `TypeNativeFunctionWithProps`, `TypeBoundFunction`) to `setObjectAssignTargetProperty` that lazily allocates the target's side property table via the existing `vm.EnsureOwnPropertiesTable` and stores through `SetOwn` — matching the enumerable-property semantics the `TypeObject`/`TypeDictObject` branches already have (#168). Existing branches (object/dict/array) are untouched.
- Added the missing `TypeBoundFunction` case to `OpGetOwnKeys`, fixed `OpIn`'s `TypeBoundFunction` case to check `bf.Properties` first, and added `TypeBoundFunction` to the `Object.keys`/`values`/`entries` switches.

Native function property *reads* via `Object.keys`/`values`/`entries`/`for-in` are left as a known, narrower pre-existing gap (writes now work; enumeration of native-function-target properties isn't covered by this PR) — not a regression, just not fully closed.

## Testing

- New smoke tests: `tests/scripts/issue254_object_assign_function_target.ts` (repro 1 + the exact `@babel/template` bind-and-assign-then-call-a-method shape) and `tests/scripts/issue254_bound_function_enumerable.ts` (repro 2).
- `go test ./tests -run TestScripts` — all green.
- `go test ./...` — all green.
- Scoped `test262 -subpath language -diff baseline.txt` — net change 0 (no regressions; the "Only in baseline/current" whole-run mismatch is the known baseline-scope artifact, not a signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)