### PR TITLE
fix(compiler): reclaim block-scope registers in a fixed order

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1433,6 +1433,11 @@ func (c *Compiler) freeScopeRegisters(st *SymbolTable) {
 	if st == nil {
 		return
 	}
+	// Iterate in a fixed order. st.store is a map, so ranging it directly frees
+	// registers in Go's randomized map order; Free pushes onto a LIFO free list,
+	// so the next allocation pops whichever register happened to land last. That
+	// made one binary compile one input two different ways (nooga#50).
+	freeable := make([]Register, 0, len(st.store))
 	for _, sym := range st.store {
 		if sym.IsGlobal || sym.IsSpilled || sym.IsCallerLocal || sym.IsNamespaceProperty {
 			continue
@@ -1440,14 +1445,18 @@ func (c *Compiler) freeScopeRegisters(st *SymbolTable) {
 		if sym.Register == nilRegister {
 			continue
 		}
+		freeable = append(freeable, sym.Register)
+	}
+	sort.Slice(freeable, func(i, j int) bool { return freeable[i] < freeable[j] })
+	for _, reg := range freeable {
 		// Captured-by-reference registers must outlive the scope: an upvalue
 		// references the slot for the rest of the enclosing function.
-		if c.regAlloc.IsCaptured(sym.Register) {
+		if c.regAlloc.IsCaptured(reg) {
 			continue
 		}
 		// Drop the blanket pin applied at declaration, then reclaim the register.
-		c.regAlloc.Unpin(sym.Register)
-		c.regAlloc.Free(sym.Register)
+		c.regAlloc.Unpin(reg)
+		c.regAlloc.Free(reg)
 	}
 }
 

--- a/tests/compile_determinism_test.go
+++ b/tests/compile_determinism_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/driver"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// hashChunkDeep hashes a chunk's code together with every nested function
+// chunk reachable through its constants. Registers are allocated per function
+// body, so a top-level-only hash would miss where allocation actually varies.
+func hashChunkDeep(c *vm.Chunk) string {
+	h := sha256.New()
+	seen := map[*vm.Chunk]bool{}
+	var walk func(*vm.Chunk)
+	walk = func(ch *vm.Chunk) {
+		if ch == nil || seen[ch] {
+			return
+		}
+		seen[ch] = true
+		h.Write(ch.Code)
+		for _, k := range ch.Constants {
+			if k.Type() != vm.TypeFunction {
+				continue
+			}
+			if fn := k.AsFunction(); fn != nil {
+				walk(fn.Chunk)
+			}
+		}
+	}
+	walk(c)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Compiling one source must always produce the same bytecode. The block below
+// declares several locals that are reclaimed together at scope exit; the
+// order they are returned to the free list decides which register the next
+// temporary receives, so any order-dependence in scope-exit reclamation shows
+// up here as a second variant (nooga#50).
+func TestCompileIsDeterministic(t *testing.T) {
+	const src = `
+function f() {
+  { let a = 1; let b = 2; let c = 3; a + b + c; }
+  return 4 + 5;
+}
+f();
+`
+	const runs = 200
+	var want string
+	for i := 0; i < runs; i++ {
+		chunk, errs := driver.CompileString(src)
+		if len(errs) > 0 {
+			t.Fatalf("compile %d: %v", i, errs)
+		}
+		got := hashChunkDeep(chunk)
+		if i == 0 {
+			want = got
+			continue
+		}
+		if got != want {
+			t.Fatalf("compile %d produced different bytecode (%s) than compile 0 (%s)", i, got[:12], want[:12])
+		}
+	}
+}


### PR DESCRIPTION
Fixes #50.

`freeScopeRegisters` ranges over the scope's symbol map and frees each local's register as it goes. Go randomizes map iteration, `Free` pushes onto a LIFO free list, and the next allocation pops whichever register landed last, so one binary compiles one input several different ways. The variants are equivalent (a temporary lands in a different register), but they defeat bytecode hashing and make per-compile perf attribution noisy.

This collects the scope's freeable registers, sorts them, and unpins and frees in that order.

My earlier comments on #50 argued this change was unsafe because it moved test262 results and, on `0af3487d`, produced compiler panics. Neither holds. The moved tests were false passes (#280) and tests fixed upstream since, and the panics come from the test262 runner nilling the `Paserati` fields after a timeout while the test goroutine can still be inside `CompileProgram` (#281). Details on #50.

## Verification

- New `tests/compile_determinism_test.go` compiles a three-local block 200 times and requires one bytecode hash. It fails on main with three variants and passes here.
- test262 against `0af3487d`, same machine, sequential, `-timeout 0.2s`: `language` and `built-ins/{Promise,String,Object,Array,Function}` produce identical pass/fail sets before and after. `built-ins/RegExp` differs by two tests that sit on the timeout boundary and behave identically on both binaries when run alone.
- `go test ./...` green.
