### PR TITLE
fix(compiler): allocate call argument registers contiguously in yield* and error throws

### DIFF
--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -3008,13 +3008,14 @@ func (c *Compiler) compileObjectDestructuringDeclaration(node *parser.ObjectDest
 	notNullJump := c.emitPlaceholderJump(vm.OpJumpIfFalse, checkReg, line)
 
 	// Throw TypeError: Cannot destructure null
-	errorReg := c.regAlloc.Alloc()
+	// OpCall reads its argument from errorReg+1: allocate the pair contiguously.
+	errorReg := c.regAlloc.AllocContiguous(2)
+	msgReg := errorReg + 1
 	defer c.regAlloc.Free(errorReg)
+	defer c.regAlloc.Free(msgReg)
 	typeErrorGlobalIdx := c.GetOrAssignGlobalIndex("TypeError")
 	c.emitGetGlobal(errorReg, typeErrorGlobalIdx, line)
 
-	msgReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(msgReg)
 	msgConstIdx := c.chunk.AddConstant(vm.String("Cannot destructure 'null'"))
 	c.emitLoadConstant(msgReg, msgConstIdx, line)
 

--- a/pkg/compiler/compile_assignment_helpers.go
+++ b/pkg/compiler/compile_assignment_helpers.go
@@ -361,13 +361,14 @@ func (c *Compiler) emitDestructuringNullCheck(valueReg Register, line int) {
 	notNullJump := c.emitPlaceholderJump(vm.OpJumpIfFalse, checkReg, line)
 
 	// Throw TypeError: Cannot destructure null
-	errorReg := c.regAlloc.Alloc()
+	// OpCall reads its argument from errorReg+1: allocate the pair contiguously.
+	errorReg := c.regAlloc.AllocContiguous(2)
+	msgReg := errorReg + 1
 	defer c.regAlloc.Free(errorReg)
+	defer c.regAlloc.Free(msgReg)
 	typeErrorGlobalIdx := c.GetOrAssignGlobalIndex("TypeError")
 	c.emitGetGlobal(errorReg, typeErrorGlobalIdx, line)
 
-	msgReg := c.regAlloc.Alloc()
-	defer c.regAlloc.Free(msgReg)
 	msgConstIdx := c.chunk.AddConstant(vm.String("Cannot destructure 'null'"))
 	c.emitLoadConstant(msgReg, msgConstIdx, line)
 

--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -1933,13 +1933,13 @@ func (c *Compiler) compilePrefixExpression(node *parser.PrefixExpression, hint R
 			// Check if this is delete super.property - this must throw ReferenceError
 			if _, isSuper := operand.Object.(*parser.SuperExpression); isSuper {
 				// delete super.property always throws ReferenceError per ECMAScript spec
-				errorReg := c.regAlloc.Alloc()
-				tempRegs = append(tempRegs, errorReg)
+				// OpCall reads its argument from errorReg+1: allocate the pair contiguously.
+				errorReg := c.regAlloc.AllocContiguous(2)
+				msgReg := errorReg + 1
+				tempRegs = append(tempRegs, errorReg, msgReg)
 				refErrorGlobalIdx := c.GetOrAssignGlobalIndex("ReferenceError")
 				c.emitGetGlobal(errorReg, refErrorGlobalIdx, node.Token.Line)
 
-				msgReg := c.regAlloc.Alloc()
-				tempRegs = append(tempRegs, msgReg)
 				msgConstIdx := c.chunk.AddConstant(vm.String("Unsupported reference to 'super'"))
 				c.emitLoadConstant(msgReg, msgConstIdx, node.Token.Line)
 
@@ -1967,13 +1967,13 @@ func (c *Compiler) compilePrefixExpression(node *parser.PrefixExpression, hint R
 			// Check if this is delete super[key] - this must throw ReferenceError
 			if _, isSuper := operand.Left.(*parser.SuperExpression); isSuper {
 				// delete super[key] always throws ReferenceError per ECMAScript spec
-				errorReg := c.regAlloc.Alloc()
-				tempRegs = append(tempRegs, errorReg)
+				// OpCall reads its argument from errorReg+1: allocate the pair contiguously.
+				errorReg := c.regAlloc.AllocContiguous(2)
+				msgReg := errorReg + 1
+				tempRegs = append(tempRegs, errorReg, msgReg)
 				refErrorGlobalIdx := c.GetOrAssignGlobalIndex("ReferenceError")
 				c.emitGetGlobal(errorReg, refErrorGlobalIdx, node.Token.Line)
 
-				msgReg := c.regAlloc.Alloc()
-				tempRegs = append(tempRegs, msgReg)
 				msgConstIdx := c.chunk.AddConstant(vm.String("Unsupported reference to 'super'"))
 				c.emitLoadConstant(msgReg, msgConstIdx, node.Token.Line)
 
@@ -3960,15 +3960,18 @@ func (c *Compiler) compileYieldDelegation(node *parser.YieldExpression, hint Reg
 	// 5. Loop: call iterator.next(sentValue) and yield the result
 	loopStart := len(c.chunk.Code)
 
-	// Get iterator.next method
-	nextMethodReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, nextMethodReg)
+	// Get iterator.next method. OpCallMethod reads its arguments from funcReg+1
+	// onwards, so the method register and the argument register MUST be
+	// adjacent. Two separate Alloc() calls do not guarantee that: Alloc() pops
+	// a LIFO free list, so once earlier statements in the generator have freed
+	// registers, the "argument" would be read from whatever stale value happens
+	// to live at nextMethodReg+1 (#267).
+	nextMethodReg := c.regAlloc.AllocContiguous(2)
+	argReg := nextMethodReg + 1
+	tempRegs = append(tempRegs, nextMethodReg, argReg)
 	nextConstIdx := c.chunk.AddConstant(vm.String("next"))
 	c.emitGetProp(nextMethodReg, iteratorReg, nextConstIdx, node.Token.Line)
 
-	// Allocate argument register for the call (must be nextMethodReg+1 per calling convention)
-	argReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, argReg)
 	// Copy sentValue into the argument register
 	c.emitOpCode(vm.OpMove, node.Token.Line)
 	c.emitByte(byte(argReg))

--- a/tests/scripts/yield_star_sent_value_register.ts
+++ b/tests/scripts/yield_star_sent_value_register.ts
@@ -1,0 +1,50 @@
+// expect: undefined,undefined,undefined|end|Cannot destructure 'null'
+// #267: yield* calls iterator.next(sentValue) via OpCallMethod, which reads its
+// argument from funcReg+1. The method and argument registers were allocated
+// with two separate Alloc() calls, so once earlier statements in the generator
+// had populated the free list they were no longer adjacent and next() received
+// whatever stale value lived at funcReg+1 (the native next function itself, the
+// iterator, ...) instead of undefined. The same latent bug existed for the
+// TypeError thrown when destructuring null/undefined.
+const seen: string[] = [];
+function makeIter(): any {
+  let i = 0;
+  return {
+    [Symbol.iterator]() { return this; },
+    next(v: any) {
+      seen.push(v === undefined ? "undefined" : typeof v);
+      return i++ < 2 ? { value: i, done: false } : { value: "end", done: true };
+    },
+  };
+}
+function* outer(arg: any, cache: Map<any, any>) {
+  // These statements churn the register free list before the yield*.
+  const q2 = [arg, cache].map((v) => v);
+  const c = cache.get(arg);
+  const d = c && c.value;
+  if (cache.has(arg)) { const v = cache.get(arg); if (v.valid) return v.value; }
+  const r = yield* makeIter();
+  return r;
+}
+const g = outer({}, new Map());
+let step = g.next();
+while (!step.done) { step = g.next(); }
+const result = step.value;
+
+// Destructuring null throws with the right message even after register churn.
+function churnThenDestructure(arg: any, cache: Map<any, any>): string {
+  const q2 = [arg, cache].map((v) => v);
+  const c = cache.get(arg);
+  const d = c && c.value;
+  if (cache.has(arg)) { const v = cache.get(arg); if (v.valid) return v.value; }
+  const src: any = null;
+  try {
+    const { x } = src;
+    return String(x) + q2.length + d;
+  } catch (e) {
+    return (e as any).message;
+  }
+}
+const msg = churnThenDestructure({}, new Map());
+
+[seen.join(","), result, msg].join("|");


### PR DESCRIPTION
Fixes #267

## Problem

Deep inside babel's `gensync` pipeline, a `yield` expression received a reference to the native `Generator.prototype.next` instead of `undefined`, so a sync-only operation took its async branch and later crashed. The issue had no standalone repro.

The cause is in the compiler's `yield*` lowering, not the VM. `OpCallMethod` reads its arguments from `funcReg+1` onwards. `compileYieldDelegation` allocated the `next` method register and the sent-value argument register with two separate `Alloc()` calls and assumed they were adjacent. `Alloc()` pops a LIFO free list, so once earlier statements in the generator body had freed registers in a non-contiguous pattern, the call read its argument from whatever stale value sat at `nextMethodReg+1`. In the issue that was the just-loaded native `next` method; the `gen.next(gen)` calls the issue also observed are the same slot holding the iterator.

Why it hid: in small functions the free list hands registers back in descending order, which by accident places `sentValueReg` at `nextMethodReg+1`, so the wrong read returns the right value. A small fuzzer over generator bodies found a five-statement trigger; the minimized version is the new smoke test. On main it prints `function,function,function`; Node and this branch print `undefined,undefined,undefined`.

## Same latent bug elsewhere

The `TypeError` for destructuring `null`/`undefined` and the `ReferenceError` for `delete super.x` built a one-argument constructor call the same way. On main the destructuring error message came back empty in the same register-churned function. All sites now allocate the pair with `AllocContiguous(2)`.

## Verification

- New smoke test `tests/scripts/yield_star_sent_value_register.ts` covers the `yield*` sent value and the destructuring error message after register churn.
- `go test ./tests -run TestScripts` and `go test ./pkg/compiler/...` green.
- test262 before/after (main vs. this branch, `-timeout 0.2s`): identical pass counts on `language/expressions/{yield,generators,async-generator,delete}`, `language/statements/{generators,async-generator}`, `language/{expressions,statements}/class/gen-method`, `language/expressions/assignment/dstr`, `language/statements/variable/dstr`, `language/statements/for-of/dstr`, `built-ins/GeneratorPrototype`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
