### PR TITLE
Fix Reflect.deleteProperty on callables (#297) and the leaked top-level script frame (#298)

### DIFF
--- a/pkg/builtins/reflect_delete.go
+++ b/pkg/builtins/reflect_delete.go
@@ -1,0 +1,401 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// reflectDeleteProperty is target.[[Delete]](key) as observed by
+// Reflect.deleteProperty (ECMA-262 28.1.4): it reports the [[Delete]]
+// result as a boolean and never converts a refused delete into a TypeError
+// the way the strict-mode `delete` operator does. The only TypeErrors it
+// produces are the Proxy ones - a non-callable trap, or a trap that
+// violates the "can't report deleting a non-configurable target property"
+// invariant - plus whatever the trap itself throws.
+//
+// The VM's own delete opcodes (OpDeleteProp/OpDeleteIndex in vm.go) hold
+// the equivalent logic inline, per object kind, interleaved with the
+// strict-mode throw/reload-frame boilerplate; this is the same dispatch
+// with the throwing removed. It has to cover every object kind, not just
+// PlainObject: functions and classes are ordinary objects too, and real
+// code deletes own properties off them (#297 - undici's
+// `Reflect.deleteProperty(Response, 'getResponseHeaders')`).
+//
+// key must already be a property key (a Symbol or a String value) - the
+// caller runs ToPropertyKey first so an abrupt completion from a
+// user-defined toString surfaces before any deletion happens.
+func reflectDeleteProperty(vmInstance *vm.VM, target vm.Value, key vm.Value) (bool, error) {
+	isSym := key.Type() == vm.TypeSymbol
+	var name string
+	if !isSym {
+		name = key.ToString()
+	}
+
+	switch target.Type() {
+	case vm.TypeProxy:
+		return proxyReflectDelete(vmInstance, target, key)
+
+	case vm.TypeObject:
+		po := target.AsPlainObject()
+		// Module Namespace Exotic Object [[Delete]] (ECMA-262 10.4.6.8): a
+		// string key that names an export can never be deleted; a symbol
+		// key goes through OrdinaryDelete.
+		if po.IsModuleNamespace() && !isSym {
+			_, exists := po.GetOwn(name)
+			return !exists, nil
+		}
+		if isSym {
+			return deleteFromTableByKey(po, vm.NewSymbolKey(key)), nil
+		}
+		// The global object keeps var/function declarations in the heap
+		// with their own DontDelete bit; mirror OpDeleteProp's handling so
+		// Reflect.deleteProperty(globalThis, 'x') agrees with `delete
+		// globalThis.x`.
+		heap := vmInstance.GetHeap()
+		if po == vmInstance.GlobalObject && heap != nil {
+			if idx, exists := heap.GetNameToIndex()[name]; exists && !heap.IsConfigurable(idx) {
+				return false, nil
+			}
+		}
+		success := deleteFromTable(po, name)
+		if success && po == vmInstance.GlobalObject && heap != nil {
+			if idx, exists := heap.GetNameToIndex()[name]; exists {
+				heap.Delete(idx)
+			}
+		}
+		return success, nil
+
+	case vm.TypeDictObject:
+		if isSym {
+			// DictObjects have no symbol-keyed storage, so the property
+			// cannot exist - OrdinaryDelete of an absent property is true.
+			return true, nil
+		}
+		d := target.AsDictObject()
+		if exists, nonConfig := d.IsOwnPropertyNonConfigurable(name); exists && nonConfig {
+			return false, nil
+		}
+		return d.DeleteOwn(name), nil
+
+	case vm.TypeArray:
+		arr := target.AsArray()
+		if isSym {
+			arr.DeleteSymbolProp(key.AsSymbolObject())
+			return true, nil
+		}
+		if idx, isIndex := vm.ParseArrayIndex(name); isIndex {
+			return arr.DeleteIndex(idx), nil
+		}
+		if name == "length" {
+			return false, nil
+		}
+		return arr.DeleteOwn(name), nil
+
+	case vm.TypeArguments:
+		args := target.AsArguments()
+		if isSym {
+			args.DeleteSymbolProp(key.AsSymbolObject())
+			return true, nil
+		}
+		return args.Delete(name), nil
+
+	case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+		return deleteFromCallable(target, key, isSym, name), nil
+
+	case vm.TypeRegExp:
+		// lastIndex lives on the RegExpObject itself, not in its side
+		// table, and is {writable: true, configurable: false}.
+		if !isSym && name == "lastIndex" {
+			return false, nil
+		}
+	}
+
+	// Every remaining exotic kind (RegExp, Map, Set, Promise, ...) keeps
+	// its ordinary own properties in a lazily-created side table; a kind
+	// with no table at all has no deletable own properties, and deleting an
+	// absent property succeeds.
+	props := vm.OwnPropertiesTable(target)
+	if props == nil {
+		return true, nil
+	}
+	if isSym {
+		return deleteFromTableByKey(props, vm.NewSymbolKey(key)), nil
+	}
+	return deleteFromTable(props, name), nil
+}
+
+// deleteFromCallable is OrdinaryDelete for the five callable kinds. Their
+// intrinsic "name"/"length" are synthesized lazily and tracked as deleted
+// via a flag rather than removed from a table; "prototype" on a function
+// that has one is {configurable: false} per MakeConstructor / ClassDefinition
+// and so can never be deleted. Everything else is an ordinary side-table
+// property (a closure checks its own table before the shared function's,
+// matching OpDeleteProp).
+func deleteFromCallable(target vm.Value, key vm.Value, isSym bool, name string) bool {
+	tables := callableTables(target)
+
+	if !isSym {
+		switch name {
+		case "name", "length":
+			// A table entry (materialized by Object.freeze/seal, or defined
+			// by user code) carries the authoritative attributes.
+			for _, t := range tables {
+				if t == nil || !t.HasOwn(name) {
+					continue
+				}
+				if exists, nonConfig := t.IsOwnPropertyNonConfigurable(name); exists && nonConfig {
+					return false
+				}
+				t.DeleteOwn(name)
+			}
+			markIntrinsicDeleted(target, name)
+			return true
+		case "prototype":
+			if callableHasPrototype(target) {
+				return false
+			}
+		}
+	}
+
+	for _, t := range tables {
+		if t == nil {
+			continue
+		}
+		if isSym {
+			k := vm.NewSymbolKey(key)
+			if !t.HasOwnByKey(k) {
+				continue
+			}
+			return deleteFromTableByKey(t, k)
+		}
+		if !t.HasOwn(name) {
+			continue
+		}
+		return deleteFromTable(t, name)
+	}
+	// Absent everywhere: OrdinaryDelete returns true.
+	return true
+}
+
+// callableTables lists the side tables an own-property lookup on a callable
+// consults, most specific first.
+func callableTables(target vm.Value) []*vm.PlainObject {
+	switch target.Type() {
+	case vm.TypeClosure:
+		cl := target.AsClosure()
+		return []*vm.PlainObject{cl.Properties, cl.Fn.Properties}
+	default:
+		return []*vm.PlainObject{vm.OwnPropertiesTable(target)}
+	}
+}
+
+// callableHasPrototype reports whether the callable has an own "prototype"
+// property in this runtime: every user function that is not an arrow or a
+// plain async function (see MaterializeIntrinsicOwnProperties for the same
+// rule), or a native/bound function that had one defined in its table.
+func callableHasPrototype(target vm.Value) bool {
+	var fn *vm.FunctionObject
+	switch target.Type() {
+	case vm.TypeFunction:
+		fn = target.AsFunction()
+	case vm.TypeClosure:
+		fn = target.AsClosure().Fn
+	default:
+		if t := vm.OwnPropertiesTable(target); t != nil && t.HasOwn("prototype") {
+			if exists, nonConfig := t.IsOwnPropertyNonConfigurable("prototype"); exists && nonConfig {
+				return true
+			}
+		}
+		return false
+	}
+	return !fn.IsArrowFunction && !(fn.IsAsync && !fn.IsGenerator)
+}
+
+// markIntrinsicDeleted records the deletion of a lazily-synthesized "name" or
+// "length" on the kinds that synthesize them (bound functions keep theirs in
+// the table, which deleteFromCallable has already handled).
+func markIntrinsicDeleted(target vm.Value, name string) {
+	switch target.Type() {
+	case vm.TypeFunction:
+		setDeletedFlag(target.AsFunction(), name)
+	case vm.TypeClosure:
+		setDeletedFlag(target.AsClosure().Fn, name)
+	case vm.TypeNativeFunction:
+		nf := target.AsNativeFunction()
+		if name == "name" {
+			nf.DeletedName = true
+		} else {
+			nf.DeletedLength = true
+		}
+	case vm.TypeNativeFunctionWithProps:
+		nfp := target.AsNativeFunctionWithProps()
+		if name == "name" {
+			nfp.DeletedName = true
+		} else {
+			nfp.DeletedLength = true
+		}
+	}
+}
+
+func setDeletedFlag(fn *vm.FunctionObject, name string) {
+	if name == "name" {
+		fn.DeletedName = true
+	} else {
+		fn.DeletedLength = true
+	}
+}
+
+// deleteFromTable is OrdinaryDelete (10.1.7) on a PlainObject-backed
+// property bag for a string key.
+func deleteFromTable(po *vm.PlainObject, name string) bool {
+	if exists, nonConfig := po.IsOwnPropertyNonConfigurable(name); exists && nonConfig {
+		return false
+	}
+	return po.DeleteOwn(name)
+}
+
+// deleteFromTableByKey is deleteFromTable for a symbol (or other non-string)
+// key.
+func deleteFromTableByKey(po *vm.PlainObject, key vm.PropertyKey) bool {
+	if exists, nonConfig := po.IsOwnPropertyNonConfigurableByKey(key); exists && nonConfig {
+		return false
+	}
+	return po.DeleteOwnByKey(key)
+}
+
+// proxyReflectDelete is the Proxy exotic object's [[Delete]] (10.5.10) with
+// the result reported rather than thrown on: run the handler's
+// deleteProperty trap if it has one, enforce the non-configurable and
+// non-extensible target invariants on a truthy answer, and otherwise defer
+// to the target's own [[Delete]].
+func proxyReflectDelete(vmInstance *vm.VM, proxyVal vm.Value, key vm.Value) (bool, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return false, vmInstance.NewTypeError("Cannot perform 'deleteProperty' on a proxy that has been revoked")
+	}
+	handler := proxy.Handler()
+	target := proxy.Target()
+
+	// GetMethod(handler, "deleteProperty"): an inherited trap counts, and
+	// undefined/null mean "no trap".
+	var trap vm.Value
+	var hasTrap bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		trap, hasTrap = handler.AsPlainObject().Get("deleteProperty")
+	case vm.TypeDictObject:
+		trap, hasTrap = handler.AsDictObject().Get("deleteProperty")
+	}
+	if !hasTrap || trap.Type() == vm.TypeUndefined || trap.Type() == vm.TypeNull {
+		return reflectDeleteProperty(vmInstance, target, key)
+	}
+	if !trap.IsCallable() {
+		return false, vmInstance.NewTypeError("'deleteProperty' on proxy: trap is not a function")
+	}
+
+	result, err := vmInstance.Call(trap, handler, []vm.Value{target, key})
+	if err != nil {
+		return false, err
+	}
+	if !result.IsTruthy() {
+		return false, nil
+	}
+
+	// Invariants (10.5.10 steps 10-13): a truthy answer is only allowed if
+	// the target has no such own property, or has one that is configurable
+	// on an extensible target.
+	display := key.ToString()
+	exists, nonConfig := targetOwnNonConfigurable(target, key)
+	if !exists {
+		return true, nil
+	}
+	if nonConfig {
+		return false, vmInstance.NewTypeError("'deleteProperty' on proxy: trap returned truish for property '" + display + "' which is non-configurable in the proxy target")
+	}
+	if !isTargetExtensible(target) {
+		return false, vmInstance.NewTypeError("'deleteProperty' on proxy: trap returned truish for property '" + display + "' but the proxy target is non-extensible")
+	}
+	return true, nil
+}
+
+// targetOwnNonConfigurable is a best-effort target.[[GetOwnProperty]](key)
+// reduced to (exists, configurable == false) for the Proxy invariant check,
+// covering the kinds whose descriptors this runtime can report.
+func targetOwnNonConfigurable(target vm.Value, key vm.Value) (exists bool, nonConfig bool) {
+	if key.Type() == vm.TypeSymbol {
+		k := vm.NewSymbolKey(key)
+		switch target.Type() {
+		case vm.TypeObject:
+			return target.AsPlainObject().IsOwnPropertyNonConfigurableByKey(k)
+		case vm.TypeArray:
+			return target.AsArray().HasOwnSymbolProp(key.AsSymbolObject()), false
+		default:
+			if t := vm.OwnPropertiesTable(target); t != nil {
+				return t.IsOwnPropertyNonConfigurableByKey(k)
+			}
+		}
+		return false, false
+	}
+	name := key.ToString()
+	switch target.Type() {
+	case vm.TypeObject:
+		return target.AsPlainObject().IsOwnPropertyNonConfigurable(name)
+	case vm.TypeDictObject:
+		return target.AsDictObject().IsOwnPropertyNonConfigurable(name)
+	case vm.TypeArray:
+		arr := target.AsArray()
+		if name == "length" {
+			return true, true
+		}
+		if idx, isIndex := vm.ParseArrayIndex(name); isIndex {
+			if idx < arr.Length() {
+				return true, arr.IsFrozen()
+			}
+			return false, false
+		}
+		_, has := arr.GetOwn(name)
+		return has, false
+	case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+		if name == "prototype" && callableHasPrototype(target) {
+			return true, true
+		}
+		for _, t := range callableTables(target) {
+			if t != nil && t.HasOwn(name) {
+				return t.IsOwnPropertyNonConfigurable(name)
+			}
+		}
+		return name == "name" || name == "length", false
+	default:
+		if t := vm.OwnPropertiesTable(target); t != nil {
+			return t.IsOwnPropertyNonConfigurable(name)
+		}
+	}
+	return false, false
+}
+
+// reflectDeletePropertyImpl is the Reflect.deleteProperty native: validate
+// the target, run ToPropertyKey, then report [[Delete]].
+func reflectDeletePropertyImpl(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
+	target, keyArg := vm.Undefined, vm.Undefined
+	if len(args) > 0 {
+		target = args[0]
+	}
+	if len(args) > 1 {
+		keyArg = args[1]
+	}
+	if !target.IsObject() && !target.IsCallable() {
+		return vm.Undefined, vmInstance.NewTypeError("Reflect.deleteProperty called on non-object")
+	}
+	key, err := toPropertyKeyValue(vmInstance, keyArg)
+	if err != nil {
+		return vm.Undefined, err
+	}
+	if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
+		// ToPropertyKey threw (e.g. a user toString); let it propagate.
+		return vm.Undefined, nil
+	}
+	ok, err := reflectDeleteProperty(vmInstance, target, key)
+	if err != nil {
+		return vm.Undefined, err
+	}
+	return vm.BooleanValue(ok), nil
+}

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -304,72 +304,10 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}))
 
 	// Reflect.deleteProperty(target, propertyKey)
-	// Per ECMAScript spec, this invokes [[Delete]] and returns the result
+	// Per ECMAScript spec, this invokes [[Delete]] and returns the result.
+	// The dispatch across object kinds lives in reflect_delete.go.
 	reflectObj.SetOwnNonEnumerable("deleteProperty", vm.NewNativeFunction(2, false, "deleteProperty", func(args []vm.Value) (vm.Value, error) {
-		if len(args) < 2 {
-			return vm.BooleanValue(false), vmInstance.NewTypeError("Reflect.deleteProperty requires 2 arguments")
-		}
-		target := args[0]
-		propKeyArg := args[1]
-
-		if !target.IsObject() {
-			return vm.BooleanValue(false), vmInstance.NewTypeError("Reflect.deleteProperty called on non-object")
-		}
-
-		// Handle PlainObject
-		if target.Type() == vm.TypeObject {
-			po := target.AsPlainObject()
-			// Module Namespace Exotic Object [[Delete]] behavior (ECMAScript 10.4.6.8)
-			if po.IsModuleNamespace() {
-				if propKeyArg.Type() == vm.TypeSymbol {
-					// For symbols: return OrdinaryDelete(O, P)
-					// Check if property is non-configurable
-					symKey := vm.NewSymbolKey(propKeyArg)
-					if exists, nonConfig := po.IsOwnPropertyNonConfigurableByKey(symKey); exists && nonConfig {
-						// Non-configurable property - return false
-						return vm.BooleanValue(false), nil
-					}
-					// Property doesn't exist or is configurable - delete it
-					success := po.DeleteOwnByKey(symKey)
-					return vm.BooleanValue(success), nil
-				}
-				// For string properties: if the property exists in exports, return false
-				propKey := propKeyArg.ToString()
-				if _, exists := po.GetOwn(propKey); exists {
-					// Export property exists - return false (don't throw)
-					return vm.BooleanValue(false), nil
-				}
-				// Property doesn't exist in exports - return true
-				return vm.BooleanValue(true), nil
-			}
-
-			propKey := propKeyArg.ToString()
-
-			// Check if property exists and is non-configurable
-			exists, nonConfig := po.IsOwnPropertyNonConfigurable(propKey)
-			if exists && nonConfig {
-				// Non-configurable property - [[Delete]] returns false
-				return vm.BooleanValue(false), nil
-			}
-
-			// Delete the property
-			success := po.DeleteOwn(propKey)
-			return vm.BooleanValue(success), nil
-		}
-
-		// Handle DictObject
-		if target.Type() == vm.TypeDictObject {
-			d := target.AsDictObject()
-			propKey := propKeyArg.ToString()
-			success := d.DeleteOwn(propKey)
-			return vm.BooleanValue(success), nil
-		}
-
-		// Handle Array - arrays use PlainObject for property storage
-		// so they're handled by the PlainObject case above
-
-		// Default: property deleted successfully or didn't exist
-		return vm.BooleanValue(true), nil
+		return reflectDeletePropertyImpl(vmInstance, args)
 	}))
 
 	// Helper: check target is an object, throw TypeError if not (Reflect methods require objects)

--- a/pkg/driver/rerun_throw_propagation_test.go
+++ b/pkg/driver/rerun_throw_propagation_test.go
@@ -1,0 +1,114 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/builtins"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// Regression test for #298: any completed top-level run on a Paserati
+// instance used to leave its "<script>" frame on the VM's frame stack, so the
+// next run's script frame was pushed as a nested direct-call frame. A
+// synchronous throw that crossed a native boundary (a Go builtin calling back
+// into JS via vm.Call and re-throwing the result) then stopped at that frame
+// as if a native caller would handle it, and the script finished with no
+// error reported at all.
+func TestSecondRunPropagatesThrowAcrossNativeCall(t *testing.T) {
+	newInstance := func(t *testing.T) *Paserati {
+		p := NewPaseratiWithInitializers(builtins.GetStandardInitializers())
+		p.SetSkipTypeCheck(true)
+		callIt := vm.NewNativeFunction(1, false, "callIt", func(args []vm.Value) (vm.Value, error) {
+			return p.GetVM().Call(args[0], vm.Undefined, nil)
+		})
+		g, ok := p.GetVM().GetGlobal("globalThis")
+		if !ok {
+			t.Fatal("globalThis not found")
+		}
+		g.AsPlainObject().SetOwn("callIt", callIt)
+		return p
+	}
+
+	const throwing = `callIt(() => { throw new Error("boom") })`
+
+	priors := []struct {
+		name string
+		run  func(p *Paserati) int
+	}{
+		{"none", func(p *Paserati) int { return 0 }},
+		{"RunCode script", func(p *Paserati) int {
+			_, errs := p.RunCode(`1+1`, RunOptions{Script: true})
+			return len(errs)
+		}},
+		{"RunCode module", func(p *Paserati) int {
+			_, errs := p.RunCode(`1+1`, RunOptions{})
+			return len(errs)
+		}},
+		{"EvalCode", func(p *Paserati) int {
+			_, errs := p.EvalCode(`1+1`, false)
+			return len(errs)
+		}},
+		{"RunCode x3", func(p *Paserati) int {
+			n := 0
+			for i := 0; i < 3; i++ {
+				_, errs := p.RunCode(`1+1`, RunOptions{Script: i%2 == 0})
+				n += len(errs)
+			}
+			return n
+		}},
+	}
+
+	for _, prior := range priors {
+		for _, script := range []bool{false, true} {
+			name := prior.name
+			if script {
+				name += "/then script"
+			} else {
+				name += "/then module"
+			}
+			t.Run(name, func(t *testing.T) {
+				p := newInstance(t)
+				if n := prior.run(p); n != 0 {
+					t.Fatalf("prior run reported %d errors", n)
+				}
+				_, errs := p.RunCode(throwing, RunOptions{Script: script})
+				if len(errs) == 0 {
+					t.Fatal("thrown error was silently lost")
+				}
+				if !strings.Contains(errs[0].Error(), "boom") {
+					t.Fatalf("unexpected error: %v", errs[0])
+				}
+			})
+		}
+	}
+}
+
+// Closures created by a completed top-level run must keep working after the
+// script frame is retired: the fix for #298 hands the frame's register window
+// back, so the run's open upvalues have to be closed first.
+func TestTopLevelClosuresSurviveFrameRetirement(t *testing.T) {
+	p := NewPaseratiWithInitializers(builtins.GetStandardInitializers())
+	p.SetSkipTypeCheck(true)
+
+	if _, errs := p.RunCode(`
+		let counter = 10;
+		globalThis.bump = () => ++counter;
+	`, RunOptions{Script: true}); len(errs) > 0 {
+		t.Fatalf("setup errors: %v", errs)
+	}
+	// A second run reuses the register window the first one occupied.
+	if _, errs := p.RunCode(`
+		let a = 1000, b = 2000, c = 3000, d = 4000;
+		a + b + c + d;
+	`, RunOptions{Script: true}); len(errs) > 0 {
+		t.Fatalf("second run errors: %v", errs)
+	}
+	val, errs := p.RunCode(`bump(); bump()`, RunOptions{Script: true})
+	if len(errs) > 0 {
+		t.Fatalf("bump errors: %v", errs)
+	}
+	if got := val.ToString(); got != "12" {
+		t.Fatalf("closure lost its captured binding: got %s, want 12", got)
+	}
+}

--- a/pkg/vm/arguments_props.go
+++ b/pkg/vm/arguments_props.go
@@ -372,3 +372,11 @@ func (a *ArgumentsObject) argumentsDelete(key string) bool {
 	}
 	return true
 }
+
+// Delete is the exported [[Delete]] for a string key on an arguments object
+// (see argumentsDelete), for builtins such as Reflect.deleteProperty that
+// need the same semantics as the `delete` operator without going through
+// the OpDeleteIndex opcode.
+func (a *ArgumentsObject) Delete(key string) bool {
+	return a.argumentsDelete(key)
+}

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -260,7 +260,17 @@ func (vm *VM) unwindException() bool {
 		}
 
 		// fmt.Printf("[DEBUG] unwindException: No handler in frame %d, unwinding to caller\n", vm.frameCount-1)
-		// No handler in current frame and not a direct call boundary, unwind to caller
+		// No handler in current frame and not a direct call boundary, unwind to caller.
+		// Close the frame's open upvalues first, exactly as OpReturn does: a
+		// closure created inside this frame that escaped (stored on an outer
+		// variable, registered as a callback) still aliases this frame's
+		// register slots through them, and the handler frame we resume in -
+		// or the next call made from it - reuses those slots straight away.
+		// Skipping this made `let x = 1; h = () => x; throw ...` observe
+		// whatever the next function call wrote into x's slot.
+		if frame.openUpvalues != nil {
+			vm.closeFrameUpvalues(frame)
+		}
 		vm.frameCount--
 		// For register-based VM, just decrement frame count
 		// Register cleanup is handled by the frame management

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -3475,3 +3475,15 @@ func formatDateTimestamp(timestamp float64) string {
 	t := time.UnixMilli(int64(timestamp))
 	return t.Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
 }
+
+// DeleteSymbolProp removes a symbol-keyed own property from the array object
+// and reports whether it was present. Symbol-keyed array properties are
+// ordinary configurable properties, so removal always succeeds.
+func (a *ArrayObject) DeleteSymbolProp(sym *SymbolObject) bool {
+	if a.symbolProps == nil {
+		return false
+	}
+	_, existed := a.symbolProps[sym]
+	delete(a.symbolProps, sym)
+	return existed
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1343,6 +1343,18 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 		return Undefined, vm.errors
 	}
 
+	// With no live frames there are no live register windows either, so a
+	// top-level run always starts from the bottom of the register stack. This
+	// reclaims what an uncaught exception left behind: unwindException pops
+	// frames without giving back their windows (see reclaimUnwoundRegisters,
+	// which only runs when a handler is found), so a script that died on a
+	// throw used to leak its whole window into every later run on this VM.
+	// Popped frames have had their upvalues closed, so nothing still aliases
+	// those slots.
+	if vm.frameCount == 0 {
+		vm.nextRegSlot = 0
+	}
+
 	// --- Push the new frame ---
 	frame := &vm.frames[vm.frameCount] // Get pointer to the frame slot
 	// Initialize the first frame to run the mainClosureObj
@@ -5959,6 +5971,7 @@ startExecution:
 					vm.currentException = vm.pendingValue
 					return InterpretRuntimeError, vm.pendingValue
 				}
+				vm.popTopLevelScriptFrame(frame)
 				return InterpretOK, result
 			}
 			// fmt.Printf("// [VM DEBUG] OpReturn: Hit in module '%s', frameCount=%d, result=%s\n", vm.currentModulePath, vm.frameCount, result.ToString())
@@ -6251,6 +6264,7 @@ startExecution:
 					vm.handleUncaughtException()
 					return InterpretRuntimeError, vm.currentException
 				}
+				vm.popTopLevelScriptFrame(frame)
 				return InterpretOK, Undefined
 			}
 
@@ -17141,6 +17155,38 @@ func (vm *VM) closeFrameUpvalues(frame *CallFrame) {
 		uv = next
 	}
 	frame.openUpvalues = nil
+}
+
+// popTopLevelScriptFrame retires the outermost "<script>" frame once its
+// chunk has run to completion (OpReturn/OpReturnUndefined at frameCount==1).
+//
+// Those two fast paths used to `return InterpretOK` with the frame still on
+// vm.frames and its register window still reserved (#298). Every completed
+// top-level Interpret therefore left one dead frame behind, so the NEXT
+// Interpret on the same VM - a second RunCode/EvalCode on a persistent
+// driver.Paserati, the REPL, a host installing globals via a helper script -
+// saw frameCount > 0 and pushed its own script frame as a *nested*,
+// isDirectCall=true frame. unwindException treats such a frame as a native
+// boundary: a throw that crossed a native call (vm.Call from a Go builtin)
+// and was re-thrown into that script stopped there on its "first pass",
+// reporting the exception as handled, and handleUncaughtException never ran.
+// The script ended with InterpretRuntimeError but an empty vm.errors, so the
+// caller saw a clean, error-free run with the throw silently dropped. The
+// leak also grew vm.frames/vm.registerStack by one window per run.
+//
+// Closing the frame's open upvalues first is what keeps closures created by
+// the script (a callback stored on globalThis, a promise reaction that runs
+// in DrainUntilIdle) working once the window is handed back: an open upvalue
+// aliases a register slot, and the next run's frame will reuse that slot.
+func (vm *VM) popTopLevelScriptFrame(frame *CallFrame) {
+	if frame.openUpvalues != nil {
+		vm.closeFrameUpvalues(frame)
+	}
+	vm.frameCount--
+	vm.nextRegSlot -= frame.allocatedRegSize
+	if vm.nextRegSlot < 0 {
+		vm.nextRegSlot = 0
+	}
 }
 
 // relocateOpenUpvalues redirects every open upvalue in the list that

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1786,6 +1786,15 @@ func (vm *VM) putSentinelReg(r []Value) {
 // negative). Left as a documented pre-existing gap rather than a local fix
 // that isn't provably correct; see issue #61.
 func (vm *VM) truncateFramesTo(entryCount int) {
+	// unwindException leaves the native-boundary frame it stopped at on the
+	// stack without popping it; dropping it here retires it for good, so its
+	// open upvalues must be closed like any other returning frame's (see the
+	// matching note in unwindException's pop loop).
+	for i := vm.frameCount - 1; i >= entryCount && i >= 0; i-- {
+		if f := &vm.frames[i]; f.openUpvalues != nil {
+			vm.closeFrameUpvalues(f)
+		}
+	}
 	vm.frameCount = entryCount
 	vm.unwindingCrossedNative = false
 }

--- a/tests/scripts/closure_upvalue_closed_on_unwind.ts
+++ b/tests/scripts/closure_upvalue_closed_on_unwind.ts
@@ -1,0 +1,20 @@
+// expect: 1
+// A closure created inside a frame that is popped by exception unwinding
+// must keep observing the frame's final values. Unwinding used to pop the
+// frame without closing its open upvalues, so the escaped closure kept
+// aliasing the dead register slot and saw whatever the next call wrote there.
+let h: () => number = () => -1;
+function g() {
+  let x = 1;
+  h = () => x;
+  throw new Error("boom");
+}
+try {
+  g();
+} catch (e) {}
+function k() {
+  let a = 99, b = 98, c = 97;
+  return a + b + c;
+}
+k();
+h();

--- a/tests/scripts/reflect_delete_property_function_target.ts
+++ b/tests/scripts/reflect_delete_property_function_target.ts
@@ -1,0 +1,77 @@
+// expect: true
+// Regression test for #297: Reflect.deleteProperty threw "called on
+// non-object" for any callable target, though functions and classes are
+// ordinary objects. Also covers symbol keys on plain objects (previously
+// stringified) and the non-configurable -> false (not throw) rule.
+const results: boolean[] = [];
+
+// Plain function target
+function F() {}
+(F as any).x = 1;
+results.push(Reflect.deleteProperty(F, "x") === true && (F as any).x === undefined);
+
+// Class target with a static field (undici's pattern)
+class C {
+  static y = 2;
+}
+results.push(Reflect.deleteProperty(C, "y") === true && (C as any).y === undefined);
+
+// Arrow function and native function targets
+const arrow = () => 1;
+(arrow as any).z = 5;
+results.push(Reflect.deleteProperty(arrow, "z") === true && (arrow as any).z === undefined);
+results.push(Reflect.deleteProperty(Math.max, "nope") === true);
+
+// Bound function target
+const bound = F.bind(null);
+(bound as any).b = 3;
+results.push(Reflect.deleteProperty(bound, "b") === true && (bound as any).b === undefined);
+
+// Non-configurable own property on a function: reports false, does not throw
+Object.defineProperty(F, "fixed", { value: 1, configurable: false });
+results.push(Reflect.deleteProperty(F, "fixed") === false && (F as any).fixed === 1);
+
+// "prototype" of an ordinary function is non-configurable
+results.push(Reflect.deleteProperty(F, "prototype") === false && F.prototype !== undefined);
+
+// Intrinsic name/length are configurable and deletable
+function G() {}
+results.push(Reflect.deleteProperty(G, "name") === true && !Object.prototype.hasOwnProperty.call(G, "name"));
+
+// Symbol key on a plain object
+const s = Symbol("k");
+const o: any = { [s]: 42, a: 1 };
+results.push(Reflect.deleteProperty(o, s) === true && !Object.prototype.hasOwnProperty.call(o, s) && o.a === 1);
+
+// Array element and length
+const arr = [1, 2, 3];
+results.push(Reflect.deleteProperty(arr, "1") === true && !Object.prototype.hasOwnProperty.call(arr, 1) && arr.length === 3);
+results.push(Reflect.deleteProperty(arr, "length") === false);
+
+// Map with an expando property
+const m: any = new Map();
+m.tag = "t";
+results.push(Reflect.deleteProperty(m, "tag") === true && m.tag === undefined);
+
+// Proxy: trap result is reported, invariant violation throws
+const p1 = new Proxy({ q: 1 }, { deleteProperty: () => false });
+results.push(Reflect.deleteProperty(p1, "q") === false);
+const frozenTarget = Object.freeze({ q: 1 });
+let threw = false;
+try {
+  Reflect.deleteProperty(new Proxy(frozenTarget, { deleteProperty: () => true }), "q");
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+results.push(threw);
+
+// Non-object targets still throw
+let nonObjThrew = false;
+try {
+  Reflect.deleteProperty(1 as any, "p");
+} catch (e) {
+  nonObjThrew = e instanceof TypeError;
+}
+results.push(nonObjThrew);
+
+results.every((r) => r) && results.length === 15;


### PR DESCRIPTION
Fixes #297 and #298, plus a related pre-existing upvalue bug found while probing. Three commits, one per fix.

## 1. `Reflect.deleteProperty` accepts every object kind (#297)

The handler only recognised PlainObject/DictObject targets, so any callable target (function, class, arrow, native, bound) threw `TypeError: Reflect.deleteProperty called on non-object`. undici's `response.js`/`request.js`/`websocket.js` do exactly this at module top level, so `require()`-ing them threw unconditionally.

New `pkg/builtins/reflect_delete.go` implements [[Delete]] for all kinds: plain/dict objects (incl. module namespaces and the global object's heap-backed DontDelete bindings), arrays, arguments, the five callable kinds (intrinsic `name`/`length`, non-configurable `prototype`, closure-table shadowing), side-table exotics (RegExp incl. `lastIndex`, Map, Set, Promise), and Proxy with trap plus invariants. Refused deletes report `false` per spec; only Proxy invariant violations throw.

Also fixed in the same method: symbol keys were stringified, and the key never went through ToPropertyKey so a throwing `toString` was lost.

## 2. Close open upvalues when unwinding pops a frame

`unwindException` popped frames with a bare `frameCount--` and never closed their upvalues (unlike `OpReturn`). An escaped closure kept aliasing the dead register slot and saw whatever the next call wrote there:

```js
let h; function g() { let x = 1; h = () => x; throw 1; }
try { g(); } catch {}
function k() { let a = 99, b = 98, c = 97; return a + b + c; }
k(); h(); // was 99, now 1
```

Same fix applied to `truncateFramesTo` for the boundary frame it drops.

## 3. Pop the top-level script frame when a run completes (#298)

The run loop's top-level fast return (`frameCount == 1 && Name == "<script>"`) in `OpReturn`/`OpReturnUndefined` returned without popping the script frame or its register window. Every completed `Interpret` left one dead frame, so the next run's script frame was pushed as a nested `isDirectCall=true` frame. The unwinder treats that as a native boundary, so a throw that crossed `vm.Call` stopped there, was reported as handled, and the run finished with zero errors.

Fix: a `popTopLevelScriptFrame` helper (closes upvalues, pops, reclaims the window), and `Interpret` resets `nextRegSlot` when no frames are live.

### test262 impact

Compared against a runner built from `main` (language and built-ins, 0.2s timeout):

| suite | before | after |
|---|---|---|
| language | 23170 / 23523 | 23069 / 23523 |
| built-ins | 16357 / 23294 | 16352 / 23294 |

- **+7 new passes**: `Reflect/deleteProperty` (delete-symbol-properties, return-abrupt-from-property-key, return-abrupt-from-result) and `Proxy/deleteProperty` (4 tests).
- **113 newly reported failures are exposed false passes, not regressions.** The runner's module mode runs the harness as one top-level chunk and the test as a second, which is exactly the #298 pattern, so every module-flagged test whose assertion failed was scored as a pass. They are all import-defer (66), import.meta, module-code TLA/instantiation, AbstractModuleSource and ShadowRealm. Verified: the `main` runner reports PASS on `built-ins/AbstractModuleSource/length.js`, which asserts `typeof AbstractModuleSource === "function"` while that global is undefined.

### Tests

- `tests/scripts/reflect_delete_property_function_target.ts` (15 sub-checks across target kinds)
- `tests/scripts/closure_upvalue_closed_on_unwind.ts`
- `pkg/driver/rerun_throw_propagation_test.go`: every prior-run/mode combination from #298, plus a check that closures created by a completed run still work after its window is reclaimed.

`go test ./tests -run TestScripts`, `./pkg/driver`, `./pkg/vm`, `./pkg/builtins` all green.

### Noticed, not touched

`1 in [1,,3]` returns true for holes, and `eval("export var x")` does not throw a SyntaxError. Both pre-existing and unrelated.
