### PR TITLE
fix(builtins): make fetch's Proxy and ResponseHeaderTimeout configurable

### DIFF
--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,25 @@ import (
 
 // Priority constant for fetch
 const PriorityFetch = 200 // After most builtins
+
+// FetchResponseHeaderTimeout bounds how long fetch() waits for response
+// headers to arrive before failing with a network error; it does not bound
+// reading the body afterward (see doFetchRequestWithContext). Defaults to
+// 30s. A host embedding this engine may set this (before any fetch() call -
+// it is read fresh per-request but not synchronized against concurrent
+// in-flight requests) to match its own configurable timeout, or to 0 to
+// disable the timeout entirely (#290).
+var FetchResponseHeaderTimeout = 30 * time.Second
+
+// FetchProxy selects the proxy to use for a given outbound fetch() request,
+// in the same shape as http.Transport.Proxy. Defaults to
+// http.ProxyFromEnvironment so the standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+// environment variables are respected without any host-side configuration -
+// http.Transport's own zero value leaves this nil, which silently makes
+// direct connections instead of erroring, so this default matters. A host
+// may override it (e.g. to force a specific proxy, or nil to disable
+// proxying) before any fetch() call (#290).
+var FetchProxy func(*http.Request) (*url.URL, error) = http.ProxyFromEnvironment
 
 type FetchInitializer struct{}
 
@@ -1227,7 +1247,8 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 	// longer than 30s and must not be killed mid-read (#205).
 	client := &http.Client{
 		Transport: &http.Transport{
-			ResponseHeaderTimeout: 30 * time.Second,
+			Proxy:                 FetchProxy,
+			ResponseHeaderTimeout: FetchResponseHeaderTimeout,
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) > 0 {

--- a/pkg/driver/fetch_transport_config_test.go
+++ b/pkg/driver/fetch_transport_config_test.go
@@ -1,0 +1,84 @@
+package driver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/nooga/paserati/pkg/builtins"
+)
+
+// TestFetchTransportDefaults is a guard against re-hardcoding the fetch
+// transport's configuration surface (#290): fetch()'s http.Transport used
+// to be built fresh per-request with Proxy left nil (so HTTP_PROXY/
+// HTTPS_PROXY were silently ignored) and ResponseHeaderTimeout hardcoded to
+// 30s with no way for a host to change it. builtins.FetchProxy/
+// FetchResponseHeaderTimeout are the fix's configuration seam; this just
+// checks their defaults didn't drift back to the broken shape.
+func TestFetchTransportDefaults(t *testing.T) {
+	if builtins.FetchProxy == nil {
+		t.Fatal("builtins.FetchProxy is nil by default; HTTP_PROXY/HTTPS_PROXY would be silently ignored (#290)")
+	}
+	if builtins.FetchResponseHeaderTimeout != 30*time.Second {
+		t.Fatalf("builtins.FetchResponseHeaderTimeout default = %v, want 30s", builtins.FetchResponseHeaderTimeout)
+	}
+}
+
+// TestFetchRespectsConfiguredProxy is the behavioral regression test for
+// #290's Proxy half: it points builtins.FetchProxy at a fixed httptest
+// server (standing in for what http.ProxyFromEnvironment would resolve
+// HTTP_PROXY to) and asserts a fetch() to a wholly different, unreachable
+// URL actually lands on the proxy - i.e. the request was routed through
+// the configured proxy rather than connecting directly (which would fail,
+// since the target host doesn't exist). Deliberately does not exercise
+// this via the HTTP_PROXY env var itself: http.ProxyFromEnvironment caches
+// its answer per-process behind a sync.Once, so a test-scoped env var
+// change can silently no-op depending on process history - testing the
+// FetchProxy seam directly is the reliable seam to assert against.
+func TestFetchRespectsConfiguredProxy(t *testing.T) {
+	var gotRequestURI string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequestURI = r.RequestURI
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("failed to parse proxy URL: %v", err)
+	}
+
+	prevProxy := builtins.FetchProxy
+	builtins.FetchProxy = func(*http.Request) (*url.URL, error) { return proxyURL, nil }
+	defer func() { builtins.FetchProxy = prevProxy }()
+
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	// This host does not exist; if the proxy weren't honored, the request
+	// would fail with a DNS/connection error instead of resolving ok.
+	script := `
+		async function run() {
+			const resp = await fetch("http://fetch-290-does-not-exist.invalid/some/path");
+			return { ok: resp.ok, status: resp.status };
+		}
+		await run();
+	`
+
+	resultVal, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed: %v (proxy not honored?)", errs[0])
+	}
+	result := resultVal.AsPlainObject()
+	okVal, _ := result.GetOwn("ok")
+	if !okVal.AsBoolean() {
+		t.Fatal("fetch() did not resolve ok; request was not routed through the configured proxy")
+	}
+
+	if gotRequestURI == "" {
+		t.Fatal("proxy never received a request; fetch() connected directly instead of using builtins.FetchProxy")
+	}
+}


### PR DESCRIPTION
Fixes #290

fetch()'s underlying `http.Transport` (built fresh per-request in `doFetchRequestWithContext`) had no `Proxy` field set and a hardcoded `ResponseHeaderTimeout: 30 * time.Second`, with no external way to configure either.

## Changes

- Added two package-level vars in `pkg/builtins` (`fetch_init.go`):
  - `FetchProxy func(*http.Request) (*url.URL, error)` — defaults to `http.ProxyFromEnvironment`, so `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` are now respected out of the box. Previously silently ignored: `http.Transport{}`'s zero value leaves `Proxy` nil, which means "connect directly," not "read the environment."
  - `FetchResponseHeaderTimeout` — defaults to `30 * time.Second` (unchanged behavior), now a variable a host can mutate before making requests instead of a hardcoded literal.
- `doFetchRequestWithContext`'s `http.Transport` construction reads both instead of hardcoding them.

This matches the fix shape suggested in the issue: a config surface a host embedding this engine can reach before/around a `fetch()` call.

## Scope note

The issue's real-world driver (`undici`'s `EnvHttpProxyAgent`) also configures a `bodyTimeout`. I did not add an equivalent — the existing `#205` comment right above this code explains the response body is intentionally left unbounded (an SSE stream must not be killed mid-read), so there's no existing "body timeout" concept to plumb a knob into. Flagging this explicitly rather than leaving it looking handled.

Also found a second, unrelated `http.Client` in `pkg/driver/builtin_modules.go` (a `paserati/http` module with its own `fetch`) with the same missing-Proxy issue, but it's dead code — `httpModule` is defined but never registered/called anywhere — so left untouched to avoid scope creep into unreachable code.

## Tests

Added `pkg/driver/fetch_transport_config_test.go`:
- `TestFetchTransportDefaults` — guards the defaults (`FetchProxy != nil`, timeout `== 30s`) against silently regressing back to the broken shape.
- `TestFetchRespectsConfiguredProxy` — behavioral test: points `FetchProxy` at an `httptest` server and fetches a nonexistent host, asserting the request actually lands on the proxy (would fail with a DNS error if not routed through it). Deliberately does not exercise this via the `HTTP_PROXY` env var itself, since `http.ProxyFromEnvironment` caches its answer per-process behind a `sync.Once`.

Verified: `go build ./...`, `go vet ./pkg/builtins/...`, `go test ./pkg/driver/...`, and the `TestScripts` smoke suite — all green.