### PR TITLE
fix(parser): destructuring-assignment RHS stops at comma, not swallows it (#283)

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -5419,8 +5419,17 @@ func (p *Parser) parseArrayDestructuringAssignment(arrayLit *ArrayLiteral) Expre
 	// Consume the '=' token (already checked in caller)
 	p.nextToken()
 
-	// Parse the right-hand side expression
-	destructure.Value = p.parseExpression(LOWEST)
+	// Parse the right-hand side expression at ARG_SEPARATOR precedence, not
+	// LOWEST (paserati#283): matching the plain-assignment path just above
+	// in parseAssignmentExpression, this must stop before a trailing comma
+	// operator - `[a, b] = c, d` is `([a, b] = c), d` (an assignment whose
+	// RHS is `c`, followed by `d`), not `[a, b] = (c, d)` (destructuring the
+	// *comma expression's* result). LOWEST let it swallow the comma and
+	// everything after it into the RHS, most visibly wrong when the
+	// destructuring assignment is itself the alternate of a ternary inside
+	// a comma expression (`cond ? x = y : [a, b] = c, d` miscompiled to
+	// destructure `(c, d)` instead of stopping the RHS at `c`).
+	destructure.Value = p.parseExpression(ARG_SEPARATOR)
 	if destructure.Value == nil {
 		p.addError(p.curToken, "expected expression after '=' in array destructuring assignment")
 		return nil
@@ -5570,8 +5579,10 @@ func (p *Parser) parseObjectDestructuringAssignment(objectLit *ObjectLiteral) Ex
 	// Consume the '=' token (already checked in caller)
 	p.nextToken()
 
-	// Parse the right-hand side expression
-	destructure.Value = p.parseExpression(LOWEST)
+	// Parse the right-hand side expression at ARG_SEPARATOR precedence, not
+	// LOWEST (paserati#283) - see the identical comment in
+	// parseArrayDestructuringAssignment.
+	destructure.Value = p.parseExpression(ARG_SEPARATOR)
 	if destructure.Value == nil {
 		p.addError(p.curToken, "expected expression after '=' in object destructuring assignment")
 		return nil

--- a/tests/scripts/issue283_ternary_comma_destructure.ts
+++ b/tests/scripts/issue283_ternary_comma_destructure.ts
@@ -1,0 +1,88 @@
+// expect: true
+// paserati#283: parseArrayDestructuringAssignment/parseObjectDestructuringAssignment
+// parsed their right-hand side at LOWEST precedence instead of ARG_SEPARATOR
+// (the same precedence parseAssignmentExpression's regular `x = value` path
+// already correctly uses right above it). LOWEST is below COMMA, so
+// `[a, b] = c, d` swallowed the comma operator into the destructuring's own
+// RHS - parsing as `[a, b] = (c, d)` (destructuring the comma expression's
+// *result*) instead of the correct `([a, b] = c), d` (an assignment whose
+// RHS is `c`, followed by a separate, discarded operand `d`).
+//
+// Most visibly wrong when the destructuring assignment is itself a
+// ternary's alternate branch, inside a comma expression - the exact shape
+// found in @babel/parser's own bundled `getParser`, whose miscompilation
+// under paserati silently emptied the enabled-plugin set for every
+// TypeScript-specific syntax family.
+const checks: boolean[] = [];
+
+// --- Case 1: exactly the reported shape - ternary alternate is an array
+// destructuring assignment, inside a comma expression ---
+// NOTE: the alternate branch below is DELIBERATELY left unparenthesized
+// (`[key, val] = item`, not `([key, val] = item)`) - wrapping it in parens
+// bounds its RHS parse at the closing paren regardless of the precedence
+// bug, which would silently stop exercising #283 at all.
+{
+  let key: any, val: any;
+  const item: any = ["typescript", {}];
+  "string" == typeof item ? key = item : [key, val] = item, 1;
+  checks.push(key === "typescript" && val && typeof val === "object");
+}
+
+// --- Case 2: the comma's second operand actually does something
+// observable (matches the issue's second, non-crashing variant) ---
+{
+  let key: any, val: any;
+  const seen = new Map<string, any>();
+  const item: any = ["typescript", {}];
+  "string" == typeof item
+    ? key = item
+    : [key, val] = item,
+    seen.has(key) || seen.set(key, val || {});
+  checks.push(
+    key === "typescript" &&
+      val &&
+      typeof val === "object" &&
+      seen.has("typescript")
+  );
+  // The source array must be left untouched.
+  checks.push(JSON.stringify(item) === '["typescript",{}]');
+}
+
+// --- Case 3: object destructuring assignment in the identical position ---
+{
+  let key: any, val: any;
+  const item: any = { key: "typescript", val: {} };
+  "string" == typeof item ? key = item : { key, val } = item, 1;
+  checks.push(key === "typescript" && val && typeof val === "object");
+}
+
+// --- Controls: each must still behave correctly, unchanged by the fix ---
+
+// A plain (non-destructuring) assignment must still stop its RHS at the
+// comma, exactly like before.
+{
+  let a: any;
+  a = 5, 10;
+  checks.push(a === 5);
+}
+
+// A parenthesized destructuring assignment as a comma operand (already
+// correct pre-fix - parens force LOWEST regardless of this precedence)
+// must keep working.
+{
+  let a: any, b: any;
+  const x = (([a, b] = [1, 2]), 99);
+  checks.push(a === 1 && b === 2 && x === 99);
+}
+
+// The ternary alone, with no comma-continuation, must still work.
+{
+  let key: any, val: any;
+  const item: any = ["typescript", {}];
+  "string" == typeof item ? (key = item) : ([key, val] = item);
+  checks.push(key === "typescript" && val && typeof val === "object");
+}
+
+// Guard against a check silently never running (e.g. a parse/compile error
+// swallowed earlier) making checks.every() pass vacuously on a short array.
+checks.length === 7 && checks.every((c) => c);


### PR DESCRIPTION
## Summary

Fixes #283 - `[a, b] = c, d` was miscompiled as `[a, b] = (c, d)` (destructuring the comma expression's *result*) instead of the correct `([a, b] = c), d` (an assignment whose RHS is `c`, followed by a separate, discarded operand `d`).

This is a **pure parser/precedence bug**, a different subsystem from #276 (a compiler/codegen defect) despite #283's own text drawing a structural parallel between them - worth being precise about for anyone bisecting later.

## Root cause

`parseArrayDestructuringAssignment` and `parseObjectDestructuringAssignment` (the `[a, b] = expr` / `{a, b} = expr` parse paths) parsed their right-hand side at `LOWEST` precedence - one level below `COMMA`. The regular assignment path (`x = value`) in `parseAssignmentExpression`, right above them in the same file, already gets this right: it parses its RHS at `ARG_SEPARATOR` (between `COMMA` and `ASSIGNMENT`) specifically so `x = value, other` parses as `(x = value), other`. The two destructuring-assignment paths just never got the same treatment.

Most visibly wrong when the destructuring assignment is itself a ternary's alternate branch, inside a comma expression - exactly the shape found verbatim in `@babel/parser`'s own bundled `getParser`:

```js
"string"==typeof t?e=t:[e,r]=t, n.has(e)||n.set(e,r||{})
```

With the RHS wrongly extended past the comma, `[e, r]` ended up destructuring `(t, n.has(e)||n.set(...))`'s *result* instead of `t` itself. One variant of this shape crashes outright (attempting `(1)[Symbol.iterator]` after the RHS collapses to a trailing literal); another silently produces wrong values with the source left unmutated. In the real bundle this silently emptied `getParser`'s enabled-plugin set on every call, so the TypeScript parser mixin was never applied - the reported blast radius was six independently-tested "each TS-specific syntax family fails to parse" symptoms (typed parameters, `let x: T`, arrow parameter types, `interface`, `type` aliases, `enum`, typed class fields), all one three-line precedence slip.

## Fix

Parse both destructuring-assignment RHS paths at `ARG_SEPARATOR`, matching the plain-assignment path exactly.

Checked for other sites with the same shape (`parseExpression(LOWEST)` used to parse an assignment RHS specifically) - the remaining `LOWEST` call sites in the parser are all statement-level or bounded-by-terminator contexts (return/throw/yield values, computed property keys, for-of/for-in expressions, class `extends` clauses) where `LOWEST` is the correct choice; these two were the only "destructuring-assignment RHS" sites.

Verified chained destructuring (`[a, b] = [c, d] = [1, 2]`) still parses right-associatively, unaffected by this change.

## Testing

- New regression test `tests/scripts/issue283_ternary_comma_destructure.ts`: the exact reported shape (both the crashing and the silently-wrong variants, array and object destructuring), plus controls confirming plain assignment, parenthesized destructuring-in-comma, and the bare ternary each still behave correctly. Verified to fail (compile errors) before this fix and pass after; each case individually checked against the pre-fix binary to confirm it actually exercises the bug (not vacuously passing via a check that never ran).
- `go test ./...` and `go test ./tests -run TestScripts` - green
- test262 diff against `baseline.txt`, full `language` suite and `built-ins`: net `+0` (the only difference in `built-ins` is the same pre-existing batch-mode-flaky test already documented from a previous PR, confirmed via a clean worktree checkout of the parent commit - not a regression from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)