### PR TITLE
fix(compiler): don't self-bind an inferred function name over a same-named outer variable

### DIFF
--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -868,12 +868,16 @@ func (c *Compiler) compileAssignmentExpression(node *parser.AssignmentExpression
 					}
 					minimalFuncLit := &parser.FunctionLiteral{Token: arrowFunc.Token, Body: body}
 					c.emitClosure(rhsValueReg, funcConstIndex, minimalFuncLit, freeSymbols)
-				} else if funcLit, ok := node.Value.(*parser.FunctionLiteral); ok {
-					// Anonymous function literal - set name before compilation
-					if funcLit.Name == nil || funcLit.Name.Value == "" {
-						funcLit.Name = &parser.Identifier{Token: funcLit.Token, Value: nameHint}
+				} else if funcLit, ok := node.Value.(*parser.FunctionLiteral); ok && (funcLit.Name == nil || funcLit.Name.Value == "") {
+					// Anonymous function literal - infer .name from the target via nameHint.
+					// Do NOT mutate funcLit.Name: that would create a named-function-expression
+					// self-binding, so `f = function() { return f }` would see the closure
+					// itself instead of the (possibly reassigned) outer `f` (#265).
+					funcConstIndex, freeSymbols, compileErr := c.compileFunctionLiteral(funcLit, nameHint)
+					if compileErr != nil {
+						return BadRegister, compileErr
 					}
-					_, err = c.compileNode(node.Value, rhsValueReg)
+					c.emitClosure(rhsValueReg, funcConstIndex, funcLit, freeSymbols)
 				} else if classExpr, ok := node.Value.(*parser.ClassExpression); ok {
 					// Anonymous class expression - set inferred name before compilation
 					// Use __Inferred__ prefix so compileClassExpression doesn't create inner binding
@@ -996,12 +1000,16 @@ func (c *Compiler) compileAssignmentExpression(node *parser.AssignmentExpression
 					}
 					minimalFuncLit := &parser.FunctionLiteral{Token: arrowFunc.Token, Body: body}
 					c.emitClosure(rhsValueReg, funcConstIndex, minimalFuncLit, freeSymbols)
-				} else if funcLit, ok := node.Value.(*parser.FunctionLiteral); ok {
-					// Anonymous function literal - set name before compilation
-					if funcLit.Name == nil || funcLit.Name.Value == "" {
-						funcLit.Name = &parser.Identifier{Token: funcLit.Token, Value: nameHint}
+				} else if funcLit, ok := node.Value.(*parser.FunctionLiteral); ok && (funcLit.Name == nil || funcLit.Name.Value == "") {
+					// Anonymous function literal - infer .name from the target via nameHint.
+					// Do NOT mutate funcLit.Name: that would create a named-function-expression
+					// self-binding, so `f = function() { return f }` would see the closure
+					// itself instead of the (possibly reassigned) outer `f` (#265).
+					funcConstIndex, freeSymbols, compileErr := c.compileFunctionLiteral(funcLit, nameHint)
+					if compileErr != nil {
+						return BadRegister, compileErr
 					}
-					_, err = c.compileNode(node.Value, rhsValueReg)
+					c.emitClosure(rhsValueReg, funcConstIndex, funcLit, freeSymbols)
 				} else if classExpr, ok := node.Value.(*parser.ClassExpression); ok {
 					// Anonymous class expression - set inferred name before compilation
 					// Use __Inferred__ prefix so compileClassExpression doesn't create inner binding

--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -945,10 +945,19 @@ func (c *Compiler) compileObjectLiteral(node *parser.ObjectLiteral, hint Registe
 						}
 						c.emitClosureGeneric(valueReg, funcConstIndex, arrowFunc.Token.Line, &parser.Identifier{Token: arrowFunc.Token, Value: propName}, freeSymbols, true)
 						valueCompiled = true
-					} else if funcLit, ok := prop.Value.(*parser.FunctionLiteral); ok {
-						if funcLit.Name == nil || funcLit.Name.Value == "" {
-							funcLit.Name = &parser.Identifier{Token: funcLit.Token, Value: propName}
+					} else if funcLit, ok := prop.Value.(*parser.FunctionLiteral); ok && (funcLit.Name == nil || funcLit.Name.Value == "") {
+						// Anonymous function expression - pass the property key as a name
+						// hint so the function's .name is inferred WITHOUT creating a
+						// named-function-expression self-binding inside its body. Mutating
+						// funcLit.Name here would make `{ sync: function() { sync() } }`
+						// resolve `sync` to itself instead of the closed-over outer `sync` (#265).
+						funcConstIndex, freeSymbols, compileErr := c.compileFunctionLiteral(funcLit, propName)
+						if compileErr != nil {
+							freePropertyRegs()
+							return BadRegister, compileErr
 						}
+						c.emitClosure(valueReg, funcConstIndex, funcLit, freeSymbols)
+						valueCompiled = true
 					} else if classExpr, ok := prop.Value.(*parser.ClassExpression); ok {
 						// Inferred name from property - use prefix so no inner binding is created
 						if classExpr.Name == nil {

--- a/tests/scripts/fn_name_inference_no_self_binding.ts
+++ b/tests/scripts/fn_name_inference_no_self_binding.ts
@@ -1,0 +1,34 @@
+// expect: 42|2|3|foo,bar,baz,q|120
+// #265: an anonymous function assigned to an object-literal property (or to a
+// variable) gets its .name inferred from the key, but that inferred name must NOT
+// become a self-binding inside the function body - a closed-over outer variable
+// with the same name has to win.
+function make(sync: (x: number) => number) {
+  return { sync: function (x: number) { return sync(x); } };
+}
+const a = make((x) => x * 2).sync(21);
+
+// Same shape, plain assignment: the body must see the (reassigned) outer f.
+var f: any = function () { return f; };
+var g = f;
+f = 2;
+const b = g();
+
+// ...and logical assignment.
+var h: any;
+h ||= function () { return h; };
+var k = h;
+h = 3;
+const c = k();
+
+// Name inference itself is unchanged.
+const o: any = { foo: function () {}, bar: function () {}, baz: () => {} };
+let q: any;
+q = function () {};
+const names = [o.foo.name, o.bar.name, o.baz.name, q.name].join(",");
+
+// A genuinely named function expression as a property still binds its own name.
+const o2 = { fact: function fact(n: number): number { return n <= 1 ? 1 : n * fact(n - 1); } };
+const d = o2.fact(5);
+
+[a, b, c, names, d].join("|");


### PR DESCRIPTION
Fixes #265

## Problem

An anonymous function stored as an object-literal property whose key matched a closed-over outer variable name called itself instead of the outer variable:

```ts
function make(sync) {
  return { sync: function (x) { return sync(x); } };
}
make((x) => x * 2).sync(21); // Node: 42, paserati: infinite recursion
```

The object-literal compiler implemented `.name` inference by mutating `funcLit.Name` to the property key before compiling. `compileFunctionLiteralWithOptions` then saw a named function expression and created a self-binding for that name inside the body, shadowing the outer `sync`.

The two assignment-expression sites (`x = function(){}`, `x ||= function(){}`) had the same latent bug: `f = function(){ return f }; g = f; f = 2; g()` returned the closure instead of `2`.

## Fix

Compile these anonymous functions via `compileFunctionLiteral(funcLit, nameHint)`, the path `let`/`const` declarations already use. `.name` is still inferred from the hint, but no inner binding is created. Genuinely named function expressions (`{ fact: function fact(n) { ... fact(n-1) } }`) are untouched and keep their self-binding. The generator repro from the issue now prints `42` too.

## Verification

- New smoke test `tests/scripts/fn_name_inference_no_self_binding.ts` covers the object-literal, plain-assignment and logical-assignment forms, name inference for function/arrow/assigned functions, and a named function expression as a property.
- `go test ./tests -run TestScripts` green; `go test ./pkg/compiler/...` green.
- test262 before/after (main vs. this branch, `-timeout 0.2s`): identical pass counts on `language/expressions/{object,assignment,function,logical-assignment,compound-assignment,class}`, `language/statements/function`, `built-ins/Function`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
