### PR TITLE
fix(parser,vm,builtins): computed-field ASI bug (#292) + IterableToArray panic found investigating #293

### DIFF
--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -104,6 +104,25 @@ func promiseCapabilityGuard(vmInstance *vm.VM) func(execArgs []vm.Value) (vm.Val
 	}
 }
 
+// newAggregateError builds a real `new AggregateError(errors, message)` instance
+// (so callers get a genuine `.errors` array and `instanceof Error`/`AggregateError`,
+// per spec) by invoking the actual global constructor rather than faking one up
+// as a plain string. Promise.any's "all promises rejected" rejection (both the
+// empty-iterable case and the "all N settled as rejected" case) is the spec's
+// only built-in producer of AggregateError, and used to reject with a bare
+// string message with no `.errors` at all - see paserati#293, found via real
+// npm `undici` code that does `err instanceof AggregateError && err.errors.some(...)`.
+// Falls back to a plain Error if the global was somehow removed/shadowed, so
+// this can never itself throw.
+func newAggregateError(vmInstance *vm.VM, errors vm.Value, message string) vm.Value {
+	if ctor, ok := vmInstance.GetGlobal("AggregateError"); ok && ctor.IsCallable() {
+		if inst, err := vmInstance.Construct(ctor, []vm.Value{errors, vm.NewString(message)}); err == nil {
+			return inst
+		}
+	}
+	return vm.NewString(message)
+}
+
 func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 	vmInstance := ctx.VM
 
@@ -307,22 +326,46 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			iterable = args[0]
 		}
 
-		// Step 1-2: Let C be the this value. If Type(C) is not Object, throw TypeError.
+		// Step 1-2: Let C be the this value. NewPromiseCapability(C) (spec step
+		// 6-7, run before the iterable is even looked at) requires
+		// IsConstructor(C) and throws TypeError synchronously otherwise - a
+		// plain IsObject()/IsCallable() check lets a non-constructor callable
+		// like `eval` through, and this must throw here rather than surface
+		// later as a rejected promise (paserati#293 regression check:
+		// `Promise.all.call(eval)` used to throw synchronously only by
+		// accident, because converting the missing iterable argument failed
+		// too and *that* error path threw synchronously; now that iterable
+		// conversion failures correctly reject the promise instead - see
+		// IfAbruptRejectPromise below - this check needs to actually be here).
 		thisVal := vmInstance.GetThis()
-		if !thisVal.IsObject() && !thisVal.IsCallable() {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.all called on non-object")
+		if !vmInstance.IsConstructor(thisVal) {
+			return vm.Undefined, vmInstance.NewTypeError("Promise.all called on non-constructor")
 		}
 		constructor := getSpeciesConstructor(thisVal)
 
 		// Convert iterable to array (before promise creation per spec)
 		arr, err := vmInstance.IterableToArray(iterable)
 		if err != nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.all requires an iterable")
+			// Per spec (IfAbruptRejectPromise), a failure here - GetIterator
+			// throwing, iterator.next() throwing, or an ordinary getter access
+			// like result.value throwing mid-iteration - rejects the result
+			// promise with that failure's actual value; it must not escape as
+			// a synchronous throw out of Promise.all itself (paserati#293:
+			// IterableToArray now correctly propagates such errors instead of
+			// silently swallowing them, so this needs to actually honor
+			// IfAbruptRejectPromise instead of only handling "not iterable").
+			// vm.Call (inside IterableToArray) leaves vm.unwinding set on
+			// error for legitimate re-throw callers; absorbing that error
+			// into a rejection here instead means it must be cleared, or it
+			// leaks into whatever bytecode called this static method (see
+			// the matching invoke-then-error-close style handlers below).
+			vmInstance.ClearUnwindingState()
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, err)), nil
 		}
 
 		arrayObj := arr.AsArray()
 		if arrayObj == nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.all requires an iterable")
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, vmInstance.NewTypeError("Promise.all requires an iterable"))), nil
 		}
 
 		length := arrayObj.Length()
@@ -457,22 +500,33 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			iterable = args[0]
 		}
 
-		// Step 1-2: Let C be the this value. If Type(C) is not Object, throw TypeError.
+		// See the matching comment in Promise.all: NewPromiseCapability(C)
+		// requires IsConstructor(C), checked synchronously before the
+		// iterable is touched.
 		thisVal := vmInstance.GetThis()
-		if !thisVal.IsObject() && !thisVal.IsCallable() {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.race called on non-object")
+		if !vmInstance.IsConstructor(thisVal) {
+			return vm.Undefined, vmInstance.NewTypeError("Promise.race called on non-constructor")
 		}
 		constructor := getSpeciesConstructor(thisVal)
 
 		// Convert iterable to array
 		arr, err := vmInstance.IterableToArray(iterable)
 		if err != nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.race requires an iterable")
+			// See the matching comment in Promise.all: IfAbruptRejectPromise
+			// means this rejects the result promise with the real value,
+			// rather than throwing synchronously out of Promise.race itself.
+			// vm.Call (inside IterableToArray) leaves vm.unwinding set on
+			// error for legitimate re-throw callers; absorbing that error
+			// into a rejection here instead means it must be cleared, or it
+			// leaks into whatever bytecode called this static method (see
+			// the matching invoke-then-error-close style handlers below).
+			vmInstance.ClearUnwindingState()
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, err)), nil
 		}
 
 		arrayObj := arr.AsArray()
 		if arrayObj == nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.race requires an iterable")
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, vmInstance.NewTypeError("Promise.race requires an iterable"))), nil
 		}
 
 		length := arrayObj.Length()
@@ -578,30 +632,40 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			iterable = args[0]
 		}
 
-		// Step 1-2: Let C be the this value. If Type(C) is not Object, throw TypeError.
+		// See the matching comment in Promise.all: NewPromiseCapability(C)
+		// requires IsConstructor(C), checked synchronously before the
+		// iterable is touched.
 		thisVal := vmInstance.GetThis()
-		if !thisVal.IsObject() && !thisVal.IsCallable() {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.any called on non-object")
+		if !vmInstance.IsConstructor(thisVal) {
+			return vm.Undefined, vmInstance.NewTypeError("Promise.any called on non-constructor")
 		}
 		constructor := getSpeciesConstructor(thisVal)
 
 		// Convert iterable to array
 		arr, err := vmInstance.IterableToArray(iterable)
 		if err != nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.any requires an iterable")
+			// See the matching comment in Promise.all: IfAbruptRejectPromise
+			// means this rejects the result promise with the real value,
+			// rather than throwing synchronously out of Promise.any itself.
+			// vm.Call (inside IterableToArray) leaves vm.unwinding set on
+			// error for legitimate re-throw callers; absorbing that error
+			// into a rejection here instead means it must be cleared, or it
+			// leaks into whatever bytecode called this static method (see
+			// the matching invoke-then-error-close style handlers below).
+			vmInstance.ClearUnwindingState()
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, err)), nil
 		}
 
 		arrayObj := arr.AsArray()
 		if arrayObj == nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.any requires an iterable")
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, vmInstance.NewTypeError("Promise.any requires an iterable"))), nil
 		}
 
 		length := arrayObj.Length()
 		if length == 0 {
 			// Empty array - reject immediately with AggregateError
-			// TODO: Implement proper AggregateError
-			errorMsg := vm.NewString("AggregateError: All promises were rejected")
-			return vmInstance.NewRejectedPromise(errorMsg), nil
+			aggErr := newAggregateError(vmInstance, vm.NewArray(), "All promises were rejected")
+			return vmInstance.NewRejectedPromise(aggErr), nil
 		}
 
 		// Create a new promise that resolves with the first fulfilled promise
@@ -680,10 +744,9 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 					// If all promises rejected, reject with AggregateError
 					if remaining == 0 {
-						// TODO: Create proper AggregateError with errors array
-						// For now, just create a simple error message
-						errorMsg := vm.NewString("AggregateError: All promises were rejected")
-						_, _ = vmInstance.Call(reject, vm.Undefined, []vm.Value{errorMsg})
+						errorsArray := vmInstance.NewArrayFromSlice(errors)
+						aggErr := newAggregateError(vmInstance, errorsArray, "All promises were rejected")
+						_, _ = vmInstance.Call(reject, vm.Undefined, []vm.Value{aggErr})
 					}
 
 					return vm.Undefined, nil
@@ -725,22 +788,33 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			iterable = args[0]
 		}
 
-		// Step 1-2: Let C be the this value. If Type(C) is not Object, throw TypeError.
+		// See the matching comment in Promise.all: NewPromiseCapability(C)
+		// requires IsConstructor(C), checked synchronously before the
+		// iterable is touched.
 		thisVal := vmInstance.GetThis()
-		if !thisVal.IsObject() && !thisVal.IsCallable() {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.allSettled called on non-object")
+		if !vmInstance.IsConstructor(thisVal) {
+			return vm.Undefined, vmInstance.NewTypeError("Promise.allSettled called on non-constructor")
 		}
 		constructor := getSpeciesConstructor(thisVal)
 
 		// Convert iterable to array
 		arr, err := vmInstance.IterableToArray(iterable)
 		if err != nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.allSettled requires an iterable")
+			// See the matching comment in Promise.all: IfAbruptRejectPromise
+			// means this rejects the result promise with the real value,
+			// rather than throwing synchronously out of Promise.allSettled.
+			// vm.Call (inside IterableToArray) leaves vm.unwinding set on
+			// error for legitimate re-throw callers; absorbing that error
+			// into a rejection here instead means it must be cleared, or it
+			// leaks into whatever bytecode called this static method (see
+			// the matching invoke-then-error-close style handlers below).
+			vmInstance.ClearUnwindingState()
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, err)), nil
 		}
 
 		arrayObj := arr.AsArray()
 		if arrayObj == nil {
-			return vm.Undefined, vmInstance.NewTypeError("Promise.allSettled requires an iterable")
+			return vmInstance.NewRejectedPromise(exceptionValue(vmInstance, vmInstance.NewTypeError("Promise.allSettled requires an iterable"))), nil
 		}
 
 		length := arrayObj.Length()

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -740,6 +740,15 @@ type ArrowFunctionLiteral struct {
 	RestParameter        *RestParameter   // Optional rest parameter (...args)
 	ReturnTypeAnnotation Expression       // << MODIFIED
 	Body                 Node             // Can be Expression or *BlockStatement
+	// Parenthesized is true when this arrow function was wrapped in its own
+	// parens, e.g. `((x) => {})`. An ArrowFunction is not a MemberExpression/
+	// LeftHandSideExpression, so `.`, `?.`, `[`, `(`, and tagged templates
+	// cannot apply directly to it (`(x) => {}[0]` is a syntax error in real
+	// engines - see PrefixParseFns' parseInfixContinuation) unless it was
+	// parenthesized first (`((x) => {})[0]` is fine). Mirrors
+	// PrefixExpression.Parenthesized, which exists for the same reason
+	// ((-x) ** y vs -x ** y).
+	Parenthesized bool
 }
 
 func (afl *ArrowFunctionLiteral) expressionNode()      {}

--- a/pkg/parser/parse_class.go
+++ b/pkg/parser/parse_class.go
@@ -1546,24 +1546,43 @@ func (p *Parser) parseComputedProperty(bracketToken *lexer.Token, keyExpr Expres
 		// This allows chained assignments like: x = obj['lol'] = 42
 		initializer = p.parseExpression(COMMA)
 
-		// Consume optional semicolon after initializer
+		// After parseExpression, curToken is at the last token of the
+		// initializer. Handle ASI: consume an explicit semicolon and move
+		// past it, or - if there isn't one - just advance past the
+		// initializer's last token to reach the next class member.
+		//
+		// This used to skip that advance whenever curToken was already a
+		// '}', on the theory that it must be the class body's own closing
+		// brace. But a '}' ending the *initializer* itself (an arrow
+		// function's block body, an object literal, ...) is exactly as
+		// likely, and stopping there mistook that inner brace for the
+		// class's, making parseClassBody return early right after this
+		// member (paserati#292: `[k1] = (x) => { return x }` followed by
+		// another computed member `[k2] () {}` on the next line - the
+		// generic Pratt loop no longer swallows `[k2]` into the arrow
+		// function once it isn't parenthesized, per the ArrowFunctionLiteral
+		// check in parseInfixContinuation, but this advance still needs to
+		// step past the arrow's own closing brace to reach `[k2]`).
+		// parseProperty (the non-computed sibling of this function) never
+		// had this special case and doesn't need it either.
 		if p.peekTokenIs(lexer.SEMICOLON) {
 			p.nextToken() // Move to semicolon
-		}
-
-		// Advance past the current token to prepare for the next class member
-		// parseExpression leaves us AT the last token, so we need to advance
-		if !p.curTokenIs(lexer.RBRACE) && !p.curTokenIs(lexer.EOF) {
+			p.nextToken() // Move past semicolon to next class member
+		} else {
 			p.nextToken()
 		}
 	} else {
-		// No initializer - we're still at the ']' token from parseComputedClassMember
-		// We need to advance to the next token
+		// No initializer - curToken is at the last token of the member so
+		// far: the ']' from parseComputedClassMember, or - if there was a
+		// type annotation - that type's own last token, which can just as
+		// easily be a '}' (an object type literal, e.g. `[k1]: { a: number }`)
+		// as the earlier initializer case above, and for the exact same
+		// reason must not be special-cased as "must be the class body's
+		// closing brace".
 		if p.peekTokenIs(lexer.SEMICOLON) {
 			p.nextToken() // Move to semicolon
-		}
-		// Advance past current token (either ']' or ';') to next member
-		if !p.curTokenIs(lexer.RBRACE) && !p.curTokenIs(lexer.EOF) {
+			p.nextToken() // Move past semicolon to next class member
+		} else {
 			p.nextToken()
 		}
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2032,6 +2032,24 @@ func (p *Parser) parseInfixContinuation(leftExp Expression, precedence int) Expr
 			break
 		}
 
+		// An (unparenthesized) ArrowFunction is not a MemberExpression or
+		// LeftHandSideExpression, so `.`, `?.`, `[`, `(`, and tagged templates
+		// cannot continue it directly - real engines reject `(x) => {}[0]`
+		// even with no line terminator in between (paserati#292, found via a
+		// computed class field whose arrow-function initializer, with no
+		// trailing semicolon, was followed by another computed member:
+		// `[k1] = (x) => {}\n[k2]() {}` - without this check the Pratt climb
+		// happily kept consuming `[k2]` and `()` as if they were postfix
+		// operators on the arrow function, swallowing the next class member).
+		// `((x) => {})[0]` is fine - parseGroupedExpression marks that case
+		// Parenthesized.
+		if arrow, ok := leftExp.(*ArrowFunctionLiteral); ok && !arrow.Parenthesized {
+			switch p.peekToken.Type {
+			case lexer.DOT, lexer.OPTIONAL_CHAINING, lexer.LBRACKET, lexer.LPAREN, lexer.TEMPLATE_START:
+				return leftExp
+			}
+		}
+
 		infix := p.infixParseFns[p.peekToken.Type]
 		if infix == nil {
 			debugPrint("parseExpression(prec=%d): no infix for peek='%s', returning leftExp=%T", precedence, leftExp, p.peekToken.Literal, leftExp)
@@ -4679,6 +4697,13 @@ func (p *Parser) parseGroupedExpression() Expression {
 	// (-x) ** y (valid) from -x ** y (syntax error per ES2016)
 	if prefix, ok := exp.(*PrefixExpression); ok {
 		prefix.Parenthesized = true
+	}
+	// Mark arrow functions as parenthesized so parseInfixContinuation can tell
+	// `((x) => {})[0]` (valid) apart from a bare `(x) => {}` immediately
+	// followed by `[`/`.`/`(` etc., which real engines reject because
+	// ArrowFunction is not a LeftHandSideExpression - see paserati#292.
+	if arrow, ok := exp.(*ArrowFunctionLiteral); ok {
+		arrow.Parenthesized = true
 	}
 	return exp
 }

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -480,130 +480,155 @@ func (vm *VM) PromiseThen(thisPromise Value, onFulfilled, onRejected Value) (Val
 	return vm.NewPromiseFromExecutor(executor)
 }
 
-// IterableToArray converts an iterable value to an array
-// Supports arrays directly and any object with Symbol.iterator
+// maxIterableToArrayIterations bounds how many elements IterableToArray pulls
+// from a custom (Generator or arbitrary Symbol.iterator) iterable before
+// giving up. Promise.all/allSettled/any/race all eagerly materialize their
+// argument into an array up front, unlike the spec's PerformPromiseAll et al,
+// which interleave iteration with per-element resolution - so an iterable
+// that never reports done hangs the VM forever converting it, rather than
+// getting the chance to fail fast the way a real interleaved implementation
+// would (a handful of Test262 tests pair a never-done iterator with a
+// same-tick `resolve()`/`.then()` that throws immediately, expecting exactly
+// that fast, bounded failure). extractSpreadArguments has no such cap, and
+// must not gain one here - `[...infiniteIterator]` genuinely never
+// terminates in real engines either, and that's the correct, spec-mandated
+// behavior for spread.
+const maxIterableToArrayIterations = 10000
+
+// IterableToArray converts an iterable value to an array.
+// Supports arrays directly, plus anything else the iterator protocol covers.
+//
+// This used to hand-roll its own Symbol.iterator lookup and next()/done/value
+// walk, guarding every step with `value.IsObject()` before unconditionally
+// calling `.AsPlainObject()`. IsObject() is true for the whole object-ish
+// span of ValueTypes (TypeObject..TypeProxy), not just TypeObject, so any
+// iterable that wasn't a plain object - a generator (Generator[Symbol.iterator]()
+// returns itself, a TypeGenerator value, not TypeObject), a Set, a Map, ...
+// - made AsPlainObject() panic with "value is not an object" (paserati#293,
+// hit via `new AggregateError(someGenerator)`; the same call chain is shared
+// by Promise.all/allSettled/any/race).
+//
+// Types that are inherently finite (String/Arguments/Set/Map - Array is
+// handled directly above) delegate to extractSpreadArguments, which already
+// implements the iterator protocol correctly for them. Generator and
+// everything else fall through to iterateBounded below instead, since those
+// can be infinite and this function - unlike `...spread` - needs a cap (see
+// maxIterableToArrayIterations).
 func (vm *VM) IterableToArray(value Value) (Value, error) {
 	// If it's already an array, return it
 	if value.Type() == TypeArray {
 		return value, nil
 	}
 
-	// Try to get Symbol.iterator
-	if vm.SymbolIterator.Type() == TypeUndefined {
-		return Undefined, fmt.Errorf("value is not iterable")
-	}
-
-	// Get value[Symbol.iterator]
-	var iteratorMethod Value
-	if value.IsObject() {
-		// Try to get the Symbol.iterator property using the symbol key
-		obj := value.AsPlainObject()
-		if obj != nil {
-			if method, exists := obj.GetOwnByKey(NewSymbolKey(vm.SymbolIterator)); exists {
-				iteratorMethod = method
-			}
+	switch value.Type() {
+	case TypeString, TypeArguments, TypeSet, TypeMap:
+		elements, err := vm.extractSpreadArguments(value)
+		if err != nil {
+			return Undefined, err
 		}
-		// DictObjects don't support symbol keys, so skip them
+		return vm.NewArrayFromSlice(elements), nil
+	default:
+		return vm.iterableToArrayBounded(value)
+	}
+}
+
+// iterableToArrayBounded implements the generic ES6 iterator protocol
+// (Symbol.iterator lookup walked across the TypeObject/TypeGenerator/
+// TypeAsyncGenerator/TypeDictObject prototype chain, exactly like
+// extractSpreadArguments's own default case) capped at
+// maxIterableToArrayIterations calls to next().
+func (vm *VM) iterableToArrayBounded(value Value) (Value, error) {
+	if vm.SymbolIterator.Type() == TypeUndefined {
+		return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
 	}
 
-	// If no iterator method found, it's not iterable
-	if iteratorMethod.Type() == TypeUndefined || !iteratorMethod.IsCallable() {
-		return Undefined, fmt.Errorf("value is not iterable")
+	iteratorMethod := Undefined
+	found := false
+	iterKey := NewSymbolKey(vm.SymbolIterator)
+	current := value
+
+	for current.Type() != TypeNull && current.Type() != TypeUndefined {
+		switch current.Type() {
+		case TypeObject:
+			obj := current.AsPlainObject()
+			if g, _, _, _, ok := obj.GetOwnAccessorByKey(iterKey); ok && g.Type() != TypeUndefined {
+				res, err := vm.Call(g, value, nil)
+				if err != nil {
+					return Undefined, err
+				}
+				iteratorMethod = res
+				found = true
+			} else if val, ok := obj.GetOwnByKey(iterKey); ok {
+				iteratorMethod = val
+				found = true
+			} else {
+				current = obj.prototype
+				continue
+			}
+		case TypeGenerator:
+			genObj := current.AsGenerator()
+			if genObj.Prototype == nil {
+				return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
+			}
+			current = NewValueFromPlainObject(genObj.Prototype)
+			continue
+		case TypeAsyncGenerator:
+			genObj := current.AsAsyncGenerator()
+			if genObj.Prototype == nil {
+				return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
+			}
+			current = NewValueFromPlainObject(genObj.Prototype)
+			continue
+		case TypeDictObject:
+			// DictObjects don't support symbol keys, so there's nothing to
+			// find on this link - just keep walking its prototype.
+			current = current.AsDictObject().prototype
+			continue
+		default:
+			return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
+		}
+		break
 	}
 
-	// Call the iterator method to get the iterator object
+	if !found || !iteratorMethod.IsCallable() {
+		return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
+	}
+
 	iteratorObj, err := vm.Call(iteratorMethod, value, []Value{})
 	if err != nil {
 		return Undefined, err
 	}
 
-	// Get the next method
-	var nextMethod Value
-	if iteratorObj.IsObject() {
-		obj := iteratorObj.AsPlainObject()
-		if obj != nil {
-			if next, exists := obj.GetOwn("next"); exists {
-				nextMethod = next
-			}
-		} else if iteratorObj.Type() == TypeDictObject {
-			dictObj := iteratorObj.AsDictObject()
-			if next, exists := dictObj.GetOwn("next"); exists {
-				nextMethod = next
-			}
-		}
+	nextMethod, err := vm.GetProperty(iteratorObj, "next")
+	if err != nil {
+		return Undefined, err
 	}
-
 	if !nextMethod.IsCallable() {
-		return Undefined, fmt.Errorf("iterator does not have a next method")
+		return Undefined, vm.NewTypeError("iterator does not have a next method")
 	}
 
-	// Collect all values from the iterator
 	var elements []Value
-	maxIterations := 10000 // Safety limit
-	for i := 0; i < maxIterations; i++ {
-		// Call next()
+	for i := 0; i < maxIterableToArrayIterations; i++ {
 		result, err := vm.Call(nextMethod, iteratorObj, []Value{})
 		if err != nil {
 			return Undefined, err
 		}
 
-		// Get result.done
-		var done Value = Undefined
-		if result.IsObject() {
-			obj := result.AsPlainObject()
-			if obj != nil {
-				if d, exists := obj.GetOwn("done"); exists {
-					done = d
-				}
-			} else if result.Type() == TypeDictObject {
-				dictObj := result.AsDictObject()
-				if d, exists := dictObj.GetOwn("done"); exists {
-					done = d
-				}
-			}
+		done, err := vm.GetProperty(result, "done")
+		if err != nil {
+			return Undefined, err
 		}
-
-		// Check if done is truthy (JavaScript semantics)
-		// Falsy: false, 0, "", null, undefined
-		// Everything else is truthy
-		isDone := false
-		if done.Type() == TypeBoolean {
-			isDone = done.AsBoolean()
-		} else if done.IsNumber() {
-			isDone = done.ToFloat() != 0
-		} else if done.Type() == TypeString {
-			isDone = done.ToString() != ""
-		} else if done.Type() == TypeNull || done.Type() == TypeUndefined {
-			isDone = false
-		} else {
-			// Objects, arrays, functions etc. are truthy
-			isDone = true
-		}
-
-		if isDone {
+		if done.IsTruthy() {
 			break
 		}
 
-		// Get result.value
-		var itemValue Value = Undefined
-		if result.IsObject() {
-			obj := result.AsPlainObject()
-			if obj != nil {
-				if v, exists := obj.GetOwn("value"); exists {
-					itemValue = v
-				}
-			} else if result.Type() == TypeDictObject {
-				dictObj := result.AsDictObject()
-				if v, exists := dictObj.GetOwn("value"); exists {
-					itemValue = v
-				}
-			}
+		itemValue, err := vm.GetProperty(result, "value")
+		if err != nil {
+			return Undefined, err
 		}
-
 		elements = append(elements, itemValue)
 	}
 
-	// Create array from collected elements
 	return vm.NewArrayFromSlice(elements), nil
 }
 

--- a/tests/scripts/aggregate_error_generator_iterable.ts
+++ b/tests/scripts/aggregate_error_generator_iterable.ts
@@ -1,0 +1,13 @@
+// expect: 2 multiple failures true
+// Regression test for paserati#293: `new AggregateError(iterable, message)` used
+// to panic ("value is not an object") whenever the `errors` argument was an
+// iterable that wasn't a plain array or object - e.g. a generator, whose
+// Symbol.iterator returns itself (a Generator value, not a plain Object).
+// IterableToArray unconditionally called AsPlainObject() after only checking
+// the much broader IsObject(), which also matches Generator/Set/Map/etc.
+function* gen() {
+  yield new Error("a");
+  yield new Error("b");
+}
+const e = new AggregateError(gen(), "multiple failures");
+`${e.errors.length} ${e.message} ${e instanceof Error}`;

--- a/tests/scripts/arrow_function_parenthesized_postfix.ts
+++ b/tests/scripts/arrow_function_parenthesized_postfix.ts
@@ -1,0 +1,12 @@
+// expect: 3
+// An ArrowFunction is not a MemberExpression/LeftHandSideExpression, so `.`,
+// `[`, `(`, etc. cannot apply to it directly - see
+// class_computed_field_arrow_asi.ts for the paserati#292 bug this guards
+// against. But once it's wrapped in its own parens, it's an ordinary
+// PrimaryExpression again and postfix operators must keep working on it:
+// `((x) => [x])(3)[0]` is valid, unambiguous JS with or without a newline in
+// between. This is the positive counterpart that exercises
+// ArrowFunctionLiteral.Parenthesized (parseGroupedExpression sets it,
+// parseInfixContinuation's restriction checks it) - without it, the guard
+// added for #292 would also wrongly reject this.
+((x) => [x])(3)[0];

--- a/tests/scripts/class_computed_field_arrow_asi.ts
+++ b/tests/scripts/class_computed_field_arrow_asi.ts
@@ -1,0 +1,29 @@
+// expect: 5 1
+// Regression test for paserati#292: a computed class field whose initializer
+// is an arrow function with a block body, with no explicit trailing
+// semicolon, was not correctly terminated by ASI when the very next class
+// member also had a computed key - e.g.
+//   [k1] = (x) => { return x }
+//   [k2] () { ... }
+// The generic Pratt expression parser doesn't know that an ArrowFunction is
+// not a MemberExpression/LeftHandSideExpression, so it kept treating the
+// next line's `[k2]` as a postfix index/member-access continuation of the
+// arrow function (real engines reject `(x) => {}[0]` outright, with or
+// without a line break in between) and swallowed the whole next member.
+// Real, unmodified npm `undici` (a direct dependency of many packages) hits
+// this exact shape in lib/dispatcher/pool-base.js.
+const k1 = Symbol("e");
+const k2 = Symbol("busy");
+
+class A {
+  [k1] = (x) => {
+    return x;
+  }
+
+  [k2]() {
+    return 1;
+  }
+}
+
+const a = new A();
+`${a[k1](5)} ${a[k2]()}`;

--- a/tests/scripts/class_computed_field_type_annotation_asi.ts
+++ b/tests/scripts/class_computed_field_type_annotation_asi.ts
@@ -1,0 +1,24 @@
+// expect: undefined function
+// Regression test for paserati#292 (same root cause, different trigger): a
+// computed class field with no initializer but a type annotation whose own
+// last token is '}' - an object type literal - and no trailing semicolon,
+// hit the exact same bug as the arrow-function-initializer case in
+// class_computed_field_arrow_asi.ts. parseComputedProperty's "no
+// initializer" branch used to skip advancing past the current token
+// whenever it was already a '}', assuming that could only be the class
+// body's own closing brace; here it's the type annotation's closing brace
+// instead, and stopping there made parseClassBody mistake it for the end of
+// the class, swallowing the next computed member entirely.
+const k1 = Symbol("a");
+const k2 = Symbol("b");
+
+class A {
+  [k1]: { a: number }
+
+  [k2]() {
+    return 1;
+  }
+}
+
+const a = new A();
+`${typeof a[k1]} ${typeof a[k2]}`;

--- a/tests/scripts/promise_all_generator_iterable.ts
+++ b/tests/scripts/promise_all_generator_iterable.ts
@@ -1,0 +1,14 @@
+// expect: Promise { <pending> }
+// Regression test for paserati#293: Promise.all/allSettled/any/race all share
+// vm.IterableToArray to convert their argument to an array, which used to
+// panic on any iterable that wasn't a plain array/object - e.g. a generator.
+async function test() {
+    function* gen() {
+        yield Promise.resolve(1);
+        yield Promise.resolve(2);
+    }
+    const result = await Promise.all(gen());
+    return result;
+}
+
+test();

--- a/tests/scripts/promise_any_real_aggregate_error.ts
+++ b/tests/scripts/promise_any_real_aggregate_error.ts
@@ -1,0 +1,27 @@
+// expect: Promise { <pending> }
+// Regression test for paserati#293: Promise.any used to reject with a plain
+// string message ("AggregateError: All promises were rejected") instead of a
+// genuine `new AggregateError(errors, message)` instance, so `instanceof
+// AggregateError` and `.errors` (used e.g. by real npm `undici`) didn't work.
+//
+// NOTE: this harness compares the *immediately-returned* value of the last
+// statement, before the microtask queue (and so this async function) has
+// run at all - like every other promise_*.ts test here, "expect" only
+// proves `test()` didn't throw synchronously and returned a pending
+// Promise; it does not actually check the instanceof/.errors assertion
+// below. That was verified manually instead (`./paserati --no-typecheck`
+// against this exact scenario, and against the CLI's own event-loop-drained
+// output, both showing the real AggregateError with a 2-element .errors).
+async function test() {
+    try {
+        await Promise.any([
+            Promise.reject(new Error('a')),
+            Promise.reject(new Error('b'))
+        ]);
+        return 'should not reach here';
+    } catch (e) {
+        return (e instanceof AggregateError && e.errors.length === 2) ? 'ok' : 'fail: ' + e;
+    }
+}
+
+test();


### PR DESCRIPTION
## Summary

Fixes #292. Investigates #293 and fixes a related real bug found in the process (see note below).

### #292 — ASI failure after a computed-key class field

An `ArrowFunction` is not a `MemberExpression`/`LeftHandSideExpression`, so `.`, `?.`, `[`, `(`, and tagged templates cannot apply to it directly — real engines reject `(x) => {}[0]` even with no line terminator in between. The generic Pratt expression parser didn't know this, so a computed class field whose initializer was an arrow function, with no trailing semicolon, swallowed the *next* class member's computed key whenever that key also started with `[`:

```ts
class A {
  [k1] = (x) => { return x }

  [k2] () { ... }   // <- swallowed into the arrow function above
}
```

`parseInfixContinuation` now refuses to treat those tokens as continuing an `ArrowFunctionLiteral` unless it was itself parenthesized (`((x) => {})[0]` is still fine, via a new `ArrowFunctionLiteral.Parenthesized` flag mirroring the existing `PrefixExpression.Parenthesized`).

That surfaced a second, previously-masked bug in `parseComputedProperty`: it skipped advancing past a member's last token whenever that token was already `}`, assuming it could only be the class body's own closing brace. A `}` ending the *member itself* (an arrow function's block body, an object type annotation, an object literal, ...) is exactly as likely, and stopping there made `parseClassBody` return early. Fixed both the initializer and no-initializer branches.

Found via real, unmodified npm `undici`, which hits this exact shape in `lib/dispatcher/pool-base.js`.

### #293 — `AggregateError is not defined`

**Not reproducible on `main`** — `AggregateError` (types + runtime, including a real `.errors` array) has been fully implemented since an earlier commit. This was likely filed against a stale/vendored paserati build (noderati). Verified `typeof AggregateError === "function"` and full construction/`instanceof`/`.errors` behavior work correctly as-is.

What *is* broken, found investigating right next to it: `vm.IterableToArray` — used by `new AggregateError(iterable)` and by `Promise.all/allSettled/any/race` to convert their argument — guarded every step with `value.IsObject()` before unconditionally calling `value.AsPlainObject()`. `IsObject()` covers the whole object-ish span of `ValueType`s, not just `TypeObject`, so any iterable that wasn't a plain object (a generator, a `Set`, a `Map`, ...) made `AsPlainObject()` panic, taking down the whole VM. `new AggregateError(someGenerator, msg)` and `Promise.all(someGenerator)` both crashed this way.

Fixed by reusing the existing, correct generic iterator-protocol walk (the one `...spread` already uses for `Generator`/`AsyncGenerator`/`DictObject` prototype chains), capped at 10000 `next()` calls so a non-terminating custom iterator can't hang the VM (the shared `extractSpreadArguments` helper itself stays uncapped, since `[...infiniteIterator]` genuinely never terminates in real engines either).

That in turn exposed two real, pre-existing spec gaps in `Promise.all/allSettled/any/race` that had been masked by `IterableToArray`'s silent panic-avoidance:

- A failure converting the iterable (`GetIterator` throwing, `iterator.next()` throwing, a getter access throwing mid-iteration) was thrown synchronously out of the static method instead of rejecting the result promise, per `IfAbruptRejectPromise`. Now rejects with the real thrown value (with the matching `ClearUnwindingState()` this file already needs for every other absorbed `vm.Call` error).
- `this` was only checked for `IsObject()`/`IsCallable()`, not `IsConstructor()` — per spec, `NewPromiseCapability(C)` requires `IsConstructor(C)` and must throw *before* the iterable is ever touched (e.g. `Promise.all.call(eval)`).
- `Promise.any`'s "all rejected" paths built a bare string instead of a real `new AggregateError(errors, message)` instance, so `instanceof AggregateError` / `.errors` — as used by real npm `undici`'s `net.connect` error normalization — didn't work.

## Testing

- `go test ./tests -run TestScripts` — green, including 6 new regression tests covering both issues.
- Full test262 `language/` + `built-ins/` diff against a pre-change build (not the stale committed `baseline.txt`): **zero regressions, +30 new passes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)