### PR TITLE
fix(compiler): thread this receiver through obj?.[expr](...) continuations

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -4009,8 +4009,11 @@ func (c *Compiler) compileOptionalIndexExpression(node *parser.OptionalIndexExpr
 	c.emitByte(byte(indexReg))       // Index register
 
 	// 5. Apply continuation chain if present
+	// Pass objectReg as the receiver for method calls in the continuation (e.g.,
+	// a?.[k]() needs `a` as `this`) - mirrors compileOptionalChainingExpression,
+	// which does the same for the dot-access form (a?.b()).
 	if node.Continuation != nil {
-		_, err := c.compileOptionalContinuation(node.Continuation, indexResultReg, hint, &tempRegs, node.Token.Line)
+		_, err := c.compileOptionalContinuationWithReceiver(node.Continuation, indexResultReg, objectReg, hint, &tempRegs, node.Token.Line)
 		if err != nil {
 			return BadRegister, err
 		}

--- a/tests/scripts/optional_index_call_this_binding.ts
+++ b/tests/scripts/optional_index_call_this_binding.ts
@@ -1,0 +1,36 @@
+// obj?.[expr](...) continuations must preserve `this` binding for method
+// calls, just like the dot-access form obj?.prop(...) already does
+// (issue #258, found while fixing #256).
+//
+// compileOptionalIndexExpression used to compile its continuation via
+// compileOptionalContinuation, which always passes BadRegister as the
+// receiver - so a method reached through a computed/bracket optional
+// access lost `this` entirely, while the equivalent dot-access call
+// worked correctly.
+
+const o: any = {
+  n: 7,
+  m(a: number) {
+    return this.n + a;
+  },
+  m2(a: number, b: number) {
+    return this.n + a + b;
+  },
+};
+
+// The core repro: obj?.["method"](args) must see `this` === obj.
+const r1 = o?.["m"](5);
+
+// Same object/method, reached via a computed (non-literal) key.
+const key = "m";
+const r2 = o?.[key](5);
+
+// Nullish base must still short-circuit to undefined, not crash.
+const n: any = null;
+const r3 = n?.["m"](5);
+
+// Multiple arguments still reach the method correctly alongside `this`.
+const r4 = o?.["m2"](10, 100);
+
+JSON.stringify([r1, r2, r3, r4]);
+// expect: [12,12,null,117]


### PR DESCRIPTION
## Summary

`obj?.[expr](...)` (a method reached through a computed/bracket
optional-chain access) lost its `this` binding entirely - the method's
`this` was `undefined` even though the equivalent dot-access form
(`obj?.prop(...)`) has always worked correctly. Found incidentally
while fixing #256 (see #257).

## Repro

```ts
const o: any = { n: 7, m(a: number) { return this.n + a; } };
console.log(o?.["m"](5));   // paserati (before this fix): TypeError, this is undefined
console.log(o?.m(5));       // already worked: 12
```

## Root cause

`compileOptionalIndexExpression` (`pkg/compiler/compile_expression.go`)
compiled its continuation via `compileOptionalContinuation`, which
always passes `BadRegister` as the receiver:

```go
func (c *Compiler) compileOptionalContinuation(cont parser.Expression, baseReg Register, hint Register, tempRegs *[]Register, line int) (Register, errors.PaseratiError) {
	// Use BadRegister as receiver - the caller can override this with compileOptionalContinuationWithReceiver
	return c.compileOptionalContinuationWithReceiver(cont, baseReg, BadRegister, hint, tempRegs, line)
}
```

`compileOptionalChainingExpression` (the dot-access path) instead calls
`compileOptionalContinuationWithReceiver` directly with `objectReg` as
the receiver - which is why `obj?.prop(...)` already worked.

## Fix

Make `compileOptionalIndexExpression` do the same: call
`compileOptionalContinuationWithReceiver` with `objectReg` as the
receiver, instead of going through the receiver-less wrapper.

## Testing

- Added `tests/scripts/optional_index_call_this_binding.ts`: the core
  `this`-binding repro (literal and computed key), the null
  short-circuit, and a multi-argument method call.
- `go test ./tests -run TestScripts` passes.
- `test262/test/language/expressions/optional-chaining/`: 38/38 pass,
  identical before and after this change (no regression).
- Manually verified the combined shape `obj?.[expr](...spread)` with a
  real method (cherry-picking #256's fix on top) resolves both `this`
  and the spread arguments correctly.
- Manually verified out of scope: multi-level continuations like
  `a?.[k].method()` (and the dot-access equivalent `a?.b.method()`)
  still lose `this` for the *second* call in the chain, identically on
  both branches, before and after this fix - a separate,
  pre-existing gap in the `isFirstCall` handling, not touched here.

## Relationship to #257

Independent at the line level (different call site, no overlapping
edits) - can merge in either order. The combined shape
`obj?.[expr](...spread)` with a real method is only exercised once both
land; verified manually above.

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)