### PR TITLE
fix(builtins): preserve existing accessor when defineProperty gets a generic descriptor

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3765,8 +3765,17 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 					return vm.Undefined, vmInstance.NewTypeError("Cannot redefine property: " + propName)
 				}
 			}
+			// A generic descriptor (no value/writable/get/set - e.g. just
+			// {enumerable: true}) must not change an existing property's
+			// kind (ValidateAndApplyPropertyDescriptor, ES2025 10.1.6.3): if
+			// the property is already an accessor, route it through the
+			// accessor path (which leaves an unspecified getter/setter
+			// untouched) rather than the data path, which would otherwise
+			// stomp the accessor with a data property whose value defaults
+			// to undefined.
+			useAccessorPath := hasGetter || hasSetter || (exists && isAccessor0 && !hasValue && !hasWritable)
 			var defined bool
-			if hasGetter || hasSetter {
+			if useAccessorPath {
 				// Accessor path
 				if keyIsSymbol {
 					defined = plainObj.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)

--- a/tests/scripts/issue302_define_property_partial_accessor.ts
+++ b/tests/scripts/issue302_define_property_partial_accessor.ts
@@ -1,0 +1,130 @@
+// expect: true
+// paserati#302: redefining an existing accessor property with a *partial*
+// descriptor - one that specifies enumerable/configurable/writable but omits
+// get/set/value - silently destroyed the existing getter/setter instead of
+// merging into it (ValidateAndApplyPropertyDescriptor, ES2025 10.1.6.3: a
+// descriptor that mentions none of Value/Writable/Get/Set is "generic" and
+// must not change the property's kind at all).
+const checks: boolean[] = [];
+
+// --- Minimal repro from the issue: a class getter flipped enumerable via a
+// shared descriptor object (the undici `kEnumerableProperty` idiom). ---
+class Foo {
+  #signal: string;
+  constructor() {
+    this.#signal = "hello";
+  }
+  get signal() {
+    return this.#signal;
+  }
+}
+const kEnumerableProperty = { enumerable: true };
+const FooProto: any = (Foo as any).prototype;
+Object.defineProperties(FooProto, {
+  signal: kEnumerableProperty,
+});
+const f = new Foo();
+checks.push(f.signal === "hello");
+checks.push(
+  Object.getOwnPropertyDescriptor(FooProto, "signal")!.enumerable === true
+);
+checks.push(
+  typeof Object.getOwnPropertyDescriptor(FooProto, "signal")!.get ===
+    "function"
+);
+
+// --- Object.defineProperty (singular), shared descriptor object reused
+// across keys - same idiom, different entry point. ---
+const o: any = {};
+Object.defineProperty(o, "x", {
+  get: function () {
+    return 42;
+  },
+  configurable: true,
+});
+Object.defineProperty(o, "x", kEnumerableProperty);
+checks.push(o.x === 42);
+checks.push(Object.getOwnPropertyDescriptor(o, "x").enumerable === true);
+
+// --- Both getter and setter must survive a generic descriptor. ---
+let backing = 1;
+Object.defineProperty(o, "y", {
+  get: function () {
+    return backing;
+  },
+  set: function (v: number) {
+    backing = v;
+  },
+  configurable: true,
+});
+Object.defineProperty(o, "y", { configurable: false });
+o.y = 99;
+checks.push(backing === 99 && o.y === 99);
+checks.push(Object.getOwnPropertyDescriptor(o, "y").configurable === false);
+
+// --- A generic descriptor on a non-configurable accessor is still a
+// no-op success when it doesn't actually change anything ... ---
+let noThrow = true;
+try {
+  Object.defineProperty(o, "y", {});
+} catch (e) {
+  noThrow = false;
+}
+checks.push(noThrow);
+
+// --- ... but still rejects an actual attribute change once locked down. ---
+let threw = false;
+try {
+  Object.defineProperty(o, "y", { configurable: true });
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+checks.push(threw);
+
+// --- A descriptor that DOES specify value/writable must still convert an
+// accessor into a real data property (the generic-descriptor carve-out must
+// not swallow legitimate kind conversions). ---
+const p: any = {};
+Object.defineProperty(p, "z", {
+  get: function () {
+    return 1;
+  },
+  configurable: true,
+});
+Object.defineProperty(p, "z", { value: 5, writable: true, configurable: true });
+checks.push(p.z === 5);
+checks.push(
+  typeof Object.getOwnPropertyDescriptor(p, "z").get === "undefined"
+);
+
+// --- A generic descriptor that merely restates the current attributes of a
+// NON-configurable accessor must still succeed as a no-op (this exercises
+// accessorRedefineAllowed with hasGetter=hasSetter=false, the exact path the
+// fix routes into for a locked-down accessor). ---
+const q: any = {};
+Object.defineProperty(q, "w", {
+  get: function () {
+    return 7;
+  },
+  enumerable: false,
+  configurable: false,
+});
+Object.defineProperty(q, "w", { enumerable: false });
+checks.push(q.w === 7);
+checks.push(Object.getOwnPropertyDescriptor(q, "w").enumerable === false);
+
+// --- Same generic-descriptor merge, through a symbol key. ---
+const sym = Symbol("k");
+const r: any = {};
+Object.defineProperty(r, sym, {
+  get: function () {
+    return 55;
+  },
+  configurable: true,
+});
+Object.defineProperty(r, sym, { enumerable: true });
+checks.push(r[sym] === 55);
+checks.push(Object.getOwnPropertyDescriptor(r, sym).enumerable === true);
+checks.push(typeof Object.getOwnPropertyDescriptor(r, sym).get === "function");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Fixes #302.

`Object.defineProperty`/`defineProperties` on a `PlainObject` chose the data-vs-accessor code path solely by whether the *incoming* descriptor mentioned `get`/`set`, ignoring whether the *existing* property was already an accessor. A generic descriptor (one specifying only `enumerable`/`configurable`, with none of `value`/`get`/`set`/`writable`) therefore fell into the data-property path and got applied via `PlainObject.DefineOwnProperty`, which tore down the accessor's getter/setter and replaced it with a plain `undefined`-valued data slot.

Per `ValidateAndApplyPropertyDescriptor` (ES2025 10.1.6.3), a descriptor with none of `[[Value]]`, `[[Writable]]`, `[[Get]]`, `[[Set]]` is "generic" and must not change a property's kind at all — it may only patch `enumerable`/`configurable` in place.

## Fix

Route to the accessor path whenever the incoming descriptor specifies `get`/`set`, **or** the existing property is already an accessor and the descriptor doesn't request a kind change (no `value`/`writable`). `DefineAccessorProperty` already leaves an unspecified getter/setter untouched, so this alone restores merge behavior; a descriptor that does specify `value`/`writable` still converts the accessor to a real data property, unchanged.

This is the exact idiom real-world code uses to flip a class getter's `enumerable` flag without rewriting it as a full descriptor — e.g. npm `undici`'s `Object.defineProperties(Request.prototype, { signal: kEnumerableProperty, ... })`, which silently destroyed every one of those accessors before this fix.

Scoped to the `PlainObject` target (class instances/prototypes, plain objects) — what's reproducible and what the issue's repro hits. `BoundFunction`/`NativeFunctionWithProps`/`TypeFunction`/`TypeClosure` targets have no attribute-preservation logic at all for their side-table properties — a separate, pre-existing gap, not touched here.

## Testing

- New regression test: `tests/scripts/issue302_define_property_partial_accessor.ts` — covers the class-getter repro, `defineProperty`/`defineProperties`, getter+setter preservation, non-configurable no-op/reject semantics (both empty and non-empty attribute paths), legitimate accessor→data conversion, and the symbol-keyed variant.
- `go test ./tests -run TestScripts`: all green.
- test262 (`built-ins/Object`, `-timeout 0.2s`): 2892 → 2906 passed (net **+14**), **zero regressions** (verified via before/after dump diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)