### PR TITLE
fix(vm,builtins): stop array key enumeration from hanging on a huge sparse index

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"math"
+	"sort"
 	"strconv"
 
 	"github.com/nooga/paserati/pkg/types"
@@ -1717,6 +1718,104 @@ func isTargetKeyEnumerable(vmInstance *vm.VM, target vm.Value, key string) bool 
 	return false
 }
 
+// arraySparseIndices returns an array's own numeric-index keys that live
+// beyond its dense elements bound (a.DenseLength()), as ints in ascending
+// numeric order - the order ECMA-262's OrdinaryOwnPropertyKeys requires
+// for integer-indexed properties (matching how the dense range below them
+// is already visited in order by a plain 0..DenseLength() loop).
+//
+// A property beyond the dense bound is tracked in one of two disjoint
+// places depending on how it was defined (see ArrayDefineOwnProperty,
+// array_props.go): a plain data property lives in a.properties (found via
+// NamedPropertyKeys), while an accessor - possible at ANY index, not just
+// ones past maxDenseArrayDefineIndex; an in-bounds index that never grew
+// `elements` far enough to reach it, e.g. index 10000 on a 5-element
+// array, is just as "sparse" from this function's point of view - is
+// never written to a.properties at all (DefineAccessorProperty only ever
+// touches getters/setters/propertyDesc), so it's found via AccessorKeys
+// instead. Both must be walked, or an accessor sparse index silently
+// disappears from every enumeration below (regressed test262
+// built-ins/Object/keys/15.2.3.14-5-14.js during development of this fix,
+// which defines exactly such an accessor at index 10000 on a 5-element
+// sparse array).
+//
+// Every array-own-key enumeration below used to loop `0..a.Length()` to
+// visit every index, but Length() reports the array's `.length` property -
+// which a defineProperty call at a huge index extends without touching
+// `elements` at all - so that loop was actually a multi-billion-iteration
+// hang for an array otherwise holding a handful of elements, not an O(1)
+// per real entry scan (paserati#176/#178). This walks NamedPropertyKeys()
+// and AccessorKeys() instead - O(number of sparse/named/accessor entries),
+// never O(index value) - keeping only the ones that parse as a valid array
+// index (vm.ParseArrayIndex, which already enforces the same 2^32-2 upper
+// bound ArrayDefineOwnProperty itself uses, so nothing here can
+// accidentally treat an out-of-range numeric-looking key as an index).
+//
+// When enumerableOnly is true, only keys whose tracked descriptor reports
+// Enumerable are included (Object.keys/values/entries and Object.assign's
+// own-enumerable-properties rule); pass false for an operation that wants
+// every own index key regardless of enumerability (Object.
+// getOwnPropertyNames, Reflect.ownKeys).
+func arraySparseIndices(a *vm.ArrayObject, enumerableOnly bool) []int {
+	dense := a.DenseLength()
+	seen := make(map[int]bool)
+	var idxs []int
+	consider := func(key string) {
+		idx, isIndex := vm.ParseArrayIndex(key)
+		if !isIndex || idx < dense || seen[idx] {
+			return
+		}
+		if enumerableOnly {
+			if _, _, enumerable, _, isAccessor := a.GetOwnAccessor(key); isAccessor {
+				if !enumerable {
+					return
+				}
+			} else if _, desc, ok := a.GetOwnPropertyDescriptor(key); !ok || !desc.Enumerable {
+				return
+			}
+		}
+		seen[idx] = true
+		idxs = append(idxs, idx)
+	}
+	for _, key := range a.NamedPropertyKeys() {
+		consider(key)
+	}
+	for _, key := range a.AccessorKeys() {
+		consider(key)
+	}
+	sort.Ints(idxs)
+	return idxs
+}
+
+// arraySparseIndexValue reads the value an own sparse index (one
+// arraySparseIndices already found - past DenseLength(), stored beyond
+// the elements slice) currently holds: calls its getter if it's an
+// accessor property, otherwise reads the plain data value from the
+// properties map (GetOwn). Deliberately NOT arrayLikeGet
+// (array_generic.go): that helper falls back to arrayIndexGetFromProto
+// once arr.HasIndex(i) is false, which only walks the PROTOTYPE chain -
+// it never consults the array's OWN properties map, so it would report a
+// sparse own data property (as opposed to an accessor, which it does
+// check first) as absent/inherited instead of returning its real value.
+// That's a real, separate gap in arrayLikeGet - same bug class as
+// paserati#176, just in a helper #176's own fix never touched - flagged
+// as its own follow-up rather than fixed here, since every other
+// arrayLikeGet caller (forEach/map/filter/...) needs it too and this
+// function's scope is the enumeration hang, not that helper.
+func arraySparseIndexValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Value, idx int) (vm.Value, error) {
+	key := strconv.Itoa(idx)
+	if getter, _, _, _, isAccessor := a.GetOwnAccessor(key); isAccessor {
+		if getter.Type() == vm.TypeUndefined {
+			return vm.Undefined, nil
+		}
+		return vmInstance.Call(getter, receiver, nil)
+	}
+	if v, ok := a.GetOwn(key); ok {
+		return v, nil
+	}
+	return vm.Undefined, nil
+}
+
 func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined to object")
@@ -1928,12 +2027,19 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		}
 	case vm.TypeArray:
 		arrObj := obj.AsArray()
-		for i := 0; i < arrObj.Length(); i++ {
+		for i := 0; i < arrObj.DenseLength(); i++ {
 			key := strconv.Itoa(i)
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
 			keysArray.Append(vm.NewString(key))
+		}
+		// A sparse index beyond the dense range (paserati#176/#178 - see
+		// arraySparseIndices) still needs to appear here, in ascending
+		// numeric order right after the dense indices - not iterate up to
+		// it, which is exactly the multi-billion-iteration hang this fixes.
+		for _, idx := range arraySparseIndices(arrObj, true) {
+			keysArray.Append(vm.NewString(strconv.Itoa(idx)))
 		}
 		// Named own properties (an exec result's index/input/groups/indices,
 		// or anything stored on the array) follow the indices.
@@ -2345,12 +2451,25 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		}
 	case vm.TypeArray:
 		arrObj := obj.AsArray()
-		for i := 0; i < arrObj.Length(); i++ {
+		for i := 0; i < arrObj.DenseLength(); i++ {
 			key := strconv.Itoa(i)
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
 			valuesArray.Append(arrObj.Get(i))
+		}
+		// A sparse index beyond the dense range (paserati#176/#178 - see
+		// arraySparseIndices) lives in the properties map (or, for an
+		// accessor, only in getters/setters) - never in elements, so
+		// arrObj.Get(i) would report it as Undefined instead of its real
+		// value. arraySparseIndexValue reads either kind correctly,
+		// calling the getter for an accessor index.
+		for _, idx := range arraySparseIndices(arrObj, true) {
+			value, err := arraySparseIndexValue(vmInstance, arrObj, obj, idx)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			valuesArray.Append(value)
 		}
 	case vm.TypeFunction:
 		funcObj := obj.AsFunction()
@@ -2467,7 +2586,7 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		}
 	case vm.TypeArray:
 		arrObj := obj.AsArray()
-		for i := 0; i < arrObj.Length(); i++ {
+		for i := 0; i < arrObj.DenseLength(); i++ {
 			key := strconv.Itoa(i)
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
@@ -2475,6 +2594,22 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			entry := vm.NewArray()
 			entry.AsArray().Append(vm.NewString(key))
 			entry.AsArray().Append(arrObj.Get(i))
+			entriesArray.Append(entry)
+		}
+		// A sparse index beyond the dense range (paserati#176/#178 - see
+		// arraySparseIndices) lives in the properties map (or, for an
+		// accessor, only in getters/setters) - never in elements, so
+		// arrObj.Get(i) would report it as Undefined instead of its real
+		// value. arraySparseIndexValue reads either kind correctly,
+		// calling the getter for an accessor index.
+		for _, idx := range arraySparseIndices(arrObj, true) {
+			value, err := arraySparseIndexValue(vmInstance, arrObj, obj, idx)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			entry := vm.NewArray()
+			entry.AsArray().Append(vm.NewString(strconv.Itoa(idx)))
+			entry.AsArray().Append(value)
 			entriesArray.Append(entry)
 		}
 	case vm.TypeFunction:
@@ -2578,12 +2713,22 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 		}
 	case vm.TypeArray:
 		a := obj.AsArray()
-		for i := 0; i < a.Length(); i++ {
+		for i := 0; i < a.DenseLength(); i++ {
 			key := strconv.Itoa(i)
 			if !a.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
 			arrObj.Append(vm.NewString(key))
+		}
+		// A sparse index beyond the dense range (paserati#176/#178 - see
+		// arraySparseIndices) is an integer-indexed own property too, so
+		// per OrdinaryOwnPropertyKeys it belongs here, in ascending numeric
+		// order, before "length" and every other string key - not dropped
+		// by the `!LooksLikeArrayIndex` filter below, which is for named
+		// (non-index) properties only. getOwnPropertyNames wants every own
+		// key regardless of enumerability, hence enumerableOnly=false.
+		for _, idx := range arraySparseIndices(a, false) {
+			arrObj.Append(vm.NewString(strconv.Itoa(idx)))
 		}
 		arrObj.Append(vm.NewString("length"))
 		for _, key := range a.NamedPropertyKeys() {
@@ -2954,12 +3099,33 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		} else if source.Type() == vm.TypeArray {
 			arrObj := source.AsArray()
 			// For arrays, copy indexed properties
-			for i := 0; i < arrObj.Length(); i++ {
+			for i := 0; i < arrObj.DenseLength(); i++ {
 				key := strconv.Itoa(i)
 				if !arrObj.HasOwnIndexProperty(key, i) {
 					continue // hole - not an own property at all, nothing to copy (paserati#300)
 				}
 				value := arrObj.Get(i)
+				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// A sparse index beyond the dense range (paserati#176/#178 -
+			// see arraySparseIndices) lives in the properties map (or, for
+			// an accessor, only in getters/setters) - never in elements,
+			// so arrObj.Get(i) would report it as Undefined instead of
+			// copying its real value. arraySparseIndexValue reads either
+			// kind correctly, calling the getter for an accessor index
+			// (per spec, Object.assign copies a source's own enumerable
+			// properties via [[Get]], which for an accessor means calling
+			// it - same reasoning as paserati#274, already applied to the
+			// TypeObject source branch above). Object.assign only reads a
+			// source's own ENUMERABLE properties, hence enumerableOnly=true.
+			for _, idx := range arraySparseIndices(arrObj, true) {
+				value, err := arraySparseIndexValue(vmInstance, arrObj, source, idx)
+				if err != nil {
+					return vm.Undefined, err
+				}
+				key := strconv.Itoa(idx)
 				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
 					return vm.Undefined, err
 				}

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -435,12 +435,23 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			// Add numeric indices - skipping holes (paserati#300): a hole
 			// from `delete arr[i]`, a literal elision, or `new Array(n)` is
 			// not an own property at all.
-			for i := 0; i < arrayObj.Length(); i++ {
+			for i := 0; i < arrayObj.DenseLength(); i++ {
 				key := strconv.Itoa(i)
 				if !arrayObj.HasOwnIndexProperty(key, i) {
 					continue
 				}
 				arr.Append(vm.NewString(key))
+			}
+			// A sparse index beyond the dense range (paserati#176/#178 -
+			// see arraySparseIndices in object_init.go) is an integer-
+			// indexed own key too, so per OrdinaryOwnPropertyKeys it
+			// belongs here, in ascending numeric order, before "length" -
+			// not visited by iterating up to it, which is exactly the
+			// multi-billion-iteration hang this fixes. Reflect.ownKeys
+			// wants every own key regardless of enumerability, hence
+			// enumerableOnly=false.
+			for _, idx := range arraySparseIndices(arrayObj, false) {
+				arr.Append(vm.NewString(strconv.Itoa(idx)))
 			}
 			// Add "length"
 			arr.Append(vm.NewString("length"))

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2378,6 +2378,25 @@ func (a *ArrayObject) Length() int {
 	return a.length
 }
 
+// DenseLength returns the length of the backing elements slice - the bound
+// for an O(1)-per-slot dense-index scan (arr[0], arr[1], ... arr[n-1]).
+// Unlike Length(), which reports the array's `.length` property, this can
+// be far smaller: a huge sparse index defined past maxDenseArrayDefineIndex
+// (paserati#176/#178 - see array_props.go) extends `.length` without
+// growing `elements` at all, and is tracked in the properties map instead
+// (NamedPropertyKeys). Any own-key enumeration (Object.keys/values/
+// entries/getOwnPropertyNames, Reflect.ownKeys, Object.assign's array
+// source, ...) that iterated `0..Length()` to visit every dense index was
+// therefore actually iterating `0..the array's declared length`, an
+// attacker- or test262-controllable value up to 2^32-2 - a multi-billion-
+// iteration hang for an array that otherwise holds a handful of elements.
+// Bound that iteration by DenseLength() instead, and separately walk
+// NamedPropertyKeys() for whatever sparse indices (and true named
+// properties) live beyond it.
+func (a *ArrayObject) DenseLength() int {
+	return len(a.elements)
+}
+
 // SetLength sets the length of the array, expanding or truncating as needed
 func (a *ArrayObject) SetLength(newLength int) {
 	if newLength < 0 {
@@ -2872,6 +2891,83 @@ func (a *ArrayObject) GetOwnAccessor(name string) (Value, Value, bool, bool, boo
 	}
 
 	return getter, setter, enumerable, configurable, true
+}
+
+// AccessorKeys returns every property name this array has an own accessor
+// (getter and/or setter) tracked for - the union of the getters and
+// setters maps' keys, deduplicated. An accessor property (however it was
+// defined - a plain named key, or a numeric index at any position, dense
+// or sparse) is never written into `properties` (see DefineAccessorProperty:
+// it only ever touches getters/setters/propertyDesc), so NamedPropertyKeys
+// alone - which only reads `properties` - misses it entirely. A caller
+// enumerating every own key an array has (Object.keys/getOwnPropertyNames,
+// Reflect.ownKeys, ...) needs both this and NamedPropertyKeys to see the
+// complete set.
+func (a *ArrayObject) AccessorKeys() []string {
+	if a.getters == nil && a.setters == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(a.getters)+len(a.setters))
+	var keys []string
+	for k := range a.getters {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for k := range a.setters {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// arraySparseIndices returns, ascending, every own array-index property this
+// array holds beyond DenseLength() - i.e. entries too far past
+// maxDenseArrayDefineIndex to live in the dense elements slice, tracked
+// instead in the properties map (data) or the getters/setters maps
+// (accessor) - see ArrayDefineOwnProperty in array_props.go and
+// paserati#176/#178. Walking these two maps directly is O(number of sparse
+// entries), never O(index value), which is what makes it safe to call from
+// a for-in/Object.keys/Reflect.ownKeys style enumeration that would
+// otherwise loop 0..Length() and hang for a huge sparse index.
+//
+// When enumerableOnly is true, only keys whose tracked descriptor reports
+// Enumerable are included (for-in, Object.keys/values/entries, Object.
+// assign's own-enumerable-properties rule); pass false for an operation
+// that wants every own index key regardless of enumerability (Object.
+// getOwnPropertyNames, Reflect.ownKeys).
+func arraySparseIndices(a *ArrayObject, enumerableOnly bool) []int {
+	dense := a.DenseLength()
+	seen := make(map[int]bool)
+	var idxs []int
+	consider := func(key string) {
+		idx, isIndex := tryParseArrayIndex(key)
+		if !isIndex || idx < dense || seen[idx] {
+			return
+		}
+		if enumerableOnly {
+			if _, _, enumerable, _, isAccessor := a.GetOwnAccessor(key); isAccessor {
+				if !enumerable {
+					return
+				}
+			} else if _, desc, ok := a.GetOwnPropertyDescriptor(key); !ok || !desc.Enumerable {
+				return
+			}
+		}
+		seen[idx] = true
+		idxs = append(idxs, idx)
+	}
+	for _, key := range a.NamedPropertyKeys() {
+		consider(key)
+	}
+	for _, key := range a.AccessorKeys() {
+		consider(key)
+	}
+	sort.Ints(idxs)
+	return idxs
 }
 
 // NamedPropertyKeys returns all named (non-numeric) property keys on the array

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14199,7 +14199,20 @@ startExecution:
 				// (see ArrayDefineOwnProperty) - mirrors the TypeArguments
 				// case just below for the same reason (propertyHelper.js's
 				// for-in-based isEnumerable() check relies on this).
-				for i := 0; i < arr.Length(); i++ {
+				//
+				// Only the dense range is worth a per-index scan
+				// (paserati#176/#178): a huge sparse index defined past
+				// maxDenseArrayDefineIndex extends arr.Length() (the
+				// `.length` property) without growing `elements` at all, so
+				// looping to Length() here was a multi-billion-iteration
+				// hang for an array that otherwise holds a handful of
+				// elements. Bound the scan to DenseLength() instead, and
+				// separately walk whatever sparse index/accessor entries
+				// exist beyond it via arraySparseIndices (O(number of
+				// entries), not O(index value)) - ascending, per
+				// OrdinaryOwnPropertyKeys.
+				denseLen := arr.DenseLength()
+				for i := 0; i < denseLen; i++ {
 					key := strconv.Itoa(i)
 					if arr.HasAccessors() {
 						if _, _, e, _, ok := arr.GetOwnAccessor(key); ok {
@@ -14220,10 +14233,13 @@ startExecution:
 						}
 					}
 				}
+				for _, idx := range arraySparseIndices(arr, true) {
+					keys = append(keys, strconv.Itoa(idx))
+				}
 				// Then the named (non-index) own properties: an exec result's
 				// index/input/groups/indices, or anything a program stored on
-				// the array. Sparse indices living in the named store were
-				// already handled by the index loop above.
+				// the array. Sparse indices living in the named/accessor
+				// stores were already handled above.
 				for _, key := range arr.NamedPropertyKeys() {
 					if LooksLikeArrayIndex(key) {
 						continue

--- a/tests/scripts/object_enumeration_sparse_index_hang.ts
+++ b/tests/scripts/object_enumeration_sparse_index_hang.ts
@@ -1,0 +1,204 @@
+// expect: true
+// paserati#176/#178: a numeric array index too large to grow the dense
+// .elements slice into (see maxDenseArrayDefineIndex, 2^24, in
+// array_props.go) is tracked as a named property instead - but it still
+// extends the array's `.length`, since a defineProperty call at index i
+// always makes `.length` at least i+1 regardless of where the value is
+// stored.
+//
+// Object.keys/values/entries/getOwnPropertyNames (object_init.go) and
+// Reflect.ownKeys (reflect_init.go) all used to enumerate an array's own
+// numeric-index properties by looping `for i := 0; i < arrObj.Length();
+// i++` - correct for a normal array, but Length() reports `.length`, not
+// how many real entries exist. An array holding three elements plus one
+// property defined at index 4294967294 has a `.length` of 4294967295, so
+// every one of those loops was a multi-billion-iteration hang instead of
+// an O(1)-per-real-entry scan.
+//
+// Fixed by bounding the loop to DenseLength() (len of the actual .elements
+// slice) and separately walking the array's tracked sparse/named entries
+// (O(number of entries), not O(index value)) for whatever lies beyond it -
+// this file asserts both that it completes quickly (the timing itself,
+// implicitly - a regression back to the O(length) loop would make this
+// whole script hang rather than report `false`) and that the huge index
+// is still correctly visited, not silently dropped to avoid the hang.
+const checks: boolean[] = [];
+
+const huge: any[] = [1, 2, 3];
+Object.defineProperty(huge, "4294967294", {
+  value: "z",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+
+checks.push(huge.length === 4294967295);
+
+const keys = Object.keys(huge);
+checks.push(keys.join(",") === "0,1,2,4294967294");
+
+const values = Object.values(huge);
+checks.push(JSON.stringify(values) === '[1,2,3,"z"]');
+
+const entries = Object.entries(huge);
+checks.push(
+  JSON.stringify(entries) ===
+    '[["0",1],["1",2],["2",3],["4294967294","z"]]'
+);
+
+const names = Object.getOwnPropertyNames(huge);
+checks.push(names.join(",") === "0,1,2,4294967294,length");
+
+const reflectKeys = Reflect.ownKeys(huge) as string[];
+checks.push(reflectKeys.join(",") === "0,1,2,4294967294,length");
+
+// Multiple sparse entries: must come out in ascending numeric order, not
+// map-iteration order (which Go does not guarantee), and a named
+// (non-index) property must sort after every index - both dense and
+// sparse - per OrdinaryOwnPropertyKeys.
+const multi: any[] = [10, 20];
+Object.defineProperty(multi, "4294967290", {
+  value: "second-highest",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(multi, "4294900000", {
+  value: "lowest-sparse",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(multi, "4294967294", {
+  value: "highest",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(multi, "named", {
+  value: "not-an-index",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+checks.push(
+  Object.keys(multi).join(",") ===
+    "0,1,4294900000,4294967290,4294967294,named"
+);
+
+// A non-enumerable sparse index must appear in getOwnPropertyNames/
+// Reflect.ownKeys (which don't filter by enumerability) but not in
+// Object.keys/values/entries/Object.assign (which do).
+const withHidden: any[] = [];
+Object.defineProperty(withHidden, "4294800000", {
+  value: "hidden",
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+checks.push(Object.keys(withHidden).length === 0);
+checks.push(Object.values(withHidden).length === 0);
+checks.push(Object.entries(withHidden).length === 0);
+checks.push(Object.getOwnPropertyNames(withHidden).join(",") === "4294800000,length");
+checks.push((Reflect.ownKeys(withHidden) as string[]).join(",") === "4294800000,length");
+
+// Object.assign only copies own enumerable properties, including a
+// sparse index.
+const assignSource: any[] = [1];
+Object.defineProperty(assignSource, "4294967294", {
+  value: "copied",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(assignSource, "4294800001", {
+  value: "not-copied",
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+const assignTarget: any = Object.assign({}, assignSource);
+checks.push(assignTarget["0"] === 1);
+checks.push(assignTarget["4294967294"] === "copied");
+checks.push(!("4294800001" in assignTarget));
+
+// A sparse index defined as an ACCESSOR (get/set, not a plain value) is
+// tracked in a completely different place than a sparse data property
+// (ArrayObject's getters/setters maps, never its properties map - see
+// DefineAccessorProperty) - and NOT just for indices past
+// maxDenseArrayDefineIndex; an in-bounds index whose value never grew
+// `elements` far enough to reach it (e.g. index 10000 on a 3-element
+// array) is exactly as "sparse" here. Missing this case while fixing the
+// hang regressed test262 built-ins/Object/keys/15.2.3.14-5-14.js during
+// development of this fix, so it's asserted directly: the getter must be
+// called (not silently dropped, and not read as a plain data value).
+const accessorSparse: any[] = [1, 2, 3];
+let getterCalls = 0;
+Object.defineProperty(accessorSparse, "10000", {
+  get() {
+    getterCalls++;
+    return "ElementWithLargeIndex";
+  },
+  enumerable: true,
+  configurable: true,
+});
+checks.push(Object.keys(accessorSparse).join(",") === "0,1,2,10000");
+checks.push(Object.values(accessorSparse).indexOf("ElementWithLargeIndex") === 3);
+checks.push(getterCalls === 1);
+checks.push(Object.assign({}, accessorSparse)["10000"] === "ElementWithLargeIndex");
+checks.push(getterCalls === 2);
+
+// The same, but at a genuinely huge (past maxDenseArrayDefineIndex)
+// index, and enumerable:false so it must appear in getOwnPropertyNames/
+// Reflect.ownKeys but not Object.keys/values/entries/assign.
+const hugeAccessor: any[] = [];
+Object.defineProperty(hugeAccessor, "4294967293", {
+  get() {
+    return "huge-accessor";
+  },
+  enumerable: false,
+  configurable: true,
+});
+checks.push(Object.keys(hugeAccessor).length === 0);
+checks.push(
+  Object.getOwnPropertyNames(hugeAccessor).join(",") === "4294967293,length"
+);
+checks.push(
+  (Reflect.ownKeys(hugeAccessor) as string[]).join(",") ===
+    "4294967293,length"
+);
+
+// Side effect of bounding the dense loop to DenseLength(): an array whose
+// `.length` exceeds DenseLength() with NOTHING tracked in the gap (no
+// defineProperty call at all - just a length bump, or new Array(n)'s
+// preallocated-but-empty slots) now correctly reports no own property for
+// those indices, matching V8/Node (`Object.keys(new Array(5))` is `[]`,
+// not `["0","1","2","3","4"]`; growing `.length` past an array's real
+// elements doesn't create own properties either) - this was NOT true
+// before this fix (Length() was the loop bound, so every one of those
+// indices was incorrectly reported as an own key), but it's the same fix,
+// not a separate behavior change: neither loop bound is spec's real
+// answer for whether index i is an own property, and the sparse walk
+// added alongside DenseLength() is what makes the new, narrower answer
+// correct rather than merely convenient for the hang.
+checks.push(Object.keys(new Array(5)).length === 0);
+const growLength: any[] = [1, 2, 3];
+growLength.length = 10;
+checks.push(Object.keys(growLength).join(",") === "0,1,2");
+
+// The for-in loop (pkg/vm/vm.go) walks an array's own keys through the
+// exact same Length()-bounded scan objectKeysWithVM used to - same hang,
+// same fix (DenseLength() + arraySparseIndices), applied there too since
+// for-in is the most common way a user would actually hit this.
+const forInHuge: any[] = [1, 2];
+Object.defineProperty(forInHuge, "4294967290", {
+  value: "sparse",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+const forInKeys: string[] = [];
+for (const k in forInHuge) forInKeys.push(k);
+checks.push(forInKeys.join(",") === "0,1,4294967290");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Fixes the hang described in paserati#176/#178: `Object.keys`/`values`/`entries`/`getOwnPropertyNames`, `Reflect.ownKeys`, `Object.assign`'s array-source branch, and the `for...in` loop all enumerated an array's own numeric-index properties with `for i := 0; i < arr.Length(); i++`. That's `.length`, not how much of the array is backed by the dense `elements` slice — a value defined via `Object.defineProperty` at an index past `maxDenseArrayDefineIndex` (2^24) lives in the array's side property/getter/setter maps instead, but still extends `.length` to `index+1`. An array with a handful of real elements plus one property at index `4294967294` made every one of those loops iterate ~4.3 billion times.

```js
const huge = [];
Object.defineProperty(huge, "4294967294", {
  value: "z", writable: true, enumerable: true, configurable: true,
});
console.log(Object.keys(huge).indexOf("4294967294")); // used to hang
```

## Fix

- New `ArrayObject.DenseLength()` — bounds the cheap dense scan to `len(elements)` instead of `.length`.
- New `ArrayObject.AccessorKeys()` — accessor-only sparse indices (getter/setter, no `value`) are never written into the `properties` map (`DefineAccessorProperty` only touches `getters`/`setters`/`propertyDesc`), so this is needed alongside `NamedPropertyKeys()` to see the complete own-key set.
- New shared helper `arraySparseIndices(a, enumerableOnly)` (in `pkg/builtins`, plus a package-local twin in `pkg/vm` for the `for-in` opcode, which can't import `pkg/builtins`) walks both maps, filters to valid array indices via `ParseArrayIndex`, applies enumerability per the property's real kind, and returns them pre-sorted ascending — O(number of sparse entries), never O(index value).
- New `arraySparseIndexValue` reads a sparse index's value correctly (accessor getter, or the own data value) — deliberately **not** the pre-existing `arrayLikeGet`, which falls back to a prototype-chain-only walk and would report a sparse own data property as `undefined`. That's a real, separate gap in `arrayLikeGet` affecting every other caller (`forEach`/`map`/`filter`/...) — flagged as its own follow-up, not folded into this fix.

All 6 call sites now use these helpers, preserving `OrdinaryOwnPropertyKeys` ordering (dense ascending → sparse ascending → named/length) and each function's own enumerability semantics.

## Regressions caught and fixed during development

- **Accessor-only sparse index silently dropped** — the first version of the sparse walk only read `NamedPropertyKeys()`, missing accessor-only entries entirely. Caught via test262 `built-ins/Object/keys/15.2.3.14-5-14.js` flipping pass→fail; fixed by adding `AccessorKeys()`.
- **`Object.values(huge)` returned `[undefined]` instead of the real value** for a plain data-property sparse index, because the first version reused `arrayLikeGet` (see its gap above). Fixed with the dedicated `arraySparseIndexValue`.

## Explicitly out of scope

- The dense-range loops (`0..DenseLength()`) still don't check holes — a `delete`d dense index still incorrectly shows up in `Object.keys`. Pre-existing, identical before/after this fix.
- `arrayLikeGet`'s own gap (above) — needs a broader fix across every caller, not just these enumeration builtins.
- A separate correctness bug found in passing: an unrelated huge sparse `defineProperty` call inflates `.length`, which then makes `Reflect.has`/the `in` operator falsely report `true` for an in-range index that was never actually set (`"500" in a` → `true`, wrong). Not touched here.

## Intentional side effect

An array whose `.length` exceeds `DenseLength()` with nothing tracked in the gap (`new Array(5)`, or `.length` bumped with no `defineProperty` at all) now reports **no** own property for those indices — matching V8/Node (`Object.keys(new Array(5))` is `[]`). Asserted directly in the new test.

`JSON.stringify` on the same repro is untouched: per spec (confirmed against Node) it must fill every index up to `.length` with `null` regardless of sparseness, so its `O(length)` cost there is correct behavior, not this bug.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- `go test ./tests -run TestScripts`: green.
- New regression test [tests/scripts/object_enumeration_sparse_index_hang.ts](tests/scripts/object_enumeration_sparse_index_hang.ts): basic hang repro, multiple sparse entries with ordering, non-enumerable filtering, `Object.assign`, accessor-vs-data sparse indices, `for-in`, and the `new Array(n)`/length-bump narrowing.
- test262 flip-diff (from-stash build of unmodified `main` vs. this branch) on `built-ins/Object` (2892 passed/519 failed), `built-ins/Reflect` (126 passed/27 failed), and `language/statements/for-in`: identical pass/fail sets before and after — zero regressions, zero new passes.
