### PR TITLE
fix(vm,builtins): array `in`/Reflect.has implement HasProperty, not HasOwnProperty

### DIFF
--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -275,16 +275,53 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			hasProperty = target.AsDictObject().Has(propKey)
 		case vm.TypeArray:
 			arr := target.AsArray()
-			if propKey == "length" {
-				hasProperty = true
+			if isSymbol {
+				// Mirrors OpIn's TypeArray symbol branch (pkg/vm/vm.go):
+				// an own symbol-keyed property (e.g. a custom
+				// Symbol.iterator override), else walk the prototype
+				// chain (Array.prototype carries the real
+				// Symbol.iterator, Symbol.toStringTag if ever set, ...).
+				// Reflect.has previously stringified every key
+				// (propKeyArg.ToString()) and fell through this entire
+				// switch with hasProperty left at its zero value, so
+				// `Reflect.has(arr, Symbol.iterator)` was unconditionally
+				// false even though `Symbol.iterator in arr` is true.
+				if arr.HasOwnSymbolProp(propKeyArg.AsSymbolObject()) {
+					hasProperty = true
+				} else {
+					hasProperty = vmInstance.HasPropertyOnPrototypeChain(target, vm.NewSymbolKey(propKeyArg))
+				}
 			} else if idx, ok := vm.ParseArrayIndex(propKey); ok {
 				// A numerically-in-range index is NOT necessarily an own
 				// property: `.length` can be inflated by an unrelated
 				// defineProperty call at a different, possibly huge, index
 				// (paserati#176/#178) without this index itself ever
 				// being set. Check real presence instead of
-				// `idx < arr.Length()`.
-				hasProperty = vm.ArrayHasOwnIndex(arr, idx)
+				// `idx < arr.Length()` - and, per Reflect.has implementing
+				// HasProperty (not HasOwnProperty), an index that isn't an
+				// own property still needs the prototype-chain walk below
+				// rather than reporting absent outright.
+				if vm.ArrayHasOwnIndex(arr, idx) {
+					hasProperty = true
+				} else {
+					hasProperty = vmInstance.HasPropertyOnPrototypeChain(target, vm.NewStringKey(propKey))
+				}
+			} else if propKey == "length" {
+				hasProperty = true
+			} else if vm.ArrayHasOwnNamedProperty(arr, propKey) {
+				// An own named (non-index) property - a plain data
+				// property (`arr.foo = 1`) or an own accessor - was
+				// never checked at all before this: only "length" and a
+				// numeric index were, so `Reflect.has(arr, "foo")` was
+				// unconditionally false regardless of whether `arr.foo`
+				// existed, even though `"foo" in arr` correctly found it.
+				hasProperty = true
+			} else {
+				// Neither an own index/named property nor "length" -
+				// still need the prototype-chain walk before reporting
+				// absent (inherited methods like Array.prototype.map,
+				// or anything else stored on Array.prototype).
+				hasProperty = vmInstance.HasPropertyOnPrototypeChain(target, vm.NewStringKey(propKey))
 			}
 		case vm.TypeFunction:
 			// Functions have properties like name, length, prototype

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -950,6 +950,22 @@ func (vm *VM) hasPropertyByKeyFromPrototypeChain(proto Value, key PropertyKey) b
 	return ok
 }
 
+// HasPropertyOnPrototypeChain reports whether key is found somewhere on
+// objVal's prototype chain (e.g. Array.prototype and beyond, for a
+// TypeArray objVal - see effectiveBuiltinPrototype for every builtin type
+// this resolves a starting prototype for) - the "or inherited" half of
+// HasProperty (`in`, Reflect.has), which an own-property-only check like
+// ArrayHasOwnIndex/ArrayHasOwnNamedProperty deliberately does not cover.
+// Exported so pkg/builtins (which cannot reach the unexported
+// effectiveBuiltinPrototype/hasPropertyByKeyFromPrototypeChain/
+// keyFromString directly - pkg/builtins imports pkg/vm, not the other way
+// around) can implement the same "own property, else walk the prototype
+// chain" precedence OpIn already uses, instead of silently treating every
+// object type's own-property check as the complete answer.
+func (vm *VM) HasPropertyOnPrototypeChain(objVal Value, key PropertyKey) bool {
+	return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(objVal), key)
+}
+
 // handleSpecialProperties handles special properties like .length
 func (vm *VM) handleSpecialProperties(objVal Value, propName string) (Value, bool) {
 	// Handle undefined/null objects

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -2526,6 +2526,25 @@ func ArrayHasOwnIndex(a *ArrayObject, idx int) bool {
 	return false
 }
 
+// ArrayHasOwnNamedProperty reports whether an array has an own NAMED
+// (non-index) property under the given key - a plain data property
+// (`arr.foo = 1`, tracked in the properties map, checked via GetOwn) or an
+// own accessor (get/set installed via Object.defineProperty). The latter
+// needs its own check: DefineAccessorProperty never writes to `properties`
+// at all, for a named key exactly as much as for a numeric one (see
+// ArrayHasOwnIndex's identical reasoning) - so GetOwn alone silently
+// drops a named accessor property (`Object.defineProperty(arr, "foo",
+// {get(){...}})` would report as absent without this).
+func ArrayHasOwnNamedProperty(a *ArrayObject, name string) bool {
+	if _, ok := a.GetOwn(name); ok {
+		return true
+	}
+	if _, _, _, _, isAccessor := a.GetOwnAccessor(name); isAccessor {
+		return true
+	}
+	return false
+}
+
 // SetExecMeta stores exec result metadata for lazy property access.
 // This avoids allocating a map for index/input/groups on every exec call.
 func (a *ArrayObject) SetExecMeta(index int, input string) {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3426,9 +3426,17 @@ startExecution:
 						// this index itself ever being set. Check real
 						// presence (dense value, or an own accessor/sparse
 						// data property at this exact index) instead of
-						// `index < arrayObj.Length()`.
-						hasProperty = ArrayHasOwnIndex(arrayObj, index)
-					} else if _, ok := arrayObj.GetOwn(propKey); ok {
+						// `index < arrayObj.Length()` - and, per `in`
+						// being HasProperty (not HasOwnProperty), an index
+						// that isn't an own property still needs the
+						// prototype-chain walk below rather than reporting
+						// absent outright (e.g. Array.prototype[5] = ...).
+						if ArrayHasOwnIndex(arrayObj, index) {
+							hasProperty = true
+						} else {
+							hasProperty = vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(objVal), keyFromString(propKey))
+						}
+					} else if ArrayHasOwnNamedProperty(arrayObj, propKey) {
 						hasProperty = true
 					} else if propKey == "length" {
 						hasProperty = true

--- a/tests/scripts/reflect_has_in_inflated_length.ts
+++ b/tests/scripts/reflect_has_in_inflated_length.ts
@@ -16,6 +16,16 @@
 // touches `elements` at all), or a sparse own data property
 // (GetOwnPropertyDescriptor) - instead of `idx < arr.Length()`, in both
 // pkg/vm/vm.go's OpIn and pkg/builtins/reflect_init.go's Reflect.has.
+//
+// This file also covers two follow-up fixes to the same two functions:
+// `in`/Reflect.has now correctly implement HasProperty (own OR inherited -
+// a numeric or named key absent as an own property falls through to the
+// prototype chain, via the new exported vm.HasPropertyOnPrototypeChain),
+// and Reflect.has now checks an array's own named (non-index) properties
+// at all (a plain data property, or an own accessor - via the new shared
+// ArrayHasOwnNamedProperty, used by both `in` and Reflect.has so they
+// can't drift from each other), and handles a symbol-keyed lookup instead
+// of stringifying every key and reporting false unconditionally.
 const checks: boolean[] = [];
 
 // Small in-range false positive: index 500 was never set, but the
@@ -100,20 +110,72 @@ checks.push("2" in plain && Reflect.has(plain, "2"));
 checks.push(!("3" in plain) && !Reflect.has(plain, "3"));
 checks.push(!("-1" in plain) && !Reflect.has(plain, "-1"));
 
-// Known, pre-existing, out-of-scope gap (identical before and after this
-// fix - confirmed by diffing against an unmodified build): a numeric key
-// that isn't an own array index never falls through to walk the
-// prototype chain, so an index set directly on Array.prototype is
-// invisible to both `in` and Reflect.has here, unlike Node (where it's
-// `true`). This fix only tightens the OWN-property check (real presence
-// vs. "numerically less than .length") - it does not add the missing
-// prototype fallback, which is a separate, broader change (`in` is
-// HasProperty, not HasOwnProperty) and is asserted here as the current,
-// unchanged behavior rather than left silently uncovered.
+// Follow-up fix: `in`/Reflect.has on arrays now correctly implement
+// HasProperty (own OR inherited), not just HasOwnProperty. A numeric key
+// that isn't an own array index falls through to the prototype chain
+// (Array.prototype and beyond) instead of reporting absent outright - so
+// an index set directly on Array.prototype IS found, matching Node. (This
+// used to be a known, pre-existing gap, pinned here as `false` - inverted
+// now that it's fixed, rather than deleted, so a regression back to the
+// old behavior fails this test instead of going unnoticed.)
 (Array.prototype as any)[999] = "inherited";
 const withInheritedIndex = [1, 2, 3];
-checks.push(!("999" in withInheritedIndex));
-checks.push(!Reflect.has(withInheritedIndex, "999"));
+checks.push("999" in withInheritedIndex);
+checks.push(Reflect.has(withInheritedIndex, "999"));
 delete (Array.prototype as any)[999];
+
+// The single most common instance of the same prototype-fallback gap: an
+// inherited METHOD. Reflect.has(arr, "map") was false for every array,
+// regardless of the array's own contents, since Reflect.has's array
+// branch had no prototype fallback at all (only "length" and a numeric
+// index were ever checked).
+checks.push("map" in plain && Reflect.has(plain, "map"));
+checks.push("join" in plain && Reflect.has(plain, "join"));
+
+// Follow-up fix: Reflect.has never checked an array's own NAMED
+// (non-index) property at all - a plain data property...
+const withNamed: any = [1, 2, 3];
+withNamed.foo = "bar";
+checks.push("foo" in withNamed && Reflect.has(withNamed, "foo"));
+// ...or an own named accessor (same DefineAccessorProperty-never-touches-
+// `properties` reasoning as the numeric-index case above, just for a
+// string key instead) - this was ALSO missing from `in` itself (not just
+// Reflect.has), caught by making both share one ArrayHasOwnNamedProperty
+// helper rather than fixing Reflect.has to merely match whatever `in`
+// happened to do.
+const withNamedAccessor: any[] = [1, 2, 3];
+Object.defineProperty(withNamedAccessor, "foo", {
+  get() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+checks.push(
+  "foo" in withNamedAccessor && Reflect.has(withNamedAccessor, "foo")
+);
+
+// A key that's genuinely absent everywhere (own, and on the prototype
+// chain) must still report false - the prototype-chain fallback must not
+// turn into a false positive for everything.
+checks.push(!("totallyMadeUp" in plain) && !Reflect.has(plain, "totallyMadeUp"));
+
+// Follow-up fix: Reflect.has(arr, someSymbol) always stringified the key
+// and fell through the whole switch with hasProperty left false,
+// regardless of whether the symbol was `Symbol.iterator` (found via the
+// prototype chain) or an own symbol-keyed property.
+checks.push(Symbol.iterator in plain && Reflect.has(plain, Symbol.iterator));
+const ownSymbol = Symbol("x");
+const withOwnSymbol: any = [1, 2, 3];
+withOwnSymbol[ownSymbol] = 42;
+checks.push(ownSymbol in withOwnSymbol && Reflect.has(withOwnSymbol, ownSymbol));
+const unusedSymbol = Symbol("unused");
+checks.push(!(unusedSymbol in plain) && !Reflect.has(plain, unusedSymbol));
+
+// The inflated-.length false positive this file originally covered must
+// still be fixed now that the array branch also walks the prototype
+// chain - the fallback must trigger only once ArrayHasOwnIndex has
+// already said "no", never take priority over it.
+checks.push(!("500" in small) && !Reflect.has(small, "500"));
 
 checks.every((c) => c === true);


### PR DESCRIPTION
Stacked on #315 (`fix-reflect-has-in-inflated-length`), which fixed the false-*positive* half of `Reflect.has`/`in` on arrays (an index numerically less than an inflated `.length` reporting as present when never actually set). This fixes **three separate false-negative gaps** in the same two functions, confirmed pre-existing and identical before/after #315 by diffing against an unmodified build:

### 1. Neither `in` nor `Reflect.has` fell through to the prototype chain for a numeric key

`in`/`Reflect.has` implement `[[HasProperty]]` (own OR inherited), not `[[HasOwnProperty]]` - so an index set directly on `Array.prototype`, or any inherited **method** (`Array.prototype.map`, `.join`, ...), was invisible:

```js
const a = [1, 2, 3];
console.log("map" in a, Reflect.has(a, "map")); // was: true false
```

Fixed via a new exported `vm.HasPropertyOnPrototypeChain(objVal, key)` (`pkg/vm/property_helpers.go`) - `pkg/builtins` can't reach the unexported `effectiveBuiltinPrototype`/`hasPropertyByKeyFromPrototypeChain`/`keyFromString` directly. Both call sites now fall through to it once `ArrayHasOwnIndex` (from #315) says "no".

### 2. `Reflect.has` never checked an array's own named (non-index) property at all

```js
const a = [1, 2, 3]; a.foo = "bar";
console.log("foo" in a, Reflect.has(a, "foo")); // was: true false
```

Fixed via a new shared `vm.ArrayHasOwnNamedProperty(a, name)`, used by **both** `in` and `Reflect.has` so they can't drift - which caught a second, unrelated bug: a named property installed as an *accessor* was invisible to `in` too (not just `Reflect.has`), because `in`'s own check was a bare `GetOwn`, and `DefineAccessorProperty` never writes to the properties map for a named key any more than a numeric one. Sharing one helper fixed both at once.

### 3. `Reflect.has(arr, someSymbol)` always stringified the key and answered `false` unconditionally

```js
const a = [1, 2, 3];
console.log(Symbol.iterator in a, Reflect.has(a, Symbol.iterator)); // was: true false
```

Fixed by adding the missing `isSymbol` branch, mirroring `OpIn`'s existing symbol branch (`HasOwnSymbolProp`, then the same prototype-chain fallback).

## Explicitly out of scope (real, confirmed, filed as follow-ups)

- `Reflect.has` has no `TypeProxy` case at all (and no `default:`) - a Proxy target's `has` trap never runs, so `Reflect.has(proxy, key)` is unconditionally `false` regardless of the trap's answer, while `in` on the same proxy correctly invokes it. Needs the revoked check, callable check, and exception propagation `OpIn`'s own Proxy branch already has.
- The same missing `default:` means `Reflect.has` on a Map/Set/Arguments/BoundFunction target answers `false` unconditionally for any key.

## Testing

- Verified against Node for every case above, plus a genuinely-absent-everywhere key, an own symbol-keyed property, and the #315 huge-sparse-index scenario still resolving correctly with the new prototype fallback in place.
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- `go test ./tests -run TestScripts`: green.
- Extended [tests/scripts/reflect_has_in_inflated_length.ts](tests/scripts/reflect_has_in_inflated_length.ts) (from #315) in place - inverted the assertions pinning the old behavior rather than deleting them, plus new coverage for all three fixes.
- test262 flip-diff (`-timeout 0.2s`, parent branch vs. this one) on `built-ins/Reflect`, `language/expressions/in`, `built-ins/Array`, `built-ins/Symbol`, `language/statements/for-in`: identical pass/fail sets - zero regressions, zero new passes.
