### PR TITLE
fix(driver): native Go functions no longer panic on extra JS arguments (#278)

### DIFF
--- a/pkg/driver/issue_278_test.go
+++ b/pkg/driver/issue_278_test.go
@@ -1,0 +1,127 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// issue278Extname mirrors a real Node builtin like path.extname: a
+// fixed-arity, non-variadic Go function that only cares about its first
+// argument. Real JS callers routinely pass such a function around as a bare
+// value and invoke it from generic machinery that always supplies a fixed
+// argument count regardless of what the callee declares - the textbook case
+// being Array.prototype.forEach, which always calls back with exactly 3
+// arguments (element, index, array) per spec.
+func issue278Extname(name string) string {
+	for i := len(name) - 1; i >= 0; i-- {
+		if name[i] == '.' {
+			return name[i:]
+		}
+	}
+	return ""
+}
+
+type issue278Thing struct{ Value string }
+
+// newIssue278Thing only declares one parameter; called as a constructor
+// with more arguments than that (paserati#278's createClassConstructor
+// path) must silently ignore the extras, exactly like a plain Function.
+func newIssue278Thing(input string) (*issue278Thing, error) {
+	return &issue278Thing{Value: input}, nil
+}
+
+// Greet only declares one parameter; called as a bound method with more
+// arguments than that (paserati#278's createBoundMethod path) must silently
+// ignore the extras too.
+func (t *issue278Thing) Greet(suffix string) string {
+	return t.Value + suffix
+}
+
+// TestModuleFunctionExtraArgsIgnored covers paserati#278: goFunctionToVM's
+// non-variadic branch sized its reflect.Value argument slice to len(args) -
+// the number of arguments the JS caller passed - rather than to the Go
+// function's own declared arity, then only filled indices below that arity.
+// When a JS call site passed MORE arguments than the Go function declares,
+// the tail of that slice stayed as unset reflect.Value{} zero values and
+// reflect.Value.Call panicked outright ("too many input arguments") instead
+// of silently dropping the extras like real JS/Go interop should.
+func TestModuleFunctionExtraArgsIgnored(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue278mod", func(m *ModuleBuilder) {
+		m.Function("extname", issue278Extname)
+		m.Class("Thing", &issue278Thing{}, newIssue278Thing)
+	})
+
+	res, errs := p.RunString(`
+		import { extname, Thing } from "issue278mod";
+		const results = ["a.ts", "b.txt", "noext"].map(extname);
+
+		const t = new Thing("hi", "ignored1", "ignored2");
+		const greeted = t.greet("!", "ignored1", "ignored2");
+
+		JSON.stringify({ results, thingValue: t.Value, greeted });
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := res.ToString()
+	want := `{"results":[".ts",".txt",""],"thingValue":"hi","greeted":"hi!"}`
+	if got != want {
+		t.Fatalf("extra JS args to a fixed-arity Go function should be silently ignored: got %s, want %s", got, want)
+	}
+}
+
+// TestModuleFunctionForEachCallback is the exact repro from the issue: a
+// fixed-arity native module function passed directly as an
+// Array.prototype.forEach callback, which per spec always invokes it with
+// 3 arguments regardless of what the callback declares.
+func TestModuleFunctionForEachCallback(t *testing.T) {
+	p := NewPaserati()
+	p.DeclareModule("issue278mod2", func(m *ModuleBuilder) {
+		m.Function("extname", issue278Extname)
+	})
+
+	res, errs := p.RunString(`
+		import { extname } from "issue278mod2";
+		// The exact real-world shape from the issue: a fixed-arity native
+		// function passed directly as a bare callback, no wrapper -
+		// Array.prototype.map (like forEach) always calls back with 3
+		// arguments (element, index, array) regardless of what the callback
+		// declares.
+		JSON.stringify(["a.ts", "b.txt"].map(extname));
+	`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := res.ToString()
+	want := `[".ts",".txt"]`
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+// TestWrapGoFunctionExtraArgsIgnored covers the same overflow bug in
+// ValueConverter.wrapGoFunction (used when a plain Go function value is
+// converted via the reflection-based ValueConverter path rather than
+// ModuleBuilder.Function).
+func TestWrapGoFunctionExtraArgsIgnored(t *testing.T) {
+	vc := &ValueConverter{}
+	fnVal := vc.wrapGoFunction(issue278Extname)
+	if fnVal.Type() == vm.TypeUndefined {
+		t.Fatal("wrapGoFunction returned undefined for a valid function")
+	}
+
+	nf := fnVal.AsNativeFunction()
+	result, err := nf.Fn([]vm.Value{
+		vm.NewString("a.ts"),
+		vm.NewString("extra1"),
+		vm.NewString("extra2"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error calling with extra args: %v", err)
+	}
+	if got := result.ToString(); got != ".ts" {
+		t.Fatalf("got %q, want %q", got, ".ts")
+	}
+}

--- a/pkg/driver/native_module.go
+++ b/pkg/driver/native_module.go
@@ -346,12 +346,19 @@ func (m *ModuleBuilder) createClassConstructor(name string, goStruct interface{}
 	classPrototypeVal := vm.NewValueFromPlainObject(classPrototype)
 
 	constructorValue := vm.NewConstructorWithProps(constructorType.NumIn(), constructorType.IsVariadic(), name, func(args []vm.Value) (vm.Value, error) {
-		// Convert VM values to Go values for constructor call
-		goArgs := make([]reflect.Value, len(args))
-		for i, arg := range args {
-			if i < constructorType.NumIn() {
-				goArgs[i] = vmValueToReflectValue(arg, constructorType.In(i))
-			}
+		// Convert VM values to Go values for constructor call. Capped at
+		// constructorType.NumIn() (paserati#278): a non-variadic Go function
+		// called with MORE JS args than it declares (routine - e.g. any
+		// generic JS machinery that always calls back with a fixed argument
+		// count, regardless of what the callee actually wants) must have
+		// those extras silently dropped, matching real JS semantics. Sizing
+		// goArgs to len(args) and only filling indices < NumIn() left the
+		// tail as unset reflect.Value{} zero values and handed
+		// reflect.Value.Call a slice longer than the function's declared
+		// arity - which panics outright rather than ignoring the extras.
+		goArgs := make([]reflect.Value, 0, constructorType.NumIn())
+		for i := 0; i < len(args) && i < constructorType.NumIn(); i++ {
+			goArgs = append(goArgs, vmValueToReflectValue(args[i], constructorType.In(i)))
 		}
 
 		// Add missing arguments as zero values if constructor expects more
@@ -444,12 +451,12 @@ func (m *ModuleBuilder) createBoundMethod(methodFunc reflect.Value) vm.Value {
 	methodType := methodFunc.Type()
 
 	return vm.NewNativeFunction(methodType.NumIn(), methodType.IsVariadic(), "bound_method", func(args []vm.Value) (vm.Value, error) {
-		// Convert VM values to Go values for method call
-		goArgs := make([]reflect.Value, len(args))
-		for i, arg := range args {
-			if i < methodType.NumIn() {
-				goArgs[i] = vmValueToReflectValue(arg, methodType.In(i))
-			}
+		// Convert VM values to Go values for method call. Capped at
+		// methodType.NumIn() (paserati#278) - see the identical comment in
+		// createClassConstructor.
+		goArgs := make([]reflect.Value, 0, methodType.NumIn())
+		for i := 0; i < len(args) && i < methodType.NumIn(); i++ {
+			goArgs = append(goArgs, vmValueToReflectValue(args[i], methodType.In(i)))
 		}
 
 		// Add missing arguments as zero values if method expects more
@@ -679,12 +686,12 @@ func goFunctionToVM(fn interface{}) vm.Value {
 			return vm.Undefined, nil
 		}
 
-		// Non-variadic function handling (original code)
-		goArgs := make([]reflect.Value, len(args))
-		for i, arg := range args {
-			if i < fnType.NumIn() {
-				goArgs[i] = vmValueToReflectValue(arg, fnType.In(i))
-			}
+		// Non-variadic function handling (original code). Capped at
+		// fnType.NumIn() (paserati#278) - see the identical comment in
+		// createClassConstructor.
+		goArgs := make([]reflect.Value, 0, fnType.NumIn())
+		for i := 0; i < len(args) && i < fnType.NumIn(); i++ {
+			goArgs = append(goArgs, vmValueToReflectValue(args[i], fnType.In(i)))
 		}
 
 		// Add missing arguments as zero values if function expects more
@@ -1037,12 +1044,12 @@ func (vc *ValueConverter) wrapGoFunction(fn interface{}) vm.Value {
 	fnType := reflect.TypeOf(fn)
 
 	return vm.NewNativeFunction(fnType.NumIn(), fnType.IsVariadic(), "native_function", func(args []vm.Value) (vm.Value, error) {
-		// Convert VM values to Go values for input
-		goArgs := make([]reflect.Value, len(args))
-		for i, arg := range args {
-			if i < fnType.NumIn() {
-				goArgs[i] = vc.convertVMValueToReflectValue(arg, fnType.In(i))
-			}
+		// Convert VM values to Go values for input. Capped at fnType.NumIn()
+		// (paserati#278) - see the identical comment in
+		// createClassConstructor.
+		goArgs := make([]reflect.Value, 0, fnType.NumIn())
+		for i := 0; i < len(args) && i < fnType.NumIn(); i++ {
+			goArgs = append(goArgs, vc.convertVMValueToReflectValue(args[i], fnType.In(i)))
 		}
 
 		// Add missing arguments as zero values if function expects more


### PR DESCRIPTION
## Summary

Fixes #278 - `goFunctionToVM` (the bridge behind `ModuleBuilder.Function`, used by every embedder-declared native module function) panicked with a raw Go `reflect: Call with too many input arguments` instead of raising a catchable JS error whenever a JS call site passed *more* arguments than a non-variadic Go function declares.

This happens routinely any time a host-provided function is passed around as a plain value and invoked by generic JS machinery that always supplies a fixed argument count - the textbook case being `Array.prototype.forEach`/`map`, which always calls back with `(element, index, array)` per spec regardless of what the callback actually declares. Real Node handles this fine (`["a.ts","b.ts"].forEach(path.extname)` just works); paserati crashed.

## Root cause

`goFunctionToVM`'s non-variadic branch sized its `[]reflect.Value` argument slice to `len(args)` - the number of arguments the *JS caller* passed - rather than to the Go function's own declared arity (`fnType.NumIn()`), then only filled indices below that arity. When `len(args) > fnType.NumIn()`, the tail of the slice stayed as unset `reflect.Value{}` zero values, and `reflect.Value.Call` panicked outright instead of ignoring the extras.

The variadic branch right next to it already gets this right (bounds its fixed-parameter loop at `fnType.NumIn() - 1`); the fix ports that same cap to the non-variadic case.

**Three more sites had the identical bug**, found by grepping for the same `make([]reflect.Value, len(args))` pattern:
- `createClassConstructor` (a `Class` constructor called with too many args)
- `createBoundMethod` (a bound instance method called with too many args)
- `ValueConverter.wrapGoFunction` (a separate, non-`ModuleBuilder` reflection-based wrapping path)

All four are fixed the same way.

## Testing

- New regression tests in `pkg/driver/issue_278_test.go`, covering all four sites (module `Function`, `Class` constructor, bound method, and `wrapGoFunction`) - verified to reproduce the exact panic (or a caught VM "Internal VM Error") before this fix, and pass after
- `go test ./...` - green
- `go test ./tests -run TestScripts` - green
- test262 diff against `baseline.txt`, scoped to `built-ins/Array`: identical single pre-existing failure on both the pre- and post-fix binary (`S15.4_A1.1_T10.js`, passes standalone under `-pattern`, matching this repo's documented batch-mode flakiness) - not a regression, otherwise net `+0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)