### PR TITLE
fix(builtins): join()/toString() must map undefined/null elements to empty string

### DIFF
--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -215,6 +215,21 @@ func arrayIndexGetFromProto(vmInstance *vm.VM, arr *vm.ArrayObject, receiver vm.
 	return vm.Undefined, false, nil
 }
 
+// joinElementToString implements ECMA-262 23.1.3.16 (Array.prototype.join)
+// step 6: "If element is undefined or null, let next be the empty String;
+// otherwise, let next be ? ToString(element)." Array.prototype.toString
+// (23.1.3.36) defers to join, so it shares this. A hole read via
+// arrayLikeGet's [[Get]] semantics already comes back as plain Undefined
+// (see arrayLikeGet's doc comment), so this one helper covers holes,
+// `delete`d slots, and a real `undefined`/`null` element alike - all must
+// join as an empty string, never the literal text "undefined"/"null".
+func joinElementToString(v vm.Value) string {
+	if v.Type() == vm.TypeUndefined || v.Type() == vm.TypeNull {
+		return ""
+	}
+	return v.ToString()
+}
+
 // arrayLikeGet returns (value, exists, error) for index i of an array-like
 // `this`. "exists" mirrors HasProperty so callers can skip holes in a sparse
 // Array or a PlainObject missing that key, matching spec semantics for

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -688,13 +688,13 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		result := first.ToString()
+		result := joinElementToString(first)
 		for i := 1; i < length; i++ {
 			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
 			if err != nil {
 				return vm.Undefined, err
 			}
-			result += separator + v.ToString()
+			result += separator + joinElementToString(v)
 		}
 		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))
@@ -716,13 +716,13 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		result := first.ToString()
+		result := joinElementToString(first)
 		for i := 1; i < length; i++ {
 			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
 			if err != nil {
 				return vm.Undefined, err
 			}
-			result += "," + v.ToString()
+			result += "," + joinElementToString(v)
 		}
 		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))

--- a/tests/scripts/destructure_array_fast_path.ts
+++ b/tests/scripts/destructure_array_fast_path.ts
@@ -5,7 +5,7 @@
 // holes -> undefined, defaults, elisions, nested patterns, rest (which stays on
 // the generic path), for-of element patterns, and deopt to the generic protocol
 // when Symbol.iterator is customized on the prototype or on an Array subclass.
-// expect: 1,2|10,undefined,undefined|5,20|1,undefined,3|2,4|7,8,9|1;2,3,4|a=1,b=2|100,200|1000,2000,3000/1000,2000,3000
+// expect: 1,2|10,,|5,20|1,,3|2,4|7,8,9|1;2,3,4|a=1,b=2|100,200|1000,2000,3000/1000,2000,3000
 let out: string[] = [];
 
 // basic + fewer-than-pattern tail

--- a/tests/scripts/destructuring_declarator_list.ts
+++ b/tests/scripts/destructuring_declarator_list.ts
@@ -1,4 +1,4 @@
-// expect: 1,2|1,2,3|1,2|1,2|10,20|10,undefined|10,20|10,20|10,20|1,2|1,2|1,2,3|1,[2,3],9|1,{"b":2},9|5,1|7,1
+// expect: 1,2|1,2,3|1,2|1,2|10,20|10,|10,20|10,20|10,20|1,2|1,2|1,2,3|1,[2,3],9|1,{"b":2},9|5,1|7,1
 // A binding pattern is legal in ANY declarator position, not just the first.
 // Both halves of that were broken:
 //

--- a/tests/scripts/issue_array_join_undefined_null.ts
+++ b/tests/scripts/issue_array_join_undefined_null.ts
@@ -1,0 +1,59 @@
+// expect: true
+// ECMA-262 23.1.3.16 Array.prototype.join step 6: "If element is undefined
+// or null, let next be the empty String; otherwise, let next be
+// ? ToString(element)." Per spec, Array.prototype.toString (23.1.3.36)
+// implements this by looking up and calling the array's own "join" method;
+// this codebase's toString instead inlines the same per-element rule
+// directly rather than doing that Get("join")+Call (a separate, narrower,
+// still-open gap - see test262 non-callable-join-string-tag.js, which
+// checks the case where "join" has been replaced with a non-callable value
+// and toString must fall back to Object.prototype.toString - not exercised
+// or fixed here). Both toString and the default String(arr) conversion
+// (via ToPrimitive calling toString, since Array.prototype.join hasn't
+// been overridden here) share this element-stringification rule with join.
+//
+// This was previously not special-cased at all: undefined/null elements
+// were passed straight through ToString, producing the literal text
+// "undefined"/"null" in the joined result instead of an empty string. A
+// real hole (from `delete arr[i]` or a literal elision `[1,,3]`) is read
+// back as plain Undefined via [[Get]] before join ever sees it, so it hits
+// the exact same code path and must join the same way.
+const checks: boolean[] = [];
+
+checks.push([1, undefined, 3].join(",") === "1,,3");
+checks.push([1, null, 3].join(",") === "1,,3");
+checks.push([1, undefined, null, 3].join(",") === "1,,,3");
+checks.push(String([1, undefined, null, 3]) === "1,,,3");
+checks.push([1, undefined, null, 3].toString() === "1,,,3");
+
+// Note: join() called with the separator argument fully omitted (not even
+// `undefined`) is a separate, pre-existing, unrelated bug - the type-checked
+// call path pads a native call up to the callee's declared arity with
+// explicit `undefined` arguments for omitted optional parameters, so `join`
+// sees len(args) >= 1 and stringifies that padding `undefined` as the
+// separator instead of falling back to its "," default (confirmed on
+// unmodified main, unrelated to element stringification). Not exercised
+// here; tracked separately. join(",") with an explicit separator (as used
+// throughout this file) is unaffected.
+
+// Leading/trailing undefined and null.
+checks.push([undefined, 1, 2].join(",") === ",1,2");
+checks.push([1, 2, null].join(",") === "1,2,");
+checks.push([undefined].join(",") === "");
+checks.push([null].join(",") === "");
+
+// A real hole (delete) must join identically to a plain undefined element.
+const deleted = [1, 2, 3];
+delete deleted[1];
+checks.push(deleted.join(",") === "1,,3");
+checks.push(deleted.toString() === "1,,3");
+
+// A real hole (literal elision) must join identically too.
+const elided = [1, , 3];
+checks.push(elided.join(",") === "1,,3");
+checks.push(elided.toString() === "1,,3");
+
+// A custom separator still applies between elements, empty string included.
+checks.push([1, undefined, 3].join(" - ") === "1 -  - 3");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

`Array.prototype.join` (and `toString`/`String(arr)`, which share the same per-element rule) did not follow ECMA-262 23.1.3.16 step 6: "If element is undefined or null, let next be the empty String; otherwise, let next be `? ToString(element)`." Elements were passed straight through `ToString`, producing the literal text `"undefined"`/`"null"` instead of an empty string:

```
[1, undefined, 3].join(",")   // was "1,undefined,3" — now "1,,3"
[1, null, 3].join(",")        // was "1,null,3"      — now "1,,3"
String([1, undefined, 3])     // was "1,undefined,3" — now "1,,3"
```

A real hole (from `delete arr[i]` or a literal elision `[1,,3]`) is read back as plain `Undefined` via `arrayLikeGet`'s `[[Get]]` semantics before `join` ever sees it, so it hit the same bug and is fixed the same way — there's no separate hole-handling path here.

## Fix

Added `joinElementToString` ([array_generic.go](pkg/builtins/array_generic.go)), a small helper implementing the "undefined or null → empty string" step, used for every element in both `join` and `toString` ([array_init.go](pkg/builtins/array_init.go)) in place of the bare `v.ToString()` call.

## Fixture updates

Two smoke-test fixtures had `// expect:` strings baked against the *old buggy* join output:
- [destructure_array_fast_path.ts](tests/scripts/destructure_array_fast_path.ts): `[c,d,e].join(",")` for a too-short source and `[h,i,j].join(",")` for an elided array
- [destructuring_declarator_list.ts](tests/scripts/destructuring_declarator_list.ts): a `JSON.stringify` of an `undefined` destructured binding, joined

Neither test's actual subject (array-destructuring fast path, declarator-list parsing) changed behavior — only the expected strings were updated to what `join` now correctly produces.

## Tests

Added [issue_array_join_undefined_null.ts](tests/scripts/issue_array_join_undefined_null.ts) covering `[undefined]`/`[null]` alone, leading/trailing, a custom separator, `String()`/`toString()`, and both hole flavors (`delete`, elision) joining identically to a plain `undefined` element.

## Explicitly NOT fixed here (separate, pre-existing gaps)

- `Array.prototype.toString` inlines the join loop directly rather than doing the spec's `Get("join")`+`Call` — so replacing `"join"` with a non-callable value doesn't fall back to `Object.prototype.toString` (test262 `non-callable-join-string-tag.js` still fails, unchanged by this PR).
- Calling a native with a declared optional parameter while omitting the argument entirely (e.g. `arr.join()` with no separator) passes an explicit `undefined` under the default type-checked compile path instead of leaving it truly absent, so `len(args) >= 1`-style checks across `pkg/builtins/*.go` misfire. Confirmed pre-existing on unmodified `main` via `git stash`, unrelated to element stringification — already tracked as separate follow-up tasks from an earlier session phase, not touched here. One assertion exercising this (`join()` with the separator fully omitted) was deliberately left out of the new test for this reason.

## Testing

- `go test ./tests -run TestScripts`: all green
- test262 `built-ins/Array` full suite (`-timeout 0.2s`): **+8 net, 0 regressions** (2605 → 2613 of 3079 passing) — 5 in `join/`, 2 in `toString/`, and 1 in `toLocaleString/` (Array has no own `toLocaleString` here, so it inherits `Object.prototype.toLocaleString`, which calls `this.toString()` — the same fixed code path)
