### PR TITLE
fix(compiler): stop generator body flag from suppressing nested block scopes (#271)

### DIFF
--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -1565,7 +1565,19 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 
 		// Compile the body specially for generators to insert OpInitYield at the right place
 		bodyReg := functionCompiler.regAlloc.Alloc()
-		functionCompiler.isCompilingFunctionBody = true
+		// Note: deliberately NOT setting isCompilingFunctionBody=true here. That flag
+		// tells the *next* BlockStatement compileNode call "you are the function's own
+		// top-level body, don't create an enclosed scope for yourself" - it's consumed
+		// (and cleared) by the very first BlockStatement dispatch it sees. A generator's
+		// top-level body is never itself passed through compileNode (its statements are
+		// walked by hand below, to splice in OpInitYield at the right place), so setting
+		// this flag true here doesn't do anything at that level - it just survives to be
+		// wrongly consumed by the first NESTED block statement instead (e.g. an `if`'s
+		// consequence), telling it to skip creating its own enclosed scope. That made a
+		// block-scoped `let`/`const` inside the first nested block get predefined
+		// directly into the generator's own top-level symbol table (and never freed on
+		// block exit) rather than a scoped child table - leaking past the block and
+		// shadowing/clobbering any enclosing binding of the same name (#271).
 
 		// Get the body as a block statement (it's always a BlockStatement for function literals)
 		blockBody := node.Body
@@ -1702,6 +1714,9 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 			_, _ = functionCompiler.compileNode(node.Body, bodyReg)
 		}
 
+		// Defensive reset only - this branch never sets isCompilingFunctionBody true
+		// (see the comment above), so this is normally a no-op. Left in case some
+		// nested compileNode call above ever sets it and fails to clear it itself.
 		functionCompiler.isCompilingFunctionBody = false
 		functionCompiler.regAlloc.Free(bodyReg)
 	} else {

--- a/tests/scripts/generator_nested_block_let_leak.ts
+++ b/tests/scripts/generator_nested_block_let_leak.ts
@@ -1,0 +1,150 @@
+// expect: true
+// #271: sibling gap in #262's fix (be20f91d). That commit predefined a
+// generator body's own *top-level* let/const bindings before OpInitYield,
+// since the generator's special statement-by-statement body compilation
+// (needed to splice OpInitYield at the right place) bypasses the general
+// BlockStatement "pass 0" predefine step that regular function bodies get.
+// But #262's fix left `isCompilingFunctionBody` set to true across that
+// whole statement-by-statement walk, so the first NESTED block statement
+// it reached (an `if`'s consequence, a bare `{ }` block, ...) wrongly read
+// that flag as "you are the function's own top-level body - don't create
+// an enclosed scope for yourself". That predefined the nested block's own
+// let/const directly into the generator's top-level symbol table (and
+// never freed the register on block exit) instead of a scoped child
+// table - leaking a block-scoped binding past its block and
+// shadowing/clobbering any enclosing binding of the same name.
+
+function makeIt(condition: boolean): any {
+  const o: any = Outer; // outer-scope variable, closed over by the generator below
+  function* g(): any {
+    if (condition) {
+      const o = { fake: true }; // block-scoped - must NOT leak past the if-block
+    }
+    return new o("real"); // must still see the OUTER `o` (the Outer class)
+  }
+  return g;
+}
+class Outer {
+  tag: string;
+  constructor(tag: string) {
+    this.tag = tag;
+  }
+}
+// Condition false: the if-block never runs at all - a leaked/uninitialized
+// register would surface as "undefined is not a constructor".
+const neverRanResult = makeIt(false)().next().value.tag === "real";
+// Condition true: the if-block does run - a leaked register would surface
+// as the *fake* object being used instead ("object is not a constructor",
+// or silently constructing from the wrong value).
+const ranResult = makeIt(true)().next().value.tag === "real";
+
+// Same shape, but with a bare `{ }` block (no control-flow keyword at all).
+function makeIt2(): any {
+  const o: any = Outer2;
+  function* g(): any {
+    {
+      const o = { fake: true };
+    }
+    return new o("real");
+  }
+  return g;
+}
+class Outer2 {
+  tag: string;
+  constructor(tag: string) {
+    this.tag = tag;
+  }
+}
+const bareBlockResult = makeIt2()().next().value.tag === "real";
+
+// A nested `let` (not `const`) shadowing an enclosing `let` of the same name,
+// read back out after the block - the non-constructor-call variant of the
+// same leak.
+function makeIt3(): any {
+  let n = 1;
+  function* g(): any {
+    if (true) {
+      let n = 2;
+    }
+    return n;
+  }
+  return g;
+}
+const letLeakResult = makeIt3()().next().value === 1;
+
+// The bug's real-world shapes: generator methods (object literals and
+// classes) and async generators route through the exact same shared
+// compileFunctionLiteral body as a plain `function*` declaration, so they
+// hit the same gap - one nested-block case per shape, matching the #262
+// sibling test's coverage (generator_local_shadows_enclosing_param.ts).
+
+function makeItObjMethod(): any {
+  const o: any = Outer;
+  const obj = {
+    *g(): any {
+      if (false) {
+        const o = { fake: true };
+      }
+      return new o("real");
+    },
+  };
+  return obj.g;
+}
+const objMethodResult = makeItObjMethod()().next().value.tag === "real";
+
+function makeItClassMethod(): any {
+  const o: any = Outer;
+  class C {
+    *g(): any {
+      if (false) {
+        const o = { fake: true };
+      }
+      return new o("real");
+    }
+  }
+  return new C().g;
+}
+const classMethodResult = makeItClassMethod()().next().value.tag === "real";
+
+async function checkAsyncShapes(): Promise<boolean> {
+  function makeItAsyncGen(): any {
+    const o: any = Outer;
+    async function* g(): any {
+      if (false) {
+        const o = { fake: true };
+      }
+      yield new o("real");
+    }
+    return g;
+  }
+  const asyncGenResult = (await makeItAsyncGen()().next()).value.tag === "real";
+
+  function makeItClassAsyncGen(): any {
+    const o: any = Outer;
+    class C {
+      async *[Symbol.asyncIterator]() {
+        if (false) {
+          const o = { fake: true };
+        }
+        yield new o("real");
+      }
+    }
+    return new C();
+  }
+  let classAsyncGenResult = false;
+  for await (const v of makeItClassAsyncGen()) {
+    classAsyncGenResult = v.tag === "real";
+    break;
+  }
+
+  return asyncGenResult && classAsyncGenResult;
+}
+const asyncShapesOk = await checkAsyncShapes();
+
+neverRanResult &&
+  ranResult &&
+  bareBlockResult &&
+  letLeakResult &&
+  objMethodResult &&
+  classMethodResult &&
+  asyncShapesOk;


### PR DESCRIPTION
## Summary

Fixes #271 - a generator's `const`/`let` inside a nested block (an `if`'s consequence, a bare `{ }` block, ...) leaked into an enclosing variable of the same name, even when the block never executed.

## Root cause

This is a sibling gap in #262's fix (`be20f91d`). That commit predefined a generator body's own **top-level** `let`/`const` bindings before `OpInitYield`, since a generator's body is compiled by a hand-rolled statement loop (needed to splice `OpInitYield` in at the right point) that bypasses the general `BlockStatement` "pass 0" predefine step regular function bodies get.

The issue itself guessed the fix was to extend that predefine loop to recurse into nested block-bearing statements too. That would have entrenched the real bug instead of fixing it: the actual root cause, confirmed by reading the bytecode disassembly of the repro, is different.

`be20f91d`'s fix left `isCompilingFunctionBody` set to `true` across the entire statement-by-statement walk. That flag exists to be consumed by exactly one `BlockStatement` `compileNode` call - the function's own top-level body - telling it "don't create an enclosed scope for yourself, you already have one from `newFunctionCompiler`". A generator's own top-level body is *never* itself passed through `compileNode` (its statements are walked by hand instead, precisely to splice in `OpInitYield`), so setting the flag true there does nothing at that level - it just survives to be wrongly consumed by the **first nested block statement** encountered while compiling those statements (an `if`'s consequence, a bare block, etc). That nested block then skipped creating its own enclosed scope and predefined its `let`/`const` directly into the generator's top-level symbol table - never freeing the register on block exit - leaking the block-scoped binding past its block and shadowing/clobbering any enclosing binding of the same name.

Confirmed via `-bytecode` on the issue's repro: before the fix, `return new o("real")` compiled to `OpMove R4, R20` - reusing the leaked/uninitialized register from the inner block's `const o = { fake: true }` - instead of `OpLoadFree R4, UpvalueIdx 1`, which is what it correctly compiles to after the fix (loading the outer captured `o`).

## Fix

Stop setting `isCompilingFunctionBody = true` in the generator body's special compilation path - it was never read at that level, only misdelivered to the wrong (nested) scope one level down.

## Testing

- Both repros from #271 now produce the correct output (matches real Node.js).
- Added [`tests/scripts/generator_nested_block_let_leak.ts`](tests/scripts/generator_nested_block_let_leak.ts), covering: `if`-block (both branches taken/not-taken), bare block, a `let` (not just `const`) variant, and the same shape across all generator forms that share `compileFunctionLiteral`'s generator branch (object-literal method, class method, `async function*`, class `async *[Symbol.asyncIterator]`) - matching the coverage convention of the #262 sibling test (`generator_local_shadows_enclosing_param.ts`). Verified this test fails on the pre-fix binary and passes after the fix.
- `go test ./tests -run TestScripts` - all green.
- `go test ./...` - all green.
- Test262 `language/` and `built-ins/` compared pre-fix vs fixed binary (dumped and diffed, not just aggregate counts): zero regressions on either subtree.