### PR TITLE
fix(vm): preserve [[HomeObject]] across tail calls

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3877,6 +3877,18 @@ startExecution:
 							frame.thisValue = Undefined
 						}
 					}
+					// Set [[HomeObject]] for super property access (see prepareCall in call.go).
+					// Arrow functions use their captured [[HomeObject]] (frame.closure.CapturedHomeObject)
+					// at read time, so frame.homeObject itself doesn't need updating for them.
+					if !calleeFunc.IsArrowFunction {
+						if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
+							frame.homeObject = calleeFunc.HomeObject
+						} else if frame.thisValue.Type() != TypeUndefined && frame.thisValue.Type() != TypeNull {
+							frame.homeObject = frame.thisValue
+						} else {
+							frame.homeObject = Undefined
+						}
+					}
 					frame.isConstructorCall = false
 					frame.isDirectCall = false
 					frame.isSentinelFrame = false
@@ -4097,6 +4109,18 @@ startExecution:
 						frame.thisValue = calleeClosure.CapturedThis
 					} else {
 						frame.thisValue = thisVal // Method call: preserve 'this'
+					}
+					// Set [[HomeObject]] for super property access (see prepareCall in call.go).
+					// Arrow functions use their captured [[HomeObject]] (frame.closure.CapturedHomeObject)
+					// at read time, so frame.homeObject itself doesn't need updating for them.
+					if !calleeFunc.IsArrowFunction {
+						if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
+							frame.homeObject = calleeFunc.HomeObject
+						} else if thisVal.Type() != TypeUndefined && thisVal.Type() != TypeNull {
+							frame.homeObject = thisVal
+						} else {
+							frame.homeObject = Undefined
+						}
 					}
 					frame.isConstructorCall = false
 					frame.isDirectCall = false

--- a/tests/scripts/tco_tail_call_super_homeobject.ts
+++ b/tests/scripts/tco_tail_call_super_homeobject.ts
@@ -1,0 +1,17 @@
+// Regression test for issue #285: a method invoked via tail call (from a
+// non-method function) must retain its [[HomeObject]] so super.x still works.
+// expect: base-parse
+class Base {
+  parse(): string {
+    return "base-parse";
+  }
+}
+class Derived extends Base {
+  parse(): string {
+    return super.parse();
+  }
+}
+function run(p: Derived): string {
+  return p.parse(); // tail call position, but p.parse is not itself a method here
+}
+run(new Derived());


### PR DESCRIPTION
## Summary

Fixes #285: a method reached via TCO (tail call) lost its `[[HomeObject]]`, breaking `super.x`/`super.x()` inside it whenever the call site was in tail position relative to its own (non-method) enclosing function.

## Root cause

`OpTailCall` and `OpTailCallMethod` in `pkg/vm/vm.go` reuse the current stack frame for the callee, reassigning `frame.closure`, `frame.thisValue`, `frame.isConstructorCall`, etc. — but `frame.homeObject` was missing from that list. It kept whatever value the *caller's* frame had, so `super` property access inside the tail-called method resolved against the wrong object (or threw `"super keyword is only valid inside methods"` if the caller had none).

## Fix

In both tail-call opcodes, after setting `frame.thisValue`, also set `frame.homeObject` using the same rule already used for regular (non-tail) calls in `prepareCall` (`pkg/vm/call.go`):

- non-arrow callee with an explicit `HomeObject` → use it
- else fall back to `this`
- else `Undefined`
- arrow functions are left untouched, since `OpGetSuper`/`OpLoadSuper` read `frame.closure.CapturedHomeObject` for them, not `frame.homeObject`.

## Testing

- Both minimal repros from #285 (tail-called `super.parse()` call and plain `super.toString` read) now print the correct values, matching Node.
- Added `tests/scripts/tco_tail_call_super_homeobject.ts` — verified it fails on the pre-fix code (`super keyword is only valid inside methods`) and passes after the fix.
- `go test ./tests -run TestScripts` and `go test ./tests/...` are green.
- Spot-checked Test262 `language/statements/class` (98.7%) and `language/expressions/super` (98.9%) — unchanged from before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)