### PR TITLE
fix(compiler): arguments.length must not count optional-param padding

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -124,7 +124,7 @@ func (c *Compiler) compileNewExpression(node *parser.NewExpression, hint Registe
 		return c.compileSpreadNewExpression(node, hint, &tempRegs)
 	}
 
-	// 1. Determine total argument count needed (including optional parameter padding)
+	// 1. Determine total argument count needed
 	totalArgCount := c.determineTotalArgCountForNew(node)
 
 	// 2. For OpNew, we need constructor + arguments in contiguous registers
@@ -2225,67 +2225,32 @@ func (c *Compiler) hasSpreadArgument(arguments []parser.Expression) bool {
 	return false
 }
 
-// Helper function to determine total argument count including optional parameters
+// determineTotalArgCount returns the number of argument registers a call
+// site needs, expanding spread elements where their length is known at
+// compile time (see calculateEffectiveArgCount).
+//
+// This used to also pad the count up to the callee's declared parameter
+// count whenever the checker resolved a static function/signature type
+// with trailing optional parameters the call omitted - e.g. `f()` against
+// `function f(a?: string) {}` reported 1 argument, not 0, and emitted an
+// explicit Undefined into that phantom slot (see the sibling
+// compileArgumentsWithOptionalHandling, which had the identical padding
+// logic and has been simplified the same way). That padding was entirely
+// redundant for its actual purpose (making a default parameter value like
+// `function f(a = 5) {}` apply when the argument is omitted): prepareCall
+// (pkg/vm/call.go), OpNew's constructor setup, and OpTailCall/
+// OpTailCallMethod's frame-reuse path all ALREADY independently fill every
+// declared parameter register from the real argument count up to the
+// callee's Arity with Undefined, regardless of what count the call site
+// passes - which is exactly why default values already worked correctly
+// under --no-typecheck, where this padding never ran (no static function
+// type to consult there). The padding's only observable effect was
+// corrupting `arguments.length` (and the arguments object's own contents)
+// with a phantom argument the caller never actually passed. Removing it
+// makes a type-checked call site match the untyped one it already agreed
+// with for every other case.
 func (c *Compiler) determineTotalArgCount(node *parser.CallExpression) int {
-	// Calculate effective argument count, expanding spread elements
-	providedArgCount := c.calculateEffectiveArgCount(node.Arguments)
-
-	// Get function type to check for optional parameters
-	functionType := node.Function.GetComputedType()
-	var expectedParamCount int
-	var optionalParams []bool
-
-	if functionType != nil {
-		if objType, ok := functionType.(*types.ObjectType); ok && objType.IsCallable() && len(objType.CallSignatures) > 0 {
-			// TODO: This is a temporary solution. The checker should resolve overloads during type checking
-			// and attach the specific selected signature to the call expression.
-			// For now, try to pick the best matching signature based on argument count
-			sig := objType.CallSignatures[0] // Default to first signature
-			bestMatch := sig
-			bestScore := -1
-
-			for _, candidateSig := range objType.CallSignatures {
-				score := 0
-				// Prefer exact parameter count match
-				if len(candidateSig.ParameterTypes) == providedArgCount {
-					score += 10
-				}
-				// Or compatible with optional parameters
-				requiredParams := 0
-				for i, isOptional := range candidateSig.OptionalParams {
-					if i < len(candidateSig.ParameterTypes) && !isOptional {
-						requiredParams++
-					}
-				}
-				if providedArgCount >= requiredParams && providedArgCount <= len(candidateSig.ParameterTypes) {
-					score += 5
-				}
-
-				if score > bestScore {
-					bestScore = score
-					bestMatch = candidateSig
-				}
-			}
-
-			expectedParamCount = len(bestMatch.ParameterTypes)
-			optionalParams = bestMatch.OptionalParams
-		}
-	}
-
-	// Determine final argument count (provided args + undefined padding for optional params)
-	finalArgCount := providedArgCount
-	if len(optionalParams) == expectedParamCount && providedArgCount < expectedParamCount {
-		// Count how many optional parameters we need to pad
-		for i := providedArgCount; i < expectedParamCount; i++ {
-			if i < len(optionalParams) && optionalParams[i] {
-				finalArgCount++
-			} else {
-				break // Stop at first required parameter
-			}
-		}
-	}
-
-	return finalArgCount
+	return c.calculateEffectiveArgCount(node.Arguments)
 }
 
 func (c *Compiler) compileCallExpression(node *parser.CallExpression, hint Register) (Register, errors.PaseratiError) {
@@ -2493,7 +2458,7 @@ func (c *Compiler) compileCallExpression(node *parser.CallExpression, hint Regis
 			return BadRegister, err
 		}
 
-		// 2. Allocate contiguous block for function + all arguments (including optional parameters)
+		// 2. Allocate contiguous block for function + all arguments
 		totalArgCount := c.determineTotalArgCount(node)
 		blockSize := 1 + totalArgCount // funcReg + arguments
 		funcReg := c.regAlloc.AllocContiguous(blockSize)
@@ -2674,7 +2639,7 @@ func (c *Compiler) compileCallExpression(node *parser.CallExpression, hint Regis
 	}
 
 	// --- Regular function call ---
-	// 1. Allocate contiguous block for function + all arguments (including optional parameters)
+	// 1. Allocate contiguous block for function + all arguments
 	totalArgCount := c.determineTotalArgCount(node)
 	blockSize := 1 + totalArgCount // funcReg + arguments
 	funcReg := c.regAlloc.AllocContiguous(blockSize)
@@ -3245,96 +3210,25 @@ func (c *Compiler) compileIfExpression(node *parser.IfExpression, hint Register)
 	return BadRegister, nil
 }
 
-// Helper function to determine total argument count for NewExpression including optional parameters
+// determineTotalArgCountForNew is the `new` expression counterpart of
+// determineTotalArgCount - see that function's comment for why it no
+// longer pads the count up to the constructor's declared parameter count
+// for omitted trailing optional parameters. OpNew's own constructor-frame
+// setup (pkg/vm/vm.go, the "Copy fixed arguments (up to Arity)" loop)
+// already independently fills every declared parameter register up to
+// Arity with Undefined regardless of the real argument count, so the
+// padding here was equally redundant and had the same
+// arguments.length-corrupting effect.
 func (c *Compiler) determineTotalArgCountForNew(node *parser.NewExpression) int {
-	// Calculate effective argument count, expanding spread elements
-	providedArgCount := c.calculateEffectiveArgCount(node.Arguments)
-
-	// Get constructor type to check for optional parameters
-	constructorType := node.Constructor.GetComputedType()
-	var expectedParamCount int
-	var optionalParams []bool
-
-	if constructorType != nil {
-		if objType, ok := constructorType.(*types.ObjectType); ok && objType.IsConstructable() && len(objType.ConstructSignatures) > 0 {
-			// For constructors, use construct signatures instead of call signatures
-			sig := objType.ConstructSignatures[0] // Default to first signature
-			bestMatch := sig
-			bestScore := -1
-
-			for _, candidateSig := range objType.ConstructSignatures {
-				score := 0
-				// Prefer exact parameter count match
-				if len(candidateSig.ParameterTypes) == providedArgCount {
-					score += 10
-				}
-				// Or compatible with optional parameters
-				requiredParams := 0
-				for i, isOptional := range candidateSig.OptionalParams {
-					if i < len(candidateSig.ParameterTypes) && !isOptional {
-						requiredParams++
-					}
-				}
-				if providedArgCount >= requiredParams && providedArgCount <= len(candidateSig.ParameterTypes) {
-					score += 5
-				}
-
-				if score > bestScore {
-					bestScore = score
-					bestMatch = candidateSig
-				}
-			}
-
-			expectedParamCount = len(bestMatch.ParameterTypes)
-			optionalParams = bestMatch.OptionalParams
-		}
-	}
-
-	// Determine final argument count (provided args + undefined padding for optional params)
-	finalArgCount := providedArgCount
-	if len(optionalParams) == expectedParamCount && providedArgCount < expectedParamCount {
-		// Count how many optional parameters we need to pad
-		for i := providedArgCount; i < expectedParamCount; i++ {
-			if i < len(optionalParams) && optionalParams[i] {
-				finalArgCount++
-			} else {
-				break // Stop at first required parameter
-			}
-		}
-	}
-
-	return finalArgCount
+	return c.calculateEffectiveArgCount(node.Arguments)
 }
 
-// Helper function to compile arguments for NewExpression with optional parameter handling
+// compileArgumentsWithOptionalHandlingForNew compiles `new` expression
+// arguments - see determineTotalArgCountForNew for why it no longer pads
+// the count for omitted trailing optional constructor parameters.
 func (c *Compiler) compileArgumentsWithOptionalHandlingForNew(node *parser.NewExpression, firstArgReg Register) ([]Register, int, errors.PaseratiError) {
-	// Get constructor type information for optional parameter analysis
-	constructorType := node.Constructor.GetComputedType()
-	var expectedParamCount int
-	var optionalParams []bool
-
-	if constructorType != nil {
-		if objType, ok := constructorType.(*types.ObjectType); ok && objType.IsConstructable() && len(objType.ConstructSignatures) > 0 {
-			sig := objType.ConstructSignatures[0] // Use first construct signature for now
-			expectedParamCount = len(sig.ParameterTypes)
-			optionalParams = sig.OptionalParams
-		}
-	}
-
-	// Determine final argument count (with padding for optional parameters)
 	providedArgCount := len(node.Arguments)
 	finalArgCount := providedArgCount
-
-	if len(optionalParams) == expectedParamCount && providedArgCount < expectedParamCount {
-		// Count how many optional parameters we need to pad
-		for i := providedArgCount; i < expectedParamCount; i++ {
-			if i < len(optionalParams) && optionalParams[i] {
-				finalArgCount++
-			} else {
-				break // Stop at first required parameter
-			}
-		}
-	}
 
 	// Ensure argument registers exist (same fix as compileArgumentsWithOptionalHandling)
 	if finalArgCount > 0 {
@@ -3367,12 +3261,6 @@ func (c *Compiler) compileArgumentsWithOptionalHandlingForNew(node *parser.NewEx
 				return nil, 0, err
 			}
 		}
-	}
-
-	// Pad missing optional parameters with undefined
-	for i := providedArgCount; i < finalArgCount; i++ {
-		targetReg := argRegs[i]
-		c.emitLoadUndefined(targetReg, node.Token.Line)
 	}
 
 	return argRegs, finalArgCount, nil
@@ -3602,7 +3490,7 @@ func (c *Compiler) compileSuperConstructorCall(node *parser.CallExpression, hint
 	*tempRegs = append(*tempRegs, superConstructorReg)
 	c.emitGetSuperConstructor(superConstructorReg, node.Token.Line)
 
-	// Determine total argument count including optional parameters
+	// Determine total argument count
 	totalArgCount := c.determineTotalArgCount(node)
 
 	// Allocate contiguous registers for the call: [function, arg1, arg2, ...]

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -2988,66 +2988,26 @@ func (c *Compiler) compileShorthandMethod(node *parser.ShorthandMethod, nameHint
 	return constIdx, freeSymbols, nil
 }
 
-// compileArgumentsWithOptionalHandling compiles the provided arguments and pads missing optional
-// parameters with undefined values. Uses contiguous allocation to place arguments in their final positions.
+// compileArgumentsWithOptionalHandling compiles the provided call arguments
+// using contiguous allocation to place them in their final positions.
+//
+// It used to also pad the argument count up to the callee's declared
+// parameter count when the checker resolved a static function type with
+// trailing optional parameters the call omitted, emitting an explicit
+// OpLoadUndefined into each padded slot - see determineTotalArgCount
+// (compile_expression.go) for the full explanation of why that padding
+// was removed: the VM's own call setup (prepareCall, OpNew, and
+// OpTailCall/OpTailCallMethod's frame-reuse path) already independently
+// fills every declared parameter register up to Arity with Undefined
+// regardless of how many arguments the call site actually passed, so the
+// padding was redundant for default-parameter application and only
+// corrupted `arguments.length`/the arguments object's contents with a
+// phantom argument. finalArgCount is now simply the number of arguments
+// the caller actually wrote (spread elements expanded where their length
+// is known - see calculateEffectiveArgCount).
 func (c *Compiler) compileArgumentsWithOptionalHandling(node *parser.CallExpression, firstTargetReg Register) ([]Register, int, errors.PaseratiError) {
-	// 1. Determine the expected argument count including optional parameters
 	providedArgCount := len(node.Arguments)
-
-	// Get function type to check for optional parameters
-	functionType := node.Function.GetComputedType()
-	var expectedParamCount int
-	var optionalParams []bool
-
-	if functionType != nil {
-		if objType, ok := functionType.(*types.ObjectType); ok && objType.IsCallable() && len(objType.CallSignatures) > 0 {
-			// TODO: This is a temporary solution. The checker should resolve overloads during type checking
-			// and attach the specific selected signature to the call expression.
-			// For now, try to pick the best matching signature based on argument count
-			sig := objType.CallSignatures[0] // Default to first signature
-			bestMatch := sig
-			bestScore := -1
-
-			for _, candidateSig := range objType.CallSignatures {
-				score := 0
-				// Prefer exact parameter count match
-				if len(candidateSig.ParameterTypes) == providedArgCount {
-					score += 10
-				}
-				// Or compatible with optional parameters
-				requiredParams := 0
-				for i, isOptional := range candidateSig.OptionalParams {
-					if i < len(candidateSig.ParameterTypes) && !isOptional {
-						requiredParams++
-					}
-				}
-				if providedArgCount >= requiredParams && providedArgCount <= len(candidateSig.ParameterTypes) {
-					score += 5
-				}
-
-				if score > bestScore {
-					bestScore = score
-					bestMatch = candidateSig
-				}
-			}
-
-			expectedParamCount = len(bestMatch.ParameterTypes)
-			optionalParams = bestMatch.OptionalParams
-		}
-	}
-
-	// Determine final argument count (provided args + undefined padding for optional params)
 	finalArgCount := providedArgCount
-	if len(optionalParams) == expectedParamCount && providedArgCount < expectedParamCount {
-		// Count how many optional parameters we need to pad
-		for i := providedArgCount; i < expectedParamCount; i++ {
-			if i < len(optionalParams) && optionalParams[i] {
-				finalArgCount++
-			} else {
-				break // Stop at first required parameter
-			}
-		}
-	}
 
 	// 2. Ensure argument registers exist and build register list
 	// CRITICAL: Arguments must be at funcReg+1, funcReg+2, ... (VM calling convention)
@@ -3115,12 +3075,6 @@ func (c *Compiler) compileArgumentsWithOptionalHandling(node *parser.CallExpress
 			}
 			effectiveArgIndex++
 		}
-	}
-
-	// 4. Pad missing optional parameters with undefined
-	for i := providedArgCount; i < finalArgCount; i++ {
-		targetReg := argRegs[i]
-		c.emitLoadUndefined(targetReg, node.Token.Line)
 	}
 
 	return argRegs, finalArgCount, nil

--- a/tests/scripts/arguments_length_optional_params.ts
+++ b/tests/scripts/arguments_length_optional_params.ts
@@ -1,0 +1,113 @@
+// expect: true
+// `arguments.length` must equal the number of arguments the caller actually
+// wrote - never inflated by the callee's own declared optional/default
+// parameters. Under type checking (the default `./paserati script.ts`
+// mode), a call omitting a value for a trailing optional parameter used to
+// see arguments.length one higher than it should, because the compiler
+// (determineTotalArgCount / compileArgumentsWithOptionalHandling in
+// pkg/compiler, and their `...ForNew` counterparts for `new` expressions)
+// padded the call site's argument count up to the callee's declared
+// parameter count and emitted an explicit OpLoadUndefined into the gap:
+//
+//   function f(a?: string) { return arguments.length; }
+//   f()   // was 1 - should be 0
+//
+// That padding turned out to be entirely redundant for its actual purpose
+// (making a default parameter value apply when its argument is omitted):
+// the VM's own call setup (prepareCall in pkg/vm/call.go, OpNew's
+// constructor-frame setup, and OpTailCall/OpTailCallMethod's frame-reuse
+// path) already independently fills every declared parameter register from
+// the real argument count up to the callee's Arity with Undefined,
+// regardless of what count the call site passes - which is exactly why
+// default values already worked correctly under --no-typecheck, where the
+// compiler-side padding never ran (no static function type to consult
+// there). Removing the padding made the two modes agree.
+const checks: boolean[] = [];
+
+// --- Plain function, optional parameter, explicit vs. omitted argument ---
+function optionalFn(a?: string): number {
+  return arguments.length;
+}
+checks.push(optionalFn() === 0);
+checks.push(optionalFn(undefined) === 1);
+checks.push(optionalFn("x") === 1);
+
+// --- Plain function, default-valued parameter: value still applies AND
+// arguments.length is still the real count. ---
+function defaultFn(a: number = 5): number {
+  return a * 1000 + arguments.length;
+}
+checks.push(defaultFn() === 5000); // default applied, 0 args
+checks.push(defaultFn(undefined) === 5001); // default applied even though "passed", 1 arg
+checks.push(defaultFn(10) === 10001); // explicit value wins, 1 arg
+
+// --- Multiple optional parameters, only some omitted. ---
+function multiOptional(a?: string, b?: string, c?: string): number {
+  return arguments.length;
+}
+checks.push(multiOptional() === 0);
+checks.push(multiOptional("a") === 1);
+checks.push(multiOptional("a", "b") === 2);
+checks.push(multiOptional("a", "b", "c") === 3);
+
+// --- Rest parameter after an optional parameter: neither arguments.length
+// nor the rest array's contents are affected by the omitted optional arg. ---
+function withRest(a?: string, ...rest: number[]): string {
+  return arguments.length + ":" + JSON.stringify(rest);
+}
+checks.push(withRest() === "0:[]");
+checks.push(withRest("x") === "1:[]");
+checks.push(withRest("x", 1, 2) === "3:[1,2]");
+
+// --- arguments object's actual contents, not just its length. ---
+function argsContents(a?: string): string {
+  return JSON.stringify(Array.from(arguments));
+}
+checks.push(argsContents() === "[]");
+checks.push(argsContents("x") === '["x"]');
+
+// --- Method calls. ---
+class Calc {
+  op(a?: number): number {
+    return arguments.length;
+  }
+}
+const calc = new Calc();
+checks.push(calc.op() === 0);
+checks.push(calc.op(undefined) === 1);
+checks.push(calc.op(5) === 1);
+
+// --- Constructor calls (`new`), including via super(). ---
+class Base {
+  len: number = -1;
+  constructor(a?: string) {
+    this.len = arguments.length;
+  }
+}
+checks.push(new Base().len === 0);
+checks.push(new Base(undefined).len === 1);
+checks.push(new Base("x").len === 1);
+
+class Derived extends Base {
+  constructor() {
+    super();
+  }
+}
+checks.push(new Derived().len === 0);
+
+// --- Overloaded function declarations still dispatch/compile correctly. ---
+function overloaded(a: string): string;
+function overloaded(a: string, b: number): string;
+function overloaded(a: string, b?: number): string {
+  return arguments.length + ":" + a + ":" + b;
+}
+checks.push(overloaded("x") === "1:x:undefined");
+checks.push(overloaded("x", 5) === "2:x:5");
+
+// --- Native builtins that rely on len(args) to detect an omitted optional
+// argument must see the real count too (the bug's original symptom). ---
+checks.push([1, 2, 3].join() === "1,2,3");
+checks.push([1, 2, 3, 4].slice().length === 4);
+checks.push("5".padStart(3) === "  5");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Under type checking (the default `./paserati script.ts` mode), a call that omits a value for a trailing optional or default-valued parameter made the callee's `arguments.length` one higher than the caller actually wrote:

```js
function f(a?: string) { return arguments.length; }
f()             // was 1 - should be 0
f(undefined)    // 1 - correct, undefined really was passed
f("x")          // 1 - correct

function f(a = 5) { return arguments.length; }
f()             // was 1 - should be 0 (default value still applied correctly)
```

Confirmed pre-existing and unrelated to type checking itself: `--no-typecheck` already produced the correct counts, which was the key clue — the checker path was doing something the untyped path didn't.

## Root cause

`determineTotalArgCount`/`compileArgumentsWithOptionalHandling` ([compile_expression.go](pkg/compiler/compile_expression.go), [compiler.go](pkg/compiler/compiler.go)) and their `...ForNew` counterparts (for `new` expressions) inspected the callee's checker-resolved function/constructor type and, whenever the call provided fewer arguments than the signature's declared parameter count with the gap covered by optional parameters, padded the compiled argument count up to match and emitted an explicit `OpLoadUndefined` into each padded register. That inflated count became the literal `Args`/`ArgCount` operand on `OpCall`/`OpCallMethod`/`OpNew`/`OpTailCall`/`OpTailCallMethod`, which the VM copies straight into `frame.argCount` — the source of `arguments.length` and the arguments object's own contents (`prepareCall` in pkg/vm/call.go).

This padding turned out to be **entirely redundant** for its apparent purpose (making a default parameter value apply when the argument is omitted): every VM call-setup path — `prepareCall`'s `TypeClosure` branch, `OpNew`'s "Copy fixed arguments (up to Arity)" loop, and both `OpTailCall`'s and `OpTailCallMethod`'s frame-reuse "Pad with undefined for optional parameters" loop — already independently fills every declared parameter register from the real argument count up to the callee's `Arity` with `Undefined`, regardless of what count the call site passes. That's exactly why default values already worked correctly under `--no-typecheck`, where the compiler-side padding never ran in the first place (no static function type to consult there). The padding had no effect on default-value correctness and only corrupted `arguments.length`.

## Fix

`determineTotalArgCount`/`compileArgumentsWithOptionalHandling` (and the `...ForNew` pair) now simply report/use the real number of arguments the call site wrote (with array-literal spread expanded where its length is known at compile time, same as before), with no signature lookup and no padding.

## Verified this doesn't affect

- **Default parameter value application** (`function f(a = 5) {}`, `f()` still yields `5`).
- **Rest parameters after an optional parameter**, and the arguments object's actual contents (not just `.length`).
- **Method calls, constructor calls (including via `super()`), and overloaded function declarations** where a later overload signature has *more* parameters than the call site under test — register sizing is now always `len(node.Arguments)`, never a signature's parameter count. Verified with a register-pressured nested-function repro (`k.m("a")` / `k.m("a", 1, 2)` against a 3-parameter overload → `1:3`, correct).
- **A call with a spread argument** (`f(...arr)`): both the plain and `New` paths check `hasSpreadArgument` and dispatch to a dedicated spread-call compiler *before* ever calling `determineTotalArgCount`/`compileArgumentsWithOptionalHandling`, so the two functions' argument-count bases never need to agree on a spread call — confirmed by tracing the dispatch order, not just by the manual repro passing.
- **Native builtins that rely on `len(args)`** to detect an omitted optional argument (this bug's original symptom, e.g. `[1,2,3].join()` defaulting its separator) now see the real, unpadded count.

## Follow-up task status

- `task_08266d7e` ("type-checked optional-parameter calls inflate arguments.length") tracked exactly this bug and is resolved by this PR.
- `task_7775441b` (audit builtins for `len(args)` checks) is now largely moot for the omitted-argument case this fixes, but remains valid for a caller that passes an explicit `undefined` argument — which was, and remains, indistinguishable from "not passed" to a native's own `len(args)` check, per spec (both are equally "the parameter's value is undefined").

## Tests

Added [arguments_length_optional_params.ts](tests/scripts/arguments_length_optional_params.ts) covering plain functions, default parameters, multiple optional parameters, rest-after-optional, arguments-object contents, methods, constructors/`super()`, overloads, and native builtins — under both type-checked and `--no-typecheck` modes.

## Testing

- `go test ./tests -run TestScripts`: all green
- test262 `language/arguments-object`, `language/statements/function`, the full `language` suite, `built-ins/Function`, `built-ins/Reflect`, and `built-ins/Array` (`-timeout 0.2s`): **0 diff, 0 regressions** across all six — no test262 coverage flips (measured via before/after `-dump` + `comm` flip-diff, not inferred from the mechanism)
