### PR TITLE
fix(compiler): give every property-access call in an optional-chain continuation its own receiver

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -464,14 +464,76 @@ func (c *Compiler) compileOptionalContinuationWithReceiver(cont parser.Expressio
 
 	case *parser.CallExpression:
 		// Call: base(args)
-		// If this is the first call in the continuation (Function is nil), we need method call
-		// with receiverReg as `this` to preserve this binding
+		// Every call whose callee is a property access needs *that access's
+		// object* as `this`, not just the first call in the continuation - a
+		// later call chained onto an earlier call's result (e.g. the second
+		// call in `e.code?.replace(a, b).replace(c, d)`) is just as much a
+		// method call as the first one. thisCallReceiver tracks the receiver
+		// for *this specific* call; the innermost call (Function == nil) is
+		// the one exception that still binds to the chain's original
+		// receiverReg, since there's no local property access to derive one
+		// from at that depth.
 		var funcReg Register
-		isFirstCall := node.Function == nil
+		var thisCallReceiver Register = BadRegister
 
-		if isFirstCall {
+		if node.Function == nil {
 			funcReg = baseReg
+			thisCallReceiver = receiverReg
+		} else if calleeMember, isMember := node.Function.(*parser.MemberExpression); isMember {
+			// Callee is itself a property access (e.g. `.replace` in the
+			// second call above) - fetch the property AND keep its object
+			// register around to use as this call's receiver.
+			objReg := baseReg
+			if calleeMember.Object != nil {
+				objReg = c.regAlloc.Alloc()
+				*tempRegs = append(*tempRegs, objReg)
+				_, err := c.compileOptionalContinuationWithReceiver(calleeMember.Object, baseReg, receiverReg, objReg, tempRegs, line)
+				if err != nil {
+					return BadRegister, err
+				}
+			}
+			funcReg = c.regAlloc.Alloc()
+			*tempRegs = append(*tempRegs, funcReg)
+			propertyName := c.extractPropertyName(calleeMember.Property)
+			if len(propertyName) > 0 && propertyName[0] == '#' {
+				fieldName := propertyName[1:]
+				brandedKey := c.getPrivateFieldKey(fieldName)
+				nameConstIdx := c.chunk.AddConstant(vm.String(brandedKey))
+				c.emitGetPrivateField(funcReg, objReg, nameConstIdx, line)
+			} else {
+				nameConstIdx := c.chunk.AddConstant(vm.String(propertyName))
+				c.emitGetProp(funcReg, objReg, nameConstIdx, line)
+			}
+			thisCallReceiver = objReg
+		} else if calleeIndex, isIndex := node.Function.(*parser.IndexExpression); isIndex {
+			// Callee is a computed property access (e.g. `obj?.a()[k]()`) -
+			// same idea as the MemberExpression case above.
+			objReg := baseReg
+			if calleeIndex.Left != nil {
+				objReg = c.regAlloc.Alloc()
+				*tempRegs = append(*tempRegs, objReg)
+				_, err := c.compileOptionalContinuationWithReceiver(calleeIndex.Left, baseReg, receiverReg, objReg, tempRegs, line)
+				if err != nil {
+					return BadRegister, err
+				}
+			}
+			indexReg := c.regAlloc.Alloc()
+			*tempRegs = append(*tempRegs, indexReg)
+			_, err := c.compileNode(calleeIndex.Index, indexReg)
+			if err != nil {
+				return BadRegister, err
+			}
+			funcReg = c.regAlloc.Alloc()
+			*tempRegs = append(*tempRegs, funcReg)
+			c.emitOpCode(vm.OpGetIndex, line)
+			c.emitByte(byte(funcReg))
+			c.emitByte(byte(objReg))
+			c.emitByte(byte(indexReg))
+			thisCallReceiver = objReg
 		} else {
+			// Callee isn't a direct property access (e.g. `a?.b()()` - calling
+			// the return value of an earlier call directly) - no `this`
+			// binding, matching plain-call JS semantics.
 			funcReg = c.regAlloc.Alloc()
 			*tempRegs = append(*tempRegs, funcReg)
 			_, err := c.compileOptionalContinuationWithReceiver(node.Function, baseReg, receiverReg, funcReg, tempRegs, line)
@@ -497,8 +559,8 @@ func (c *Compiler) compileOptionalContinuationWithReceiver(cont parser.Expressio
 				return BadRegister, err
 			}
 
-			if isFirstCall && receiverReg != BadRegister {
-				c.emitSpreadCallMethod(hint, funcReg, receiverReg, arrayReg, line)
+			if thisCallReceiver != BadRegister {
+				c.emitSpreadCallMethod(hint, funcReg, thisCallReceiver, arrayReg, line)
 			} else {
 				c.emitSpreadCall(hint, funcReg, arrayReg, line)
 			}
@@ -525,9 +587,9 @@ func (c *Compiler) compileOptionalContinuationWithReceiver(cont parser.Expressio
 			}
 		}
 
-		// Emit call - use method call if this is the first call and we have a receiver
-		if isFirstCall && receiverReg != BadRegister {
-			c.emitCallMethod(hint, funcCallReg, receiverReg, byte(argCount), line)
+		// Emit call - use method call whenever this call's callee was a property access
+		if thisCallReceiver != BadRegister {
+			c.emitCallMethod(hint, funcCallReg, thisCallReceiver, byte(argCount), line)
 		} else {
 			c.emitCall(hint, funcCallReg, byte(argCount), line)
 		}

--- a/tests/scripts/optional_chain_second_call_this_binding.ts
+++ b/tests/scripts/optional_chain_second_call_this_binding.ts
@@ -1,0 +1,87 @@
+// A second (or later) call chained onto an optional-chain continuation's
+// first call must still see the right `this` - not just the very first
+// call in the chain (issue #260, found while chasing #256/#258).
+//
+// compileOptionalContinuationWithReceiver used to gate method-call `this`
+// binding on `isFirstCall` (node.Function == nil), so only the innermost
+// call in the continuation ever got a receiver; every later call chained
+// onto a property access lost `this` and became a plain call.
+
+const o: any = {
+  n: 1,
+  add(x: number) {
+    this.n += x;
+    return this;
+  },
+};
+
+// The core repro: obj?.method(a).method(b) - the second .add() must still
+// see `this` === o.
+o?.add(1).add(2);
+const r1 = o.n; // 4
+
+// Three deep, to make sure the fix isn't a one-level special case.
+const o2: any = {
+  n: 10,
+  add(x: number) {
+    this.n += x;
+    return this;
+  },
+};
+o2?.add(1).add(2).add(3);
+const r2 = o2.n; // 16
+
+// Bracket-access second call: obj?.method(a)["method"](b).
+const o3: any = { n: 100, add(x: number) { this.n += x; return this; } };
+o3?.add(1)["add"](2);
+const r3 = o3.n; // 103
+
+// Bracket-access FIRST call (the #258 shape) with a dot-access second call,
+// chained together - confirms this is a distinct fix site from #258's.
+const o4: any = { n: 1000, add(x: number) { this.n += x; return this; } };
+o4?.["add"](1).add(2);
+const r4 = o4.n; // 1003
+
+// Spread arguments on the second call.
+const o5: any = {
+  n: 0,
+  add(...xs: number[]) {
+    this.n += xs.reduce((a, b) => a + b, 0);
+    return this;
+  },
+};
+o5?.add(1).add(...[2, 3, 4]);
+const r5 = o5.n; // 10
+
+// obj?.b()() - the callee of the second call is a call's *return value*,
+// not a property access, so it correctly gets NO `this` binding (matches
+// plain JS semantics for calling a returned function directly).
+function makeAdder(base: number) {
+  return function (x: number) {
+    return base + x;
+  };
+}
+const holder: any = { make: makeAdder };
+const r6 = holder?.make(10)(5); // 15
+
+// Nullish base still short-circuits the whole chain to undefined, even
+// with multiple chained calls following it.
+const n: any = null;
+const r7 = n?.add(1).add(2); // undefined
+
+// a?.b.method() - a plain (uncalled) member access immediately followed by
+// a call, both inside the continuation. This is the exact shape #259
+// measured as NaN on main and called out-of-scope for that fix (it lives
+// at this fix site, not #259's); confirm it's now resolved too.
+const o6: any = { inner: { n: 3, m2(a: number) { return this.n + a; } } };
+const r8 = o6?.inner.m2(4); // 7
+
+// obj.method?.().b() - the receiver-less compileOptionalContinuation path
+// used by compileOptionalCallExpression's own continuation sites. The
+// call being continued here isn't itself optional, but the continuation
+// after it goes through the same fixed code, so it benefits too.
+const holder2: any = { m: () => ({ n: 5, get() { return this.n; } }) };
+const r9 = holder2.m?.().get(); // 5
+
+JSON.stringify([r1, r2, r3, r4, r5, r6, r7, r8, r9]);
+// expect: [4,16,103,1003,10,15,null,7,5]


### PR DESCRIPTION
## Summary

A second (or later) call chained onto an optional-chain continuation's
first call lost its `this` binding, even though the first call in the
chain got it correctly. Found immediately after #256/#258 while
re-checking the real `@babel/core`/jiti call site those fixes were
originally chasing.

## Repro

```ts
const e: any = { code: "GENSYNC_EXPECTED_START" };
console.log(e.code?.replace("BABEL_", "").replace("PARSE_ERROR", "ParseError"));
```

Real Node: `"GENSYNC_EXPECTED_START"`. Before this fix, paserati threw
`TypeError: String.prototype.replace called on null or undefined` -
the second `.replace()`'s `this` was `undefined`.

## Root cause

`compileOptionalContinuationWithReceiver` gated method-call `this`
binding on `isFirstCall` (`node.Function == nil`) - only the innermost
call in the continuation (closest to the original `?.`) ever got a
receiver. Every later call chained onto a property access took the
plain-call branch (`emitCall`, no `this`) regardless of the receiver it
was holding, because that receiver was always the *chain's original*
object, not the object the *current* call's method was actually fetched
from.

## Fix

Replace the single `isFirstCall` gate with per-call receiver
resolution: when a continuation `CallExpression`'s callee
(`node.Function`) is itself a `MemberExpression` or `IndexExpression`,
compile that property access explicitly (object → register, property →
register) and use the object register as *this* call's receiver -
independent of depth. Two cases keep the old behavior, correctly:
- `node.Function == nil` (the innermost call) still uses the chain's
  original `receiverReg`, since there's no local property access at
  that depth to derive one from.
- A callee that isn't a property access at all (e.g. `a?.b()()` -
  calling a call's return value directly) still gets no `this`,
  matching plain JS call semantics.

## Testing

- Added `tests/scripts/optional_chain_second_call_this_binding.ts`:
  two-argument chains, three-deep chains, bracket-access second calls,
  a bracket-access *first* call with a dot-access second call (crossing
  #258's fix site), spread arguments on the second call, the `a?.b()()`
  negative control, and the null short-circuit.
- `go test ./tests -run TestScripts` passes.
- Manually re-verified all three repros from #260, including the exact
  minimized `@babel/core` shape.
- **Closes a gap #259 explicitly called out of scope**: `a?.inner.m2(4)`
  (plain member access immediately followed by a call, inside a
  continuation) was measured as `NaN` on `main` during that PR and
  documented as a separate, un-fixed issue. Re-measured with this fix:
  now returns the correct value. Added to this PR's test file.
- Also improves `obj.method?.().b()` (`compileOptionalCallExpression`'s
  own continuation sites reuse the same fixed function) -
  `holder.m?.().get()` now correctly binds `get`'s `this` to the object
  `m()` returned. Added to the test file as well.

Note on test262: `language/expressions/optional-chaining` is 38/38 on
`main` already (saturated - it was 38/38 before #258 too), so it isn't
useful regression evidence for this specific change. `TestScripts` plus
the repros/test file above are the actual gate here.

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)