### PR TITLE
fix(parser): reject module-only syntax in eval and new Function

### DIFF
--- a/pkg/builtins/function_init.go
+++ b/pkg/builtins/function_init.go
@@ -515,6 +515,9 @@ func functionConstructorImpl(vmInstance *vm.VM, driver interface{}, args []vm.Va
 	// Parse the source code
 	lx := lexer.NewLexer(source)
 	p := parser.NewParser(lx)
+	// Per ECMA-262 20.2.1.1.1 CreateDynamicFunction, the body parses with the
+	// FunctionBody goal - reject import/export declarations and import.meta.
+	p.SetDisallowModuleSyntax(true)
 	prog, parseErrs := p.ParseProgram()
 	if len(parseErrs) > 0 {
 		return vm.Undefined, vmInstance.NewSyntaxError(parseErrs[0].Error())
@@ -625,6 +628,9 @@ func asyncFunctionConstructorImpl(vmInstance *vm.VM, driver interface{}, args []
 	// Parse the source code
 	lx := lexer.NewLexer(source)
 	p := parser.NewParser(lx)
+	// Per ECMA-262 20.2.1.1.1 CreateDynamicFunction, the body parses with the
+	// FunctionBody goal - reject import/export declarations and import.meta.
+	p.SetDisallowModuleSyntax(true)
 	prog, parseErrs := p.ParseProgram()
 	if len(parseErrs) > 0 {
 		return vm.Undefined, vmInstance.NewSyntaxError(parseErrs[0].Error())

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -427,6 +427,10 @@ func (p *Paserati) EvalCode(code string, inheritStrict bool) (vm.Value, []error)
 	// Parse the source code
 	lx := lexer.NewLexer(code)
 	ps := parser.NewParser(lx)
+	// Per ECMA-262 19.2.1.1 PerformEval, eval always parses with the Script
+	// goal, regardless of whether the calling context is a module - reject
+	// import/export/import.meta and top-level await.
+	ps.SetDisallowModuleSyntax(true)
 	// Set strict mode before parsing so legacy octal etc. are rejected during parse
 	if inheritStrict {
 		ps.SetStrictMode(true)
@@ -490,6 +494,9 @@ func (p *Paserati) IndirectEvalCode(code string) (vm.Value, []error) {
 	lx := lexer.NewLexer(code)
 	ps := parser.NewParser(lx)
 	ps.SetDisallowSuper(true)
+	// Per ECMA-262 19.2.1.1 PerformEval, eval always parses with the Script
+	// goal - reject import/export/import.meta and top-level await.
+	ps.SetDisallowModuleSyntax(true)
 	prog, parseErrs := ps.ParseProgram()
 	if len(parseErrs) > 0 {
 		errs := make([]error, len(parseErrs))
@@ -547,6 +554,10 @@ func (p *Paserati) DirectEvalCode(code string, inheritStrict bool, scopeDesc *vm
 	// Parse the source code
 	lx := lexer.NewLexer(code)
 	ps := parser.NewParser(lx)
+	// Per ECMA-262 19.2.1.1 PerformEval, eval always parses with the Script
+	// goal, regardless of whether the calling context is a module - reject
+	// import/export/import.meta and top-level await.
+	ps.SetDisallowModuleSyntax(true)
 	// Set strict mode before parsing so legacy octal etc. are rejected during parse
 	if inheritStrict {
 		ps.SetStrictMode(true)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -66,6 +66,14 @@ type Parser struct {
 	// Eval context flags
 	disallowSuper bool // When true, super expressions throw SyntaxError (for indirect eval)
 
+	// disallowModuleSyntax is set when parsing with the Script or FunctionBody
+	// grammar goal (eval, new Function/AsyncFunction) rather than the Module
+	// goal. Per ECMA-262 19.2.1.1 (PerformEval) and 20.2.1.1.1
+	// (CreateDynamicFunction), such code must raise an early SyntaxError for
+	// import/export declarations and import.meta, which are Module-only
+	// productions.
+	disallowModuleSyntax bool
+
 	// Strict mode tracking
 	strictMode bool // True when parsing strict mode code
 
@@ -429,6 +437,24 @@ func (p *Parser) SetDisallowSuper(disallow bool) {
 	p.disallowSuper = disallow
 }
 
+// SetDisallowModuleSyntax switches this parse to the Script/FunctionBody
+// grammar goal: import/export declarations and import.meta become early
+// SyntaxErrors, matching PerformEval (ECMA-262 19.2.1.1) and
+// CreateDynamicFunction (20.2.1.1.1). Call this immediately after
+// constructing the parser, before any tokens are consumed - it also bumps
+// the "inside a non-async function" context so an unparenthesized top-level
+// 'await' in this parse is treated as a plain identifier reference rather
+// than an AwaitExpression, exactly as it already is inside an ordinary
+// (non-async) function body: neither eval nor a Function()/AsyncFunction()
+// body's outermost statement list is Module top-level, so top-level await
+// never applies there.
+func (p *Parser) SetDisallowModuleSyntax(disallow bool) {
+	p.disallowModuleSyntax = disallow
+	if disallow {
+		p.inNonAsyncFunction++
+	}
+}
+
 // SetStrictMode sets whether the parser should operate in strict mode.
 // This is used for eval() to inherit strict mode from the calling context.
 func (p *Parser) SetStrictMode(strict bool) {
@@ -706,12 +732,18 @@ func (p *Parser) parseStatement() Statement {
 	case lexer.IMPORT:
 		// Check if this is import.meta, import(), or import declaration
 		if p.peekTokenIs(lexer.DOT) {
-			// This is import.meta, parse as expression statement
+			// This is import.meta/import.defer/import.source - parse as an
+			// expression statement; parseImportMetaExpression rejects it
+			// itself when disallowModuleSyntax is set.
 			return p.parseExpressionStatement()
 		}
 		if p.peekTokenIs(lexer.LPAREN) {
-			// This is import(), parse as expression statement (dynamic import)
+			// This is import(), parse as expression statement (dynamic
+			// import) - a Script-goal production, always allowed.
 			return p.parseExpressionStatement()
+		}
+		if p.disallowModuleSyntax {
+			p.addError(p.curToken, "SyntaxError: 'import' declarations are only valid in module code")
 		}
 		// A nil *ImportDeclaration must not escape as a non-nil Statement.
 		if decl := p.parseImportDeclaration(); decl != nil {
@@ -719,6 +751,9 @@ func (p *Parser) parseStatement() Statement {
 		}
 		return nil
 	case lexer.EXPORT:
+		if p.disallowModuleSyntax {
+			p.addError(p.curToken, "SyntaxError: 'export' declarations are only valid in module code")
+		}
 		return p.parseExportDeclaration()
 	case lexer.LBRACE:
 		// Check if this is a block statement or destructuring assignment
@@ -2519,10 +2554,16 @@ func (p *Parser) parseImportMetaExpression() Expression {
 		p.nextToken() // Move to '.'
 		if p.peekTokenIs(lexer.IDENT) && p.peekToken.Literal == "meta" {
 			p.nextToken() // Move to 'meta'
+			if p.disallowModuleSyntax {
+				p.addError(importToken, "SyntaxError: 'import.meta' is only valid in module code")
+			}
 			return &ImportMetaExpression{Token: importToken}
 		} else if p.peekTokenIs(lexer.IDENT) && (p.peekToken.Literal == "defer" || p.peekToken.Literal == "source") {
 			importPhase := p.peekToken.Literal
 			p.nextToken() // Move to 'defer' or 'source'
+			if p.disallowModuleSyntax {
+				p.addError(importToken, "SyntaxError: 'import."+importPhase+"' is only valid in module code")
+			}
 
 			// Expect LPAREN after defer/source
 			if !p.expectPeek(lexer.LPAREN) {

--- a/tests/scripts/issue301_eval_function_module_syntax.ts
+++ b/tests/scripts/issue301_eval_function_module_syntax.ts
@@ -1,0 +1,86 @@
+// expect: true
+// paserati#301: direct eval, indirect eval, and new Function accept source
+// that is only valid as a Module and must be an early SyntaxError as a
+// Script/FunctionBody (ECMA-262 19.2.1.1 PerformEval parses the source with
+// the Script goal; 20.2.1.1.1 CreateDynamicFunction with FunctionBody).
+// Only dynamic import(...) - itself a Script-goal production - stays legal.
+const checks: boolean[] = [];
+
+function throwsSyntaxError(fn: () => void): boolean {
+  try {
+    fn();
+    return false;
+  } catch (e) {
+    return e instanceof SyntaxError;
+  }
+}
+
+function throwsAnything(fn: () => void): boolean {
+  try {
+    fn();
+    return false;
+  } catch (e) {
+    return true;
+  }
+}
+
+// --- Direct eval ---
+checks.push(throwsSyntaxError(() => eval("export var x;")));
+checks.push(throwsSyntaxError(() => eval("export default 1;")));
+checks.push(throwsSyntaxError(() => eval("export {};")));
+checks.push(throwsSyntaxError(() => eval('import x from "y";')));
+checks.push(throwsSyntaxError(() => eval("import.meta")));
+
+// --- Indirect eval ---
+const indirectEval = eval;
+checks.push(throwsSyntaxError(() => indirectEval("export var x;")));
+checks.push(throwsSyntaxError(() => indirectEval("export default 1;")));
+checks.push(throwsSyntaxError(() => indirectEval("export {};")));
+checks.push(throwsSyntaxError(() => indirectEval('import x from "y";')));
+checks.push(throwsSyntaxError(() => indirectEval("import.meta")));
+
+// --- new Function ---
+checks.push(throwsSyntaxError(() => new Function("export var x;")));
+checks.push(throwsSyntaxError(() => new Function("export default 1;")));
+checks.push(throwsSyntaxError(() => new Function("export {};")));
+checks.push(throwsSyntaxError(() => new Function('import x from "y";')));
+checks.push(throwsSyntaxError(() => new Function("import.meta")));
+
+// --- Dynamic import() is a Script-goal production and must stay legal in
+// all three contexts (it just fails to resolve a module, which isn't a
+// SyntaxError). ---
+checks.push(!throwsSyntaxError(() => eval('import("nonexistent-module")')));
+checks.push(
+  !throwsSyntaxError(() => indirectEval('import("nonexistent-module")'))
+);
+checks.push(
+  !throwsSyntaxError(() => new Function('return import("nonexistent-module")'))
+);
+
+// --- A nested async function inside a Function() body can still use a real
+// (non-top-level) await - the fix must not disturb ordinary await. ---
+checks.push(
+  !throwsSyntaxError(() =>
+    new Function("return (async function(){ return await 1; })();")()
+  )
+);
+
+// --- Direct/indirect eval's own top level must not silently accept
+// top-level await as if it were module code: 'await' parses as a plain
+// identifier reference there, not an AwaitExpression, so it is not a number. ---
+checks.push(eval("typeof await") === "undefined");
+checks.push(indirectEval("typeof await") === "undefined");
+
+// --- The exact issue-table repro: before this fix, direct eval("await 1;")
+// silently returned 1 with no throw at all (treating it as real top-level
+// await). It must now throw. Spec wants an early SyntaxError here (a Script
+// grammar can't have "await 1" adjacent with no operator/ASI between the
+// now-plain-identifier 'await' and '1'); this runtime instead throws
+// ReferenceError ('await' is read as a value before failing to continue the
+// statement) because of a separate, pre-existing ASI-leniency gap that
+// already accepts "x 1" as two statements with no line break anywhere in
+// this parser (independent of eval/await) - not fixed here. What matters for
+// this issue is that it no longer silently succeeds as top-level await. ---
+checks.push(throwsAnything(() => eval("await 1;")));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Fixes #301.

Direct eval, indirect eval, and `new Function`/`AsyncFunction` accepted source that is only valid as a Module and must be an early `SyntaxError` as a Script/FunctionBody: `export`/`import` declarations, `import.meta`, and `import.defer()`/`import.source()` (the same Module-only production family). Per ECMA-262 19.2.1.1 `PerformEval`, eval always parses with the **Script** goal regardless of the caller's own module-or-not status; per 20.2.1.1.1 `CreateDynamicFunction`, a dynamic function's body parses with the **FunctionBody** goal. Neither grammar goal permits those productions.

There was no parser-level gating for any of this — the existing `EnableModuleMode`/`DisableModuleMode`/`SetForceScriptMode` machinery lives on the checker/compiler only, and its one actual rejection (`import.meta`, in the compiler) was never wired into eval at all.

## Fix

Add a `Parser`-level flag, `SetDisallowModuleSyntax`, mirroring the existing `SetDisallowSuper`. When set:
- static `import`/`export` declarations raise an early `SyntaxError` instead of parsing (dynamic `import(...)` — itself a Script-goal production — stays legal)
- `import.meta`/`import.defer(...)`/`import.source(...)` raise an early `SyntaxError` instead of parsing
- an unparenthesized top-level `await` is treated as a plain identifier reference rather than an `AwaitExpression`, by bumping the existing `inNonAsyncFunction` counter (which already has exactly this effect for an ordinary non-async function body) — nested async functions are unaffected, since they save/restore that counter around their own bodies

Wired into all three eval driver entry points (`EvalCode`, `IndirectEvalCode`, `DirectEvalCode`) and both dynamic function constructors (`Function`, `AsyncFunction`).

## Known limitation (not fixed here)

`eval("await 1;")` now throws (previously silently returned `1` as if it were real top-level await) but throws `ReferenceError` rather than the spec's `SyntaxError`, because of a separate, pre-existing ASI-leniency gap in this parser that already accepts `x 1` as two statements with no line break between them, independent of `await` (verified: `eval("x 1")` behaves identically on `main` for plain identifiers). What this issue asks for — that module-only syntax no longer silently succeeds — is satisfied; closing that ASI gap is a separate, broader change.

## Also found, not fixed here (flagged separately)

While verifying this fix I found that a genuine runtime exception thrown by code passed to **indirect eval** escapes the caller's `try/catch` entirely — confirmed pre-existing on `main` before I touched any code, and unrelated to this change. It only became visible while testing here because `eval("await 1;")` now actually throws instead of silently succeeding. Spun off as a separate task rather than folded into this PR.

## Testing

- New regression test: `tests/scripts/issue301_eval_function_module_syntax.ts` — covers `export`/`import`/`import.meta` rejection across direct eval, indirect eval, and `new Function`; confirms dynamic `import()` stays legal in all three; confirms a nested async function's real `await` inside a `Function()` body still works; confirms eval's top-level `await` no longer behaves as real top-level await.
- `go test ./tests -run TestScripts`: all green.
- test262, before/after dump diff:
  - `language` (23523 tests): +5 passing, **0 regressions** — the exact tests named in the issue (`eval-code/direct/export.js`, `eval-code/direct/import.js`, `eval-code/indirect/export.js`, `eval-code/indirect/import.js`, `expressions/import.meta/not-accessible-from-direct-eval.js`).
  - `built-ins` (23294 tests): +1 passing, **0 regressions**.
  - `built-ins/Function` (509 tests): unchanged, 0 regressions.
  - Confirmed via `grep` that `EvalCode`/`IndirectEvalCode`/`DirectEvalCode` have exactly the call sites this PR touches — no REPL/`-e`/module-loading path is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)