### PR TITLE
fix(builtins): construct the promise capability instead of calling it

### DIFF
--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -445,7 +445,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Use the species constructor to create the result promise
 		if constructor.IsCallable() {
-			return vmInstance.Call(constructor, vm.Undefined, []vm.Value{executor})
+			return vmInstance.Construct(constructor, []vm.Value{executor})
 		}
 		return vmInstance.NewPromiseFromExecutor(executor)
 	}))
@@ -566,7 +566,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Use the species constructor to create the result promise
 		if constructor.IsCallable() {
-			return vmInstance.Call(constructor, vm.Undefined, []vm.Value{executor})
+			return vmInstance.Construct(constructor, []vm.Value{executor})
 		}
 		return vmInstance.NewPromiseFromExecutor(executor)
 	}))
@@ -713,7 +713,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Use the species constructor to create the result promise
 		if constructor.IsCallable() {
-			return vmInstance.Call(constructor, vm.Undefined, []vm.Value{executor})
+			return vmInstance.Construct(constructor, []vm.Value{executor})
 		}
 		return vmInstance.NewPromiseFromExecutor(executor)
 	}))
@@ -880,7 +880,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Use the species constructor to create the result promise
 		if constructor.IsCallable() {
-			return vmInstance.Call(constructor, vm.Undefined, []vm.Value{executor})
+			return vmInstance.Construct(constructor, []vm.Value{executor})
 		}
 		return vmInstance.NewPromiseFromExecutor(executor)
 	}))
@@ -930,7 +930,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		thisVal := vmInstance.GetThis()
 		constructor := getSpeciesConstructor(thisVal)
 		if constructor.IsCallable() {
-			return vmInstance.Call(constructor, vm.Undefined, []vm.Value{executor})
+			return vmInstance.Construct(constructor, []vm.Value{executor})
 		}
 		return vmInstance.NewPromiseFromExecutor(executor)
 	}))

--- a/tests/promise_capability_construct_test.go
+++ b/tests/promise_capability_construct_test.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/driver"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestPromiseCombinatorConstructsCapability guards NewPromiseCapability(C):
+// the combinators must CONSTRUCT the `this` constructor, not call it. Calling
+// it threw "Class constructor SubPromise cannot be invoked without 'new'", so
+// Promise.all/race/any/allSettled were unusable on a Promise subclass.
+//
+// Type checking is skipped because `class SubPromise extends Promise` is
+// rejected by the checker today ("superclass 'Promise' does not have a
+// constructor"), which is a separate gap; this test is about runtime semantics.
+//
+// Test262 does not catch this. Its tests for it - built-ins/Promise/{all,race,
+// any,allSettled,try}/ctx-ctor.js and the resolve-throws-iterator-return-*
+// family - abort on the throw, and the runner scores the aborted run as a pass.
+//
+// Only all and race are covered: Promise.any and Promise.allSettled return a
+// native promise for an empty iterable via an early return that never consults
+// the constructor, so they still answer `Promise` rather than the subclass.
+// That is a separate defect from Call-versus-Construct and is not fixed here.
+func TestPromiseCombinatorConstructsCapability(t *testing.T) {
+	for _, combinator := range []string{"all", "race"} {
+		t.Run(combinator, func(t *testing.T) {
+			code := `
+var callCount = 0;
+class SubPromise extends Promise {
+  constructor(executor) {
+    super(executor);
+    callCount += 1;
+  }
+}
+var out;
+try {
+  var r = Promise.` + combinator + `.call(SubPromise, []);
+  out = (r instanceof SubPromise) && callCount > 0 ? "constructed" : "wrong";
+} catch (e) {
+  out = "threw: " + e.message;
+}
+out;`
+			p := driver.NewPaserati()
+			p.SetSkipTypeCheck(true)
+			result, errs := p.RunString(code)
+			if len(errs) > 0 {
+				t.Fatalf("evaluation failed: %v", errs)
+			}
+			if !result.IsString() {
+				t.Fatalf("expected string result, got %s", result.TypeName())
+			}
+			if got := vm.AsString(result); got != "constructed" {
+				t.Errorf("Promise.%s.call(SubPromise, []) = %q, want %q", combinator, got, "constructed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
`NewPromiseCapability(C)` constructs `C`. The combinators called it, so any class used as the `this` of `Promise.all` / `race` / `any` / `allSettled` / `try` threw before doing any work:

```js
class S extends Promise { constructor(ex) { super(ex); } }

Promise.all([])                // ok
Promise.all.call(Promise, [])  // ok
Promise.all.call(S, [])        // TypeError: Class constructor S cannot be
                               // invoked without 'new'
Promise.resolve.call(S, 1)     // ok - resolve already constructed correctly
```

Five sites in `pkg/builtins/promise_init.go` passed the species constructor to `vmInstance.Call`. `vm.Construct` already existed at `pkg/vm/vm_init.go:1594` and is what the spec requires; this switches those five to it.

## Still broken, and deliberately not touched here

`Promise.any` and `Promise.allSettled` answer a native `Promise` rather than the subclass for an empty iterable, through a `length == 0` early return that never consults the constructor:

```
all         | ctor: S       | r instanceof S: true
race        | ctor: S       | r instanceof S: true
any         | ctor: Promise | r instanceof S: false
allSettled  | ctor: Promise | r instanceof S: false
```

That is a different mechanism from call-versus-construct and changing it means moving the empty-iterable rejection through the capability, so it belongs in its own change. The test covers `all` and `race` only.

## Why Test262 did not catch it

The tests that cover this are `built-ins/Promise/{all,race,any,allSettled,try}/ctx-ctor.js` and the `resolve-throws-iterator-return-*` family. The thrown `TypeError` aborts the script before any assertion runs, and the runner scores the aborted run as a pass.

Appending `throw new Error("REACHED_END")` to `built-ins/Promise/all/ctx-ctor.js` still reports pass on `main`; moving the same throw to just above the `Promise.all.call(...)` line reports fail. With this change the appended throw is reached, so the assertions run.

The visible consequence: `built-ins/Promise` reports **530 passing / 173 failing both before and after this fix**, because the suite was already counting those tests as passes. This is an instance of A1 in `docs/runtime-production-roadmap.md`, offered as a measurement rather than a claim.

## Verification

- New test `TestPromiseCombinatorConstructsCapability` fails before, passes after. It skips type checking, because `class S extends Promise` is currently rejected by the checker ("superclass 'Promise' does not have a constructor") — a separate gap, and this test is about runtime semantics.
- `go test ./...` green.
- Test262 `language`: 23,266 passing after against 23,260 before, no new failures.
