### PR TITLE
fix(builtins): Object.assign now invokes source getters and target setters (#274)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2798,14 +2798,28 @@ func reflectOwnKeysImpl(args []vm.Value) (vm.Value, error) {
 // dispatch in op_setprop.go's TypeArray branch) - and anything else becomes
 // a plain named property, exactly like the `.provisional` case that
 // motivated this fix.
-func setObjectAssignTargetProperty(target vm.Value, key string, value vm.Value) {
+//
+// This is the [[Set]] half of Object.assign's copy: CreateDataProperty-like
+// for a plain data slot, but if target already has key as an own accessor
+// property, [[Set]] must invoke its setter rather than clobbering it with a
+// data value (paserati#274) - mirrors the own-accessor check vm.SetProperty
+// makes for the same reason.
+func setObjectAssignTargetProperty(vmInstance *vm.VM, target vm.Value, key string, value vm.Value) error {
 	switch target.Type() {
 	case vm.TypeObject:
+		plainTarget := target.AsPlainObject()
+		if _, setter, _, _, isAccessor := plainTarget.GetOwnAccessor(key); isAccessor {
+			if setter.Type() == vm.TypeUndefined {
+				return nil // accessor with no setter: [[Set]] silently no-ops (non-strict)
+			}
+			_, err := vmInstance.Call(setter, target, []vm.Value{value})
+			return err
+		}
 		// Object.assign copies as if by ordinary [[Set]] - the property must
 		// land enumerable on the target, not non-enumerable (paserati#168).
 		// SetOwnNonEnumerable exists for built-in method registration, not
 		// for this.
-		target.AsPlainObject().SetOwn(key, value)
+		plainTarget.SetOwn(key, value)
 	case vm.TypeDictObject:
 		target.AsDictObject().SetOwn(key, value)
 	case vm.TypeArray:
@@ -2846,6 +2860,7 @@ func setObjectAssignTargetProperty(target vm.Value, key string, value vm.Value) 
 			props.SetOwn(key, value)
 		}
 	}
+	return nil
 }
 
 func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
@@ -2897,14 +2912,35 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		if source.Type() == vm.TypeObject {
 			plainObj := source.AsPlainObject()
 			for _, key := range plainObj.OwnKeys() {
-				value, _ := plainObj.GetOwn(key)
-				setObjectAssignTargetProperty(target, key, value)
+				// Object.assign reads each source property via [[Get]], which
+				// for an accessor property means calling its getter rather
+				// than copying the (unset) data slot underneath it
+				// (paserati#274).
+				var value vm.Value
+				if getter, _, _, _, isAccessor := plainObj.GetOwnAccessor(key); isAccessor {
+					if getter.Type() == vm.TypeUndefined {
+						value = vm.Undefined
+					} else {
+						var err error
+						value, err = vmInstance.Call(getter, source, nil)
+						if err != nil {
+							return vm.Undefined, err
+						}
+					}
+				} else {
+					value, _ = plainObj.GetOwn(key)
+				}
+				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
+					return vm.Undefined, err
+				}
 			}
 		} else if source.Type() == vm.TypeDictObject {
 			dictObj := source.AsDictObject()
 			for _, key := range dictObj.OwnKeys() {
 				value, _ := dictObj.GetOwn(key)
-				setObjectAssignTargetProperty(target, key, value)
+				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
+					return vm.Undefined, err
+				}
 			}
 		} else if source.Type() == vm.TypeArray {
 			arrObj := source.AsArray()
@@ -2912,7 +2948,9 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			for i := 0; i < arrObj.Length(); i++ {
 				key := strconv.Itoa(i)
 				value := arrObj.Get(i)
-				setObjectAssignTargetProperty(target, key, value)
+				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
+					return vm.Undefined, err
+				}
 			}
 			// Also copy length property. Deliberately no vm.TypeArray case
 			// here (unlike setObjectAssignTargetProperty above, which now

--- a/tests/scripts/issue274_object_assign_accessors.ts
+++ b/tests/scripts/issue274_object_assign_accessors.ts
@@ -1,0 +1,123 @@
+// expect: true
+// paserati#274: Object.assign neither read through a source getter nor wrote
+// through a target setter - it treated every property as a plain data slot
+// regardless of the source's or target's actual accessor properties.
+//
+// Per spec, Object.assign copies each own enumerable source property via
+// [[Get]] (which for an accessor property means calling the getter) and
+// writes it onto the target via [[Set]] (which must invoke a setter if the
+// target already defines one there).
+const checks: boolean[] = [];
+
+// --- Read side: source getter must be invoked, not skipped. ---
+const source: any = {};
+Object.defineProperty(source, "types", {
+  get() {
+    return { real: true };
+  },
+  enumerable: true,
+  configurable: true,
+});
+const target: any = Object.assign({}, source);
+checks.push(typeof target.types === "object");
+checks.push(JSON.stringify(target.types) === '{"real":true}');
+// The property genuinely lands on target - it's the *value* that was wrong.
+checks.push("types" in target);
+checks.push(JSON.stringify(Object.keys(target)) === '["types"]');
+
+// A getter that returns different values on each call - Object.assign must
+// call it exactly once per assign, at copy time (like real [[Get]]), not
+// defer/re-invoke it.
+let getterCalls = 0;
+const source2: any = {};
+Object.defineProperty(source2, "n", {
+  get() {
+    getterCalls++;
+    return getterCalls;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const target2: any = Object.assign({}, source2);
+checks.push(target2.n === 1);
+checks.push(getterCalls === 1);
+
+// --- Write side: target setter must be invoked, not clobbered. ---
+const target3: any = {};
+let captured: any;
+Object.defineProperty(target3, "x", {
+  set(v: any) {
+    captured = v;
+  },
+  enumerable: true,
+  configurable: true,
+});
+Object.assign(target3, { x: 42 });
+checks.push(captured === 42);
+// The setter itself decided to drop the value on the floor - Object.assign
+// must not additionally create a shadow data property with the raw value.
+checks.push(target3.x === undefined);
+
+// --- Both sides together: a getter's value flows through a setter. ---
+const src: any = {};
+Object.defineProperty(src, "v", {
+  get() {
+    return "hello";
+  },
+  enumerable: true,
+  configurable: true,
+});
+const dst: any = {};
+let dstCaptured: any;
+Object.defineProperty(dst, "v", {
+  set(v: any) {
+    dstCaptured = v;
+  },
+  enumerable: true,
+  configurable: true,
+});
+Object.assign(dst, src);
+checks.push(dstCaptured === "hello");
+
+// Object spread already handled this correctly - keep it passing alongside
+// the Object.assign fix (regression guard, not a new assertion about spread).
+const spreadTarget: any = { ...source };
+checks.push(typeof spreadTarget.types === "object");
+
+// A throwing getter must propagate as a catchable exception, not get
+// swallowed or crash the VM - the getter is invoked via vmInstance.Call from
+// native Go code, outside any bytecode frame's normal unwinding path.
+let threw = false;
+const throwSrc: any = {};
+Object.defineProperty(throwSrc, "boom", {
+  get() {
+    throw new Error("from getter");
+  },
+  enumerable: true,
+  configurable: true,
+});
+try {
+  Object.assign({}, throwSrc);
+} catch (e: any) {
+  threw = e.message === "from getter";
+}
+checks.push(threw);
+
+// Same for a throwing setter.
+let setterThrew = false;
+const throwDst: any = {};
+Object.defineProperty(throwDst, "boom", {
+  set(_v: any) {
+    throw new Error("from setter");
+  },
+  enumerable: true,
+  configurable: true,
+});
+try {
+  Object.assign(throwDst, { boom: 1 });
+} catch (e: any) {
+  setterThrew = e.message === "from setter";
+}
+checks.push(setterThrew);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Fixes #274 - `Object.assign` neither invoked a source's getter nor a target's setter; it copied every property as if it were a plain data slot regardless of the source's or target's actual accessor properties.

This is a third distinct `Object.assign` defect in this one builtin (after #168 and #254), all found via real npm package usage rather than by testing `Object.assign` directly.

## Root cause

Per spec, `Object.assign` copies each own enumerable source property via `[[Get]]` (which for an accessor property means calling the getter) and writes it onto the target via `[[Set]]` (which must invoke a setter the target already defines there).

`Object.assign`'s own copy loop read source properties with `plainObj.GetOwn(key)` - the raw data-slot read, which for an accessor property returns nothing meaningful (the value lives behind the getter/setter, not in the data slot underneath them) - and `setObjectAssignTargetProperty`'s `TypeObject` case wrote with a plain `SetOwn(key, value)`, with no accessor check at all.

Object spread (`OpObjectSpread`) already gets the source side right - it checks `GetOwnAccessor` and calls the getter. `Object.assign`'s separate Go-native implementation just never got the same treatment.

## Fix

- **Read side**: check `GetOwnAccessor` for each own enumerable source key (mirroring `OpObjectSpread`) and call the getter via `vmInstance.Call` if present.
- **Write side**: check the target's own `GetOwnAccessor` before falling back to `SetOwn`, and call the setter via `vmInstance.Call` if present - mirroring the same own-accessor check `vm.SetProperty` already makes for ordinary property assignment.

Both directions propagate a throwing getter/setter as a catchable exception via the native function's own `(Value, error)` return - the same convention `vm.SetProperty`'s callers already rely on.

### Non-goals (deliberately left alone)

- **Symbol-keyed source properties**: `Object.assign` already didn't copy them before this change, and `OpObjectSpread`'s symbol-key handling is a separate ~50-line path this fix doesn't touch. No repro, not in the issue.
- **Prototype-chain setter lookup on the target**: matches `vm.SetProperty`'s existing own-accessor-only check, not a spec-perfect `[[Set]]` walk up the chain.

## A bug in the fix, caught by the test

`GetOwnAccessor` returns `(getter, setter, enumerable, configurable, isAccessor)`. My first pass at the target-setter branch destructured that tuple as `(setter, _, _, _, isAccessor)` - swapped - so it silently read the *getter* (`Undefined`, since the test's accessor was set-only) instead of the setter, and the setter branch always took the "no setter, no-op" path. The setter-side assertion (`captured === 42`) is what caught this - concrete evidence the test earns its place rather than being decoration.

## Testing

- Both of the issue's repros now produce the correct output (matches real Node.js): the getter's return value is copied, and the setter is invoked with the assigned value.
- Added [`tests/scripts/issue274_object_assign_accessors.ts`](tests/scripts/issue274_object_assign_accessors.ts): source-getter read (including "called exactly once"), target-setter write (including that the setter's own decision to drop a value isn't overridden by a shadow data property), a getter's value flowing through a setter end-to-end, a regression guard that object spread still works, and a throwing getter/throwing setter each propagating as a catchable exception. Verified this test fails on the pre-fix binary (`false`, not a crash) and passes after the fix.
- `go test ./tests -run TestScripts` - all green.
- `go test ./...` - all green.
- Test262 `language/` and `built-ins/` compared pre-fix vs fixed binary (dumped and diffed, not just aggregate counts): `language/` identical; `built-ins/` gains exactly the two directly relevant tests (`built-ins/Object/assign/source-get-attr-error.js`, `built-ins/Object/assign/target-set-user-error.js`), zero regressions.