### PR TITLE
fix(parser): accept from, type, and satisfies as import binding names

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -3981,7 +3981,14 @@ func (p *Parser) curTokenIs(t lexer.TokenType) bool {
 // isContextualKeywordAsIdent checks if the current token is a contextual keyword
 // that can be used as an identifier (e.g., set, get, from, of, as, async, static, type)
 func (p *Parser) isContextualKeywordAsIdent() bool {
-	switch p.curToken.Type {
+	return isContextualKeywordType(p.curToken.Type)
+}
+
+// isContextualKeywordType reports whether t is a contextual keyword: reserved
+// in some grammar positions but a plain identifier everywhere else, including
+// as an import/export binding name.
+func isContextualKeywordType(t lexer.TokenType) bool {
+	switch t {
 	case lexer.SET, lexer.GET, lexer.FROM, lexer.OF, lexer.AS,
 		lexer.ASYNC, lexer.STATIC, lexer.TYPE, lexer.READONLY,
 		lexer.OVERRIDE, lexer.ABSTRACT, lexer.UNDEFINED, lexer.IS,
@@ -11124,9 +11131,9 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 			}
 
 			// Handle different import name patterns
-			if p.curToken.Type == lexer.IDENT || p.curToken.Type == lexer.SATISFIES {
-				// Regular identifier, or contextual keyword used as a binding name
-				// (semver exports `satisfies`).
+			if isImportBindingName(p.curToken.Type) {
+				// Regular identifier, or a contextual keyword used as a binding
+				// name (e.g. `{ from }`, `{ async as fn }`).
 				imported = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
 				importedToken = p.curToken
 			} else if p.curToken.Type == lexer.STRING {
@@ -11154,7 +11161,9 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 				p.nextToken() // consume 'as'
 
 				if !isImportBindingName(p.curToken.Type) {
-					p.peekError(lexer.IDENT)
+					// curToken (not peekToken) is the offending token here: the
+					// two nextToken() calls above already moved past 'as' onto it.
+					p.addErrorWithCode(p.curToken, errors.TS1003, "Identifier expected.")
 					return nil
 				}
 				local = &Identifier{Token: p.curToken, Value: p.curToken.Literal}
@@ -11190,10 +11199,10 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 				return specs
 			}
 
-			// Next specifier should be identifier, string, default, or type
-			if p.curToken.Type != lexer.IDENT && p.curToken.Type != lexer.STRING &&
-				p.curToken.Type != lexer.DEFAULT && p.curToken.Type != lexer.TYPE &&
-				p.curToken.Type != lexer.SATISFIES {
+			// Next specifier should be an identifier, contextual keyword, string,
+			// 'default', or 'type'.
+			if !isImportBindingName(p.curToken.Type) && p.curToken.Type != lexer.STRING &&
+				p.curToken.Type != lexer.DEFAULT {
 				p.addError(p.curToken, "Expected identifier, string literal, 'default', or 'type' in import specifier")
 				return nil
 			}
@@ -11215,11 +11224,12 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 }
 
 // isImportBindingName reports whether a token can name an import binding.
-// `from`, `type`, and `satisfies` are contextual keywords elsewhere but plain
-// identifiers in this position: `import from from "m"` binds the default
-// export as `from`.
+// Contextual keywords (`from`, `type`, `satisfies`, `async`, `get`, `set`,
+// `of`, `as`, `static`, `readonly`, `override`, `abstract`, `undefined`, `is`)
+// are plain identifiers in this position: `import from from "m"` binds the
+// default export as `from`, and likewise for the others.
 func isImportBindingName(t lexer.TokenType) bool {
-	return t == lexer.IDENT || t == lexer.FROM || t == lexer.TYPE || t == lexer.SATISFIES
+	return t == lexer.IDENT || isContextualKeywordType(t)
 }
 
 // parseExportDeclaration parses various export statement forms:

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -713,7 +713,11 @@ func (p *Parser) parseStatement() Statement {
 			// This is import(), parse as expression statement (dynamic import)
 			return p.parseExpressionStatement()
 		}
-		return p.parseImportDeclaration()
+		// A nil *ImportDeclaration must not escape as a non-nil Statement.
+		if decl := p.parseImportDeclaration(); decl != nil {
+			return decl
+		}
+		return nil
 	case lexer.EXPORT:
 		return p.parseExportDeclaration()
 	case lexer.LBRACE:
@@ -10894,8 +10898,9 @@ func (p *Parser) parseImportDeclaration() *ImportDeclaration {
 	// Move to the next token to see what kind of import this is
 	p.nextToken()
 
-	// Check for type-only import: import type { ... } from "module"
-	if p.curToken.Type == lexer.TYPE {
+	// Check for type-only import: import type { ... } from "module".
+	// `type` directly followed by `from` or `,` is a default binding named "type".
+	if p.curToken.Type == lexer.TYPE && p.peekToken.Type != lexer.FROM && p.peekToken.Type != lexer.COMMA {
 		stmt.IsTypeOnly = true
 		p.nextToken() // consume 'type' keyword
 	}
@@ -10940,7 +10945,7 @@ func (p *Parser) parseImportDeclaration() *ImportDeclaration {
 	var specifiers []ImportSpecifier
 
 	// Check for different import patterns
-	if p.curToken.Type == lexer.IDENT {
+	if isImportBindingName(p.curToken.Type) {
 		// Default import: import defaultName from "module"
 		// Or mixed: import defaultName, { named } from "module"
 		// Or mixed: import defaultName, * as name from "module"
@@ -11081,9 +11086,11 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 		if !p.expectPeek(lexer.AS) {
 			return nil
 		}
-		if !p.expectPeek(lexer.IDENT) {
+		if !isImportBindingName(p.peekToken.Type) {
+			p.peekError(lexer.IDENT)
 			return nil
 		}
+		p.nextToken()
 
 		namespaceSpec := &ImportNamespaceSpecifier{
 			Token: p.curToken,
@@ -11146,7 +11153,7 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 				p.nextToken() // consume imported name/string/default
 				p.nextToken() // consume 'as'
 
-				if p.curToken.Type != lexer.IDENT {
+				if !isImportBindingName(p.curToken.Type) {
 					p.peekError(lexer.IDENT)
 					return nil
 				}
@@ -11196,9 +11203,23 @@ func (p *Parser) parseImportSpecifierList() []ImportSpecifier {
 		if !p.expectPeek(lexer.RBRACE) {
 			return nil
 		}
+	} else {
+		// Without this, an unexpected token here returned nil with no error
+		// recorded, and the caller's nil *ImportDeclaration reached the
+		// module loader as a non-nil Statement and dereferenced.
+		p.addError(p.curToken, "Expected '{', '*', or an identifier after 'import'")
+		return nil
 	}
 
 	return specs
+}
+
+// isImportBindingName reports whether a token can name an import binding.
+// `from`, `type`, and `satisfies` are contextual keywords elsewhere but plain
+// identifiers in this position: `import from from "m"` binds the default
+// export as `from`.
+func isImportBindingName(t lexer.TokenType) bool {
+	return t == lexer.IDENT || t == lexer.FROM || t == lexer.TYPE || t == lexer.SATISFIES
 }
 
 // parseExportDeclaration parses various export statement forms:

--- a/tests/scripts/import_binding_contextual_keywords.ts
+++ b/tests/scripts/import_binding_contextual_keywords.ts
@@ -1,0 +1,19 @@
+// expect: dflt,dflt,dflt,dflt,dflt,dflt,namedFrom,namedFrom
+// skip-typecheck
+// isImportBindingName only special-cased `from`/`type`/`satisfies`, but any
+// contextual keyword (see isContextualKeywordAsIdent) is a legal import
+// binding name, not just those three: `async`, `get`, `set`, `of`, `static`,
+// and `readonly` as default-import names, and `from` as a named-import
+// shorthand and alias source, all used to fail with "Expected '{', '*', or
+// an identifier after 'import'" / "Expected identifier, string literal, or
+// 'default' in import specifier".
+import async from "./import_binding_contextual_keywords_helper.ts";
+import get from "./import_binding_contextual_keywords_helper.ts";
+import set from "./import_binding_contextual_keywords_helper.ts";
+import of from "./import_binding_contextual_keywords_helper.ts";
+import static from "./import_binding_contextual_keywords_helper.ts";
+import readonly from "./import_binding_contextual_keywords_helper.ts";
+import { from } from "./import_binding_contextual_keywords_helper.ts";
+import { from as fromAlias } from "./import_binding_contextual_keywords_helper.ts";
+
+[async, get, set, of, static, readonly, from, fromAlias].join(",");

--- a/tests/scripts/import_binding_contextual_keywords_helper.ts
+++ b/tests/scripts/import_binding_contextual_keywords_helper.ts
@@ -1,0 +1,3 @@
+// Helper for import_binding_contextual_keywords.ts; not a test on its own.
+export default "dflt";
+export const from = "namedFrom";

--- a/tests/scripts/import_binding_named_from.ts
+++ b/tests/scripts/import_binding_named_from.ts
@@ -1,0 +1,12 @@
+// expect: dflt,dflt,named,named
+// skip-typecheck
+// `from`, `type`, and `satisfies` are contextual keywords, so they are legal
+// import binding names. `import from from "m"` used to take a parser path that
+// returned a nil *ImportDeclaration without recording an error; the typed nil
+// reached the module loader as a non-nil Statement and was dereferenced
+// (test262 language/module-code/source-phase-import fixtures).
+import from from "./import_binding_named_from_helper.ts";
+import type from "./import_binding_named_from_helper.ts";
+import { named as satisfies } from "./import_binding_named_from_helper.ts";
+import * as ns from "./import_binding_named_from_helper.ts";
+[from, type, satisfies, ns.named].join(",");

--- a/tests/scripts/import_binding_named_from_helper.ts
+++ b/tests/scripts/import_binding_named_from_helper.ts
@@ -1,0 +1,3 @@
+// Helper for import_binding_named_from.ts; not a test on its own.
+export default "dflt";
+export const named = "named";


### PR DESCRIPTION
`import from from "./m.js"` crashes the CLI:

```
panic: runtime error: invalid memory address or nil pointer dereference
  driver.(*Paserati).preloadNativeModules
```

`from` is lexed as a keyword, so the default-binding branch of `parseImportDeclaration` did not match and the specifier-list parser fell through every case and returned nil without recording an error. The resulting nil `*ImportDeclaration` went into the `Statement` interface as a non-nil value, nothing stopped the pipeline, and the module loader dereferenced it. `import type from`, `import * as from`, and `import { a as from }` failed the same way or with "Identifier expected". All four are legal: `from`, `type`, and `satisfies` are contextual keywords, not reserved words.

Three changes:

- Accept those tokens wherever an import binding is named (default binding, namespace alias, named alias). `type` still starts a type-only import unless it is directly followed by `from` or `,`.
- Record an error when the specifier list starts with a token none of the branches handle, so a failed import parse always surfaces.
- Unwrap the nil at the statement dispatcher, so a nil `*ImportDeclaration` can never reach later stages as a non-nil `Statement`.

This is the last of the four recovered VM panics the `language` suite printed on every run: the `source-phase-import` fixtures use `import source from ...` and `import from from ...` as default bindings, and the loader panicked in `extractImportSpecs` on the typed nil.

## Verification

- New `tests/scripts/import_binding_named_from.ts` imports `from`, `type`, `satisfies`, and a namespace from a helper module. It fails on `main` and passes here.
- test262 on `67d90d68`: `language/module-code/source-phase-import/import-source.js` goes from fail to pass; the rest of `language` and `built-ins/Promise` are unchanged once batch timeouts are rerun alone.
- `go test ./...` green.
