### PR TITLE
fix(compiler): handle spread args in optional-chain call continuation

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -480,6 +480,31 @@ func (c *Compiler) compileOptionalContinuationWithReceiver(cont parser.Expressio
 			}
 		}
 
+		// If any argument uses spread syntax (e.g. obj?.method(...args)), the fixed
+		// contiguous-register calling convention below can't represent it - the spread's
+		// runtime-expanded length isn't known at compile time. Build an arguments array
+		// at runtime instead and use the spread call opcodes, mirroring compileMultiSpreadCall.
+		if c.hasSpreadArgument(node.Arguments) {
+			arrayReg := c.regAlloc.Alloc()
+			*tempRegs = append(*tempRegs, arrayReg)
+
+			arrayLiteral := &parser.ArrayLiteral{
+				Elements: node.Arguments,
+				Token:    node.Token,
+			}
+			_, err := c.compileArrayLiteral(arrayLiteral, arrayReg)
+			if err != nil {
+				return BadRegister, err
+			}
+
+			if isFirstCall && receiverReg != BadRegister {
+				c.emitSpreadCallMethod(hint, funcReg, receiverReg, arrayReg, line)
+			} else {
+				c.emitSpreadCall(hint, funcReg, arrayReg, line)
+			}
+			return hint, nil
+		}
+
 		// Compile arguments
 		argCount := len(node.Arguments)
 		blockSize := 1 + argCount

--- a/tests/scripts/optional_member_call_spread.ts
+++ b/tests/scripts/optional_member_call_spread.ts
@@ -21,9 +21,10 @@ const o: any = {
 const r1 = o?.m(...args);
 
 // obj?.["method"](...args) - same shape via computed/bracket access.
-// (Uses an arrow, not a method: obj?.[expr](...) continuations don't
-// thread a `this` receiver at all - a separate, pre-existing gap
-// unrelated to spread arguments - so this isolates the spread handling.)
+// (Uses an arrow, not a method: this isolates the spread-handling fix
+// in this PR from the separate this-binding fix for obj?.[expr](...)
+// continuations tracked in #258/PR #259 - see
+// optional_index_call_this_binding.ts for that coverage.)
 const o2: any = { m: (...a: number[]) => a.reduce((x, y) => x + y, 0) };
 const r2 = o2?.["m"](...args);
 

--- a/tests/scripts/optional_member_call_spread.ts
+++ b/tests/scripts/optional_member_call_spread.ts
@@ -1,0 +1,44 @@
+// Optional member access (obj?.method(...)) whose continuation is a call
+// with spread arguments must be compiled with spread-aware calling
+// convention, not the fixed-register-block path (issue #256).
+//
+// This is the mirror image of optional_call_member_spread.ts (#188):
+// here the `?.` is on the member access, and the trailing `(...)` is an
+// ordinary call that becomes part of the same optional chain.
+
+const args = [1, 2, 3];
+
+// obj?.method(...args) - the core repro from #256.
+// A real method (not an arrow) so `this` binding through the spread
+// call path is actually exercised (this discriminates a wrong-register
+// receiver from a merely-not-crashing call).
+const o: any = {
+  n: 7,
+  m(...a: number[]) {
+    return this.n + a.length;
+  },
+};
+const r1 = o?.m(...args);
+
+// obj?.["method"](...args) - same shape via computed/bracket access.
+// (Uses an arrow, not a method: obj?.[expr](...) continuations don't
+// thread a `this` receiver at all - a separate, pre-existing gap
+// unrelated to spread arguments - so this isolates the spread handling.)
+const o2: any = { m: (...a: number[]) => a.reduce((x, y) => x + y, 0) };
+const r2 = o2?.["m"](...args);
+
+// Mixed regular + spread arguments through the optional-access path.
+const r3 = o?.m(10, ...args, 20);
+
+// Nullish base must still short-circuit to undefined (per spec/Node),
+// not crash, even though the continuation contains a spread call.
+const n: any = null;
+const r4 = n?.m(...args);
+
+// a?.b.c(...args) - multi-level continuation (Member -> Call) ending in
+// a spread call; only the leading access is optional.
+const o3: any = { inner: { g: (...a: number[]) => a.reduce((x, y) => x + y, 0) } };
+const r5 = o3?.inner.g(...[10, 20, 3]);
+
+JSON.stringify([r1, r2, r3, r4, r5]);
+// expect: [10,6,12,null,33]


### PR DESCRIPTION
## Summary

`obj?.method(...args)` (the `?.` on the member access, with the trailing
call as an ordinary continuation) silently corrupted the following
bytecode, or crashed with an invalid-opcode error when the base was
`null`. This is the mirror image of #188 (`obj.method?.(...args)`,
where the `?.` is on the call).

## Root cause

`obj?.method(...)` parses as an `OptionalChainingExpression` whose
`Continuation` is a `*parser.CallExpression` (same argument shape as
any other call, spread elements included). The continuation's
call-compiling path in `compileOptionalContinuationWithReceiver`
(`pkg/compiler/compile_expression.go`) allocated a fixed contiguous
register block sized by `len(node.Arguments)` with no spread check -
unlike the top-level `compileCallExpression` dispatcher, which already
checks `hasSpreadArgument` and routes to `compileMultiSpreadCall`. A
bare `*parser.SpreadElement` compiled through the fixed-block path
produced bytecode the `OpCall`/`OpCallMethod` convention was never
designed to receive, corrupting the instruction stream that followed
(sometimes silently - execution just stopped making progress with no
error - sometimes as a raw `Unknown opcode 255` crash).

## Fix

Add the same `hasSpreadArgument` check to that continuation's call
branch. When present, build the arguments array at runtime (mirroring
`compileMultiSpreadCall`) and emit `OpSpreadCall`/`OpSpreadCallMethod`
instead, preserving the receiver register for the first call in the
chain so `this` binding still works for method-shaped optional chains.

## Testing

- Added `tests/scripts/optional_member_call_spread.ts` covering:
  `obj?.method(...args)` with a real method (exercises `this` binding
  through the new path), the bracket-access variant, mixed
  regular+spread args, the null-base short-circuit (must evaluate to
  `undefined`, not crash), and a multi-level `a?.b.c(...args)`
  continuation.
- `go test ./tests -run TestScripts` passes.
- Manually re-verified all repros from #256 (including the
  `JSON.stringify` null-short-circuit case matching real Node's
  `undefined` output) and the combined `obj?.push?.(...arr)` shape.

## Known pre-existing gap (not in scope here)

While testing I found that `obj?.[expr](...)` continuations never
thread a `this` receiver at all (`compileOptionalIndexExpression` calls
`compileOptionalContinuation`, not the `...WithReceiver` variant) -
independent of spread arguments; `o?.["m"](1,2)` with a real method
also loses `this`. This predates and is unrelated to this fix (the
non-spread case reproduces the same way on `main`); I've scoped the new
test's bracket-access case to a `this`-free function to isolate the
spread-handling fix from that separate gap. Will file a follow-up
issue.

Fixes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)