### PR TITLE
fix(vm): array spread must call an own accessor's getter, not read raw storage

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17682,31 +17682,67 @@ func (vm *VM) parseArrayIndex(key string) (int, bool) {
 func (vm *VM) extractSpreadArguments(iterableVal Value) ([]Value, error) {
 	switch iterableVal.Type() {
 	case TypeArray:
-		// Fast path for arrays. A real spread reads the source through its
-		// default iterator (%Array.prototype%[Symbol.iterator]), which reads
-		// each index via ordinary [[Get]] - and [[Get]] on a hole (from
-		// `delete arr[i]`, a literal elision `[1,,3]`, or `new Array(n)`)
-		// always yields a genuine, PRESENT `undefined`, never "no property
-		// at all". So the spread result must never itself contain a hole.
-		// A raw `copy(args, arrayObj.elements)` (the previous implementation)
-		// carried a Hole value straight through unchanged instead - and, for
-		// an array whose `.length` exceeds its elements slice (e.g.
-		// `new Array(6)`, or `arr.length = 6` on a 3-element array - see
-		// ArrayObject.SetLength, which deliberately never grows the elements
-		// slice on its own), it silently truncated the spread to
-		// `len(elements)` rather than the array's actual `.length`.
-		// arrayObj.Get(i) already resolves a Hole to Undefined and returns
-		// Undefined for any out-of-slice index up to length, fixing both.
-		// It does not consult own accessors installed via
-		// Object.defineProperty (see arrayLikeGet in array_generic.go for
-		// the accessor-aware version generic Array.prototype methods use) -
-		// that's a separate, pre-existing gap, unaffected by this fix in
-		// either direction: an accessor's raw backing slot was already read
-		// as-is by the old `copy`, and still is here.
+		// A real spread reads the source through its default iterator
+		// (%Array.prototype%[Symbol.iterator]), which reads each index via
+		// ordinary [[Get]]:
+		//  - [[Get]] on a hole (from `delete arr[i]`, a literal elision
+		//    `[1,,3]`, or `new Array(n)`) always yields a genuine, PRESENT
+		//    `undefined`, never "no property at all" - so the spread result
+		//    must never itself contain a hole, and it must go all the way to
+		//    the array's actual `.length` rather than stopping at
+		//    `len(elements)` (e.g. `new Array(6)`, or `arr.length = 6` on a
+		//    3-element array - see ArrayObject.SetLength, which deliberately
+		//    never grows the elements slice on its own) (paserati#309).
+		//  - an own accessor installed via Object.defineProperty (at any
+		//    index, including a plain in-bounds one; DefineAccessorProperty
+		//    never touches `elements`, it only ever writes to
+		//    getters/setters/propertyDesc, so an accessor index's raw
+		//    backing slot is stale or a leftover Hole) must have its getter
+		//    invoked, exactly like plain property access (`a[i]`) or the
+		//    generic Array.prototype methods already do via arrayLikeGet
+		//    (pkg/builtins/array_generic.go - this can't call that helper
+		//    directly, since pkg/builtins imports pkg/vm, not the other way
+		//    around, so the same accessor-first precedence is duplicated
+		//    here instead). A getter that throws propagates as this
+		//    function's error, matching a thrown exception during a real
+		//    spread (paserati#314).
 		arrayObj := AsArray(iterableVal)
 		length := arrayObj.length
 		args := make([]Value, length)
+		if !arrayObj.HasAccessors() {
+			// Fast path for the common case: no own accessor anywhere on
+			// the array, so ordinary [[Get]] never needs to call into
+			// script. arrayObj.Get(i) already resolves a Hole to Undefined
+			// and returns Undefined for any out-of-slice index up to
+			// length, and re-reads the live slice on every call, so it's
+			// safe even though nothing here can mutate the array mid-loop.
+			for i := 0; i < length; i++ {
+				args[i] = arrayObj.Get(i)
+			}
+			return args, nil
+		}
+		// Slow path: the array has at least one own accessor. A getter is
+		// arbitrary script: it can shrink (or replace) `elements` out from
+		// under this loop (`a.length = 0`, `a.pop()`, ...) before a later
+		// iteration's read runs. arrayObj.Get(i) re-checks the live slice
+		// length on every non-accessor read rather than trusting a
+		// snapshot - an index the getter invalidated reads as Undefined
+		// (consistent with arr.Get/HasIndex's own out-of-bounds behavior)
+		// instead of a Go slice-bounds panic.
 		for i := 0; i < length; i++ {
+			key := strconv.Itoa(i)
+			if getter, _, _, _, ok := arrayObj.GetOwnAccessor(key); ok {
+				if getter.Type() == TypeUndefined {
+					args[i] = Undefined
+					continue
+				}
+				v, err := vm.Call(getter, iterableVal, nil)
+				if err != nil {
+					return nil, err
+				}
+				args[i] = v
+				continue
+			}
 			args[i] = arrayObj.Get(i)
 		}
 		return args, nil

--- a/tests/scripts/spread_array_accessor_getter.ts
+++ b/tests/scripts/spread_array_accessor_getter.ts
@@ -1,0 +1,128 @@
+// expect: true
+// A real array spread (`[...arr]`, `f(...arr)`) reads the source through its
+// default iterator, which reads each index via ordinary [[Get]] - so an own
+// accessor property (installed via Object.defineProperty, get/set instead
+// of a plain value) must have its getter invoked, exactly like plain
+// property access (`arr[i]`) already does.
+//
+// extractSpreadArguments's TypeArray fast path (pkg/vm/vm.go) used to
+// bypass this entirely: `copy(args, arrayObj.elements)` reads the raw
+// backing slot directly, and DefineAccessorProperty never writes an
+// accessor's value into `elements` at all (it only ever touches
+// getters/setters/propertyDesc - see pkg/vm/array_props.go) - so the
+// spread result carried whatever was in that slot before the accessor was
+// installed (or a Hole, for an index that was never a data property to
+// begin with) instead of calling the getter.
+//
+// This does NOT cover holes/length handling (a separate, pre-existing gap
+// in the same fast path - see the array-spread hole-propagation fix) -
+// only the accessor case.
+const checks: boolean[] = [];
+
+// Basic case: a getter on an in-bounds index of a dense array.
+const a: any[] = [1, 2, 3];
+let getCalls = 0;
+Object.defineProperty(a, "1", {
+  get() {
+    getCalls++;
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+
+checks.push(a[1] === 42); // sanity: plain property access already worked
+
+const spread = [...a];
+checks.push(JSON.stringify(spread) === "[1,42,3]");
+checks.push(getCalls === 2); // once for the a[1] sanity check above, once for the spread
+
+// Spread into a function call goes through the same fast path.
+function collect(...args: any[]) {
+  return args;
+}
+checks.push(JSON.stringify(collect(...a)) === "[1,42,3]");
+
+// Multiple accessors, ascending order - the getter for each index must be
+// called at most once, and results must land at the right positions.
+const multi: any[] = [10, 20, 30, 40];
+const calls: number[] = [];
+Object.defineProperty(multi, "0", {
+  get() {
+    calls.push(0);
+    return "first";
+  },
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(multi, "3", {
+  get() {
+    calls.push(3);
+    return "last";
+  },
+  enumerable: true,
+  configurable: true,
+});
+checks.push(JSON.stringify([...multi]) === '["first",20,30,"last"]');
+checks.push(calls.join(",") === "0,3");
+
+// An accessor with no getter (setter-only) reads as `undefined`, per
+// ordinary [[Get]] on an accessor property whose [[Get]] is absent - not
+// the stale/raw backing slot.
+const setterOnly: any[] = [1, 2, 3];
+Object.defineProperty(setterOnly, "1", {
+  set(_v: any) {},
+  enumerable: true,
+  configurable: true,
+});
+checks.push(JSON.stringify([...setterOnly]) === "[1,null,3]");
+
+// A getter that throws must propagate out of the spread as a real
+// exception, not be swallowed or read as some placeholder value.
+const throwing: any[] = [1, 2, 3];
+Object.defineProperty(throwing, "0", {
+  get() {
+    throw new Error("boom");
+  },
+  enumerable: true,
+  configurable: true,
+});
+let threw = false;
+try {
+  [...throwing];
+} catch (e: any) {
+  threw = e.message === "boom";
+}
+checks.push(threw);
+
+// The common case (no accessors at all) must remain exactly as fast/
+// correct as before - this is the pre-existing fast path, unaffected by
+// the accessor-aware slow path added alongside it.
+const plain = [1, 2, 3];
+checks.push(JSON.stringify([...plain]) === "[1,2,3]");
+
+// A getter is arbitrary script - it can shrink the array's own backing
+// storage (`.length = 0`, `.pop()`, ...) out from under the spread that's
+// still in the middle of reading it. This must never panic the VM (the
+// slow path indexes the raw backing slice for every non-accessor read,
+// so a shrink invalidates indices a naive snapshot-length loop would
+// still try to read) - it's not required to match a real iterator's
+// "re-read .length every step" semantics (that's out of scope here, see
+// the file-level comment), just not crash.
+const shrinking: any[] = [1, 2, 3];
+Object.defineProperty(shrinking, "0", {
+  get() {
+    shrinking.length = 0;
+    return "g";
+  },
+  configurable: true,
+});
+let shrinkPanicked = false;
+try {
+  JSON.stringify([...shrinking]);
+} catch (e) {
+  shrinkPanicked = true;
+}
+checks.push(!shrinkPanicked);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
`extractSpreadArguments`'s `TypeArray` fast path (used by `[...arr]`, spread call arguments, and any other spread of a real Array) read every element with `copy(args, arrayObj.elements)` - the raw backing slice, unconditionally. A real spread reads the source through its default iterator (`%Array.prototype%[Symbol.iterator]%`), which reads each index via ordinary `[[Get]]` - so an own accessor property (get/set installed via `Object.defineProperty`, at any index, including a plain in-bounds one) must have its getter invoked. `DefineAccessorProperty` never touches `elements` at all - only `getters`/`setters`/`propertyDesc` - so an accessor index's raw slot is stale (or a leftover Hole), not the value `[[Get]]` must produce:

```js
const a = [1, 2, 3];
Object.defineProperty(a, 1, { get() { return 42; }, enumerable: true, configurable: true });
console.log(a[1]);                    // 42 - correct, plain property read already worked
console.log(JSON.stringify([...a]));  // was [1,2,3], should be [1,42,3]
```

## Fix

When `arrayObj.HasAccessors()`, take a slow per-index path that checks `GetOwnAccessor` first (calling the getter, or reading `Undefined` for a setter-only accessor) before falling back to the raw element - mirroring the accessor-first-then-raw-element precedence `arrayLikeGet` (`pkg/builtins/array_generic.go`) already uses for the generic `Array.prototype` methods (`forEach`/`map`/`filter`/...). This can't call `arrayLikeGet` directly (`pkg/builtins` imports `pkg/vm`, not the other way around), so the same precedence is duplicated in `pkg/vm/vm.go`. The common case (no accessors anywhere on the array) keeps the original raw-copy fast path unchanged.

## Regression caught during review

A getter is arbitrary script, and the first version of the slow path snapshotted `n := len(arrayObj.elements)` once but then indexed the live slice for every non-accessor read - a getter that shrinks the array's own backing storage mid-spread (`a.length = 0`, `a.pop()`, a `splice`, ...) made a later iteration's raw read run past the now-smaller slice: a genuine Go slice-bounds **panic** reaching script-reachable code, strictly worse than the stale value being fixed. Fixed by re-checking the live slice length on every non-accessor read; an index a getter invalidated now reads as `Undefined` instead of panicking.

## Explicitly out of scope

- A sparse accessor defined past the array's dense storage (paserati#176/#178-style sparse indices) - both the fast and slow path stay bounded to `len(elements)`.
- Length-vs-elements-slice-size gaps in general (`new Array(6)`, a manual `.length` bump) and the raw-Hole-value leak on the non-accessor path. **This is the exact scope of the still-open, unmerged [PR #309](https://github.com/nooga/paserati/pull/309)** (`fix-array-spread-hole-propagation`), which independently rewrites these same lines to `for i := 0; i < arrayObj.length; i++ { args[i] = arrayObj.Get(i) }`. Whichever of these two branches merges second will conflict on exactly this code - the correct union: iterate to `arrayObj.length` (not `len(elements)`), check `GetOwnAccessor` first per index, and fall back to `arrayObj.Get(i)` (not the raw `elements[i]`) rather than either branch's narrower version alone.
- Two adjacent, real bugs found and confirmed against Node while testing this, filed as their own follow-ups rather than folded in: `Array.from(arr)` and destructuring rest (`const [x, ...rest] = arr`, `OpArraySlice`) both have the identical raw-read-instead-of-getter gap.

## Testing

- Exact repro above, plus call-spread (`f(...a)`), a setter-only accessor (reads as `undefined`), a throwing getter (propagates as a real exception), multiple accessors at different indices, the plain no-accessor fast path (unchanged), and the shrinking-getter panic case - all confirmed against Node as the reference.
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- `go test ./tests -run TestScripts`: green.
- New regression test [tests/scripts/spread_array_accessor_getter.ts](tests/scripts/spread_array_accessor_getter.ts).
- test262 flip-diff (from-stash build of unmodified `main` vs. this branch, `-timeout 0.2s`) on `built-ins/Array`, `language/expressions/array`, `language/expressions/call`, and `language/statements/for-of`: identical pass/fail sets before and after - zero regressions, zero new passes.
