### PR TITLE
fix(builtins): Array.prototype.join() defaults its separator by value, not arg count

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -677,8 +677,21 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
+		// Per ECMA-262 23.1.3.16 Array.prototype.join step 3: "If separator
+		// is undefined, let sep be the single-element String ','" - an
+		// explicit `undefined` argument must default to "," exactly like an
+		// omitted one, not stringify to the literal "undefined". This also
+		// matters when type checking is enabled: the compiler pads a call
+		// site to a native function's declared (checker-known) arity with
+		// explicit `undefined` arguments for any parameter the checker
+		// considers optional-but-unprovided (compileArgumentsWithOptionalHandling,
+		// pkg/compiler/compiler.go), so `arr.join()` and `arr.join(undefined)`
+		// are indistinguishable from this function's point of view - only a
+		// `len(args) >= 1` check (as opposed to checking the value itself)
+		// would wrongly treat the padded call the same as an explicit
+		// separator.
 		separator := ","
-		if len(args) >= 1 {
+		if len(args) >= 1 && !args[0].IsUndefined() {
 			separator = args[0].ToString()
 		}
 		if length == 0 {

--- a/tests/scripts/array_join_default_separator.ts
+++ b/tests/scripts/array_join_default_separator.ts
@@ -1,0 +1,30 @@
+// expect: true
+// Array.prototype.join() called with zero arguments (relying on the
+// default "," separator) produced the wrong output when TypeScript type
+// checking is enabled (the default mode this test runs in - no
+// // no-typecheck directive - specifically to catch this): the compiler
+// pads a call site to a native function's checker-known arity with
+// explicit `undefined` arguments for any parameter the checker considers
+// optional-but-unprovided (compileArgumentsWithOptionalHandling,
+// pkg/compiler/compiler.go), so `arr.join()` arrived at the native `join`
+// implementation as `args = [undefined]` rather than `args = []`. The
+// implementation's `len(args) >= 1` check then treated that padded
+// argument as an explicitly-provided separator and stringified it,
+// joining elements with the literal string "undefined" instead of ",".
+//
+// Per ECMA-262 23.1.3.16 step 3, an explicit `undefined` separator must
+// ALSO default to "," - the fix checks the value itself, not just whether
+// an argument slot was filled, which handles both the type-checker padding
+// and a real `arr.join(undefined)` call the same (correct) way.
+const checks: boolean[] = [];
+
+checks.push([1, 2, 3].join() === "1,2,3");
+checks.push([1, 2, 3].join(undefined) === "1,2,3");
+checks.push([1, 2, 3].join(",") === "1,2,3");
+checks.push([1, 2, 3].join("-") === "1-2-3");
+checks.push(Object.keys([1, 2, 3]).join() === "0,1,2");
+checks.push(Object.keys({ a: 1, b: 2 }).join() === "a,b");
+checks.push([].join() === "");
+checks.push(["only"].join() === "only");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

`Array.prototype.join()` called with zero arguments produced the wrong output when TypeScript type checking is enabled:

```bash
./paserati -e 'console.log([1,2,3].join());'
# printed: 1undefined2undefined3   (expected: 1,2,3)
./paserati --no-typecheck -e 'console.log([1,2,3].join());'
# printed: 1,2,3   (correct)
```

## Root cause

`join` checked `len(args) >= 1` to decide whether a separator was provided, defaulting to `","` only when the argument slot was completely absent. That's wrong on two counts:

1. **Per ECMA-262 23.1.3.16 step 3**, an explicit `undefined` separator must *also* default to `","` — `arr.join(undefined)` was stringifying it to the literal `"undefined"` instead, independent of any type-checking concern at all.
2. **When TypeScript type checking is enabled** (the default `./paserati script.ts` mode), the compiler pads a call site that omits a checker-known-optional parameter with an explicit `undefined` argument (`compileArgumentsWithOptionalHandling`, `pkg/compiler/compiler.go`) — so `arr.join()` arrived at this function as `args = [undefined]`, not `args = []`, making the `len(args)` check see a "provided" separator on every plain `.join()` call. `--no-typecheck` skips the checker entirely and never pads anything, which is why the bug was invisible there.

## Fix

Check the value, not just the count — `len(args) >= 1 && !args[0].IsUndefined()`. This is the exact pattern both `TypedArray.prototype.join` implementations (`typedarray_base_init.go`, `typedarray_common.go`) already used correctly; `Array.prototype.join` was the one left behind.

## Scope — what this does *not* fix

This fixes the observable symptom for `join` specifically. It does **not** fix the compiler-side root cause:

- The same call-site padding also inflates `arguments.length` for ordinary user-defined functions with optional parameters under type checking (verified: `function f(a?: string) { return arguments.length; } f()` returns `1`, not `0`, only when type checking is enabled). Spun off separately — fixing it safely needs to preserve the padding's other job (feeding default-parameter-value logic) without also miscounting `arguments.length`.
- A broader audit of other builtins using the same `len(args) >= N`-without-a-value-check pattern is also spun off separately rather than folded in here (the already-correct `TypedArray` `join`s are evidence someone already patched this class of bug piecemeal and missed `Array`'s).

## Testing

- New regression test: `tests/scripts/array_join_default_separator.ts` — runs in the **default type-checked mode** (no `// no-typecheck` directive) specifically so it would have caught this bug. Covers `.join()`, `.join(undefined)`, `.join(",")`, `.join("-")`, empty/single-element arrays, and `Object.keys(...).join()`.
- `go test ./tests -run TestScripts`: all green.
- test262: `built-ins/Array/prototype/join` +1/0 regressions (23 tests); `built-ins/Array/prototype/toString` unchanged, 0 regressions (11 tests); full `built-ins/Array` suite +1/0 regressions (3079 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)