### PR TITLE
fix(vm,compiler): rest-parameter identity, constant-pool overflow, async arguments

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -845,38 +845,45 @@ func newFunctionCompiler(enclosingCompiler *Compiler) *Compiler {
 // Returns the generated chunk and any errors encountered (including type errors).
 func (c *Compiler) Compile(node parser.Node) (resultChunk *vm.Chunk, resultErrs []errors.PaseratiError) {
 	// Register exhaustion (RegisterAllocator.Alloc/AllocContiguous panicking
-	// once a function's 255-register budget is used up) is raised from
-	// hundreds of unchecked call sites throughout the compiler, so it isn't
-	// practical to thread a normal error return through all of them. Instead
-	// Alloc panics with a typed registerExhaustionPanic, and this top-level
-	// recover is the single place that turns it into an ordinary, catchable
-	// compile error instead of letting it unwind as a raw Go panic and take
-	// the whole process down (issue #239) - nested function literals are
-	// compiled synchronously within this same call (see newFunctionCompiler),
-	// so this one recover catches exhaustion at any nesting depth. Anything
-	// else re-panics unchanged: a real compiler bug (nil deref, index out of
-	// range, ...) should still fail loudly rather than be laundered into a
-	// generic "compile error".
+	// once a function's 255-register budget is used up) and constant-pool
+	// exhaustion (Chunk.AddConstant panicking once a chunk's 65,536-entry
+	// pool is full, A5) are both raised from hundreds of unchecked call sites
+	// throughout the compiler, so it isn't practical to thread a normal error
+	// return through all of them. Instead each condition panics with its own
+	// typed value, and this top-level recover is the single place that turns
+	// either into an ordinary, catchable compile error instead of letting it
+	// unwind as a raw Go panic and take the whole process down (issue #239) -
+	// nested function literals are compiled synchronously within this same
+	// call (see newFunctionCompiler), so this one recover catches either at
+	// any nesting depth. Anything else re-panics unchanged: a real compiler
+	// bug (nil deref, index out of range, ...) should still fail loudly
+	// rather than be laundered into a generic "compile error".
 	defer func() {
-		if r := recover(); r != nil {
-			exhaustion, ok := r.(registerExhaustionPanic)
-			if !ok {
-				panic(r)
-			}
-			msg := "register exhaustion: expression too deeply nested"
-			if exhaustion.functionName != "" {
-				msg = fmt.Sprintf("%s (in function %q)", msg, exhaustion.functionName)
-			}
-			var src *source.SourceFile
-			if c.chunk != nil {
-				src = c.chunk.Source
-			}
-			resultChunk = nil
-			resultErrs = []errors.PaseratiError{&errors.CompileError{
-				Position: errors.Position{Line: c.line, Source: src},
-				Msg:      msg,
-			}}
+		r := recover()
+		if r == nil {
+			return
 		}
+		var msg string
+		switch p := r.(type) {
+		case registerExhaustionPanic:
+			msg = "register exhaustion: expression too deeply nested"
+			if p.functionName != "" {
+				msg = fmt.Sprintf("%s (in function %q)", msg, p.functionName)
+			}
+		case vm.ConstantPoolExhaustionPanic:
+			msg = fmt.Sprintf("compile error: %s", p.Error())
+		default:
+			panic(r)
+		}
+		var src *source.SourceFile
+		if c.chunk != nil {
+			src = c.chunk.Source
+		}
+		resultChunk = nil
+		resultErrs = []errors.PaseratiError{&errors.CompileError{
+			Position: errors.Position{Line: c.line, Source: src},
+			Msg:      msg,
+		}}
 	}()
 
 	// --- Type Checking Step ---

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -1165,3 +1165,45 @@ func TestJumpOffsetOverflowIsGracefulError(t *testing.T) {
 		t.Fatalf("expected a 'function too large' error, got: %v", compileErrs)
 	}
 }
+
+// TestConstantPoolOverflowIsGracefulError covers the paserati A5 finding:
+// a chunk whose constant pool needs more than 65,536 distinct entries used
+// to silently narrow the overflowed index back into uint16 range and
+// compile successfully with a wrong constant reference (see
+// docs/runtime-production-roadmap.md's appendix repro, which observed
+// "audit-constant-1" printed instead of the last assigned string). The fix
+// panics with vm.ConstantPoolExhaustionPanic from Chunk.AddConstant, and
+// Compile()'s top-level recover must turn that into an ordinary compile
+// error - never a raw process panic, and never a successfully compiled
+// chunk with a wrapped-around constant index.
+func TestConstantPoolOverflowIsGracefulError(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("var x;\n")
+	// One more than the pool can hold; each string literal is a distinct
+	// constant since none repeats.
+	for i := 0; i < 65537; i++ {
+		fmt.Fprintf(&b, "x = \"audit-constant-%d\";\n", i)
+	}
+	b.WriteString("x;\n")
+
+	program, parseErrs := compileSource(b.String())
+	if len(parseErrs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", parseErrs)
+	}
+
+	// The call itself must not panic - that is the core of the regression.
+	_, compileErrs := NewCompiler().Compile(program)
+	if len(compileErrs) == 0 {
+		t.Fatal("expected a compile error for the overflowing constant pool, got none")
+	}
+	found := false
+	for _, e := range compileErrs {
+		if strings.Contains(e.Error(), "too many distinct constants") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'too many distinct constants' error, got: %v", compileErrs)
+	}
+}

--- a/pkg/driver/async_arguments_length_test.go
+++ b/pkg/driver/async_arguments_length_test.go
@@ -1,0 +1,119 @@
+package driver
+
+import "testing"
+
+// TestAsyncFunctionArgumentsLength reproduces the reported bug directly:
+// executeAsyncFunctionBody (pkg/vm/async.go) builds an async function's
+// initial frame by hand instead of going through prepareCall (call.go), and
+// never set frame.args - the field OpGetArguments actually reads to build
+// the `arguments` object; frame.argCount only sizes the separate
+// register-copy loop. `arguments.length` read 0 regardless of the actual
+// call. Uses RunCode's support for a resolved top-level-await result rather
+// than a pending Promise, matching the sibling rest-parameter tests in this
+// package.
+func TestAsyncFunctionArgumentsLength(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		async function first(a, b, c) { return arguments.length; }
+		const n = await first(1, 2, 3);
+		n === 3
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected await first(1, 2, 3) to resolve arguments.length to 3, got %v", result.ToString())
+	}
+}
+
+// TestAsyncFunctionArgumentsIndexing covers indexed reads/writes and mapped
+// (sloppy-mode, simple-parameter-list) aliasing between `arguments[i]` and
+// its corresponding parameter binding - the frame.args fix must supply
+// OpGetArguments with the real argument values, not just the right count.
+// Mapped indices within the declared arity alias live registers (already
+// correctly populated by the preceding rest-parameter fix) rather than
+// reading frame.args, so `extraIndexed` - an argument beyond the function's
+// arity, necessarily unmapped - is the part of this test that actually
+// discriminates the frame.args fix; the rest holds either way but is worth
+// asserting alongside it.
+func TestAsyncFunctionArgumentsIndexing(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		async function f(a, b) {
+			const before = arguments[0] === 1 && arguments[1] === 2;
+			arguments[0] = 99;
+			const aliasedByArgWrite = a === 99;
+			a = 7;
+			const aliasedByParamWrite = arguments[0] === 7;
+			return before && aliasedByArgWrite && aliasedByParamWrite;
+		}
+		async function extra(a) { return arguments[1]; }
+		const extraIndexed = (await extra(1, 2)) === 2;
+		(await f(1, 2)) && extraIndexed
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected mapped and unmapped arguments indexing to hold in an async function, got %v", result.ToString())
+	}
+}
+
+// TestAsyncFunctionArgumentsCallee covers arguments.callee, since this fix
+// also set frame.calleeValue (mirroring prepareCall) - a field
+// OpGetArguments only falls back to frame.closure for when it's
+// TypeUndefined, so setting it to the wrong value would be worse than
+// leaving it unset. Covers both a direct call and a bound call, where
+// arguments.callee must still name the original target function, not the
+// bound wrapper.
+func TestAsyncFunctionArgumentsCallee(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		async function f(a) { return arguments.callee === f; }
+		const direct = await f(1);
+
+		async function g() { return arguments.callee.name; }
+		const bound = g.bind(null);
+		const boundNamesTarget = (await bound()) === "g";
+
+		direct && boundNamesTarget
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected arguments.callee to identify the original function for both direct and bound async calls, got %v", result.ToString())
+	}
+}
+
+// TestAsyncFunctionArgumentsNotStaleAcrossFrameReuse covers the slot-reuse
+// hazard this bug's fix is adjacent to: vm.frames is a fixed array reused by
+// index, so a first call's argument state must not leak into a later,
+// differently-shaped call landing on the same physical slot.
+func TestAsyncFunctionArgumentsNotStaleAcrossFrameReuse(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		function sync5(a, b, c, d, e) { return arguments.length; }
+		async function asyncFew(x) { return arguments.length; }
+		sync5(1, 2, 3, 4, 5);
+		await asyncFew(1)
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if result.ToString() != "1" {
+		t.Errorf("expected asyncFew(1)'s arguments.length to read 1, not a stale count from the prior sync5 call, got %v", result.ToString())
+	}
+}

--- a/pkg/driver/async_rest_param_test.go
+++ b/pkg/driver/async_rest_param_test.go
@@ -1,0 +1,77 @@
+package driver
+
+import "testing"
+
+// TestAsyncFunctionRestParamAwaited reproduces the bug this file's sibling
+// smoke tests (tests/scripts/async_rest_param_identity.ts,
+// async_rest_param_mixed.ts) can only cover for the synchronously-resolved
+// case: executeAsyncFunctionBody (pkg/vm/async.go) built its initial frame
+// by hand instead of going through prepareCall (call.go), and never
+// reproduced prepareCall's variadic/rest-parameter handling. A rest-only
+// async function called with fewer arguments than its arity left the rest
+// register at Undefined instead of an empty array - `await af()` returned
+// `undefined` where `[]` was expected. This exercises the exact repro from
+// the bug report, through an actual `await`, using RunCode's support for a
+// resolved top-level-await result rather than a pending Promise.
+func TestAsyncFunctionRestParamAwaited(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		async function af(...args) { return args; }
+		const a1 = await af();
+		Array.isArray(a1) && a1.length === 0
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected await af() to resolve to an empty array, got %v", result.ToString())
+	}
+}
+
+// TestAsyncFunctionRestParamFreshIdentity covers the same A4-shaped identity
+// requirement as tests/scripts/rest_param_fresh_identity.ts, but for the
+// async call path (executeAsyncFunctionBody), which builds its rest array
+// separately from the ordinary/sync call path this fix mirrors.
+func TestAsyncFunctionRestParamFreshIdentity(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		async function af(...args) { return args; }
+		const a1 = await af();
+		const a2 = await af();
+		a1.push(42);
+		a1 !== a2 && a2.length === 0
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected two await af() calls to return distinct, independent arrays, got %v", result.ToString())
+	}
+}
+
+// TestAsyncFunctionRestParamMixedAwaited covers a rest parameter alongside
+// preceding fixed parameters, with extra arguments actually present, rather
+// than only the fully-empty case.
+func TestAsyncFunctionRestParamMixedAwaited(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	js := `
+		async function afMixed(a, ...rest) { return [a, rest]; }
+		const r = await afMixed(1, 2, 3);
+		r[0] === 1 && Array.isArray(r[1]) && r[1].length === 2 && r[1][0] === 2 && r[1][1] === 3
+	`
+	result, errs := p.RunCode(js, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	if !result.IsTruthy() {
+		t.Errorf("expected afMixed(1, 2, 3) to resolve to [1, [2, 3]], got %v", result.ToString())
+	}
+}

--- a/pkg/driver/variadic_call_bench_test.go
+++ b/pkg/driver/variadic_call_bench_test.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// BenchmarkVariadicEmptyRestCall measures the paserati A4 fix's stated cost
+// (docs/runtime-production-roadmap.md, A4's acceptance criteria: "Record any
+// allocation increase as the cost of the semantic repair... Ordinary call
+// performance is a required canary"). The fix removed a shared, mutable
+// `emptyRestArray` singleton that every variadic call with no extra
+// arguments used to return, replacing it with a fresh NewArray() per call so
+// two callers' empty rest arrays are no longer the same identity. That turns
+// what used to be a zero-allocation path (for the empty-rest case
+// specifically) into a one-array-allocation path on every such call.
+//
+// This benchmark isolates exactly that call shape - a variadic function
+// called with zero extra arguments - compiled once and invoked repeatedly
+// through vm.Call so the reported allocs/op reflect the call path itself,
+// not script compilation or an enclosing JS loop's own overhead.
+func BenchmarkVariadicEmptyRestCall(b *testing.B) {
+	p := NewPaserati()
+	if _, errs := p.RunString(`function f(...args) { return args; }`); len(errs) > 0 {
+		b.Fatalf("setup failed: %v", errs)
+	}
+	fn, ok := p.GetVM().GetGlobal("f")
+	if !ok {
+		b.Fatal("global function f not found after setup")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := p.GetVM().Call(fn, vm.Undefined, nil); err != nil {
+			b.Fatalf("call failed: %v", err)
+		}
+	}
+}

--- a/pkg/vm/async.go
+++ b/pkg/vm/async.go
@@ -134,6 +134,18 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 	frame.isSentinelFrame = false  // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
 	frame.promiseObj = promiseObj  // Link frame to promise object - critical for OpAwait!
 	frame.generatorObj = nil       // Clear generator object when reusing frame
+	// Clear any stale cached `arguments` object left behind by whatever call
+	// last occupied this frame slot, for the same reuse-by-index reason as
+	// openUpvalues below: every other fresh-frame setup (prepareCall,
+	// op_spreadnew.go, every resumeGenerator*/resumeAsyncFunction* resume)
+	// explicitly resets this to Undefined, and this hand-built setup is the
+	// one path that historically didn't. Not independently confirmed
+	// reachable right now - a separate, pre-existing bug makes
+	// `arguments.length` read 0 inside every async function regardless of
+	// this field, which masks the staleness this would otherwise cause - but
+	// that bug is no reason to leave the same reset gap here that the
+	// openUpvalues comment already documents for this exact function.
+	frame.argumentsObject = Undefined
 	// Clear any stale open-upvalue chain left behind by whatever call last
 	// occupied this frame slot. Every other fresh-frame setup does this
 	// (prepareCall's regular path, every sentinelFrame reuse, every
@@ -176,11 +188,51 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 		frame.registers[i] = Undefined
 	}
 
-	// Set up arguments in registers
-	frame.argCount = len(args)
-	for i, arg := range args {
-		if i < len(frame.registers) {
-			frame.registers[i] = arg
+	// Set up arguments in registers. Mirrors prepareCall's argument-copying
+	// and variadic-handling logic specifically (call.go), not its full frame
+	// setup - this path builds its frame by hand instead of going through
+	// prepareCall (see the openUpvalues comment above for why), so it must
+	// independently reproduce prepareCall's variadic handling too.
+	// It previously didn't: a rest-only async function (e.g. `async
+	// function f(...args) {}`) called with fewer arguments than its arity
+	// left the rest-parameter register at its zeroed Undefined default
+	// instead of an empty array, since nothing here ever checked
+	// funcObj.Variadic. `await f()` observed `undefined` where `[]` was
+	// expected.
+	argCount := len(args)
+	frame.argCount = argCount
+	maxArgsToCopy := argCount
+	if funcObj.Arity > maxArgsToCopy {
+		maxArgsToCopy = funcObj.Arity
+	}
+	if maxArgsToCopy > len(frame.registers) {
+		maxArgsToCopy = len(frame.registers)
+	}
+	for i := 0; i < maxArgsToCopy; i++ {
+		if i < argCount {
+			frame.registers[i] = args[i]
+		} else {
+			frame.registers[i] = Undefined
+		}
+	}
+
+	if funcObj.Variadic {
+		extraArgCount := argCount - funcObj.Arity
+		var restArray Value
+		if extraArgCount <= 0 {
+			restArray = NewArray()
+		} else {
+			restArray = NewArray()
+			restArrayObj := restArray.AsArray()
+			for i := 0; i < extraArgCount; i++ {
+				argIndex := funcObj.Arity + i
+				if argIndex < len(args) {
+					restArrayObj.Append(args[argIndex])
+				}
+			}
+		}
+		if funcObj.Arity < len(frame.registers) {
+			frame.registers[funcObj.Arity] = restArray
 		}
 	}
 

--- a/pkg/vm/async.go
+++ b/pkg/vm/async.go
@@ -134,17 +134,34 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 	frame.isSentinelFrame = false  // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
 	frame.promiseObj = promiseObj  // Link frame to promise object - critical for OpAwait!
 	frame.generatorObj = nil       // Clear generator object when reusing frame
+	// frame.args is the field OpGetArguments actually reads to build the
+	// `arguments` object (frame.argCount only sizes the register-copy loop
+	// below) - see its "args were copied when the frame was created in
+	// prepareCall" comment in vm.go. prepareCall (call.go) and every other
+	// frame-setup path sets this; this hand-built one previously didn't, so
+	// it stayed at whatever `frame.args` slice (or nil) was left by the last
+	// call to reuse this physical vm.frames[N] slot - independent of the
+	// correctly-set argCount/registers, so an async function's own
+	// `arguments.length` always read as if called with the *previous*
+	// occupant's argument count (typically 0, since a freshly-extended
+	// vm.frames backing array zero-initializes every field). Set from the
+	// same `args` this function already copies into registers, before
+	// anything could mutate it.
+	frame.args = args
+	// Store original callee for arguments.callee, mirroring prepareCall.
+	// calleeVal is this function's own top-level parameter, not
+	// necessarily the same value prepareCallWithGeneratorMode's two separate
+	// calleeVal/originalCallee parameters would use on every path - verified
+	// directly for both a plain call and a bound call (arguments.callee must
+	// name the original target, not the bound wrapper) in
+	// pkg/driver/async_arguments_length_test.go's TestAsyncFunctionArgumentsCallee.
+	frame.calleeValue = calleeVal
 	// Clear any stale cached `arguments` object left behind by whatever call
 	// last occupied this frame slot, for the same reuse-by-index reason as
 	// openUpvalues below: every other fresh-frame setup (prepareCall,
 	// op_spreadnew.go, every resumeGenerator*/resumeAsyncFunction* resume)
 	// explicitly resets this to Undefined, and this hand-built setup is the
-	// one path that historically didn't. Not independently confirmed
-	// reachable right now - a separate, pre-existing bug makes
-	// `arguments.length` read 0 inside every async function regardless of
-	// this field, which masks the staleness this would otherwise cause - but
-	// that bug is no reason to leave the same reset gap here that the
-	// openUpvalues comment already documents for this exact function.
+	// one path that historically didn't.
 	frame.argumentsObject = Undefined
 	// Clear any stale open-upvalue chain left behind by whatever call last
 	// occupied this frame slot. Every other fresh-frame setup does this

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/nooga/paserati/pkg/source"
@@ -828,7 +829,17 @@ type Chunk struct {
 	// Constant deduplication caches for O(1) lookup (avoids O(n) linear search)
 	stringConstCache map[string]uint16  // Cache for string constants
 	intConstCache    map[int64]uint16   // Cache for integer constants
-	floatConstCache  map[float64]uint16 // Cache for float constants
+	// floatConstCache is keyed by the constant's raw IEEE-754 bit pattern,
+	// not the float64 itself: Go's built-in float equality (and so its map
+	// key equality) treats +0.0 == -0.0 as true and NaN == NaN as always
+	// false. A plain float64 key would therefore alias -0 constants onto an
+	// existing +0 entry (a silent wrong-value bug - see A5's dedup
+	// acceptance criteria) while making every NaN constant uncacheable
+	// (harmless before the pool had a hard cap; now it needlessly spends
+	// slots against constantPoolCapacity). Bit-pattern keys make both
+	// distinctions exact and let repeated identical NaN literals dedup
+	// normally.
+	floatConstCache map[uint64]uint16
 }
 
 // GetLine returns the source line number corresponding to a given bytecode offset.
@@ -890,10 +901,42 @@ func (c *Chunk) WriteUint16(val uint16) {
 	c.Lines = append(c.Lines, c.currentLine)
 }
 
+// constantPoolCapacity is the number of distinct constants a chunk can hold:
+// LoadConst and friends address the pool with a uint16 operand, so indices
+// 0..65535 are representable and a 65,537th distinct entry is not (A5).
+const constantPoolCapacity = 65536
+
+// ConstantPoolExhaustionPanic is the panic value AddConstant raises when a
+// chunk's constant pool is already at constantPoolCapacity and a genuinely
+// new (non-duplicate) constant is requested. It is a distinct, exported type
+// so a caller in another package - the compiler's top-level recover in
+// Compile() - can identify it specifically and turn it into a normal,
+// catchable errors.PaseratiError instead of either crashing the process or
+// (the bug this replaces) silently narrowing the overflowed index back into
+// uint16 range and returning the wrong existing constant. AddConstant is
+// called from well over a hundred unchecked compiler call sites, so
+// panicking here - rather than threading an error return through all of
+// them - mirrors regalloc.go's registerExhaustionPanic for the same reason.
+type ConstantPoolExhaustionPanic struct {
+	// Capacity is the pool's fixed capacity (constantPoolCapacity) at the
+	// time of the panic, included so callers don't need to import the
+	// unexported constant to report a useful message.
+	Capacity int
+}
+
+func (p ConstantPoolExhaustionPanic) Error() string {
+	return fmt.Sprintf("too many distinct constants in one chunk: exceeds the %d-entry limit addressable by a constant-pool index", p.Capacity)
+}
+
 // AddConstant adds a value to the chunk's constant pool and returns its index.
 // Returns a uint16 as we might need more than 256 constants.
-// Deduplicates constants to avoid storing the same value multiple times.
+// Deduplicates constants to avoid storing the same value multiple times: an
+// already-present constant is always returned from cache/scan, even once the
+// pool is at capacity, so filling the pool cannot break code that only
+// re-references constants it already emitted.
 // Uses type-specific caches for O(1) lookup of common types (strings, integers, floats).
+// Panics with ConstantPoolExhaustionPanic (see above) if a genuinely new
+// constant would push the pool past constantPoolCapacity.
 func (c *Chunk) AddConstant(v Value) uint16 {
 	// Fast path: use type-specific caches for common types
 	switch v.Type() {
@@ -904,6 +947,7 @@ func (c *Chunk) AddConstant(v Value) uint16 {
 		} else if idx, exists := c.stringConstCache[s]; exists {
 			return idx
 		}
+		c.checkConstantPoolCapacity()
 		// Add new constant
 		c.Constants = append(c.Constants, v)
 		idx := uint16(len(c.Constants) - 1)
@@ -917,32 +961,31 @@ func (c *Chunk) AddConstant(v Value) uint16 {
 		} else if idx, exists := c.intConstCache[i]; exists {
 			return idx
 		}
+		c.checkConstantPoolCapacity()
 		c.Constants = append(c.Constants, v)
 		idx := uint16(len(c.Constants) - 1)
 		c.intConstCache[i] = idx
 		return idx
 
 	case TypeFloatNumber:
-		f := v.AsFloat()
+		bits := math.Float64bits(v.AsFloat())
 		if c.floatConstCache == nil {
-			c.floatConstCache = make(map[float64]uint16)
-		} else if idx, exists := c.floatConstCache[f]; exists {
+			c.floatConstCache = make(map[uint64]uint16)
+		} else if idx, exists := c.floatConstCache[bits]; exists {
 			return idx
 		}
+		c.checkConstantPoolCapacity()
 		c.Constants = append(c.Constants, v)
 		idx := uint16(len(c.Constants) - 1)
-		c.floatConstCache[f] = idx
+		c.floatConstCache[bits] = idx
 		return idx
 
 	case TypeDictObject:
 		// Skip deduplication for DictObject to avoid memory corruption issues
 		// (DictObjects like enums are typically unique anyway)
+		c.checkConstantPoolCapacity()
 		c.Constants = append(c.Constants, v)
-		idx := len(c.Constants) - 1
-		if idx > 65535 {
-			panic("Too many constants in one chunk.")
-		}
-		return uint16(idx)
+		return uint16(len(c.Constants) - 1)
 	}
 
 	// Fallback: linear search for other types (functions, objects, etc.)
@@ -953,12 +996,19 @@ func (c *Chunk) AddConstant(v Value) uint16 {
 	}
 
 	// Constant doesn't exist, add it
+	c.checkConstantPoolCapacity()
 	c.Constants = append(c.Constants, v)
-	idx := len(c.Constants) - 1
-	if idx > 65535 {
-		panic("Too many constants in one chunk.")
+	return uint16(len(c.Constants) - 1)
+}
+
+// checkConstantPoolCapacity panics with ConstantPoolExhaustionPanic if the
+// pool is already full. Call immediately before appending a confirmed-new
+// constant - never after, which would let a 65,537th entry get appended (and
+// so be observably reachable by a stale index range) before the check fires.
+func (c *Chunk) checkConstantPoolCapacity() {
+	if len(c.Constants) >= constantPoolCapacity {
+		panic(ConstantPoolExhaustionPanic{Capacity: constantPoolCapacity})
 	}
-	return uint16(idx)
 }
 
 // --- Disassembly ---

--- a/pkg/vm/bytecode_test.go
+++ b/pkg/vm/bytecode_test.go
@@ -1,0 +1,139 @@
+package vm
+
+import (
+	"math"
+	"testing"
+)
+
+// TestAddConstantFloatCacheDistinguishesSignedZeroAndNaN covers the other
+// half of the A5 acceptance list: numeric constant dedup must not let host
+// map equality stand in for JavaScript constant equivalence. Go's float64
+// equality (and so a map keyed directly by float64) treats +0.0 == -0.0 as
+// true and NaN == NaN as always false - the former would silently alias a
+// -0 constant onto an existing +0 entry (Object.is/1÷x can observe the
+// difference), the latter would make every NaN literal uncacheable and so
+// needlessly spend pool slots once AddConstant enforces a hard cap.
+func TestAddConstantFloatCacheDistinguishesSignedZeroAndNaN(t *testing.T) {
+	c := NewChunk()
+
+	posZeroIdx := c.AddConstant(NumberValue(0))
+	negZeroIdx := c.AddConstant(NumberValue(math.Copysign(0, -1)))
+	if posZeroIdx == negZeroIdx {
+		t.Fatalf("+0 and -0 got the same constant index %d; they are observably distinct values (1/+0 vs 1/-0, Object.is)", posZeroIdx)
+	}
+	// Re-adding +0 must still hit the original entry, not grow the pool.
+	if again := c.AddConstant(NumberValue(0)); again != posZeroIdx {
+		t.Fatalf("re-adding +0 got index %d, want the original %d", again, posZeroIdx)
+	}
+
+	nan1Idx := c.AddConstant(NaN)
+	nan2Idx := c.AddConstant(NaN)
+	if nan1Idx != nan2Idx {
+		t.Fatalf("two identical NaN constants got different indices (%d, %d): NaN literals must dedup like any other bit-identical constant", nan1Idx, nan2Idx)
+	}
+}
+
+// TestAddConstantCapacityBoundary covers the paserati A5 finding: AddConstant
+// used to narrow the pool index to uint16 without checking it fit, so a
+// 65,537th distinct constant silently wrapped and returned an existing
+// constant's index instead of failing. These tests drive a chunk to exactly
+// constantPoolCapacity entries and check the boundary from both sides.
+func TestAddConstantCapacityBoundary(t *testing.T) {
+	c := NewChunk()
+
+	// Fill the pool with exactly constantPoolCapacity distinct constants.
+	// Every index returned along the way must match the insertion order -
+	// there is no capacity check to trigger yet.
+	for i := 0; i < constantPoolCapacity; i++ {
+		idx := c.AddConstant(IntegerValue(int32(i)))
+		if int(idx) != i {
+			t.Fatalf("AddConstant(%d): got index %d, want %d", i, idx, i)
+		}
+	}
+	if len(c.Constants) != constantPoolCapacity {
+		t.Fatalf("pool has %d entries, want exactly %d", len(c.Constants), constantPoolCapacity)
+	}
+
+	// A duplicate of an already-present constant must still resolve from
+	// cache once the pool is completely full - filling the pool must not
+	// break code that only re-references constants it already emitted.
+	for _, probe := range []int32{0, 1, int32(constantPoolCapacity - 1)} {
+		idx := c.AddConstant(IntegerValue(probe))
+		if int(idx) != int(probe) {
+			t.Fatalf("duplicate AddConstant(%d) at capacity: got index %d, want %d (cache lookup must not be gated by the capacity check)", probe, idx, probe)
+		}
+	}
+	if len(c.Constants) != constantPoolCapacity {
+		t.Fatalf("duplicate lookups grew the pool to %d entries, want unchanged %d", len(c.Constants), constantPoolCapacity)
+	}
+
+	// A genuinely new constant at capacity must panic with the typed value,
+	// not silently narrow its index into range 0..65535 and return the
+	// wrong existing constant (the original A5 bug), and must not corrupt
+	// the pool by appending anyway.
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("AddConstant of a new value at capacity should panic instead of silently wrapping")
+			}
+			p, ok := r.(ConstantPoolExhaustionPanic)
+			if !ok {
+				t.Fatalf("expected ConstantPoolExhaustionPanic, got %T: %v", r, r)
+			}
+			if p.Capacity != constantPoolCapacity {
+				t.Fatalf("panic reported Capacity=%d, want %d", p.Capacity, constantPoolCapacity)
+			}
+		}()
+		c.AddConstant(IntegerValue(int32(constantPoolCapacity))) // one past every existing entry
+	}()
+	if len(c.Constants) != constantPoolCapacity {
+		t.Fatalf("failed AddConstant left the pool at %d entries, want unchanged %d (must not append then panic)", len(c.Constants), constantPoolCapacity)
+	}
+
+	// One below capacity must still succeed normally: the fix must not have
+	// shaved a legitimate slot off the top along with the buggy one.
+	c2 := NewChunk()
+	for i := 0; i < constantPoolCapacity-1; i++ {
+		c2.AddConstant(IntegerValue(int32(i)))
+	}
+	idx := c2.AddConstant(IntegerValue(int32(constantPoolCapacity - 1)))
+	if int(idx) != constantPoolCapacity-1 {
+		t.Fatalf("the last legitimately representable constant got index %d, want %d", idx, constantPoolCapacity-1)
+	}
+}
+
+// TestAddConstantCapacityBoundaryStrings covers the same boundary through the
+// string fast path specifically (the one the A5 appendix repro exercises),
+// since each Value-kind branch in AddConstant has its own capacity check.
+func TestAddConstantCapacityBoundaryStrings(t *testing.T) {
+	c := NewChunk()
+	for i := 0; i < constantPoolCapacity; i++ {
+		c.AddConstant(NewString(intToDigits(i)))
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("AddConstant of a new string at capacity should panic instead of silently wrapping")
+		}
+		if _, ok := r.(ConstantPoolExhaustionPanic); !ok {
+			t.Fatalf("expected ConstantPoolExhaustionPanic, got %T: %v", r, r)
+		}
+	}()
+	c.AddConstant(NewString(intToDigits(constantPoolCapacity)))
+}
+
+func intToDigits(i int) string {
+	// Minimal decimal formatter to avoid pulling in strconv just for test data.
+	if i == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[pos:])
+}

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -420,12 +420,12 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			// extraArgCount is negative when called with fewer arguments than
 			// the non-rest parameter count (now legal - see the arity-checking
 			// comment above, paserati#170) - treat that the same as exactly
-			// zero extra arguments: an empty rest array, reusing the shared
-			// one rather than falling into the loop below with a negative
-			// bound (which happens to still produce an empty array, just via
-			// an unnecessary fresh allocation).
+			// zero extra arguments: an empty rest array. Each call must get a
+			// fresh, independently identifiable array (paserati A4) - a shared
+			// singleton here would let one call's mutation of its rest array
+			// leak into every other call's.
 			if extraArgCount <= 0 {
-				restArray = vm.emptyRestArray
+				restArray = NewArray()
 			} else {
 				restArray = NewArray()
 				restArrayObj := restArray.AsArray()

--- a/pkg/vm/op_spreadnew.go
+++ b/pkg/vm/op_spreadnew.go
@@ -41,7 +41,7 @@ func populateSpreadCallRegisters(vmInstance *VM, calleeFunc *FunctionObject, spr
 		extraArgCount := argCount - calleeFunc.Arity
 		var restArray Value
 		if extraArgCount <= 0 {
-			restArray = vmInstance.emptyRestArray
+			restArray = NewArray()
 		} else {
 			restArray = NewArray()
 			restArrayObj := restArray.AsArray()

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -248,10 +248,6 @@ type VM struct {
 	// This is used by OpSetGlobal to determine if a deleted property error should be thrown
 	globalsFromGlobalObject map[uint16]bool
 
-	// Singleton empty array for rest parameters optimization
-	// Used when variadic functions are called with no extra arguments
-	emptyRestArray Value
-
 	// Built-in prototypes owned by this VM
 	ObjectPrototype               Value
 	FunctionPrototype             Value
@@ -522,7 +518,6 @@ func NewVM() *VM {
 		registerStack:           make([]Value, RegFileSize*MaxFrames), // VM-wide register file (never reallocated)
 		propCache:               make(map[int]*PropInlineCache),       // Initialize inline cache
 		cacheStats:              ICacheStats{},                        // Initialize cache statistics
-		emptyRestArray:          NewArray(),                           // Initialize singleton empty array for rest params
 		errors:                  make([]errors.PaseratiError, 0),      // Initialize error list
 		moduleContexts:          make(map[string]*ModuleContext),      // Initialize module context cache
 		completionStack:         make([]Completion, 0, 4),             // Initialize completion stack
@@ -3885,7 +3880,7 @@ startExecution:
 						extraArgCount := argCount - calleeFunc.Arity
 						var restArray Value
 						if extraArgCount <= 0 {
-							restArray = vm.emptyRestArray
+							restArray = NewArray()
 						} else {
 							restArray = NewArray()
 							restArrayObj := restArray.AsArray()
@@ -4106,7 +4101,7 @@ startExecution:
 						extraArgCount := argCount - calleeFunc.Arity
 						var restArray Value
 						if extraArgCount <= 0 {
-							restArray = vm.emptyRestArray
+							restArray = NewArray()
 						} else {
 							restArray = NewArray()
 							restArrayObj := restArray.AsArray()
@@ -11136,7 +11131,7 @@ startExecution:
 					var restArray Value
 
 					if extraArgCount == 0 {
-						restArray = vm.emptyRestArray
+						restArray = NewArray()
 					} else {
 						restArray = NewArray()
 						restArrayObj := restArray.AsArray()
@@ -11371,7 +11366,7 @@ startExecution:
 					var restArray Value
 
 					if extraArgCount == 0 {
-						restArray = vm.emptyRestArray
+						restArray = NewArray()
 					} else {
 						restArray = NewArray()
 						restArrayObj := restArray.AsArray()
@@ -11842,7 +11837,7 @@ startExecution:
 						extraArgCount := finalArgCount - constructorFunc.Arity
 						var restArray Value
 						if extraArgCount <= 0 {
-							restArray = vm.emptyRestArray
+							restArray = NewArray()
 						} else {
 							restArray = NewArray()
 							restArrayObj := restArray.AsArray()
@@ -13981,7 +13976,7 @@ startExecution:
 					frame.registers[i] = Undefined
 				}
 				if calleeFunc.Variadic && calleeFunc.Arity < len(frame.registers) && argCount <= calleeFunc.Arity {
-					frame.registers[calleeFunc.Arity] = vm.emptyRestArray
+					frame.registers[calleeFunc.Arity] = NewArray()
 				}
 
 				// Switch to new frame
@@ -14048,7 +14043,7 @@ startExecution:
 					frame.registers[i] = Undefined
 				}
 				if calleeFunc.Variadic && calleeFunc.Arity < len(frame.registers) && argCount <= calleeFunc.Arity {
-					frame.registers[calleeFunc.Arity] = vm.emptyRestArray
+					frame.registers[calleeFunc.Arity] = NewArray()
 				}
 
 				// Switch to new frame

--- a/tests/scripts/async_arguments_length.ts
+++ b/tests/scripts/async_arguments_length.ts
@@ -1,0 +1,14 @@
+// expect: Promise { 3 }
+// Regression test: executeAsyncFunctionBody (pkg/vm/async.go) builds an
+// async function's initial frame by hand instead of going through the
+// ordinary call path (prepareCall, call.go), and never set frame.args - the
+// field OpGetArguments actually reads to build the `arguments` object
+// (frame.argCount only sizes the register-copy loop). `arguments.length`
+// read 0 inside every async function regardless of how many arguments were
+// passed. `first` has no internal await, so it resolves synchronously and
+// the resolved value is directly observable as the script's last-statement
+// value (see async_function_basic.ts for the same convention).
+async function first(a: number, b: number, c: number) {
+  return arguments.length;
+}
+first(1, 2, 3);

--- a/tests/scripts/async_rest_param_identity.ts
+++ b/tests/scripts/async_rest_param_identity.ts
@@ -1,0 +1,16 @@
+// expect: Promise { [] }
+// Regression test: an async function's frame setup (executeAsyncFunctionBody
+// in pkg/vm/async.go) built its register window by hand instead of going
+// through the ordinary call path (prepareCall in call.go), and never
+// reproduced that path's variadic/rest-parameter handling. A rest-only
+// async function called with fewer arguments than its arity left the rest
+// register at its zeroed Undefined default instead of an empty array -
+// `await af()` observed `undefined` where `[]` was expected. No `await`
+// appears in this file: `af` has no internal await, so it resolves
+// synchronously and the resolved value is directly observable as the
+// script's last-statement value (see async_function_basic.ts for the same
+// convention).
+async function af(...args: any[]) {
+  return args;
+}
+af();

--- a/tests/scripts/async_rest_param_mixed.ts
+++ b/tests/scripts/async_rest_param_mixed.ts
@@ -1,0 +1,8 @@
+// expect: Promise { [1, [2, 3]] }
+// Companion to async_rest_param_identity.ts: covers a rest parameter
+// alongside preceding fixed parameters, and with extra arguments actually
+// present, rather than only the fully-empty case.
+async function afMixed(a: number, ...rest: number[]) {
+  return [a, rest];
+}
+afMixed(1, 2, 3);

--- a/tests/scripts/rest_param_fresh_identity.ts
+++ b/tests/scripts/rest_param_fresh_identity.ts
@@ -1,0 +1,64 @@
+// Regression test for paserati roadmap item A4: an empty rest parameter
+// used to be the same mutable shared array object on every call, so
+// mutating one caller's rest array leaked into every other call's (and its
+// length stayed wrong afterward). Every call must now get a fresh,
+// independently identifiable empty array. Covers direct, spread, bound,
+// constructor, generator, and tail-call routes. Async functions are known
+// to still return `undefined` instead of the rest array at all when
+// awaited (a separate, pre-existing bug unrelated to this fix - see the
+// spawned "Fix rest params in awaited async functions" task), so the async
+// route is intentionally left out here rather than asserted against.
+// expect: true
+
+function direct(...args: any[]) {
+  return args;
+}
+
+let d1 = direct();
+let d2 = direct();
+d1.push(42);
+let directOk = d1 !== d2 && d2.length === 0 && d1.length === 1;
+
+function callSpread(fn: (...a: any[]) => any) {
+  return fn(...([] as any[]));
+}
+let s1 = callSpread(direct);
+let s2 = callSpread(direct);
+s1.push(1);
+let spreadOk = s1 !== s2 && s2.length === 0;
+
+let bound = direct.bind(null);
+let b1 = bound();
+let b2 = bound();
+b1.push(1);
+let boundOk = b1 !== b2 && b2.length === 0;
+
+class C {
+  args: any[];
+  constructor(...args: any[]) {
+    this.args = args;
+  }
+}
+let c1 = new C();
+let c2 = new C();
+c1.args.push(1);
+let ctorOk = c1.args !== c2.args && c2.args.length === 0;
+
+function tail(n: number, ...args: any[]): any[] {
+  if (n <= 0) return args;
+  return tail(n - 1);
+}
+let t1 = tail(3);
+let t2 = tail(3);
+t1.push(1);
+let tailOk = t1 !== t2 && t2.length === 0;
+
+function* gen(...args: any[]) {
+  yield args;
+}
+let g1 = gen().next().value as any[];
+let g2 = gen().next().value as any[];
+g1.push(1);
+let genOk = g1 !== g2 && g2.length === 0;
+
+directOk && spreadOk && boundOk && ctorOk && tailOk && genOk;


### PR DESCRIPTION
First three work items from `docs/runtime-production-roadmap.md`'s "quick wins" pick (A4, A5), plus two follow-on bugs found while fixing A4 and reproducing it in async functions.

## A4 — fresh rest-parameter identity

`vm.emptyRestArray` was a single shared, mutable array returned by every variadic call with no extra arguments — two calls' "empty" rest arrays were the same object. Removed the singleton; every call site (ordinary, spread, bound, constructor, tail-call reuse) now allocates a fresh array. Cost measured directly (`pkg/driver/variadic_call_bench_test.go`): the empty-rest call path goes from 0 allocs/83ns to 1 alloc (112B)/113ns.

## A5 — checked constant-pool capacity

`Chunk.AddConstant`'s string/int/float fast paths narrowed the pool index to `uint16` with no bounds check, so a chunk needing >65,536 distinct constants silently wrapped and returned the wrong constant. Now checks capacity before appending and panics with a typed `ConstantPoolExhaustionPanic`, caught by `Compile()`'s existing top-level recover (same pattern as `registerExhaustionPanic`, #239) and turned into an ordinary compile error. Also fixed `floatConstCache` aliasing `+0`/`-0` and never-deduping `NaN` (Go float equality ≠ JS constant equivalence).

## Async function bugs (found while verifying A4)

`executeAsyncFunctionBody` (`pkg/vm/async.go`) builds an async function's initial frame by hand instead of through the ordinary call path (`prepareCall`), so every field that path sets has to be independently reproduced — and wasn't, in three ways, fixed as three separate commits:

- A rest-only async function called with fewer args than its arity returned `undefined` instead of `[]` for the rest parameter.
- `frame.argumentsObject` (cached `arguments` object) was never reset across frame-slot reuse.
- `frame.args` (what `arguments.length`/indexing actually reads) and `frame.calleeValue` (`arguments.callee`) were never set at all — `arguments.length` read `0` regardless of the real call, in every async function.

Each is its own commit; commit messages have full root-cause detail. This is the third fix to the same function for the same structural cause (hand-built frame drifting out of parity with `prepareCall`) — D3 in the roadmap ("extract a common frame-entry/exit contract") is the actual fix for the class.

## Not done

A5's full scope (checked emitter helpers, an inventory of every other narrow field, wide/split-chunk forms), D3's argument-movement optimization, and D3's frame-setup consolidation itself.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` (including `tests -run TestScripts`) all green on every commit. New regression tests: `pkg/vm/bytecode_test.go`, `pkg/compiler/compiler_test.go`, `pkg/driver/variadic_call_bench_test.go`, `pkg/driver/async_rest_param_test.go`, `pkg/driver/async_arguments_length_test.go`, plus `tests/scripts/rest_param_fresh_identity.ts`, `async_rest_param_identity.ts`, `async_rest_param_mixed.ts`, `async_arguments_length.ts`. Every bug fix's tests verified to fail before and pass after via `git stash`.