### PR TITLE
perf(vm): keep the tail-call [[HomeObject]] update out of the dispatch loop

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -25,6 +25,30 @@ func (e exceptionError) GetExceptionValue() Value {
 	return e.exception
 }
 
+// setTailCallHomeObject gives a tail-called callee its [[HomeObject]] for
+// super property access (see prepareCall below). Arrow functions read
+// their captured [[HomeObject]] (frame.closure.CapturedHomeObject) at use
+// time, so the frame's own field is left alone for them.
+//
+// Kept out of (*VM).run deliberately. Inlined in the OpTailCall and
+// OpTailCallMethod cases, these lines grew run's amd64 stack frame by four
+// spill slots and cost 28% on a call-free arithmetic loop that never reaches
+// them; the dispatch loop's register allocation is the thing being protected.
+//
+//go:noinline
+func setTailCallHomeObject(frame *CallFrame, calleeFunc *FunctionObject, thisVal Value) {
+	if calleeFunc.IsArrowFunction {
+		return
+	}
+	if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
+		frame.homeObject = calleeFunc.HomeObject
+	} else if thisVal.Type() != TypeUndefined && thisVal.Type() != TypeNull {
+		frame.homeObject = thisVal
+	} else {
+		frame.homeObject = Undefined
+	}
+}
+
 // prepareCall sets up a function call and returns whether the interpreter should switch to the new frame.
 // For native functions, it executes immediately and returns false.
 // For closures/functions, it sets up the frame and returns true to switch context.

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1479,6 +1479,30 @@ func (vm *VM) InterpretWithCallerScope(chunk *Chunk, callerRegs []Value, callerT
 	return result, errs
 }
 
+// setTailCallHomeObject gives a tail-called callee its [[HomeObject]] for
+// super property access (see prepareCall in call.go). Arrow functions read
+// their captured [[HomeObject]] (frame.closure.CapturedHomeObject) at use
+// time, so the frame's own field is left alone for them.
+//
+// Kept out of (*VM).run deliberately. Inlined in the OpTailCall and
+// OpTailCallMethod cases, these lines grew run's amd64 stack frame by four
+// spill slots and cost 28% on a call-free arithmetic loop that never reaches
+// them; the dispatch loop's register allocation is the thing being protected.
+//
+//go:noinline
+func setTailCallHomeObject(frame *CallFrame, calleeFunc *FunctionObject, thisVal Value) {
+	if calleeFunc.IsArrowFunction {
+		return
+	}
+	if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
+		frame.homeObject = calleeFunc.HomeObject
+	} else if thisVal.Type() != TypeUndefined && thisVal.Type() != TypeNull {
+		frame.homeObject = thisVal
+	} else {
+		frame.homeObject = Undefined
+	}
+}
+
 // run is the main execution loop.
 // It now returns the InterpretResult status AND the final script Value.
 func (vm *VM) run() (status InterpretResult, resultValue Value) {
@@ -3877,18 +3901,7 @@ startExecution:
 							frame.thisValue = Undefined
 						}
 					}
-					// Set [[HomeObject]] for super property access (see prepareCall in call.go).
-					// Arrow functions use their captured [[HomeObject]] (frame.closure.CapturedHomeObject)
-					// at read time, so frame.homeObject itself doesn't need updating for them.
-					if !calleeFunc.IsArrowFunction {
-						if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
-							frame.homeObject = calleeFunc.HomeObject
-						} else if frame.thisValue.Type() != TypeUndefined && frame.thisValue.Type() != TypeNull {
-							frame.homeObject = frame.thisValue
-						} else {
-							frame.homeObject = Undefined
-						}
-					}
+					setTailCallHomeObject(frame, calleeFunc, frame.thisValue)
 					frame.isConstructorCall = false
 					frame.isDirectCall = false
 					frame.isSentinelFrame = false
@@ -4110,18 +4123,7 @@ startExecution:
 					} else {
 						frame.thisValue = thisVal // Method call: preserve 'this'
 					}
-					// Set [[HomeObject]] for super property access (see prepareCall in call.go).
-					// Arrow functions use their captured [[HomeObject]] (frame.closure.CapturedHomeObject)
-					// at read time, so frame.homeObject itself doesn't need updating for them.
-					if !calleeFunc.IsArrowFunction {
-						if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
-							frame.homeObject = calleeFunc.HomeObject
-						} else if thisVal.Type() != TypeUndefined && thisVal.Type() != TypeNull {
-							frame.homeObject = thisVal
-						} else {
-							frame.homeObject = Undefined
-						}
-					}
+					setTailCallHomeObject(frame, calleeFunc, thisVal)
 					frame.isConstructorCall = false
 					frame.isDirectCall = false
 					frame.isSentinelFrame = false

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1479,30 +1479,6 @@ func (vm *VM) InterpretWithCallerScope(chunk *Chunk, callerRegs []Value, callerT
 	return result, errs
 }
 
-// setTailCallHomeObject gives a tail-called callee its [[HomeObject]] for
-// super property access (see prepareCall in call.go). Arrow functions read
-// their captured [[HomeObject]] (frame.closure.CapturedHomeObject) at use
-// time, so the frame's own field is left alone for them.
-//
-// Kept out of (*VM).run deliberately. Inlined in the OpTailCall and
-// OpTailCallMethod cases, these lines grew run's amd64 stack frame by four
-// spill slots and cost 28% on a call-free arithmetic loop that never reaches
-// them; the dispatch loop's register allocation is the thing being protected.
-//
-//go:noinline
-func setTailCallHomeObject(frame *CallFrame, calleeFunc *FunctionObject, thisVal Value) {
-	if calleeFunc.IsArrowFunction {
-		return
-	}
-	if calleeFunc.HomeObject.Type() != TypeUndefined && calleeFunc.HomeObject.Type() != TypeNull {
-		frame.homeObject = calleeFunc.HomeObject
-	} else if thisVal.Type() != TypeUndefined && thisVal.Type() != TypeNull {
-		frame.homeObject = thisVal
-	} else {
-		frame.homeObject = Undefined
-	}
-}
-
 // run is the main execution loop.
 // It now returns the InterpretResult status AND the final script Value.
 func (vm *VM) run() (status InterpretResult, resultValue Value) {


### PR DESCRIPTION
Fixes #295.

`26a3bd68` inlined the [[HomeObject]] update into the `OpTailCall` and `OpTailCallMethod` cases of `(*VM).run`. On amd64 that grew `run`'s stack frame by four spill slots and the function by 1.3 KB, and benchmarks that never reach those lines paid for it. This moves the block into a `//go:noinline` helper called from both cases. Behaviour is unchanged; `tco_tail_call_super_homeobject.ts` still passes.

## Measurement

Same box (`c7a.2xlarge`, EPYC 9R14, go1.26.0 linux/amd64), one compiled `./tests` binary per commit, pinned corpus overlaid, four interleaved counterbalanced rounds, median. Percent versus the parent of `26a3bd68`:

| benchmark | `26a3bd68` | `0ec3c9a0` (main) | this PR | n |
|---|---|---|---|---|
| Arith | +37.2% | +26.3% | +0.2% | 12 |
| Factorial | +23.6% | +45.1% | -0.1% | 12 |
| MatrixMult | +6.4% | +5.1% | -0.2% | 12 |
| OctaneNavierStokes | +47.6% | +20.2% | -0.4% | 20 |
| OctaneRichards | +0.1% | +28.5% | +0.1% | 20 |
| OctaneDeltaBlue | +1.7% | +36.2% | -0.3% | 20 |
| OctaneRayTrace | +2.3% | +10.5% | -0.1% | 20 |
| SetIndex | +7.5% | +2.7% | +1.5% | 12 |
| Add | +1.8% | +0.1% | -1.1% | 12 |

`26a3bd68` and `main` share a byte-identical `run()` and land on different subsets, which is the placement half of the problem; with this change every benchmark is back on the parent.

From `go tool nm` and `objdump` on the same binaries:

| binary | `run()` bytes | frame |
|---|---|---|
| parent `f9569ee4` | 359,066 | `SUBQ $0x1f18, SP` |
| `26a3bd68` / `main` | 360,346 | `SUBQ $0x1f38, SP` |
| this PR | 358,874 | `SUBQ $0x1f18, SP` |

## Verification

- `go test ./...` green; `tco_tail_call_super_homeobject.ts` and the other `tco_*` scripts pass.
- The table above, four rounds on one box, with the parent as the null.
