### PR TITLE
fix(vm): array spread must resolve source holes to a present undefined

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17658,10 +17658,33 @@ func (vm *VM) parseArrayIndex(key string) (int, bool) {
 func (vm *VM) extractSpreadArguments(iterableVal Value) ([]Value, error) {
 	switch iterableVal.Type() {
 	case TypeArray:
-		// Fast path for arrays
+		// Fast path for arrays. A real spread reads the source through its
+		// default iterator (%Array.prototype%[Symbol.iterator]), which reads
+		// each index via ordinary [[Get]] - and [[Get]] on a hole (from
+		// `delete arr[i]`, a literal elision `[1,,3]`, or `new Array(n)`)
+		// always yields a genuine, PRESENT `undefined`, never "no property
+		// at all". So the spread result must never itself contain a hole.
+		// A raw `copy(args, arrayObj.elements)` (the previous implementation)
+		// carried a Hole value straight through unchanged instead - and, for
+		// an array whose `.length` exceeds its elements slice (e.g.
+		// `new Array(6)`, or `arr.length = 6` on a 3-element array - see
+		// ArrayObject.SetLength, which deliberately never grows the elements
+		// slice on its own), it silently truncated the spread to
+		// `len(elements)` rather than the array's actual `.length`.
+		// arrayObj.Get(i) already resolves a Hole to Undefined and returns
+		// Undefined for any out-of-slice index up to length, fixing both.
+		// It does not consult own accessors installed via
+		// Object.defineProperty (see arrayLikeGet in array_generic.go for
+		// the accessor-aware version generic Array.prototype methods use) -
+		// that's a separate, pre-existing gap, unaffected by this fix in
+		// either direction: an accessor's raw backing slot was already read
+		// as-is by the old `copy`, and still is here.
 		arrayObj := AsArray(iterableVal)
-		args := make([]Value, len(arrayObj.elements))
-		copy(args, arrayObj.elements)
+		length := arrayObj.length
+		args := make([]Value, length)
+		for i := 0; i < length; i++ {
+			args[i] = arrayObj.Get(i)
+		}
 		return args, nil
 
 	case TypeArguments:

--- a/tests/scripts/spread_array_hole_resolves_to_undefined.ts
+++ b/tests/scripts/spread_array_hole_resolves_to_undefined.ts
@@ -1,0 +1,92 @@
+// expect: true
+// Array spread ([...arr], a function call's ...arr, etc.) iterates its
+// source through the array's default iterator (%Array.prototype%[Symbol.
+// iterator]), which reads each index via ordinary [[Get]] - and [[Get]] on
+// a hole (from `delete arr[i]`, `new Array(n)`, or `arr.length = n` growing
+// past the backing storage) always yields a genuine, PRESENT `undefined`,
+// never "no property at all". So a hole in the SOURCE must never survive
+// into the spread RESULT as a hole - the result must have a real, present
+// `undefined` at that index instead.
+//
+// extractSpreadArguments (pkg/vm/vm.go) used to fast-path TypeArray sources
+// with a raw `copy(args, arrayObj.elements)`, which carried a Hole value
+// straight through unchanged, AND silently truncated the result to
+// len(elements) instead of the array's actual .length whenever the two
+// diverge (SetLength deliberately never grows the elements slice on its
+// own - see `new Array(n)` and `arr.length = n` below). Both are fixed by
+// reading every index 0..length-1 through ArrayObject.Get, which already
+// resolves a Hole (and any index past the elements slice, up to length) to
+// Undefined.
+//
+// Note: on this branch, a literal elision (`[1,,3]`) is not yet a real
+// hole - it's a separate, already-fixed gap tracked elsewhere (paserati
+// #300) that isn't merged here. It's still included below since it must
+// keep behaving correctly (present undefined) either way, before or after
+// that separate fix lands.
+const checks: boolean[] = [];
+
+function present(arr: any, i: number): boolean {
+  return arr.hasOwnProperty(i) && i in arr;
+}
+
+// A hole from `delete`.
+const deleted: any[] = [1, 2, 3];
+delete deleted[1];
+const spreadDeleted: any = [...deleted];
+checks.push(spreadDeleted.length === 3);
+checks.push(present(spreadDeleted, 1));
+checks.push(spreadDeleted[1] === undefined);
+checks.push(JSON.stringify(spreadDeleted) === "[1,null,3]");
+checks.push(Object.keys(spreadDeleted).join(",") === "0,1,2");
+
+// A hole from `new Array(n)` - the elements slice starts out completely
+// empty; every index up to length is a hole.
+const sparse: any = new Array(3);
+const spreadSparse: any = [...sparse];
+checks.push(spreadSparse.length === 3);
+checks.push(present(spreadSparse, 0) && present(spreadSparse, 1) && present(spreadSparse, 2));
+checks.push(JSON.stringify(spreadSparse) === "[null,null,null]");
+
+// A hole from growing .length past the backing elements slice.
+const grown: any = [1, 2, 3];
+grown.length = 6;
+const spreadGrown: any = [...grown];
+checks.push(spreadGrown.length === 6);
+checks.push(present(spreadGrown, 3) && present(spreadGrown, 4) && present(spreadGrown, 5));
+checks.push(JSON.stringify(spreadGrown) === "[1,2,3,null,null,null]");
+
+// A literal elision - not (yet) a real hole here, but must spread as a
+// present undefined regardless.
+const elided: any = [1, , 3];
+const spreadElided: any = [...elided];
+checks.push(spreadElided.length === 3);
+checks.push(present(spreadElided, 1));
+checks.push(JSON.stringify(spreadElided) === "[1,null,3]");
+
+// A hole propagating through a function call's spread arguments.
+function collect(...args: any[]): any[] {
+  return args;
+}
+const collected = collect(...deleted);
+checks.push(collected.length === 3);
+checks.push(present(collected, 1));
+checks.push(collected[1] === undefined);
+
+// A hole propagating through a spread `new` call.
+class Point {
+  x: any;
+  y: any;
+  z: any;
+  constructor(x: any, y: any, z: any) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}
+const p = new Point(...deleted);
+checks.push(p.x === 1 && p.y === undefined && p.z === 3);
+
+// Regular (non-hole) elements are unaffected.
+checks.push(JSON.stringify([...[10, 20, 30]]) === "[10,20,30]");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

A real spread (`[...arr]`, `f(...arr)`, `new C(...arr)`) reads its source through the array's default iterator (`%Array.prototype%[Symbol.iterator]`), which reads each index via ordinary `[[Get]]` — and `[[Get]]` on a hole (from `delete arr[i]`, a literal elision `[1,,3]`, or `new Array(n)`) always yields a genuine, **present** `undefined`, never "no property at all". So a hole in the spread *source* must never survive into the spread *result* as a hole.

`extractSpreadArguments`'s `TypeArray` fast path ([vm.go](pkg/vm/vm.go)) used to do a raw `copy(args, arrayObj.elements)`, which carried a `Hole` value straight through into the destination unchanged:

```js
const d = [1,2,3]; delete d[1];
const s = [...d];
s.hasOwnProperty(1), (1 in s)   // was false, true (inconsistent hole leaking through) — now true, true
```

## A second bug found in the same fast path

Fixing this surfaced a more severe bug sharing the same root cause (reading the raw elements slice instead of the array's logical length): `ArrayObject.SetLength` deliberately never grows the backing elements slice when `.length` is increased past it — arrays are sparse — so `len(arrayObj.elements)` and `arrayObj.length` can diverge arbitrarily. The old code sized its result off `len(elements)`, silently **truncating** the spread instead of respecting the array's actual `.length`:

```js
const n = new Array(3);
[...n]                         // was [] (length 0!)             — now [undefined,undefined,undefined]

const a = [1,2,3]; a.length = 6;
[...a]                         // was [1,2,3] (length 3)         — now [1,2,3,undefined,undefined,undefined]
```

## Fix

Both are fixed together: read every index `0..length-1` through `ArrayObject.Get` (which already resolves a `Hole`, and any index past the elements slice up to `length`, to `Undefined`), using `arrayObj.length` as the iteration bound instead of `len(arrayObj.elements)`.

**Verified no hang/crash on a pathological case** (`arr.length = 1e8; [...arr]` — a shape flagged for `Object.keys` as a known open limitation): completes in ~1s using ~4.8GB for the 100M materialized elements — a real but bounded, expected consequence of correctness (any array-based engine without dictionary-mode sparse storage must materialize that many elements for a genuine spread), not a hang.

## Explicitly NOT fixed here (separate, confirmed pre-existing, unaffected either way)

- An accessor property installed via `Object.defineProperty` on an array index is still ignored during spread — the raw backing slot is read instead of calling the getter. Spawned as a separate follow-up task.
- An override of `Array.prototype[Symbol.iterator]` still has no effect on array spread (the fast path never consulted the iterator protocol, before or after this change).

## Tests

Added [spread_array_hole_resolves_to_undefined.ts](tests/scripts/spread_array_hole_resolves_to_undefined.ts) covering a hole from `delete`, from `new Array(n)`, from growing `.length` past the backing slice, and (defensively — it isn't yet a real hole on this branch, see the still-unmerged #300/#305 literal-elision fix) a literal elision — across `[...arr]`, a spread function call, and a spread `new` call.

## Testing

- `go test ./tests -run TestScripts`: all green
- test262 `built-ins/Array`, `language/*spread*`, `ArrayIteratorPrototype`, and `language/rest-parameters` (`-timeout 0.2s`): **0 diff, 0 regressions** across all four (this specific gap isn't covered by test262, same as the earlier #300-family fixes)
