### PR TITLE
fix(compiler): destructuring-assignment targets now honor upvalue captures (#276)

### DIFF
--- a/pkg/compiler/compile_assignment.go
+++ b/pkg/compiler/compile_assignment.go
@@ -1364,6 +1364,7 @@ func (c *Compiler) compileArrayDestructuringAssignment(node *parser.ArrayDestruc
 
 			var baseReg, propReg Register = BadRegister, BadRegister
 			var identSymbol Symbol
+			var identDefiningTable *SymbolTable
 			var identFound bool
 			var isSimpleTarget bool
 
@@ -1371,7 +1372,7 @@ func (c *Compiler) compileArrayDestructuringAssignment(node *parser.ArrayDestruc
 			switch targetNode := element.Target.(type) {
 			case *parser.Identifier:
 				// Simple identifier - resolve now but don't assign yet
-				identSymbol, _, identFound = c.currentSymbolTable.Resolve(targetNode.Value)
+				identSymbol, identDefiningTable, identFound = c.currentSymbolTable.Resolve(targetNode.Value)
 				isSimpleTarget = true
 
 			case *parser.MemberExpression:
@@ -1433,6 +1434,13 @@ func (c *Compiler) compileArrayDestructuringAssignment(node *parser.ArrayDestruc
 							c.emitSetGlobal(identSymbol.GlobalIndex, restArrayReg, line)
 						} else if identSymbol.IsSpilled {
 							c.emitStoreSpill(identSymbol.SpillIndex, restArrayReg, line)
+						} else if identDefiningTable != c.currentSymbolTable && c.enclosing != nil &&
+							c.isDefinedInEnclosingCompiler(identDefiningTable) {
+							// Rest target captured from an enclosing function
+							// (#276) - see the identical comment in
+							// compileIdentifierAssignment.
+							upvalueIndex := c.addFreeSymbol(targetNode, &identSymbol)
+							c.emitSetUpvalue(upvalueIndex, restArrayReg, line)
 						} else {
 							if restArrayReg != identSymbol.Register {
 								c.emitMove(identSymbol.Register, restArrayReg, line)
@@ -1685,7 +1693,7 @@ func (c *Compiler) compileIdentifierAssignment(identTarget *parser.Identifier, v
 	}
 
 	// Resolve the identifier to determine how to store it
-	symbol, _, found := c.currentSymbolTable.Resolve(identTarget.Value)
+	symbol, definingTable, found := c.currentSymbolTable.Resolve(identTarget.Value)
 	if !found {
 		// Variable not found in any scope. In strict mode an unresolvable
 		// reference is a ReferenceError per ECMAScript spec; a name that already
@@ -1731,8 +1739,23 @@ func (c *Compiler) compileIdentifierAssignment(identTarget *parser.Identifier, v
 	} else if symbol.IsSpilled {
 		// For spilled variables, store to spill slot
 		c.emitStoreSpill(symbol.SpillIndex, valueReg, line)
+	} else if definingTable != c.currentSymbolTable && c.enclosing != nil && c.isDefinedInEnclosingCompiler(definingTable) {
+		// The variable is a free variable captured from an enclosing function
+		// (#276): symbol.Register is a register index in THAT function's own
+		// frame, not this one - writing it with a plain OpMove here would
+		// target an arbitrary register number this function's own register
+		// allocator never allocated or accounted for in its RegisterSize,
+		// silently corrupting whatever real local happens to sit at that
+		// index (or, if the number exceeds this function's RegisterSize
+		// entirely, panicking with "index out of range" the moment the VM
+		// tries to write it). Route through the same upvalue machinery
+		// compileAssignmentExpression uses for `x = value` on a captured
+		// variable: register it as a free symbol and store via OpSetUpvalue.
+		upvalueIndex := c.addFreeSymbol(identTarget, &symbol)
+		c.emitSetUpvalue(upvalueIndex, valueReg, line)
 	} else {
-		// For local variables, move to the allocated register
+		// For local variables (including an outer block scope of this same
+		// function), move to the allocated register.
 		if valueReg != symbol.Register {
 			c.emitMove(symbol.Register, valueReg, line)
 		}

--- a/pkg/compiler/compile_assignment_helpers.go
+++ b/pkg/compiler/compile_assignment_helpers.go
@@ -21,6 +21,13 @@ type DestructuringTargetRef struct {
 	SymbolName string
 	IsGlobal   bool
 	GlobalIdx  uint16
+	// IsUpvalue is true when Symbol was resolved from an ENCLOSING function's
+	// scope rather than this one (#276): Symbol.Register is then a register
+	// index in that other function's frame, meaningless as a register number
+	// here, so the assignment must go through UpvalueIndex/OpSetUpvalue
+	// instead of a raw move into Symbol.Register.
+	IsUpvalue    bool
+	UpvalueIndex uint16
 
 	// For MemberExpression targets (obj.prop)
 	ObjReg  Register // Pre-evaluated object
@@ -64,7 +71,7 @@ func (c *Compiler) compileDestructuringTargetRef(target parser.Expression, line 
 			}
 		}
 
-		symbol, _, found := c.currentSymbolTable.Resolve(targetNode.Value)
+		symbol, definingTable, found := c.currentSymbolTable.Resolve(targetNode.Value)
 		if !found {
 			// In strict mode an unresolvable reference is a ReferenceError; in
 			// non-strict mode it's an implicit global. A name that already has a
@@ -82,6 +89,20 @@ func (c *Compiler) compileDestructuringTargetRef(target parser.Expression, line 
 			ref.IsGlobal = symbol.IsGlobal
 			if symbol.IsGlobal {
 				ref.GlobalIdx = symbol.GlobalIndex
+			} else if !symbol.IsSpilled && definingTable != c.currentSymbolTable &&
+				c.enclosing != nil && c.isDefinedInEnclosingCompiler(definingTable) {
+				// The variable is a free variable captured from an enclosing
+				// function (#276). symbol.Register is a register index in
+				// THAT function's own frame - using it as a register number
+				// in this one (as the plain-local branch below would) either
+				// corrupts an unrelated local sharing that number here, or,
+				// if the number exceeds this function's own RegisterSize,
+				// panics the VM with a raw "index out of range" the moment
+				// it's written. Route through the same upvalue machinery
+				// compileAssignmentExpression uses for `x = value` against a
+				// captured variable.
+				ref.IsUpvalue = true
+				ref.UpvalueIndex = c.addFreeSymbol(targetNode, &symbol)
 			}
 		}
 		return ref, nil
@@ -179,6 +200,10 @@ func (c *Compiler) assignToDestructuringTargetRef(ref *DestructuringTargetRef, v
 				c.emitSetGlobal(ref.Symbol.GlobalIndex, valueReg, line)
 			} else if ref.Symbol.IsSpilled {
 				c.emitStoreSpill(ref.Symbol.SpillIndex, valueReg, line)
+			} else if ref.IsUpvalue {
+				// Captured from an enclosing function - see the identical
+				// comment in compileDestructuringTargetRef (#276).
+				c.emitSetUpvalue(ref.UpvalueIndex, valueReg, line)
 			} else {
 				if valueReg != ref.Symbol.Register {
 					c.emitMove(ref.Symbol.Register, valueReg, line)

--- a/pkg/compiler/compile_for_of_new.go
+++ b/pkg/compiler/compile_for_of_new.go
@@ -392,8 +392,17 @@ func (c *Compiler) compileForOfStatementLabeled(node *parser.ForOfStatement, lab
 			} else {
 				if symbolRef.IsGlobal {
 					c.emitSetGlobal(symbolRef.GlobalIndex, valueReg, node.Token.Line)
+				} else if !symbolRef.IsSpilled && definingTable != c.currentSymbolTable &&
+					c.enclosing != nil && c.isDefinedInEnclosingCompiler(definingTable) {
+					// `for (capturedVar of items)` where capturedVar belongs to
+					// an enclosing function (#276): symbolRef.Register is a
+					// register index in THAT function's frame, not this one -
+					// see the identical comment in compileIdentifierAssignment.
+					upvalueIndex := c.addFreeSymbol(target, &symbolRef)
+					c.emitSetUpvalue(upvalueIndex, valueReg, node.Token.Line)
+				} else if symbolRef.IsSpilled {
+					c.emitStoreSpill(symbolRef.SpillIndex, valueReg, node.Token.Line)
 				} else {
-					_ = definingTable
 					c.emitMove(symbolRef.Register, valueReg, node.Token.Line)
 				}
 			}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1500,6 +1500,35 @@ func (vm *VM) run() (status InterpretResult, resultValue Value) {
 			}
 			stack := debug.Stack()
 			fmt.Fprintf(os.Stderr, "[VM PANIC] recovered: %v\n%s", r, stack)
+			// #276: a panic shaped like "index out of range [N] with length M"
+			// here almost always means the CURRENT frame's register window
+			// (length M, always exactly its function's RegisterSize - see
+			// the allocation sites in call.go/async.go/vm.go, none of which
+			// ever pad or shrink it) is too small for the bytecode actually
+			// executing against it - i.e. a compiler register-count
+			// under-count for that specific function, not a VM bookkeeping
+			// bug. Dump the offending frame's identity so a future
+			// recurrence is immediately actionable instead of requiring a
+			// fresh multi-hour investigation like #276's own.
+			if vm.frameCount > 0 {
+				pf := &vm.frames[vm.frameCount-1]
+				fnName := "<unknown>"
+				var regSize, allocSize int
+				var isGen, isAsync bool
+				if pf.closure != nil && pf.closure.Fn != nil {
+					fnName = pf.closure.Fn.Name
+					regSize = pf.closure.Fn.RegisterSize
+					isGen = pf.closure.Fn.IsGenerator
+					isAsync = pf.closure.Fn.IsAsync
+				}
+				allocSize = pf.allocatedRegSize
+				fmt.Fprintf(os.Stderr,
+					"[VM PANIC] frame#%d func=%q RegisterSize=%d allocatedRegSize=%d ip=%d isGenerator=%v isAsync=%v generatorObj=%v promiseObj=%v\n",
+					vm.frameCount-1, fnName, regSize, allocSize, pf.ip, isGen, isAsync, pf.generatorObj != nil, pf.promiseObj != nil)
+				if pf.closure != nil && pf.closure.Fn != nil && pf.closure.Fn.Chunk != nil {
+					fmt.Fprintf(os.Stderr, "[VM PANIC] chunk disassembly:\n%s\n", pf.closure.Fn.Chunk.DisassembleChunk(fnName))
+				}
+			}
 			// vm.runtimeError() reads current frame/chunk state to attach a
 			// source position; if the panic itself corrupted that state,
 			// runtimeError could panic in turn. Guard against that so a
@@ -19329,6 +19358,26 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 		genObj.State = GeneratorCompleted
 		genObj.Done = true
 		genObj.Frame = nil
+		// Unlike this function's other early returns above, this path
+		// previously left vm.frameCount/vm.nextRegSlot untouched - a real
+		// leak, distinct from #276's register-undercount panic, flagged in
+		// #276's own investigation but not itself the cause of that crash
+		// (a leak displaces future allocations, it can't shrink a frame's
+		// own window). Left unreclaimed, the generator+sentinel frames this
+		// call pushed stay "allocated" forever from the VM's point of view,
+		// visible only as accumulating register-stack/frame-stack pressure
+		// under repeated failed .throw() calls. Mirror resumeGenerator's own
+		// error-path cleanup so this call leaves the stack exactly as it
+		// found it, matching every other return in this function.
+		if vm.frameCount > 0 {
+			vm.frameCount--
+			if vm.frameCount > 0 {
+				vm.nextRegSlot -= regSize
+			}
+		}
+		if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
+			vm.frameCount--
+		}
 		if vm.currentException != Null {
 			return Undefined, exceptionError{exception: vm.currentException}
 		}
@@ -19510,6 +19559,26 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 				status, result.ToString(), vm.currentException.ToString())
 		}
 		if status == InterpretRuntimeError {
+			// An error while running the finally/iterator-cleanup handler
+			// completes the generator (per resumeGeneratorWithException's
+			// identical handling) - this path previously left genObj.State
+			// as GeneratorExecuting forever and leaked the generator+sentinel
+			// frames this call pushed (same leak class as
+			// resumeGeneratorWithException's error path, see its comment;
+			// distinct from and not the cause of #276's register-undercount
+			// panic).
+			genObj.State = GeneratorCompleted
+			genObj.Done = true
+			genObj.Frame = nil
+			if vm.frameCount > 0 {
+				vm.frameCount--
+				if vm.frameCount > 0 {
+					vm.nextRegSlot -= regSize
+				}
+			}
+			if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
+				vm.frameCount--
+			}
 			// vm.run() returns the exception as the result value
 			if result != Null && result != Undefined {
 				if debugExceptions {

--- a/tests/scripts/issue276_destructure_upvalue_target.ts
+++ b/tests/scripts/issue276_destructure_upvalue_target.ts
@@ -1,0 +1,107 @@
+// expect: true
+// paserati#276: a destructuring-assignment target that resolves to a
+// variable captured (by reference) from an ENCLOSING function was compiled
+// as if it were a plain local register of the CURRENT function -
+// compileDestructuringTargetRef/assignToDestructuringTargetRef's identifier
+// case (and its siblings for `for (x of ...)` reassignment and rest-element
+// targets) only checked IsGlobal/IsSpilled, never whether the resolved
+// symbol actually belonged to this function's own register space. Writing
+// straight to that foreign register number either silently clobbered
+// whatever unrelated local of the CURRENT function happened to share that
+// number, or - if the number exceeded the current function's own
+// RegisterSize - crashed the VM outright with a raw
+// "index out of range [N] with length M" panic, no JS-visible error at all.
+//
+// This is #276's actual root cause: the panic's own call stack (three
+// levels of nested generator resumption, from Babel/gensync's config
+// loader) was purely incidental context around a call to an ordinary,
+// non-generator closure - not itself a generator/async bug. The minimal
+// repro below is extracted from the exact real-world function that
+// panicked (@babel/generator's comment-stripping helper, structurally
+// `list.forEach(node => { [node.a, out] = f(node.a, out); ... })`).
+const checks: boolean[] = [];
+
+// --- Case 1: plain identifier destructuring target from an enclosing scope ---
+function makeAccumulator(): (list: { v: number }[]) => number {
+  let total = 0;
+  function step(t: { v: number }): undefined {
+    // `total` is captured from `makeAccumulator`'s own frame, not a local of
+    // `step`. The array literal on the left mixes a member-expression target
+    // (t.v, local) with a plain-identifier target (total, captured) - the
+    // exact shape that panicked.
+    [t.v, total] = [t.v * 2, total + t.v];
+  }
+  return (list) => {
+    list.forEach(step);
+    return total;
+  };
+}
+const acc = makeAccumulator();
+checks.push(acc([{ v: 1 }, { v: 2 }, { v: 3 }]) === 6); // 1 + 2 + 3
+
+// --- Case 2: `for (capturedVar of items)` reassigning an enclosing local ---
+function makeLast(): (items: number[]) => number | undefined {
+  let last: number | undefined;
+  function run(items: number[]): void {
+    for (last of items) {
+      // body intentionally empty - just exercises the reassignment path
+    }
+  }
+  return (items) => {
+    run(items);
+    return last;
+  };
+}
+const lastOf = makeLast();
+checks.push(lastOf([10, 20, 30]) === 30);
+
+// --- Case 3: rest-element destructuring target from an enclosing scope ---
+function makeRestCollector(): (arr: number[]) => number[] | undefined {
+  let rest: number[] | undefined;
+  function run(arr: number[]): void {
+    let first: number;
+    [first, ...rest] = arr;
+  }
+  return (arr) => {
+    run(arr);
+    return rest;
+  };
+}
+const restOf = makeRestCollector();
+const restResult = restOf([1, 2, 3, 4]);
+checks.push(
+  restResult !== undefined &&
+    restResult.length === 3 &&
+    restResult[0] === 2
+);
+
+// --- Case 4: a default-value expression that itself reads the captured
+// target (exercises compileConditionalAssignmentWithTargetRef's read of
+// ref.Symbol through the same upvalue path the write above uses) ---
+function makeDefaultReader(): (list: { v: number }[]) => number {
+  let total = 0;
+  function step(t: { v: number }): undefined {
+    [t.v, total = total + 1] = [t.v * 2, undefined];
+  }
+  return (list) => {
+    list.forEach(step);
+    return total;
+  };
+}
+const defaultReader = makeDefaultReader();
+checks.push(defaultReader([{ v: 1 }, { v: 2 }]) === 2);
+
+// --- Case 5: the same captured variable read AND written within one
+// destructuring assignment (checks addFreeSymbol's dedup against whatever
+// index a separate read of the same upvalue already registered) ---
+function makeReadWriteSame(): number {
+  let r = 1;
+  function inner(a: { x: number }): number {
+    [a.x, r] = [r, r + 1];
+    return r;
+  }
+  return inner({ x: 0 });
+}
+checks.push(makeReadWriteSame() === 2);
+
+checks.every((c) => c);


### PR DESCRIPTION
## Summary

Fixes #276 - the raw Go `index out of range` VM panic reported three levels deep in nested generator resumption while running Babel's config/plugin loader (via gensync) through paserati.

**Root cause was not generator/async at all.** The generator-resumption frames in the original panic's Go stack trace were incidental context. The actually-panicking frame was an ordinary, non-generator, non-async closure whose compiled `RegisterSize` was smaller than a register index its own bytecode wrote to - confirmed directly by a new panic diagnostic (`isGenerator=false isAsync=false generatorObj=false`), added in the second commit here.

The real bug: several destructuring-assignment code paths resolved an identifier target with a plain `currentSymbolTable.Resolve()` and then emitted a raw `OpMove` straight into `resolvedSymbol.Register`, without checking whether that symbol actually belonged to the *current* function's own register space, or to an *enclosing* function's (i.e. a variable captured by reference as an upvalue). When the target was such a captured variable, `Register` was a register number from the enclosing function's frame - foreign to the current function's compiled `RegisterSize`. Writing it either silently corrupted an unrelated local sharing that register number, or, when the foreign number exceeded the current function's own `RegisterSize`, crashed the VM outright.

`compileAssignmentExpression` already has the correct pattern for plain `x = value` against a captured variable (check `isDefinedInEnclosingCompiler`, route through `addFreeSymbol` + `OpSetUpvalue`). It just never got ported to:
- `compileDestructuringTargetRef` / `assignToDestructuringTargetRef` (the shared iterator-protocol destructuring-assignment path, e.g. `[a.b, c] = someIterable`)
- `compileIdentifierAssignment` (nested destructuring targets, e.g. `[[a, b], c] = x`)
- `for (x of items)` reassignment of an existing binding
- rest-element destructuring-assignment targets (`[a, ...rest] = x`)

All four now check for the enclosing-scope case and emit `OpSetUpvalue` instead.

## Reproduction

The real `babel.cjs`/`jiti.cjs` bundles (from `jiti` 2.7.0, as in the original report) actually run through paserati's own compiler+VM with no CommonJS shim needed beyond stubbing a handful of Node builtins (`fs`, `path`, `os`, ...) - webpack's own bundled module system handles the rest. That let me reproduce the exact panic end-to-end, then use the new panic diagnostic to identify the offending function directly instead of guessing from a source position the panic handler's own comment already flags as unreliable.

The panicking function turned out to be `@babel/generator`'s comment-stripping helper (`extractComments`), structurally:
```js
list.forEach(node => {
  [node.a, out] = f(node.a, out);   // `out` captured from the enclosing function
  ...
});
```//
Extracted verbatim into [`tests/scripts/issue276_destructure_upvalue_target.ts`](tests/scripts/issue276_destructure_upvalue_target.ts), which:
- fails (wrong value, not a crash - this repro happens to land under the panic threshold, which is actually the more dangerous half of the bug: silent corruption with no visible error) before this fix
- passes after
- With the fix applied, the full real `babel.cjs` pipeline (shimmed as above) now transforms input successfully end-to-end, confirmed manually.

## Commits

1. **fix(compiler): destructuring-assignment targets now honor upvalue captures** - the actual fix + regression test.
2. **fix(vm): richer VM-panic diagnostics; reclaim leaked generator frames on error** - a separate, smaller VM fix that surfaced during the investigation:
   - `run()`'s panic recovery now dumps the panicking frame's identity (function name, `RegisterSize`, generator/async flags, disassembly) - this is what let #276 be pinned down instead of chased down the generator-resumption red herring.
   - `resumeGeneratorWithException`/`resumeGeneratorWithReturn`'s error paths previously leaked the generator+sentinel frames they pushed (and, for the latter, left the generator object stuck in `GeneratorExecuting` forever) instead of cleaning up like every other return in those functions. This is **not** #276's cause (a leak can't shrink an existing frame's window) but was a real, distinct bug worth closing alongside this investigation.

## Testing

- `go test ./...` - green
- `go test ./tests -run TestScripts` - green
- test262 diff against `baseline.txt`, scoped to `language`, `language/statements/for-of`, `language/expressions/assignment`, `built-ins/GeneratorPrototype`, `built-ins/AsyncGeneratorPrototype`, `language/statements/generators` - net `+0` in every scope (no regressions)
- New regression test `tests/scripts/issue276_destructure_upvalue_target.ts`, verified to fail before / pass after this fix

## For the issue thread

Worth noting on #276 itself: the reporter's negative-probe ledger was all `yield*`-chained generator nesting, while real gensync drives nested `.next()` calls via plain repeated calls from a non-generator loop (`evaluateSync`) - but more importantly, generator/async machinery was never actually implicated. The one-line diagnostic `isGenerator=false isAsync=false generatorObj=false` on the panicking frame is what redirected the investigation to the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)