### PR TITLE
fix(vm,builtins): Reflect.has/`in` must check real presence, not `.length`

### DIFF
--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -277,8 +277,14 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			arr := target.AsArray()
 			if propKey == "length" {
 				hasProperty = true
-			} else if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 && idx < arr.Length() {
-				hasProperty = true
+			} else if idx, ok := vm.ParseArrayIndex(propKey); ok {
+				// A numerically-in-range index is NOT necessarily an own
+				// property: `.length` can be inflated by an unrelated
+				// defineProperty call at a different, possibly huge, index
+				// (paserati#176/#178) without this index itself ever
+				// being set. Check real presence instead of
+				// `idx < arr.Length()`.
+				hasProperty = vm.ArrayHasOwnIndex(arr, idx)
 			}
 		case vm.TypeFunction:
 			// Functions have properties like name, length, prototype

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2495,6 +2495,37 @@ func (a *ArrayObject) HasIndex(index int) bool {
 	return a.elements[index].typ != TypeHole
 }
 
+// ArrayHasOwnIndex reports whether an array genuinely has an own property
+// at the given index - the correct check for `index in arr` / Reflect.has,
+// as opposed to `index < arr.Length()` (a bug that shipped in both: an
+// index numerically less than `.length` is NOT necessarily an own
+// property - `.length` can be inflated by an unrelated defineProperty call
+// at a completely different, possibly huge, index - see paserati#176/#178
+// and array_props.go's maxDenseArrayDefineIndex).
+//
+// Three cases, in order: a dense-range index with a real (non-hole) value
+// (HasIndex); an own accessor at that index (DefineAccessorProperty never
+// touches `elements` at all - not even for a plain in-bounds index - so
+// this must be checked regardless of whether idx is in the dense range);
+// and finally a sparse own data property tracked in the properties map for
+// an index past the dense range (GetOwnPropertyDescriptor).
+func ArrayHasOwnIndex(a *ArrayObject, idx int) bool {
+	if idx < 0 {
+		return false
+	}
+	if a.HasIndex(idx) {
+		return true
+	}
+	key := strconv.Itoa(idx)
+	if _, _, _, _, isAccessor := a.GetOwnAccessor(key); isAccessor {
+		return true
+	}
+	if _, _, ok := a.GetOwnPropertyDescriptor(key); ok {
+		return true
+	}
+	return false
+}
+
 // SetExecMeta stores exec result metadata for lazy property access.
 // This avoids allocating a map for index/input/groups on every exec call.
 func (a *ArrayObject) SetExecMeta(index int, input string) {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3418,16 +3418,16 @@ startExecution:
 				case TypeArray:
 					// For arrays, check if the property is a valid index or known property
 					arrayObj := objVal.AsArray()
-					if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
-						if arrayObj.HasOwnIndexProperty(propKey, index) {
-							hasProperty = true
-						} else {
-							// A hole (from `delete arr[i]`, a literal elision,
-							// or `new Array(n)`) is not an own property at
-							// all - fall through to the prototype chain like
-							// any other absent index (paserati#300).
-							hasProperty = vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(objVal), keyFromString(propKey))
-						}
+					if index, ok := tryParseArrayIndex(propKey); ok {
+						// A numerically-in-range index is NOT necessarily an
+						// own property: `.length` can be inflated by an
+						// unrelated defineProperty call at a different,
+						// possibly huge, index (paserati#176/#178) without
+						// this index itself ever being set. Check real
+						// presence (dense value, or an own accessor/sparse
+						// data property at this exact index) instead of
+						// `index < arrayObj.Length()`.
+						hasProperty = ArrayHasOwnIndex(arrayObj, index)
 					} else if _, ok := arrayObj.GetOwn(propKey); ok {
 						hasProperty = true
 					} else if propKey == "length" {

--- a/tests/scripts/reflect_has_in_inflated_length.ts
+++ b/tests/scripts/reflect_has_in_inflated_length.ts
@@ -1,0 +1,119 @@
+// expect: true
+// Reflect.has and the `in` operator on arrays used to report an index as
+// present merely because it was numerically less than the array's
+// `.length`, regardless of whether that index was ever actually set.
+// `.length` can be inflated by an entirely unrelated Object.defineProperty
+// call at a different (possibly huge) index (paserati#176/#178: an index
+// past maxDenseArrayDefineIndex, 2^24, is tracked in the array's side
+// property/getter/setter maps instead of the dense `elements` slice, but
+// still extends `.length` to index+1) - so an array holding a handful of
+// real elements plus one property at a huge index made every unset index
+// in between falsely report as present.
+//
+// Fixed via a shared ArrayHasOwnIndex helper (pkg/vm/value.go) that checks
+// real presence - a dense value (HasIndex), an own accessor at that index
+// (checked regardless of dense/sparse, since DefineAccessorProperty never
+// touches `elements` at all), or a sparse own data property
+// (GetOwnPropertyDescriptor) - instead of `idx < arr.Length()`, in both
+// pkg/vm/vm.go's OpIn and pkg/builtins/reflect_init.go's Reflect.has.
+const checks: boolean[] = [];
+
+// Small in-range false positive: index 500 was never set, but the
+// unrelated defineProperty at 1000000 inflates .length past it.
+const small: any[] = [];
+Object.defineProperty(small, "1000000", {
+  value: "z",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+checks.push(!("500" in small));
+checks.push(!Reflect.has(small, "500"));
+checks.push("1000000" in small);
+checks.push(Reflect.has(small, "1000000"));
+checks.push("length" in small);
+checks.push(Reflect.has(small, "length"));
+
+// Huge sparse index scenario: a handful of real dense elements plus one
+// property at a genuinely huge index (past maxDenseArrayDefineIndex).
+// Every unset index in between - both within and beyond the dense range -
+// must report absent; the dense elements and the sparse index itself must
+// still report present.
+const huge: any[] = [1, 2, 3];
+Object.defineProperty(huge, "4294967294", {
+  value: "z",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+checks.push("0" in huge && Reflect.has(huge, "0"));
+checks.push("2" in huge && Reflect.has(huge, "2"));
+checks.push(!("3" in huge) && !Reflect.has(huge, "3")); // in-range (< length), never set
+checks.push(!("1000000" in huge) && !Reflect.has(huge, "1000000")); // in-range, never set
+checks.push("4294967294" in huge && Reflect.has(huge, "4294967294"));
+checks.push("length" in huge && Reflect.has(huge, "length"));
+
+// A non-enumerable property is still an OWN property - `in`/Reflect.has
+// don't filter by enumerability (unlike Object.keys et al).
+const hidden: any[] = [];
+Object.defineProperty(hidden, "10", {
+  value: "hidden",
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+checks.push("10" in hidden && Reflect.has(hidden, "10"));
+
+// An own accessor (get/set, no `value`) is a real own property too, at
+// any index - a plain in-bounds one (DefineAccessorProperty never touches
+// `elements`, even in-bounds) and a sparse one past dense storage.
+const accessorInBounds: any[] = [1, 2, 3];
+Object.defineProperty(accessorInBounds, "1", {
+  get() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+checks.push("1" in accessorInBounds && Reflect.has(accessorInBounds, "1"));
+
+const accessorSparse: any[] = [1, 2, 3];
+Object.defineProperty(accessorSparse, "10000", {
+  get() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+checks.push(
+  "10000" in accessorSparse && Reflect.has(accessorSparse, "10000")
+);
+checks.push(
+  !("9999" in accessorSparse) && !Reflect.has(accessorSparse, "9999")
+);
+
+// A plain dense array with no accessors/sparse entries at all must keep
+// behaving exactly as before - the common case, unaffected.
+const plain = [1, 2, 3];
+checks.push("0" in plain && Reflect.has(plain, "0"));
+checks.push("2" in plain && Reflect.has(plain, "2"));
+checks.push(!("3" in plain) && !Reflect.has(plain, "3"));
+checks.push(!("-1" in plain) && !Reflect.has(plain, "-1"));
+
+// Known, pre-existing, out-of-scope gap (identical before and after this
+// fix - confirmed by diffing against an unmodified build): a numeric key
+// that isn't an own array index never falls through to walk the
+// prototype chain, so an index set directly on Array.prototype is
+// invisible to both `in` and Reflect.has here, unlike Node (where it's
+// `true`). This fix only tightens the OWN-property check (real presence
+// vs. "numerically less than .length") - it does not add the missing
+// prototype fallback, which is a separate, broader change (`in` is
+// HasProperty, not HasOwnProperty) and is asserted here as the current,
+// unchanged behavior rather than left silently uncovered.
+(Array.prototype as any)[999] = "inherited";
+const withInheritedIndex = [1, 2, 3];
+checks.push(!("999" in withInheritedIndex));
+checks.push(!Reflect.has(withInheritedIndex, "999"));
+delete (Array.prototype as any)[999];
+
+checks.every((c) => c === true);


### PR DESCRIPTION
`Reflect.has(arr, key)` and `key in arr`, for a numeric-looking key, both reported an array index as present whenever it was numerically less than `.length` - regardless of whether that index was ever actually set. An unrelated `Object.defineProperty` call at a completely different (possibly huge) index inflates `.length` to `index+1` without the array acquiring any of the indices in between as own properties (paserati#176/#178: an index past `maxDenseArrayDefineIndex`, 2^24, is tracked in the array's side property/getter/setter maps instead of the dense `elements` slice, but still extends `.length`):

```js
const a = [];
Object.defineProperty(a, "1000000", { value: "z", writable: true, enumerable: true, configurable: true });
console.log(Reflect.has(a, "500")); // was true - WRONG, index 500 was never set
console.log("500" in a);            // same bug
```

## Fix

A new shared `vm.ArrayHasOwnIndex(arr, idx)` (`pkg/vm/value.go`) checks real presence - a dense value (`HasIndex`), an own accessor at that exact index (checked regardless of dense/sparse, since `DefineAccessorProperty` never writes to `elements` at all, not even for a plain in-bounds index), or a sparse own data property tracked past the dense range (`GetOwnPropertyDescriptor`) - instead of `idx < arr.Length()`. Both `OpIn`'s `TypeArray` case (`pkg/vm/vm.go`) and `Reflect.has`'s `TypeArray` case (`pkg/builtins/reflect_init.go`) now call it, parsing the key via the existing `ParseArrayIndex`/`tryParseArrayIndex` (already enforces the correct 2^32-2 index upper bound) rather than a bare `strconv.Atoi`.

`Reflect.get`/`Reflect.set`'s own similar-looking `idx < arr.Length()` checks are deliberately left alone: `Get`/array element access self-bounds-check against the real backing storage regardless, so there's no false *value* returned there - only `has`'s boolean answer was wrong.

## Explicitly out of scope

Confirmed pre-existing and **identical before and after this change** (diffed against an unmodified build):

- Neither `in` nor `Reflect.has` on arrays fall through to the prototype chain for a numeric-looking key that isn't an own index - `in` is HasProperty (own OR inherited), not HasOwnProperty, so `Array.prototype[999] = "x"; "999" in [1,2,3]` is `true` in Node but `false` here, unchanged by this fix (it only tightens the *own*-property check). Filed as its own follow-up, and asserted directly in the new test as the current, unchanged behavior rather than left silently uncovered.
- `Reflect.has` never checks an array's own named (non-index) properties at all (e.g. a plain `arr.foo = 1`) - a separate false-negative in the same function, pre-existing, not touched. Filed as its own follow-up.

## Testing

- Verified against Node as the reference: the exact repro above; a huge sparse index scenario (every unset index in between reports absent; dense elements, the sparse index, and `length` all report present); a non-enumerable property (still an own property); an own accessor at a plain in-bounds index and at a sparse index; and the unaffected plain-array common case.
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- `go test ./tests -run TestScripts`: green.
- New regression test [tests/scripts/reflect_has_in_inflated_length.ts](tests/scripts/reflect_has_in_inflated_length.ts).
- test262 flip-diff (from-stash build of unmodified `main` vs. this branch, `-timeout 0.2s`) on `built-ins/Reflect` (126 passed/27 failed), `language/expressions/in` (36 passed/0 failed), `built-ins/Array`, and `language/statements/for-in`: identical pass/fail sets before and after - zero regressions, zero new passes.
