### PR TITLE
feat(parser,checker): support type annotations on catch clause bindings

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -3956,16 +3956,42 @@ func (c *Checker) checkCatchClause(clause *parser.CatchClause) {
 
 	// Define the catch parameter if present
 	if clause.Parameter != nil {
-		// In JavaScript/TypeScript, catch parameter is implicitly 'any' type
+		// The catch binding is implicitly 'any'. TypeScript allows an explicit
+		// annotation, but only 'any' or 'unknown' (TS1196).
+		bindingType := types.Type(types.Any)
+		if clause.TypeAnnotation != nil {
+			annotated := c.resolveTypeAnnotation(clause.TypeAnnotation)
+			if annotated == types.Any || annotated == types.Unknown {
+				bindingType = annotated
+			} else if annotated != nil {
+				c.addErrorWithCode(clause.TypeAnnotation, errors.TS1196, "Catch clause variable type annotation must be 'any' or 'unknown' if specified.")
+			}
+		}
 		switch param := clause.Parameter.(type) {
 		case *parser.Identifier:
 			// Simple identifier: catch (e)
-			if !c.env.Define(param.Value, types.Any, false) {
+			if !c.env.Define(param.Value, bindingType, false) {
 				c.addError(param, fmt.Sprintf("parameter '%s' already declared", param.Value))
 			}
-			param.SetComputedType(types.Any)
+			param.SetComputedType(bindingType)
 		case *parser.ArrayParameterPattern, *parser.ObjectParameterPattern:
 			// Destructuring pattern: catch ([x, y]) or catch ({message})
+			// Destructuring an 'unknown' binding is an error, exactly as it would be
+			// for `const { x } = e` with e: unknown. The bindings themselves still get
+			// defined (as any) so the body checks without cascading errors.
+			if bindingType == types.Unknown {
+				switch pattern := param.(type) {
+				case *parser.ObjectParameterPattern:
+					for _, prop := range pattern.Properties {
+						if prop == nil || prop.Key == nil {
+							continue
+						}
+						c.addErrorWithCode(prop.Key, errors.TS2339, fmt.Sprintf("Property '%s' does not exist on type 'unknown'.", c.extractPropertyName(prop.Key)))
+					}
+				case *parser.ArrayParameterPattern:
+					c.addErrorWithCode(pattern, errors.TS2461, "Type 'unknown' is not an array type.")
+				}
+			}
 			// Type check the pattern and define all bindings
 			c.visit(clause.Parameter)
 			// The visit will define all bindings from the pattern

--- a/pkg/errors/tscodes.go
+++ b/pkg/errors/tscodes.go
@@ -12,6 +12,7 @@ const (
 	TS1005  = "TS1005"  // '<token>' expected
 	TS1100  = "TS1100"  // Invalid use of 'X' in strict mode
 	TS1109  = "TS1109"  // Expression expected
+	TS1196  = "TS1196"  // Catch clause variable type annotation must be 'any' or 'unknown' if specified
 	TS1042  = "TS1042"  // 'X' modifier cannot be used here
 	TS1127  = "TS1127"  // Invalid character
 	TS1206  = "TS1206"  // Decorators are not valid here
@@ -24,6 +25,7 @@ const (
 	TS2304  = "TS2304"  // Cannot find name 'X'
 	TS2322  = "TS2322"  // Type 'X' is not assignable to type 'Y'
 	TS2339  = "TS2339"  // Property 'X' does not exist on type 'Y'
+	TS2461  = "TS2461"  // Type 'X' is not an array type
 	TS2345  = "TS2345"  // Argument of type 'X' is not assignable to parameter of type 'Y'
 	TS2362  = "TS2362"  // The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type
 	TS2363  = "TS2363"  // The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -1149,9 +1149,10 @@ func (ts *TryStatement) String() string {
 
 // CatchClause represents a catch block.
 type CatchClause struct {
-	Token     *lexer.Token    // The 'catch' token
-	Parameter Expression      // Exception variable: identifier or destructuring pattern (optional in ES2019+)
-	Body      *BlockStatement // The catch block
+	Token          *lexer.Token    // The 'catch' token
+	Parameter      Expression      // Exception variable: identifier or destructuring pattern (optional in ES2019+)
+	TypeAnnotation Expression      // Optional TS annotation on the binding: catch (e: unknown). Only any/unknown are legal (TS1196).
+	Body           *BlockStatement // The catch block
 }
 
 func (cc *CatchClause) String() string {
@@ -1160,6 +1161,10 @@ func (cc *CatchClause) String() string {
 	if cc.Parameter != nil {
 		out.WriteString(" (")
 		out.WriteString(cc.Parameter.String())
+		if cc.TypeAnnotation != nil {
+			out.WriteString(": ")
+			out.WriteString(cc.TypeAnnotation.String())
+		}
 		out.WriteString(")")
 	}
 	out.WriteString(" ")

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -10245,6 +10245,17 @@ func (p *Parser) parseCatchClause() *CatchClause {
 			return nil
 		}
 
+		// Optional TypeScript type annotation: catch (e: unknown) / catch ({ message }: any).
+		// The checker restricts it to 'any' or 'unknown' (TS1196).
+		if p.peekTokenIs(lexer.COLON) {
+			p.nextToken() // Consume ':'
+			p.nextToken() // Move to the start of the type expression
+			clause.TypeAnnotation = p.parseTypeExpression()
+			if clause.TypeAnnotation == nil {
+				return nil
+			}
+		}
+
 		if !p.expectPeek(lexer.RPAREN) {
 			return nil // Expected ')' after catch parameter
 		}

--- a/tests/scripts/catch_clause_type_annotation.ts
+++ b/tests/scripts/catch_clause_type_annotation.ts
@@ -1,0 +1,27 @@
+// expect: boom|42|destr7
+// TypeScript allows a type annotation on the catch binding, but only 'any' or
+// 'unknown' (anything else is TS1196). The parser used to reject the colon with
+// "')' expected".
+function f(): string {
+  try {
+    throw new Error("boom");
+  } catch (e: unknown) {
+    if (e instanceof Error) return e.message;
+    return String(e);
+  }
+}
+function g(): number {
+  try {
+    throw 41;
+  } catch (e: any) {
+    return e + 1;
+  }
+}
+function h(): string {
+  try {
+    throw { message: "destr", code: 7 };
+  } catch ({ message, code }: any) {
+    return message + code;
+  }
+}
+[f(), g(), h()].join("|");

--- a/tests/scripts/catch_clause_type_annotation_error.ts
+++ b/tests/scripts/catch_clause_type_annotation_error.ts
@@ -1,0 +1,6 @@
+// expect_compile_error: Catch clause variable type annotation must be 'any' or 'unknown' if specified.
+try {
+  throw 1;
+} catch (e: string) {
+  e;
+}


### PR DESCRIPTION
## Problem

```ts
try { throw 1; } catch (e: unknown) { ... }
```

failed to parse with `TS1005: ')' expected` at the colon. TypeScript permits an annotation on the catch binding, but only `any` or `unknown`; anything else is TS1196.

## Changes

- **Parser**: `parseCatchClause` accepts an optional `: Type` after an identifier or destructuring pattern and stores it on the new `CatchClause.TypeAnnotation` field (also printed by `String()`).
- **Checker**: the annotation is resolved. `any` and `unknown` become the binding's type, including through type aliases. Anything else reports TS1196 with TypeScript's exact wording, `Catch clause variable type annotation must be 'any' or 'unknown' if specified.` Destructuring an `unknown` binding reports TS2339 per object property (`Property 'x' does not exist on type 'unknown'.`) or TS2461 for an array pattern, matching what `const { x } = e` with `e: unknown` reports. The bindings are still defined so the body checks without cascading errors.
- **Errors**: TS1196 and TS2461 added to `tscodes.go`.

## Verification

- New smoke tests: `catch_clause_type_annotation.ts` (`unknown` with `instanceof` narrowing, `any`, annotated object pattern) and `catch_clause_type_annotation_error.ts` (expects the TS1196 compile error).
- `go test ./tests -run TestScripts`, `go test ./pkg/parser/... ./pkg/checker/...` green.
- TypeScript conformance in strict-errors mode: `parser/ecmascript5/CatchClauses` goes from 0/1 to 1/1. `statements/tryStatements` is unchanged (1/3) because `catchClauseWithTypeAnnotation.ts` also depends on three pre-existing gaps unrelated to this feature:
  - property access on `unknown` reports our PS2001 message where TypeScript reports TS18046
  - `// @ts-ignore` is not supported anywhere in the checker
  - redeclaring the catch binding inside the body should report TS2492 or TS2403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
