### PR TITLE
Fix #262 (generator const/let shadowing) and #263 (Error.captureStackTrace missing)

### DIFF
--- a/pkg/builtins/error_init.go
+++ b/pkg/builtins/error_init.go
@@ -40,6 +40,9 @@ func (e *ErrorInitializer) InitTypes(ctx *TypeContext) error {
 		WithSimpleConstructSignature([]types.Type{types.String}, errorProtoType).            // new Error(msg)
 		WithSimpleConstructSignature([]types.Type{types.String, types.Any}, errorProtoType). // new Error(msg, options)
 		WithProperty("isError", types.NewSimpleFunction([]types.Type{types.Any}, types.Boolean)).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void)).
 		WithProperty("prototype", errorProtoType)
 
 	// Define the constructor globally
@@ -191,6 +194,49 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.BooleanValue(isErrorValue(vmInstance, arg)), nil
 		}))
 
+		// Add Error.captureStackTrace (V8/Node non-standard extension, #263).
+		// Real code widely calls this unconditionally in its own error-handling
+		// paths; without it, that code crashes with "undefined is not a
+		// function" and masks whatever error it was trying to report.
+		ctorPropsObj.Properties.SetOwnNonEnumerable("captureStackTrace", vm.NewNativeFunction(2, false, "captureStackTrace", func(args []vm.Value) (vm.Value, error) {
+			if len(args) == 0 || !args[0].IsObject() {
+				return vm.Undefined, vmInstance.NewTypeError("Error.captureStackTrace target must be an object")
+			}
+			target := args[0]
+
+			// Optional constructorOpt: frames at or above it (i.e. its own call
+			// and everything it called) are omitted from the captured trace,
+			// matching V8 semantics. Anything that isn't a callable is just
+			// ignored - no filtering happens, same as if it were omitted.
+			var excludeFn *vm.FunctionObject
+			if len(args) > 1 {
+				switch ctorOpt := args[1]; ctorOpt.Type() {
+				case vm.TypeClosure:
+					excludeFn = ctorOpt.AsClosure().Fn
+				case vm.TypeFunction:
+					excludeFn = ctorOpt.AsFunction()
+				}
+			}
+
+			stackTrace := vmInstance.CaptureStackTraceExcluding(excludeFn)
+			stackValue := vm.NewString(stackTrace)
+
+			// Per real V8, "stack" is non-enumerable - including when
+			// captureStackTrace is the one creating it (e.g. on a plain object
+			// target that had no prior "stack" property at all). Go through
+			// SetOwnNonEnumerable for a PlainObject target so a fresh property
+			// gets the right attributes; fall back to the generic SetProperty
+			// (which preserves an existing property's own attributes, and is
+			// the best DictObject can do since it has no non-enumerable concept
+			// at all) for anything else.
+			if target.Type() == vm.TypeObject {
+				target.AsPlainObject().SetOwnNonEnumerable("stack", stackValue)
+			} else if err := vmInstance.SetProperty(target, "stack", stackValue); err != nil {
+				return vm.Undefined, err
+			}
+			return vm.Undefined, nil
+		}))
+
 		errorConstructor = ctorWithProps
 	}
 
@@ -218,7 +264,10 @@ func (e *EvalErrorInitializer) Priority() int { return 22 }
 func (e *EvalErrorInitializer) InitTypes(ctx *TypeContext) error {
 	t := types.NewObjectType().WithSimpleCallSignature([]types.Type{}, types.Any).WithSimpleCallSignature([]types.Type{types.String}, types.Any).
 		WithSimpleConstructSignature([]types.Type{}, types.Any).
-		WithSimpleConstructSignature([]types.Type{types.String}, types.Any)
+		WithSimpleConstructSignature([]types.Type{types.String}, types.Any).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void))
 	return ctx.DefineGlobal("EvalError", t)
 }
 func (e *EvalErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
@@ -233,7 +282,10 @@ func (e *RangeErrorInitializer) Priority() int { return 22 }
 func (e *RangeErrorInitializer) InitTypes(ctx *TypeContext) error {
 	t := types.NewObjectType().WithSimpleCallSignature([]types.Type{}, types.Any).WithSimpleCallSignature([]types.Type{types.String}, types.Any).
 		WithSimpleConstructSignature([]types.Type{}, types.Any).
-		WithSimpleConstructSignature([]types.Type{types.String}, types.Any)
+		WithSimpleConstructSignature([]types.Type{types.String}, types.Any).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void))
 	return ctx.DefineGlobal("RangeError", t)
 }
 func (e *RangeErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
@@ -248,7 +300,10 @@ func (e *URIErrorInitializer) Priority() int { return 22 }
 func (e *URIErrorInitializer) InitTypes(ctx *TypeContext) error {
 	t := types.NewObjectType().WithSimpleCallSignature([]types.Type{}, types.Any).WithSimpleCallSignature([]types.Type{types.String}, types.Any).
 		WithSimpleConstructSignature([]types.Type{}, types.Any).
-		WithSimpleConstructSignature([]types.Type{types.String}, types.Any)
+		WithSimpleConstructSignature([]types.Type{types.String}, types.Any).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void))
 	return ctx.DefineGlobal("URIError", t)
 }
 func (e *URIErrorInitializer) InitRuntime(ctx *RuntimeContext) error {

--- a/pkg/builtins/reference_error_init.go
+++ b/pkg/builtins/reference_error_init.go
@@ -31,6 +31,9 @@ func (r *ReferenceErrorInitializer) InitTypes(ctx *TypeContext) error {
 		WithSimpleCallSignature([]types.Type{types.String}, referenceErrorProtoType).
 		WithSimpleConstructSignature([]types.Type{}, referenceErrorProtoType).
 		WithSimpleConstructSignature([]types.Type{types.String}, referenceErrorProtoType).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void)).
 		WithProperty("prototype", referenceErrorProtoType)
 
 	// Define the constructor globally

--- a/pkg/builtins/syntax_error_init.go
+++ b/pkg/builtins/syntax_error_init.go
@@ -31,6 +31,9 @@ func (s *SyntaxErrorInitializer) InitTypes(ctx *TypeContext) error {
 		WithSimpleCallSignature([]types.Type{types.String}, syntaxErrorProtoType).
 		WithSimpleConstructSignature([]types.Type{}, syntaxErrorProtoType).
 		WithSimpleConstructSignature([]types.Type{types.String}, syntaxErrorProtoType).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void)).
 		WithProperty("prototype", syntaxErrorProtoType)
 
 	// Define the constructor globally

--- a/pkg/builtins/type_error_init.go
+++ b/pkg/builtins/type_error_init.go
@@ -31,6 +31,9 @@ func (t *TypeErrorInitializer) InitTypes(ctx *TypeContext) error {
 		WithSimpleCallSignature([]types.Type{types.String}, typeErrorProtoType).
 		WithSimpleConstructSignature([]types.Type{}, typeErrorProtoType).
 		WithSimpleConstructSignature([]types.Type{types.String}, typeErrorProtoType).
+		WithProperty("captureStackTrace", types.NewObjectType().
+			WithSimpleCallSignature([]types.Type{types.Any}, types.Void).
+			WithSimpleCallSignature([]types.Type{types.Any, types.Any}, types.Void)).
 		WithProperty("prototype", typeErrorProtoType)
 
 	// Define the constructor globally

--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -1639,6 +1639,44 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 				}
 			}
 
+			// Predefine top-level let/const bindings from remaining statements BEFORE
+			// OpInitYield too (#262). Regular (non-generator) function bodies get this
+			// via the general BlockStatement "pass 0" predefine step in compileNode,
+			// but a generator's body is compiled statement-by-statement here instead
+			// (to splice in OpInitYield at the right point), which skipped that pass
+			// entirely for let/const. Left unhandled, a body-local `const`/`let` had no
+			// entry in the generator's own symbol table until its declaration statement
+			// was compiled - so an *enclosing function's* same-named parameter or outer
+			// binding was found instead by the Resolve() calls compileConstStatement/
+			// compileLetStatement use to detect an already-predefined binding, and the
+			// body-local declaration silently wrote into (what it thought was) that
+			// existing register instead of ever defining its own local, leaving every
+			// read of the name resolve as a captured upvalue of the outer binding.
+			for _, stmt := range remainingStmts {
+				switch s := stmt.(type) {
+				case *parser.LetStatement:
+					for _, name := range parser.DeclaredNames(s) {
+						functionCompiler.predefineLexicalName(name, false, s.Token.Line)
+					}
+				case *parser.ConstStatement:
+					for _, name := range parser.DeclaredNames(s) {
+						functionCompiler.predefineLexicalName(name, true, s.Token.Line)
+					}
+				case *parser.ObjectDestructuringDeclaration:
+					if s.Token.Literal == "let" || s.Token.Literal == "const" {
+						for _, name := range extractDestructuringVarNames(s) {
+							functionCompiler.predefineLexicalName(name, s.Token.Literal == "const", s.Token.Line)
+						}
+					}
+				case *parser.ArrayDestructuringDeclaration:
+					if s.Token.Literal == "let" || s.Token.Literal == "const" {
+						for _, name := range extractArrayDestructuringVarNames(s) {
+							functionCompiler.predefineLexicalName(name, s.Token.Literal == "const", s.Token.Line)
+						}
+					}
+				}
+			}
+
 			// NOW emit OpInitYield after desugared parameters and var hoisting
 			functionCompiler.emitOpCode(vm.OpInitYield, node.Body.Token.Line)
 			debugPrintf("// [Generator] Emitted OpInitYield after %d desugared parameter declarations\n", desugarCount)

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -578,7 +578,20 @@ type StackFrame struct {
 
 // CaptureStackTrace captures the current call stack and returns it as a formatted string
 func (vm *VM) CaptureStackTrace() string {
-	frames := vm.getStackFrames()
+	return vm.formatStackFrames(vm.getStackFrames())
+}
+
+// CaptureStackTraceExcluding captures the current call stack like CaptureStackTrace,
+// but - mirroring V8's Error.captureStackTrace(targetObject, constructorOpt) -
+// omits the frame for constructorOpt and every frame more recent than it (i.e.
+// everything from the top of the stack down through constructorOpt's own call).
+// If target is nil, or isn't found on the current stack at all, this behaves
+// exactly like CaptureStackTrace.
+func (vm *VM) CaptureStackTraceExcluding(target *FunctionObject) string {
+	return vm.formatStackFrames(vm.getStackFramesExcluding(target))
+}
+
+func (vm *VM) formatStackFrames(frames []StackFrame) string {
 	if len(frames) == 0 {
 		return ""
 	}
@@ -595,10 +608,36 @@ func (vm *VM) CaptureStackTrace() string {
 
 // getStackFrames extracts stack frame information from the current VM call stack
 func (vm *VM) getStackFrames() []StackFrame {
+	return vm.getStackFramesExcluding(nil)
+}
+
+// getStackFramesExcluding is getStackFrames, but starts collecting one frame
+// further out (older) than the most recent frame whose closure targets
+// `target` (see CaptureStackTraceExcluding) - i.e. target's own frame and
+// everything more recent than it (called from inside it, or after it but
+// before this capture) are omitted. Pass nil to skip nothing. If target
+// doesn't actually appear on the current stack, nothing is skipped -
+// matching V8, where passing a constructorOpt that was never called leaves
+// the trace untouched rather than swallowing it entirely.
+func (vm *VM) getStackFramesExcluding(target *FunctionObject) []StackFrame {
+	startIdx := vm.frameCount - 1
+	if target != nil {
+		for i := vm.frameCount - 1; i >= 0; i-- {
+			f := &vm.frames[i]
+			if f.isNativeFrame {
+				continue
+			}
+			if f.closure != nil && f.closure.Fn == target {
+				startIdx = i - 1
+				break
+			}
+		}
+	}
+
 	var frames []StackFrame
 
-	// Walk through all active frames
-	for i := vm.frameCount - 1; i >= 0; i-- {
+	// Walk through all active frames, starting below target's own frame (if found)
+	for i := startIdx; i >= 0; i-- {
 		frame := &vm.frames[i]
 
 		// Skip native frames - they don't have meaningful source location info

--- a/tests/scripts/error_capture_stack_trace.ts
+++ b/tests/scripts/error_capture_stack_trace.ts
@@ -1,0 +1,50 @@
+// expect: true
+// Error.captureStackTrace (#263): V8/Node non-standard extension widely
+// called unconditionally by real code in its own error-handling paths.
+// It must exist, not throw, and actually set a stack string on the target.
+
+// Present and callable, not just a stub type.
+const hasCaptureStackTrace = typeof Error.captureStackTrace === "function";
+
+const e = new Error("x");
+const originalStack = e.stack;
+function marker() {}
+Error.captureStackTrace(e, marker);
+
+// Should not throw, and should still leave a non-empty stack in place
+// (marker was never called, so nothing should be trimmed away).
+const stackStillPresent = typeof e.stack === "string" && e.stack.length > 0;
+
+// Passing a target that isn't an object should throw a TypeError rather
+// than silently doing nothing.
+let threwOnBadTarget = false;
+try {
+  Error.captureStackTrace(42 as any);
+} catch (err) {
+  threwOnBadTarget = err instanceof TypeError;
+}
+
+// When constructorOpt genuinely is on the stack (the common real-world
+// pattern: a subclass constructor excluding its own frame), that frame
+// should be trimmed from the resulting trace.
+class MyError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    Error.captureStackTrace(this, MyError);
+  }
+}
+function makeMyError() {
+  return new MyError("boom");
+}
+const myErr = makeMyError();
+// The constructor's own frame ("at MyError (...)") must be trimmed away;
+// "makeMyError"'s frame (which legitimately contains "MyError" as a
+// substring) must remain, so check for the exact frame text instead of a
+// loose substring match.
+const ownFrameTrimmed = !myErr.stack!.includes("at MyError (");
+
+hasCaptureStackTrace &&
+  typeof originalStack === "string" &&
+  stackStillPresent &&
+  threwOnBadTarget &&
+  ownFrameTrimmed;

--- a/tests/scripts/generator_local_shadows_enclosing_param.ts
+++ b/tests/scripts/generator_local_shadows_enclosing_param.ts
@@ -1,0 +1,114 @@
+// expect: true
+// #262: a generator body's own local const/let that shadows an *enclosing*
+// function's parameter of the same name must read its own freshly-assigned
+// value, not the captured outer parameter. Only affected generator bodies
+// nested inside another function and returned from it - the generator's
+// special OpInitYield-splicing body compilation skipped the same TDZ
+// predefine pass that regular (non-generator) function bodies get from the
+// general BlockStatement handling, so the local const/let never got its own
+// entry in the generator's symbol table and every read of it resolved as a
+// captured upvalue of the outer parameter instead.
+
+function outerConst(n: number) {
+  function* g() {
+    const n = 99;
+    return n;
+  }
+  return g;
+}
+const constResult = outerConst(1)().next().value === 99;
+
+function outerLet(n: number) {
+  function* g() {
+    let n = 99;
+    return n;
+  }
+  return g;
+}
+const letResult = outerLet(1)().next().value === 99;
+
+// The generator's *own* parameter of the same name must still resolve to
+// its own argument, not the enclosing function's parameter.
+function outerOwnParam(n: number) {
+  function* g(n: number) {
+    return n;
+  }
+  return g;
+}
+const ownParamResult = outerOwnParam(1)(99).next().value === 99;
+
+// A module-level (not enclosing-function-parameter) outer binding shadowed
+// the same way already worked before the fix - keep it passing.
+const moduleN = 1;
+function* gModule() {
+  const n = 99;
+  return n;
+}
+const moduleResult = gModule().next().value === 99 && moduleN === 1;
+
+// The bug's real-world shapes: generator methods (object literals and
+// classes) route through the exact same shared compileFunctionLiteral body
+// as a plain `function*` declaration, so they hit the same gap.
+function outerObjMethod(n: number) {
+  const obj = {
+    *g() {
+      const n = 99;
+      return n;
+    },
+  };
+  return obj.g;
+}
+const objMethodResult = outerObjMethod(1)().next().value === 99;
+
+function outerClassMethod(n: number) {
+  class C {
+    *g() {
+      const n = 99;
+      return n;
+    }
+  }
+  return new C().g;
+}
+const classMethodResult = outerClassMethod(1)().next().value === 99;
+
+// Class async-generator method via a computed name - the exact shape #247
+// hit (`async *[Symbol.asyncIterator]()`), just with the enclosing-param
+// shadow from this issue instead of #247's concurrency trigger.
+async function checkAsyncShapes(): Promise<boolean> {
+  function outerAsyncGen(n: number): any {
+    async function* g() {
+      const n = 99;
+      yield n;
+    }
+    return g;
+  }
+  const asyncIter = outerAsyncGen(1)();
+  const asyncGenResult = (await asyncIter.next()).value === 99;
+
+  function outerClassAsyncGen(n: number) {
+    class C {
+      async *[Symbol.asyncIterator]() {
+        const n = 99;
+        yield n;
+      }
+    }
+    return new C();
+  }
+  let classAsyncGenResult = false;
+  for await (const v of outerClassAsyncGen(1)) {
+    classAsyncGenResult = v === 99;
+    break;
+  }
+
+  return asyncGenResult && classAsyncGenResult;
+}
+
+const asyncShapesOk = await checkAsyncShapes();
+
+constResult &&
+  letResult &&
+  ownParamResult &&
+  moduleResult &&
+  objMethodResult &&
+  classMethodResult &&
+  asyncShapesOk;


### PR DESCRIPTION
Fixes #262, fixes #263.

## #262 — generator body's local const/let shadowed by an enclosing parameter

**Root cause:** a generator's body is compiled by a hand-rolled statement loop (needed to splice `OpInitYield` in after desugared parameters), bypassing the normal `BlockStatement` compilation path entirely — including its "pass 0" step that pre-registers every `let`/`const` name in the block's own symbol table (with a TDZ marker) before any statement compiles.

Without that pre-registration, when the generator's own `const n = 99` was compiled, the symbol-table lookup used to detect "is this name already predefined" walked *past* the missing local entry and matched the *enclosing function's* parameter of the same name instead — so the local declaration silently reused that outer binding's register instead of ever defining its own, and every later read of `n` resolved as a captured upvalue of the outer value.

**Fix:** predefine top-level `let`/`const` (including destructured) names from the generator's remaining statements before emitting `OpInitYield`, reusing the same `predefineLexicalName` helper regular blocks already use.

Verified across every shape sharing this one `OpInitYield` call site (only one, confirmed by `grep`): `function*`, `let` variant, own-parameter shadowing (still correct), module-level shadowing (already worked), object-literal `*method()`, class `*method()`, `async function*`, and class `async *[Symbol.asyncIterator]()` — the exact shape #247 hit.

## #263 — `Error.captureStackTrace` missing

Added `Error.captureStackTrace(targetObject, constructorOpt)` — a V8/Node non-standard extension that real code widely calls unconditionally in its own error-handling paths. Without it, that code crashed with `undefined is not a function` and masked whatever error it was trying to report (concretely: jiti's own module-loading error path).

Checked against real Node (v26.3.0) and matched:
- non-object target → `TypeError`
- `constructorOpt`'s own frame (and everything more recent than it) is trimmed from the captured trace when found on the stack; left untouched otherwise
- `stack` stays non-enumerable even when created fresh on a plain object

Added the type signature to `Error` and every `NativeError` subclass constructor type. Note: the *runtime* object only gets the method on `Error` itself — `NativeError` subclasses don't actually inherit static methods from `Error`'s constructor at property-lookup time despite `SetPrototype` wiring the chain. That's a separate, pre-existing gap (also affects `Error.isError`) left out of scope here.

## Verification

- `go test ./tests -run TestScripts`, `go build ./...`, `go vet ./...` all clean.
- Test262 `language/` + `built-ins/`: built an unpatched worktree at the pre-fix commit (confirmed it reproduces both bugs), ran both subsets on it and on the fix, diffed the two dumps directly — 0 new passes, 0 new failures either way (expected: neither bug is on spec-covered surface).
- New regression tests: `tests/scripts/generator_local_shadows_enclosing_param.ts`, `tests/scripts/error_capture_stack_trace.ts`.
