### PR TITLE
fix(vm,parser,compiler): array holes are real absent own properties, not present undefined

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -199,18 +199,7 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			// array's elision, or a prior `delete arr[i]`) as absent
 			// rather than just checking the index is in bounds.
 			if index, err := strconv.Atoi(propName); err == nil && index >= 0 {
-				if arrObj.HasAccessors() {
-					if _, _, _, _, ok := arrObj.GetOwnAccessor(propName); ok {
-						return vm.BooleanValue(true), nil
-					}
-				}
-				if arrObj.HasIndex(index) {
-					return vm.BooleanValue(true), nil
-				}
-				// Beyond the dense elements slice: a huge sparse index (see
-				// maxDenseArrayDefineIndex) is tracked in the properties map.
-				_, hasOwn := arrObj.GetOwn(propName)
-				return vm.BooleanValue(hasOwn), nil
+				return vm.BooleanValue(arrObj.HasOwnIndexProperty(propName, index)), nil
 			}
 			// Check custom named properties (e.g., pos, end for TypeScript node arrays)
 			_, hasOwn := arrObj.GetOwn(propName)
@@ -1940,7 +1929,11 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	case vm.TypeArray:
 		arrObj := obj.AsArray()
 		for i := 0; i < arrObj.Length(); i++ {
-			keysArray.Append(vm.NewString(strconv.Itoa(i)))
+			key := strconv.Itoa(i)
+			if !arrObj.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
+			keysArray.Append(vm.NewString(key))
 		}
 		// Named own properties (an exec result's index/input/groups/indices,
 		// or anything stored on the array) follow the indices.
@@ -2353,6 +2346,10 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	case vm.TypeArray:
 		arrObj := obj.AsArray()
 		for i := 0; i < arrObj.Length(); i++ {
+			key := strconv.Itoa(i)
+			if !arrObj.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
 			valuesArray.Append(arrObj.Get(i))
 		}
 	case vm.TypeFunction:
@@ -2471,8 +2468,12 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	case vm.TypeArray:
 		arrObj := obj.AsArray()
 		for i := 0; i < arrObj.Length(); i++ {
+			key := strconv.Itoa(i)
+			if !arrObj.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
 			entry := vm.NewArray()
-			entry.AsArray().Append(vm.NewString(strconv.Itoa(i)))
+			entry.AsArray().Append(vm.NewString(key))
 			entry.AsArray().Append(arrObj.Get(i))
 			entriesArray.Append(entry)
 		}
@@ -2578,7 +2579,11 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 	case vm.TypeArray:
 		a := obj.AsArray()
 		for i := 0; i < a.Length(); i++ {
-			arrObj.Append(vm.NewString(strconv.Itoa(i)))
+			key := strconv.Itoa(i)
+			if !a.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
+			arrObj.Append(vm.NewString(key))
 		}
 		arrObj.Append(vm.NewString("length"))
 		for _, key := range a.NamedPropertyKeys() {
@@ -2778,7 +2783,11 @@ func reflectOwnKeysImpl(args []vm.Value) (vm.Value, error) {
 	} else if obj.Type() == vm.TypeArray {
 		a := obj.AsArray()
 		for i := 0; i < a.Length(); i++ {
-			outArr.Append(vm.NewString(strconv.Itoa(i)))
+			key := strconv.Itoa(i)
+			if !a.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
+			outArr.Append(vm.NewString(key))
 		}
 		outArr.Append(vm.NewString("length"))
 	}
@@ -2947,6 +2956,9 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			// For arrays, copy indexed properties
 			for i := 0; i < arrObj.Length(); i++ {
 				key := strconv.Itoa(i)
+				if !arrObj.HasOwnIndexProperty(key, i) {
+					continue // hole - not an own property at all, nothing to copy (paserati#300)
+				}
 				value := arrObj.Get(i)
 				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
 					return vm.Undefined, err
@@ -3032,8 +3044,8 @@ func objectHasOwnWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			return vm.BooleanValue(true), nil
 		}
 		// Check numeric indices
-		if index, err := strconv.Atoi(propName); err == nil {
-			return vm.BooleanValue(index >= 0 && index < arrObj.Length()), nil
+		if index, err := strconv.Atoi(propName); err == nil && index >= 0 {
+			return vm.BooleanValue(arrObj.HasOwnIndexProperty(propName, index)), nil
 		}
 	}
 
@@ -3984,7 +3996,7 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 				if propName == "length" {
 					targetDescFound = true
 					targetConfigurable = false
-				} else if index, parseErr := strconv.Atoi(propName); parseErr == nil && index >= 0 && index < arrObj.Length() {
+				} else if index, parseErr := strconv.Atoi(propName); parseErr == nil && index >= 0 && arrObj.HasOwnIndexProperty(propName, index) {
 					targetDescFound = true
 					targetConfigurable = !arrObj.IsFrozen()
 				} else if _, desc, ok := arrObj.GetOwnPropertyDescriptor(propName); ok {
@@ -4243,6 +4255,13 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			descriptor.SetOwn("configurable", vm.BooleanValue(false))
 			return vm.NewValueFromPlainObject(descriptor), nil
 		} else if index, err := strconv.Atoi(propName); err == nil && index >= 0 && index < arrObj.Length() {
+			// A hole (from `delete arr[i]`, a literal elision, or `new
+			// Array(n)`) is not an own property at all - report undefined
+			// rather than a data descriptor whose value happens to be
+			// undefined (paserati#300).
+			if !arrObj.HasOwnIndexProperty(propName, index) {
+				return vm.Undefined, nil
+			}
 			value = arrObj.Get(index)
 			// arrObj.Get only looks at the dense .elements slice; an index
 			// beyond maxDenseArrayDefineIndex/maxDenseArraySetIndex is

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -432,9 +432,15 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		case vm.TypeArray:
 			arrayObj := target.AsArray()
-			// Add numeric indices
+			// Add numeric indices - skipping holes (paserati#300): a hole
+			// from `delete arr[i]`, a literal elision, or `new Array(n)` is
+			// not an own property at all.
 			for i := 0; i < arrayObj.Length(); i++ {
-				arr.Append(vm.NewString(strconv.Itoa(i)))
+				key := strconv.Itoa(i)
+				if !arrayObj.HasOwnIndexProperty(key, i) {
+					continue
+				}
+				arr.Append(vm.NewString(key))
 			}
 			// Add "length"
 			arr.Append(vm.NewString("length"))

--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -463,9 +463,29 @@ func (c *Compiler) compileArrowFunctionWithName(node *parser.ArrowFunctionLitera
 	return constIdx, freeSymbols, nil
 }
 
+// compileArrayLiteralElement compiles one element of an array literal
+// (identified by its position in node.Elements) into targetReg. A genuine
+// elision - node.Elisions[index] true, e.g. the middle slot of [1,,3] -
+// loads the Hole sentinel instead of compiling the UndefinedLiteral
+// placeholder Elements holds there, so the resulting array has a real
+// sparse hole at that index (paserati#300: HasIndex/hasOwnProperty/`in`/
+// Object.keys etc. all already treat a Hole value as an absent own
+// property) rather than a present element whose value happens to be
+// undefined.
+func (c *Compiler) compileArrayLiteralElement(node *parser.ArrayLiteral, index int, targetReg Register, line int) (Register, errors.PaseratiError) {
+	if index < len(node.Elisions) && node.Elisions[index] {
+		c.emitLoadNewConstant(targetReg, vm.Hole, line)
+		return targetReg, nil
+	}
+	return c.compileNode(node.Elements[index], targetReg)
+}
+
 func (c *Compiler) compileArrayLiteral(node *parser.ArrayLiteral, hint Register) (Register, errors.PaseratiError) {
 	elementCount := len(node.Elements)
-	// Normalize elisions (holes) to explicit undefined literals so runtime sees correct length and values
+	// Normalize elisions (holes) to explicit undefined literals so runtime sees correct length and values.
+	// This is now purely a safety net - the parser always fills Elements with
+	// an UndefinedLiteral at an elided position (see ArrayLiteral.Elisions) -
+	// but keep it in case some other AST construction path still leaves a nil.
 	for i, elem := range node.Elements {
 		if elem == nil {
 			node.Elements[i] = &parser.UndefinedLiteral{Token: parser.GetTokenFromNode(node)}
@@ -536,9 +556,9 @@ func (c *Compiler) compileArrayLiteralSimple(node *parser.ArrayLiteral, hint Reg
 			// (control flows to the chunking path below)
 		} else {
 			// Compile elements directly into contiguous positions
-			for i, elem := range node.Elements {
+			for i := range node.Elements {
 				targetReg := firstTargetReg + Register(i)
-				if _, err := c.compileNode(elem, targetReg); err != nil {
+				if _, err := c.compileArrayLiteralElement(node, i, targetReg, line); err != nil {
 					// Free already allocated registers on error
 					for j := 0; j < elementCount; j++ {
 						c.regAlloc.Free(firstTargetReg + Register(j))
@@ -596,21 +616,23 @@ func (c *Compiler) compileArrayLiteralSimple(node *parser.ArrayLiteral, hint Reg
 		// Try to allocate a contiguous block for this chunk
 		startReg, ok := c.regAlloc.TryAllocContiguous(n)
 		if !ok {
-			// If contiguous allocation fails, fall back to one-by-one insertion
+			// If contiguous allocation fails, fall back to one-by-one
+			// insertion via OpArrayCopy (count=1): a raw slice write into
+			// arrObj.elements, same as the chunk-copy path below - unlike
+			// OpSetIndex (a full property-set with prototype/setter/proxy
+			// semantics meant for real `arr[i] = v` assignments), this can't
+			// mishandle a Hole value from an elision (paserati#300).
 			for i := 0; i < n; i++ {
 				elemReg := c.regAlloc.Alloc()
-				if _, err := c.compileNode(node.Elements[offset+i], elemReg); err != nil {
+				if _, err := c.compileArrayLiteralElement(node, offset+i, elemReg, line); err != nil {
 					c.regAlloc.Free(elemReg)
 					return BadRegister, err
 				}
-				// Emit OpSetIndex to set array[offset+i] = element
-				indexReg := c.regAlloc.Alloc()
-				c.emitLoadNewConstant(indexReg, vm.Number(float64(offset+i)), line)
-				c.emitOpCode(vm.OpSetIndex, line)
-				c.emitByte(byte(hint))     // array
-				c.emitByte(byte(indexReg)) // index
-				c.emitByte(byte(elemReg))  // value
-				c.regAlloc.Free(indexReg)
+				c.emitOpCode(vm.OpArrayCopy, line)
+				c.emitByte(byte(hint))
+				c.emitUint16(uint16(offset + i))
+				c.emitByte(byte(elemReg))
+				c.emitByte(1)
 				c.regAlloc.Free(elemReg)
 			}
 			offset += n
@@ -618,7 +640,7 @@ func (c *Compiler) compileArrayLiteralSimple(node *parser.ArrayLiteral, hint Reg
 		}
 		// Compile chunk elements into the allocated registers
 		for i := 0; i < n; i++ {
-			if _, err := c.compileNode(node.Elements[offset+i], startReg+Register(i)); err != nil {
+			if _, err := c.compileArrayLiteralElement(node, offset+i, startReg+Register(i), line); err != nil {
 				// Free already allocated regs before returning
 				for j := 0; j <= i; j++ {
 					c.regAlloc.Free(startReg + Register(j))

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -1656,6 +1656,19 @@ type ArrayLiteral struct {
 	BaseExpression              // Embed base for ComputedType (e.g., types.ArrayType)
 	Token          *lexer.Token // The '[' token
 	Elements       []Expression
+	// Elisions marks which of Elements is a genuine elision - a real hole
+	// written in source as an empty slot between commas ([1,,3], a
+	// trailing [1,2,,], or new Array-style leading/only commas [,,,]) -
+	// rather than an explicit `undefined`. Elements still holds an
+	// UndefinedLiteral placeholder at that position (so every other AST
+	// consumer - the checker, tuple-context checking, for-of spread
+	// compilation, and the cover-grammar conversion to a destructuring
+	// target - sees the exact same non-nil node shape it always has and
+	// needs no changes); only compileArrayLiteral (compile_literal.go)
+	// consults this parallel slice, to emit a real Hole value (paserati#300)
+	// instead of Undefined at that position. nil (not every literal has
+	// elisions) or, when non-nil, always the same length as Elements.
+	Elisions []bool
 }
 
 func (al *ArrayLiteral) expressionNode()      {}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -6493,12 +6493,23 @@ func (p *Parser) parseArrayLiteral() Expression {
 	// parseExpressionList expects an element expression before commas; for sparse arrays,
 	// treat missing elements as undefined placeholders.
 	elements := []Expression{}
+	var elisions []bool // lazily backfilled to stay parallel to elements - see below
+	sawElision := false
 	// Advance to first token after '['
 	p.nextToken()
 	for !p.curTokenIs(lexer.RBRACKET) && !p.curTokenIs(lexer.EOF) {
 		if p.curTokenIs(lexer.COMMA) {
-			// Elision: push an explicit undefined literal node
+			// Elision: push an explicit undefined literal node, and record
+			// this position as a genuine hole (as opposed to a literal
+			// `undefined`) for compileArrayLiteral - see ArrayLiteral.Elisions.
+			if !sawElision {
+				// First hole seen: backfill `false` for every element parsed
+				// so far so elisions stays index-aligned with elements.
+				elisions = make([]bool, len(elements))
+				sawElision = true
+			}
 			elements = append(elements, &UndefinedLiteral{Token: p.curToken})
+			elisions = append(elisions, true)
 			// Consume comma and continue; multiple commas generate multiple holes
 			p.nextToken()
 			continue
@@ -6532,6 +6543,10 @@ func (p *Parser) parseArrayLiteral() Expression {
 		}
 
 		elements = append(elements, elem)
+		if sawElision {
+			// Keep elisions parallel to elements once any hole has been seen.
+			elisions = append(elisions, false)
+		}
 		if debugParser {
 			debugPrint("parseArrayLiteral: appended element=%T ('%s')", elem, elem.String())
 		}
@@ -6555,6 +6570,7 @@ func (p *Parser) parseArrayLiteral() Expression {
 		return nil
 	}
 	array.Elements = elements
+	array.Elisions = elisions
 	return array
 }
 

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -1,5 +1,43 @@
 package vm
 
+// HasOwnIndexProperty reports whether a numeric index is a genuine own
+// property of the array - the same three-way check ArrayObject.Get's
+// callers (hasOwnProperty, `in`, Object.keys/values/entries/
+// getOwnPropertyNames, Reflect.ownKeys, Object.assign,
+// getOwnPropertyDescriptor, and the Proxy invariant checks that mirror it)
+// must all agree on, or a hole (from `delete arr[i]`, a literal elision, or
+// `new Array(n)`) gets reported as a present property whose value happens
+// to be undefined (paserati#300):
+//
+//  1. An accessor explicitly installed at this index via
+//     Object.defineProperty takes priority - it's tracked separately from
+//     `elements` (see ArrayDefineOwnProperty's doc comment).
+//  2. Otherwise, HasIndex covers the dense `elements` range, correctly
+//     reporting a hole as absent.
+//  3. Beyond that range (see maxDenseArrayDefineIndex), a huge sparse index
+//     defined via Object.defineProperty (paserati#176/#178) is tracked in
+//     the properties map instead of `elements`, so it must still count as
+//     present even though HasIndex can't see it.
+//
+// propName must be index formatted as a decimal string (the same key
+// GetOwnAccessor/GetOwn use); callers that already have both the parsed int
+// and its string form pass both to avoid re-formatting.
+func (a *ArrayObject) HasOwnIndexProperty(propName string, index int) bool {
+	if index < 0 {
+		return false
+	}
+	if a.HasAccessors() {
+		if _, _, _, _, ok := a.GetOwnAccessor(propName); ok {
+			return true
+		}
+	}
+	if a.HasIndex(index) {
+		return true
+	}
+	_, ok := a.GetOwn(propName)
+	return ok
+}
+
 // maxDenseArrayDefineIndex bounds how far ArrayDefineOwnProperty will grow
 // the elements slice via ArrayObject.Set for a single index write. A valid
 // array index can be as large as 2^32-2 (ArraySetLength's bound - see

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -1397,6 +1397,15 @@ func (v Value) ToString() string {
 		return "null"
 	case TypeUndefined:
 		return "undefined"
+	case TypeHole:
+		// Hole is never itself a user-observable value - ArrayObject.Get
+		// converts it to Undefined before user code ever sees one - so this
+		// case exists only to give bytecode disassembly (-bytecode, which
+		// calls ToString on every constant, including a Hole emitted for an
+		// array-literal elision - see compileArrayLiteralElement,
+		// paserati#300) something readable instead of falling into the
+		// generic "<unknown type N>" fallback below.
+		return "<hole>"
 	case TypeRegExp:
 		regex := v.AsRegExpObject()
 		if regex != nil {
@@ -1795,6 +1804,15 @@ func (v Value) inspectWithDepth(nested bool, depth int, maxDepth int) string {
 		return "null"
 	case TypeUndefined:
 		return "undefined"
+	case TypeHole:
+		// A real sparse hole (`delete arr[i]`, a literal elision like
+		// [1,,3], or new Array(n) - paserati#300) reaches this via the
+		// TypeArray case above iterating arr.elements directly; unlike a
+		// property read (which HasIndex/Get already turn into Undefined
+		// before user code sees it), inspecting the array exposes the hole
+		// itself. Node/V8 group consecutive holes into "<N empty items>";
+		// this is the simpler per-element form, not that compact grouping.
+		return "<empty>"
 	case TypeRegExp:
 		regex := v.AsRegExpObject()
 		if regex != nil {
@@ -1940,8 +1958,15 @@ func (v Value) Is(other Value) bool {
 
 	// Types are the same
 	switch v.typ {
-	case TypeUndefined, TypeNull:
-		return true // Singleton types are always equal to themselves
+	case TypeUndefined, TypeNull, TypeHole:
+		// Singleton types are always equal to themselves. TypeHole is
+		// included here purely so the constant pool's dedup can compare
+		// two Hole constants (emitted for array-literal elisions, see
+		// compileArrayLiteralElement, paserati#300) without hitting the
+		// panic below - Hole is never itself a user-observable value
+		// (ArrayObject.Get converts it to Undefined before user code ever
+		// sees it), so this never affects real equality semantics.
+		return true
 	case TypeBoolean:
 		return v.AsBoolean() == other.AsBoolean() // Compare boolean payloads directly
 	case TypeIntegerNumber:
@@ -2008,8 +2033,15 @@ func (v Value) StrictlyEquals(other Value) bool {
 
 	// Types are the same
 	switch v.typ {
-	case TypeUndefined, TypeNull:
-		return true // Singleton types are always equal to themselves
+	case TypeUndefined, TypeNull, TypeHole:
+		// Singleton types are always equal to themselves. TypeHole is
+		// included defensively for the same reason as in Is() above - a
+		// Hole never actually reaches this comparison today (it's only
+		// ever live in a register between emitLoadNewConstant and the
+		// immediately following OpMakeArray/OpArrayCopy/OpAllocArray), but
+		// there's no reason to leave a latent panic here for whoever next
+		// puts one somewhere new.
+		return true
 	case TypeBoolean:
 		return v.AsBoolean() == other.AsBoolean()
 	case TypeIntegerNumber:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3419,8 +3419,15 @@ startExecution:
 					// For arrays, check if the property is a valid index or known property
 					arrayObj := objVal.AsArray()
 					if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
-						// Check if index is within bounds
-						hasProperty = index < arrayObj.Length()
+						if arrayObj.HasOwnIndexProperty(propKey, index) {
+							hasProperty = true
+						} else {
+							// A hole (from `delete arr[i]`, a literal elision,
+							// or `new Array(n)`) is not an own property at
+							// all - fall through to the prototype chain like
+							// any other absent index (paserati#300).
+							hasProperty = vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(objVal), keyFromString(propKey))
+						}
 					} else if _, ok := arrayObj.GetOwn(propKey); ok {
 						hasProperty = true
 					} else if propKey == "length" {

--- a/tests/scripts/issue300_array_holes_delete_and_new_array.ts
+++ b/tests/scripts/issue300_array_holes_delete_and_new_array.ts
@@ -1,0 +1,68 @@
+// expect: true
+// paserati#300: array holes are materialized as present undefined slots -
+// `in`, hasOwnProperty, Object.keys/getOwnPropertyNames/entries/values,
+// Object.getOwnPropertyDescriptor, Reflect.ownKeys, Object.assign, and
+// for-in all reported a hole (from `delete arr[i]` or `new Array(n)`) as a
+// present own property instead of an absent one, because they checked only
+// "is this index in bounds" instead of consulting the array's actual hole
+// tracking (ArrayObject.HasIndex, already used correctly by
+// hasOwnProperty/for-in/the iteration builtins before this fix - see the
+// new ArrayObject.HasOwnIndexProperty helper that now unifies all of these).
+//
+// A hole created by a literal elision ([1,,3]) is a separate, NOT-yet-fixed
+// gap (elisions are still materialized as real `undefined` values by the
+// parser/compiler) - not covered here.
+const checks: boolean[] = [];
+
+// --- delete arr[i] ---
+const d: any = [1, 2, 3];
+delete d[1];
+checks.push((1 in d) === false);
+checks.push(d.hasOwnProperty(1) === false);
+checks.push(Object.keys(d).join(",") === "0,2");
+checks.push(Object.getOwnPropertyNames(d).join(",") === "0,2,length");
+checks.push(JSON.stringify(Object.entries(d)) === '[["0",1],["2",3]]');
+checks.push(Object.values(d).join(",") === "1,3");
+checks.push(Object.getOwnPropertyDescriptor(d, "1") === undefined);
+checks.push(Reflect.ownKeys(d).join(",") === "0,2,length");
+
+const visitedForOf: number[] = [];
+d.forEach((v: any, i: number) => visitedForOf.push(i));
+checks.push(visitedForOf.join(",") === "0,2");
+
+const visitedForIn: string[] = [];
+for (const k in d) visitedForIn.push(k);
+checks.push(visitedForIn.join(",") === "0,2");
+
+const assigned: any = Object.assign({}, d);
+checks.push(Object.keys(assigned).join(",") === "0,2");
+checks.push(assigned[0] === 1 && assigned[2] === 3);
+
+// --- new Array(n) ---
+const s: any = new Array(3);
+checks.push((0 in s) === false);
+checks.push(s.hasOwnProperty(0) === false);
+checks.push(Object.keys(s).join(",") === "");
+checks.push(Object.getOwnPropertyDescriptor(s, "0") === undefined);
+checks.push(Reflect.ownKeys(s).join(",") === "length");
+
+// --- A defineProperty-tracked huge sparse index (paserati#176/#178) must
+// still count as present through the same shared helper - a hole check
+// must not start dropping these. (Object.keys/values/entries/
+// getOwnPropertyNames/Reflect.ownKeys on such an array separately hang,
+// pre-existing on main and unrelated to this fix - not exercised here;
+// flagged as its own follow-up.) ---
+const huge: any = [];
+Object.defineProperty(huge, "4294967294", {
+  value: "z",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+checks.push(("4294967294" in huge) === true);
+checks.push(huge.hasOwnProperty("4294967294") === true);
+checks.push(
+  Object.getOwnPropertyDescriptor(huge, "4294967294").value === "z"
+);
+
+checks.every((c) => c === true);

--- a/tests/scripts/issue300_array_holes_literal_elision.ts
+++ b/tests/scripts/issue300_array_holes_literal_elision.ts
@@ -1,0 +1,58 @@
+// expect: true
+// paserati#300: array literal elisions ([1,,3]) used to be materialized as
+// a genuine `undefined` value rather than a real sparse hole - the parser
+// converted every elided slot into an explicit UndefinedLiteral with no way
+// for the compiler to tell it apart from a literal `undefined`. Fixed via a
+// parallel ArrayLiteral.Elisions field the parser now populates and
+// compileArrayLiteralElement (compile_literal.go) consults to emit the
+// vm.Hole sentinel instead, so `in`/hasOwnProperty/Object.keys/etc. (already
+// fixed to respect holes from `delete`/`new Array(n)` - see
+// issue300_array_holes_delete_and_new_array.ts) now agree for literals too.
+//
+// Elisions mixed with a spread element in the same literal ([1,,...xs,,2])
+// are a separate, NOT-yet-fixed gap (that path still materializes them as
+// real `undefined`) - not covered here.
+const checks: boolean[] = [];
+
+const h: any = [1, , 3];
+checks.push(h.length === 3);
+checks.push((1 in h) === false);
+checks.push(h.hasOwnProperty(1) === false);
+checks.push(Object.keys(h).join(",") === "0,2");
+checks.push(Object.getOwnPropertyNames(h).join(",") === "0,2,length");
+checks.push(JSON.stringify(Object.entries(h)) === '[["0",1],["2",3]]');
+checks.push(JSON.stringify(h) === "[1,null,3]");
+
+const visited: number[] = [];
+h.forEach((v: any, i: number) => visited.push(i));
+checks.push(visited.join(",") === "0,2");
+
+// Leading/trailing/multiple consecutive elisions.
+const leading: any = [, , 1];
+checks.push(leading.length === 3);
+checks.push((0 in leading) === false && (1 in leading) === false);
+checks.push((2 in leading) === true && leading[2] === 1);
+
+const trailing: any = [1, ,];
+checks.push(trailing.length === 2);
+checks.push((1 in trailing) === false);
+
+// A real `undefined` element (not an elision) must NOT become a hole.
+const real: any = [1, undefined, 3];
+checks.push((1 in real) === true);
+checks.push(real.hasOwnProperty(1) === true);
+checks.push(Object.keys(real).join(",") === "0,1,2");
+
+// A large literal (forces the chunked compile path, compile_literal.go) with
+// multiple elisions must still get real holes at exactly those positions.
+const bigParts: string[] = [];
+for (let i = 0; i < 50; i++) {
+  bigParts.push(i === 20 || i === 21 ? "" : "1");
+}
+const big: any = eval("[" + bigParts.join(",") + "]");
+checks.push(big.length === 50);
+checks.push((20 in big) === false && (21 in big) === false);
+checks.push((19 in big) === true && (22 in big) === true);
+checks.push(Object.keys(big).length === 48);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Fixes #300.

Array holes — from `delete arr[i]`, `new Array(n)`, or a literal elision like `[1,,3]` — were materialized as present properties whose value happens to be `undefined`, instead of genuinely absent own properties, across nearly every observation path.

After this fix, `delete`/`new Array(n)`/literal elisions all produce real absent own properties consistently across `in`, `hasOwnProperty`, `Object.keys`/`values`/`entries`/`getOwnPropertyNames`, `Object.getOwnPropertyDescriptor`, `Reflect.ownKeys`, `Object.assign`, and `for-in`.

## Root causes (two independent gaps)

1. **Most own-property observers never consulted hole-tracking at all** — `in` (`OpIn`, `pkg/vm/vm.go`), `Object.hasOwn`, `Object.keys`/`values`/`entries`/`getOwnPropertyNames`, `Reflect.ownKeys`, `Object.assign`'s array-source copy, and `Object.getOwnPropertyDescriptor`'s array branch (plus its Proxy invariant-checking twin) all just checked "is this index < length" instead of "is this index actually present". Fixed by factoring the three-way presence check `hasOwnProperty` already got right (an explicit accessor takes priority; then `HasIndex` for the dense range; then the properties-map fallback for a `defineProperty`-tracked huge sparse index, #176/#178) into one `ArrayObject.HasOwnIndexProperty` helper, and routing all of the above through it. `in`'s fix additionally falls through to the prototype chain for an absent index, matching real `[[HasProperty]]` semantics.

2. **Literal elisions were never real holes to begin with** — the parser converted every elided slot into an explicit `UndefinedLiteral`, indistinguishable from a literal `undefined`. Fixed via a new parallel `ArrayLiteral.Elisions []bool` field the parser populates (`Elements` itself is untouched, so the checker, tuple-context checking, for-of spread compilation, and destructuring-assignment cover-grammar all see the exact same AST shape and need no changes); only a new `compileArrayLiteralElement` helper consults it, emitting the `vm.Hole` sentinel via the constant pool instead of compiling the placeholder. `Value.Is` (used by the constant pool's dedup) had no case for `TypeHole` and panicked once two Hole constants landed in the same chunk — fixed, and `StrictlyEquals` got the same defensive case.

## Judgment calls worth flagging explicitly

- **The large/chunked array-literal path's register-pressure fallback switched from `OpSetIndex` to `OpArrayCopy`.** `OpSetIndex` is a full property-set with prototype-setter/frozen/proxy semantics, meant for real `arr[i] = v` assignments — the wrong primitive for literal construction regardless of holes (`CreateDataProperty` doesn't consult any of that), and it can't safely carry a `Hole` value through. `OpArrayCopy` is the same raw slice write the chunk-copy fast path already uses. This is a correctness improvement for **non-hole elements too**, not just holes — flagging since it's the one change here with effects beyond hole semantics.
- **`console.log`/REPL printing of a hole-containing array now shows `<empty>` per element** (`inspectWithDepth`), and `-bytecode` disassembly shows `<hole>` for the constant — both newly reachable now that literal holes are real, and both previously would have hit a generic `<unknown type N>` fallback. This is per-element, not Node's grouped `<N empty items>` — a simpler form, not a bug.

## Deliberately NOT fixed here

- An elision that coexists with a spread element in the same literal (`[1,,...xs,,2]`) still compiles through `compileArrayLiteralWithSpread`, untouched by this fix, and still materializes as `undefined` rather than a hole — harder, since that path's `OpArraySpread` reads through the iterator protocol, which itself resolves holes to `undefined`.
- `built-ins/Array/S15.4_A1.1_T10.js` flips pass/fail in test262 depending on run order. Confirmed via direct repro that it's a genuine 0.2s-timeout flake, consistently timing out in isolation on unmodified `main` — not a regression.

## Found in passing, not fixed here (spun off separately — none of these are actually about array holes)

- `Object.keys`/`values`/`entries`/`getOwnPropertyNames`/`Reflect.ownKeys` hang on an array with a huge `defineProperty`-tracked sparse index (unbounded `0..length` loop).
- `Array.prototype.join()` with no argument uses `"undefined"` as the separator instead of `","` when type checking is enabled.
- `Array.prototype.join`/`toString` don't map `null`/`undefined` elements to the empty string.
- Array spread (`[...arr]`) propagates a hole into the result instead of resolving it to a real `undefined` per the iterator protocol.
- (Also, unrelated to holes: a runtime exception thrown by indirect-eval'd code escapes the caller's `try`/`catch` — found while working #301, not #300, listed here only for completeness of the session's spun-off work.)

## Testing

- New regression tests: `tests/scripts/issue300_array_holes_delete_and_new_array.ts` (delete/new Array(n)/huge sparse index across all the fixed observers) and `tests/scripts/issue300_array_holes_literal_elision.ts` (literal elisions, leading/trailing/multiple, real-`undefined`-must-not-become-a-hole, and the large/chunked compile path).
- `go test ./tests -run TestScripts`: all green, including a stress check where `TryAllocContiguous` was temporarily stubbed to always fail (forcing the `OpArrayCopy` fallback path to execute) before being reverted.
- test262, full `built-ins` + `language` suites (`-timeout 0.2s`), before/after dump diff: **+53 passing, 0 regressions** (the one apparent flip, `S15.4_A1.1_T10.js`, is the pre-existing flake above, verified on unmodified `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)