### PR TITLE
fix(vm,builtins): Reflect.has handles Proxy traps and every target kind

### DIFF
--- a/pkg/builtins/reflect_has.go
+++ b/pkg/builtins/reflect_has.go
@@ -1,0 +1,254 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// reflectHas is target.[[HasProperty]](key) as observed by Reflect.has
+// (ECMA-262 28.1.7): unlike the `in` operator (which throws when its RHS
+// isn't an object), the only TypeErrors here are the Proxy ones - a
+// non-callable trap, or a trap whose false answer violates the "target
+// has a non-configurable own property" / "target is non-extensible"
+// invariant - plus whatever the trap itself throws. The caller
+// (reflect_init.go) has already validated target.IsObject() ||
+// target.IsCallable() before this runs.
+//
+// key is expected to already be a property key value (a Symbol, or
+// anything else stringified via key.ToString()) - unlike
+// reflectDeleteProperty's contract, the caller here does NOT run
+// ToPropertyKey first (no ToPrimitive-with-hint-string / user-defined
+// toString/Symbol.toPrimitive dance), so an object key whose own toString
+// throws will not surface that abruptly the way the spec's algorithm
+// requires. That gap predates this function and is not fixed here.
+func reflectHas(vmInstance *vm.VM, target vm.Value, key vm.Value) (bool, error) {
+	isSym := key.Type() == vm.TypeSymbol
+	var name string
+	if !isSym {
+		name = key.ToString()
+	}
+	var propKey vm.PropertyKey
+	if isSym {
+		propKey = vm.NewSymbolKey(key)
+	} else {
+		propKey = vm.NewStringKey(name)
+	}
+
+	switch target.Type() {
+	case vm.TypeProxy:
+		return proxyReflectHas(vmInstance, target, key)
+
+	case vm.TypeObject:
+		obj := target.AsPlainObject()
+		if isSym {
+			// Own-only for a symbol key on a plain object - pre-existing,
+			// not part of this fix (obj.Has's own prototype-aware walk
+			// only takes a string key today).
+			_, ok := obj.GetOwnByKey(propKey)
+			return ok, nil
+		}
+		return obj.Has(name), nil
+
+	case vm.TypeDictObject:
+		return target.AsDictObject().Has(name), nil
+
+	case vm.TypeArray:
+		arr := target.AsArray()
+		if isSym {
+			if arr.HasOwnSymbolProp(key.AsSymbolObject()) {
+				return true, nil
+			}
+			return vmInstance.HasPropertyOnPrototypeChain(target, propKey), nil
+		}
+		// A numerically-in-range index is NOT necessarily an own
+		// property (paserati#176/#178 - see ArrayHasOwnIndex), and an
+		// index that isn't an own property still needs the
+		// prototype-chain walk (Array.prototype[5] = ...) rather than
+		// reporting absent outright - `in`/Reflect.has implement
+		// HasProperty, not HasOwnProperty.
+		if idx, ok := vm.ParseArrayIndex(name); ok {
+			if vm.ArrayHasOwnIndex(arr, idx) {
+				return true, nil
+			}
+			return vmInstance.HasPropertyOnPrototypeChain(target, propKey), nil
+		}
+		if name == "length" {
+			return true, nil
+		}
+		if vm.ArrayHasOwnNamedProperty(arr, name) {
+			return true, nil
+		}
+		return vmInstance.HasPropertyOnPrototypeChain(target, propKey), nil
+
+	case vm.TypeMap, vm.TypeSet:
+		// Map/Set: own "size", then the lazily-created side table
+		// (OwnPropertiesTable - the same one Object.freeze/seal and a
+		// plain `map.foo = 1` assignment use), then Map.prototype/
+		// Set.prototype and beyond.
+		if !isSym && name == "size" {
+			return true, nil
+		}
+		if props := vm.OwnPropertiesTable(target); props != nil {
+			if isSym {
+				if props.HasOwnByKey(propKey) {
+					return true, nil
+				}
+			} else if props.HasOwn(name) {
+				return true, nil
+			}
+		}
+		return vmInstance.HasPropertyOnPrototypeChain(target, propKey), nil
+
+	case vm.TypePromise:
+		// Promises don't expose own state as ordinary properties, but a
+		// plain property CAN still be assigned onto one (the same side
+		// table Map/Set use) - check that, then Promise.prototype.
+		if props := vm.OwnPropertiesTable(target); props != nil {
+			if isSym {
+				if props.HasOwnByKey(propKey) {
+					return true, nil
+				}
+			} else if props.HasOwn(name) {
+				return true, nil
+			}
+		}
+		if vmInstance.PromisePrototype.IsObject() {
+			return vmInstance.HasPropertyOnGivenPrototypeChain(vmInstance.PromisePrototype, propKey), nil
+		}
+		return false, nil
+
+	case vm.TypeArguments:
+		// Mirrors OpIn's own TypeArguments case (pkg/vm/vm.go) exactly -
+		// including its non-symbol-only scope; a symbol key on an
+		// Arguments object isn't handled by either `in` or here.
+		argObj := target.AsArguments()
+		if !isSym {
+			if name == "length" {
+				return true, nil
+			}
+			if name == "callee" && !argObj.IsStrict() {
+				return true, nil
+			}
+			if idx, ok := vm.ParseArrayIndex(name); ok {
+				return idx < argObj.Length(), nil
+			}
+		}
+		if vmInstance.ObjectPrototype.IsObject() {
+			if isSym {
+				return vmInstance.HasPropertyOnGivenPrototypeChain(vmInstance.ObjectPrototype, propKey), nil
+			}
+			return vmInstance.ObjectPrototype.AsPlainObject().Has(name), nil
+		}
+		return false, nil
+
+	case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+		// Every callable kind used to answer false for anything beyond
+		// its own "name"/"length"/"prototype" and side-table properties -
+		// so `Reflect.has(fn, "call")` was false even though
+		// `"call" in fn` (which does walk FunctionPrototype) was true.
+		// callableTables (reflect_delete.go) is reused here for the
+		// exact same "closure's own table, then the shared function's"
+		// order OpDeleteProp/OpIn already use.
+		// HasOwnFunctionIntrinsic correctly excludes "prototype" for an
+		// arrow function or a native (non-constructor) function/method -
+		// unlike a bare `name == "prototype"` check, which the original
+		// pre-#316 Reflect.has used and which this reflect_has.go
+		// initially carried forward unconditionally for EVERY callable
+		// kind grouped in this case, including plain native methods that
+		// never have one (`Reflect.has(Array.prototype.push, "prototype")`
+		// would have incorrectly been true). It returns false for
+		// TypeBoundFunction entirely (bound functions' name/length are
+		// real entries in bf.Properties, not synthesized - the table
+		// check right below already covers them).
+		if !isSym && vm.HasOwnFunctionIntrinsic(target, name) {
+			return true, nil
+		}
+		for _, t := range callableTables(target) {
+			if t == nil {
+				continue
+			}
+			if isSym {
+				if t.HasOwnByKey(propKey) {
+					return true, nil
+				}
+			} else if t.HasOwn(name) {
+				return true, nil
+			}
+		}
+		if isSym {
+			// See HasFunctionPrototypeProperty's doc comment: a symbol
+			// key on a callable isn't handled by the string-only
+			// FunctionPrototype fallback, so it stays unconditionally
+			// false here - same as it already was before this fix.
+			return false, nil
+		}
+		return vmInstance.HasFunctionPrototypeProperty(name), nil
+	}
+
+	// Not (yet) handled: RegExp (an own side-table property exists via
+	// OwnPropertiesTable, but RegExpPrototype's fallback isn't wired up
+	// here), WeakMap/WeakSet/WeakRef/FinalizationRegistry,
+	// Generator/AsyncGenerator. Each answers false unconditionally, same
+	// as before this fix - a real gap, not silently implied covered by a
+	// blanket default (effectiveBuiltinPrototype, the obvious-looking
+	// shortcut, only resolves a prototype for Array/Map/Set/WeakRef/
+	// FinalizationRegistry - a default case built on it would look like
+	// it covers these kinds and actually return false for all of them).
+	return false, nil
+}
+
+// proxyReflectHas is the Proxy exotic object's [[HasProperty]] (10.5.7)
+// with the result reported rather than thrown on: run the handler's
+// `has` trap if it has one, enforce the non-configurable and
+// non-extensible target invariants on a false answer, and otherwise
+// defer to the target's own [[HasProperty]] (recursing through
+// reflectHas, since the target can itself be a Proxy, or any other kind
+// this function already knows how to answer for).
+func proxyReflectHas(vmInstance *vm.VM, proxyVal vm.Value, key vm.Value) (bool, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return false, vmInstance.NewTypeError("Cannot perform 'has' on a proxy that has been revoked")
+	}
+	handler := proxy.Handler()
+	target := proxy.Target()
+
+	// GetMethod(handler, "has"): an inherited trap counts, and
+	// undefined/null mean "no trap".
+	var trap vm.Value
+	var hasTrap bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		trap, hasTrap = handler.AsPlainObject().Get("has")
+	case vm.TypeDictObject:
+		trap, hasTrap = handler.AsDictObject().Get("has")
+	}
+	if !hasTrap || trap.Type() == vm.TypeUndefined || trap.Type() == vm.TypeNull {
+		return reflectHas(vmInstance, target, key)
+	}
+	if !trap.IsCallable() {
+		return false, vmInstance.NewTypeError("'has' on proxy: trap is not a function")
+	}
+
+	result, err := vmInstance.Call(trap, handler, []vm.Value{target, key})
+	if err != nil {
+		return false, err
+	}
+	if result.IsTruthy() {
+		return true, nil
+	}
+
+	// Invariants (10.5.7 steps 11-12): a false answer is only allowed if
+	// the target has no such own property, or has one that is
+	// configurable on an extensible target.
+	display := key.ToString()
+	exists, nonConfig := targetOwnNonConfigurable(target, key)
+	if !exists {
+		return false, nil
+	}
+	if nonConfig {
+		return false, vmInstance.NewTypeError("'has' on proxy: trap returned falsish for property '" + display + "' which exists in the proxy target as non-configurable")
+	}
+	if !isTargetExtensible(target) {
+		return false, vmInstance.NewTypeError("'has' on proxy: trap returned falsish for property '" + display + "' but the proxy target is non-extensible")
+	}
+	return false, nil
+}

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -244,6 +244,10 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}))
 
 	// Reflect.has(target, propertyKey)
+	// Reflect.has(target, propertyKey)
+	// Per ECMAScript spec, this invokes [[HasProperty]] and returns the
+	// result. The dispatch across object kinds (including the Proxy 'has'
+	// trap) lives in reflect_has.go.
 	reflectObj.SetOwnNonEnumerable("has", vm.NewNativeFunction(2, false, "has", func(args []vm.Value) (vm.Value, error) {
 		if len(args) < 2 {
 			return vm.BooleanValue(false), vmInstance.NewTypeError("Reflect.has requires 2 arguments")
@@ -256,93 +260,10 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.BooleanValue(false), vmInstance.NewTypeError("Reflect.has called on non-object")
 		}
 
-		// Handle symbol property keys
-		isSymbol := propKeyArg.Type() == vm.TypeSymbol
-		propKey := propKeyArg.ToString()
-
-		// Use the 'in' operator logic
-		hasProperty := false
-		switch target.Type() {
-		case vm.TypeObject:
-			obj := target.AsPlainObject()
-			if isSymbol {
-				// For symbols, check using HasByKey with symbol key
-				_, hasProperty = obj.GetOwnByKey(vm.NewSymbolKey(propKeyArg))
-			} else {
-				hasProperty = obj.Has(propKey)
-			}
-		case vm.TypeDictObject:
-			hasProperty = target.AsDictObject().Has(propKey)
-		case vm.TypeArray:
-			arr := target.AsArray()
-			if isSymbol {
-				// Mirrors OpIn's TypeArray symbol branch (pkg/vm/vm.go):
-				// an own symbol-keyed property (e.g. a custom
-				// Symbol.iterator override), else walk the prototype
-				// chain (Array.prototype carries the real
-				// Symbol.iterator, Symbol.toStringTag if ever set, ...).
-				// Reflect.has previously stringified every key
-				// (propKeyArg.ToString()) and fell through this entire
-				// switch with hasProperty left at its zero value, so
-				// `Reflect.has(arr, Symbol.iterator)` was unconditionally
-				// false even though `Symbol.iterator in arr` is true.
-				if arr.HasOwnSymbolProp(propKeyArg.AsSymbolObject()) {
-					hasProperty = true
-				} else {
-					hasProperty = vmInstance.HasPropertyOnPrototypeChain(target, vm.NewSymbolKey(propKeyArg))
-				}
-			} else if idx, ok := vm.ParseArrayIndex(propKey); ok {
-				// A numerically-in-range index is NOT necessarily an own
-				// property: `.length` can be inflated by an unrelated
-				// defineProperty call at a different, possibly huge, index
-				// (paserati#176/#178) without this index itself ever
-				// being set. Check real presence instead of
-				// `idx < arr.Length()` - and, per Reflect.has implementing
-				// HasProperty (not HasOwnProperty), an index that isn't an
-				// own property still needs the prototype-chain walk below
-				// rather than reporting absent outright.
-				if vm.ArrayHasOwnIndex(arr, idx) {
-					hasProperty = true
-				} else {
-					hasProperty = vmInstance.HasPropertyOnPrototypeChain(target, vm.NewStringKey(propKey))
-				}
-			} else if propKey == "length" {
-				hasProperty = true
-			} else if vm.ArrayHasOwnNamedProperty(arr, propKey) {
-				// An own named (non-index) property - a plain data
-				// property (`arr.foo = 1`) or an own accessor - was
-				// never checked at all before this: only "length" and a
-				// numeric index were, so `Reflect.has(arr, "foo")` was
-				// unconditionally false regardless of whether `arr.foo`
-				// existed, even though `"foo" in arr` correctly found it.
-				hasProperty = true
-			} else {
-				// Neither an own index/named property nor "length" -
-				// still need the prototype-chain walk before reporting
-				// absent (inherited methods like Array.prototype.map,
-				// or anything else stored on Array.prototype).
-				hasProperty = vmInstance.HasPropertyOnPrototypeChain(target, vm.NewStringKey(propKey))
-			}
-		case vm.TypeFunction:
-			// Functions have properties like name, length, prototype
-			fn := target.AsFunction()
-			if propKey == "name" || propKey == "length" || propKey == "prototype" {
-				hasProperty = true
-			} else if fn.Properties != nil {
-				hasProperty = fn.Properties.Has(propKey)
-			}
-		case vm.TypeClosure:
-			// Closures also have properties
-			cl := target.AsClosure()
-			if propKey == "name" || propKey == "length" || propKey == "prototype" {
-				hasProperty = true
-			} else if cl.Properties != nil {
-				hasProperty = cl.Properties.Has(propKey)
-			} else if cl.Fn.Properties != nil {
-				hasProperty = cl.Fn.Properties.Has(propKey)
-			}
+		hasProperty, err := reflectHas(vmInstance, target, propKeyArg)
+		if err != nil {
+			return vm.BooleanValue(false), err
 		}
-
 		return vm.BooleanValue(hasProperty), nil
 	}))
 

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -966,6 +966,97 @@ func (vm *VM) HasPropertyOnPrototypeChain(objVal Value, key PropertyKey) bool {
 	return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(objVal), key)
 }
 
+// HasPropertyOnGivenPrototypeChain is HasPropertyOnPrototypeChain for a
+// caller that already knows which prototype value to start walking from
+// (e.g. PromisePrototype or ObjectPrototype), rather than one
+// effectiveBuiltinPrototype can derive purely from an object's own
+// runtime type - effectiveBuiltinPrototype only resolves a starting
+// prototype for Array/Map/Set/WeakRef/FinalizationRegistry, so it cannot
+// serve every builtin kind a caller like Reflect.has needs to walk.
+func (vm *VM) HasPropertyOnGivenPrototypeChain(proto Value, key PropertyKey) bool {
+	return vm.hasPropertyByKeyFromPrototypeChain(proto, key)
+}
+
+// HasOwnFunctionIntrinsic reports whether a callable (Function, Closure,
+// NativeFunction, NativeFunctionWithProps) has "name", "length", or
+// "prototype" as an own property right now. name/length are synthesized
+// lazily rather than stored in a Properties table, and tracked as deleted
+// via DeletedName/DeletedLength rather than actually removed from
+// anywhere (see MaterializeIntrinsicOwnProperties and
+// object_init.go's GetOwnPropertyDescriptor, which this mirrors exactly).
+//
+// "prototype" is own only for TypeFunction/TypeClosure, and only when the
+// function is not an arrow function (arrow functions are never
+// constructible and never get a synthesized own "prototype" - see
+// FunctionObject.IsArrowFunction). TypeNativeFunction never has one at
+// all (a native method isn't a constructor); TypeNativeFunctionWithProps
+// (a native CONSTRUCTOR like Array, Object, Map, ...) can have a real own
+// "prototype", but as an actual entry in its own Properties table set at
+// setup time, not a synthesized intrinsic - callers need to check that
+// table themselves rather than treat "prototype" as automatically true
+// for every callable kind (a real, previously-shipped bug: `"prototype"
+// in nativeMethod` would incorrectly answer true for a plain native
+// method that never had one).
+//
+// Returns false for name/length/prototype when the callable kind doesn't
+// synthesize that particular one, and for any OTHER key entirely - a
+// caller must still fall back to its own Properties-table and
+// prototype-chain checks for those.
+func HasOwnFunctionIntrinsic(target Value, name string) bool {
+	switch target.Type() {
+	case TypeFunction:
+		fn := target.AsFunction()
+		switch name {
+		case "name":
+			return !fn.DeletedName
+		case "length":
+			return !fn.DeletedLength
+		case "prototype":
+			return !fn.IsArrowFunction
+		}
+	case TypeClosure:
+		fn := target.AsClosure().Fn
+		switch name {
+		case "name":
+			return !fn.DeletedName
+		case "length":
+			return !fn.DeletedLength
+		case "prototype":
+			return !fn.IsArrowFunction
+		}
+	case TypeNativeFunction:
+		nf := target.AsNativeFunction()
+		switch name {
+		case "name":
+			return !nf.DeletedName
+		case "length":
+			return !nf.DeletedLength
+		}
+	case TypeNativeFunctionWithProps:
+		nfp := target.AsNativeFunctionWithProps()
+		switch name {
+		case "name":
+			return !nfp.DeletedName
+		case "length":
+			return !nfp.DeletedLength
+		}
+	}
+	return false
+}
+
+// HasFunctionPrototypeProperty is hasFunctionPrototypeProperty, exported
+// for pkg/builtins: Reflect.has's callable cases (Function, Closure,
+// NativeFunction, NativeFunctionWithProps, BoundFunction) need the exact
+// same "own side table, then FunctionPrototype" fallback OpIn's own
+// callable cases already use internally, for a string key (this does not
+// handle a symbol key - FunctionPrototype's own representation, a
+// PlainObject in the common case but possibly a NativeFunctionWithProps,
+// needs a manual walk to support that correctly; see OpIn's
+// TypeFunction/TypeClosure symbol branches in vm.go for the pattern).
+func (vm *VM) HasFunctionPrototypeProperty(propKey string) bool {
+	return vm.hasFunctionPrototypeProperty(propKey)
+}
+
 // handleSpecialProperties handles special properties like .length
 func (vm *VM) handleSpecialProperties(objVal Value, propName string) (Value, bool) {
 	// Handle undefined/null objects

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3444,27 +3444,51 @@ startExecution:
 						hasProperty = vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(objVal), keyFromString(propKey))
 					}
 				case TypeFunction:
-					// Functions are objects and can have properties
+					// Functions are objects and can have properties. "name"/
+					// "length"/"prototype" are own intrinsics synthesized
+					// lazily rather than stored in Properties - see
+					// HasOwnFunctionIntrinsic (which correctly excludes
+					// "prototype" for an arrow function, unlike a bare
+					// `propKey == "prototype"` check would). Reflect.has
+					// (pkg/builtins/reflect_has.go) already handled these;
+					// `in` did not, so `"name" in function(){}` was false
+					// while Reflect.has(function(){}, "name") was true.
 					fn := objVal.AsFunction()
-					if fn.Properties != nil && fn.Properties.Has(propKey) {
+					if HasOwnFunctionIntrinsic(objVal, propKey) {
+						hasProperty = true
+					} else if fn.Properties != nil && fn.Properties.Has(propKey) {
 						hasProperty = true
 					} else {
 						// Check FunctionPrototype for inherited properties (call, apply, bind)
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
 					}
 				case TypeNativeFunctionWithProps:
-					// Native functions with properties (like Number, String, etc.)
+					// Native functions with properties (like Number, String, etc.).
+					// Same "name"/"length" own-intrinsic gap as TypeFunction
+					// above - see its comment. Unlike TypeFunction/
+					// TypeClosure, "prototype" here is never a synthesized
+					// intrinsic (HasOwnFunctionIntrinsic correctly says so) -
+					// a native constructor's own "prototype" (Array, Object,
+					// Map, ...) is a REAL entry in nf.Properties instead, so
+					// the fn.Properties.Has(propKey) check below already
+					// covers it.
 					nf := objVal.AsNativeFunctionWithProps()
-					if nf.Properties != nil && nf.Properties.Has(propKey) {
+					if HasOwnFunctionIntrinsic(objVal, propKey) {
+						hasProperty = true
+					} else if nf.Properties != nil && nf.Properties.Has(propKey) {
 						hasProperty = true
 					} else {
 						// Check FunctionPrototype for inherited properties (call, apply, bind)
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
 					}
 				case TypeClosure:
-					// Closures can have their own properties (in cl.Properties) or inherit from FunctionObject
+					// Closures can have their own properties (in cl.Properties) or inherit from FunctionObject.
+					// Same "name"/"length"/"prototype" own-intrinsic gap as
+					// TypeFunction above - see its comment.
 					cl := objVal.AsClosure()
-					if cl.Properties != nil && cl.Properties.Has(propKey) {
+					if HasOwnFunctionIntrinsic(objVal, propKey) {
+						hasProperty = true
+					} else if cl.Properties != nil && cl.Properties.Has(propKey) {
 						hasProperty = true
 					} else if cl.Fn != nil && cl.Fn.Properties != nil && cl.Fn.Properties.Has(propKey) {
 						hasProperty = true
@@ -3473,8 +3497,17 @@ startExecution:
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
 					}
 				case TypeNativeFunction:
-					// Native functions don't have custom properties but inherit from FunctionPrototype
-					hasProperty = vm.hasFunctionPrototypeProperty(propKey)
+					// Native functions don't have custom properties, but do
+					// carry the same "name"/"length" own intrinsics as any
+					// other callable (see TypeFunction's comment above,
+					// and TypeNativeFunctionWithProps's for why "prototype"
+					// is correctly excluded - a native method is never a
+					// constructor) before falling back to FunctionPrototype.
+					if HasOwnFunctionIntrinsic(objVal, propKey) {
+						hasProperty = true
+					} else {
+						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
+					}
 				case TypeBoundFunction:
 					// Bound functions can have their own properties (in
 					// bf.Properties, e.g. from direct assignment or

--- a/tests/scripts/reflect_has_target_types.ts
+++ b/tests/scripts/reflect_has_target_types.ts
@@ -1,0 +1,124 @@
+// expect: true
+// Reflect.has's dispatch across target kinds (pkg/builtins/reflect_has.go)
+// used to have no TypeProxy case at all - a Proxy's own 'has' trap never
+// ran, so Reflect.has(proxy, key) was unconditionally false regardless of
+// what the trap would answer, even though the `in` operator on the same
+// Proxy correctly invoked it - and no case (nor a default:) for most
+// other object kinds, so Reflect.has on a Map/Set/Arguments/BoundFunction/
+// plain Function/NativeFunctionWithProps/Promise target answered false
+// unconditionally for any key, own or not.
+const checks: boolean[] = [];
+
+// --- Proxy: 'has' trap is invoked, its result is used ---
+const trapCalls: string[] = [];
+const proxyWithTrap: any = new Proxy([], {
+  has(_target: any, key: any) {
+    trapCalls.push(String(key));
+    return key === "zzz";
+  },
+});
+checks.push("zzz" in proxyWithTrap && Reflect.has(proxyWithTrap, "zzz"));
+checks.push(!("yyy" in proxyWithTrap) && !Reflect.has(proxyWithTrap, "yyy"));
+checks.push(trapCalls.length === 4); // one call per `in`/Reflect.has above
+
+// --- Proxy: no 'has' trap falls back to the target's own [[HasProperty]] ---
+const proxyNoTrap: any = new Proxy({ a: 1 }, {});
+checks.push("a" in proxyNoTrap && Reflect.has(proxyNoTrap, "a"));
+checks.push(!("b" in proxyNoTrap) && !Reflect.has(proxyNoTrap, "b"));
+
+// --- Proxy: a revoked proxy throws, doesn't silently answer false ---
+const revocable = Proxy.revocable({}, {});
+revocable.revoke();
+let revokedThrew = false;
+try {
+  Reflect.has(revocable.proxy, "a");
+} catch (e: any) {
+  revokedThrew = e instanceof TypeError;
+}
+checks.push(revokedThrew);
+
+// --- Proxy: a trap that throws propagates the real exception ---
+const throwingTrapProxy: any = new Proxy({}, {
+  has() {
+    throw new Error("boom");
+  },
+});
+let trapThrew = false;
+try {
+  Reflect.has(throwingTrapProxy, "a");
+} catch (e: any) {
+  trapThrew = e.message === "boom";
+}
+checks.push(trapThrew);
+
+// --- Proxy: a non-callable trap throws a TypeError ---
+const nonCallableTrapProxy: any = new Proxy({}, { has: 42 });
+let nonCallableThrew = false;
+try {
+  Reflect.has(nonCallableTrapProxy, "a");
+} catch (e: any) {
+  nonCallableThrew = e instanceof TypeError;
+}
+checks.push(nonCallableThrew);
+
+// --- Proxy: invariant - a false trap answer for a non-configurable own
+// target property is rejected with a TypeError, matching `in`. ---
+const invariantTarget: any = {};
+Object.defineProperty(invariantTarget, "a", {
+  value: 1,
+  configurable: false,
+  enumerable: true,
+  writable: true,
+});
+const invariantProxy: any = new Proxy(invariantTarget, {
+  has() {
+    return false;
+  },
+});
+let invariantThrew = false;
+try {
+  Reflect.has(invariantProxy, "a");
+} catch (e: any) {
+  invariantThrew = e instanceof TypeError;
+}
+checks.push(invariantThrew);
+
+// --- Map/Set: own "size", a plain assigned property, and inherited
+// methods (Map.prototype.get, Set.prototype.add) ---
+const m: any = new Map();
+m.foo = "bar";
+checks.push("size" in m && Reflect.has(m, "size"));
+checks.push("get" in m && Reflect.has(m, "get"));
+checks.push("foo" in m && Reflect.has(m, "foo"));
+checks.push(!("nope" in m) && !Reflect.has(m, "nope"));
+const s: any = new Set();
+checks.push("add" in s && Reflect.has(s, "add"));
+
+// --- Arguments: length, numeric indices, and an Object.prototype method ---
+function withArgs(_a: any, _b: any) {
+  checks.push("length" in arguments && Reflect.has(arguments, "length"));
+  checks.push("0" in arguments && Reflect.has(arguments, "0"));
+  checks.push(!("5" in arguments) && !Reflect.has(arguments, "5"));
+  checks.push(
+    "toString" in arguments && Reflect.has(arguments, "toString")
+  );
+}
+withArgs(1, 2);
+
+// --- Callables: a plain function/BoundFunction/native constructor all
+// find an inherited Function.prototype method, not just their own
+// name/length/prototype intrinsics. ---
+function plainFn() {}
+checks.push("call" in plainFn && Reflect.has(plainFn, "call"));
+checks.push("name" in plainFn && Reflect.has(plainFn, "name"));
+const bound: any = plainFn.bind(null);
+checks.push("call" in bound && Reflect.has(bound, "call"));
+checks.push("name" in bound && Reflect.has(bound, "name"));
+checks.push("isArray" in Array && Reflect.has(Array, "isArray"));
+checks.push("call" in Array && Reflect.has(Array, "call"));
+
+// --- Promise: no own enumerable state, but Promise.prototype.then is found ---
+const p: any = Promise.resolve(1);
+checks.push("then" in p && Reflect.has(p, "then"));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Stacked on #316 (`fix-array-has-property-prototype-and-named`), which fixed the array-specific "own property, else prototype chain" gaps in `Reflect.has` and `in`. This addresses the same function's much broader dispatch gap: `Reflect.has` had no `TypeProxy` case at all, and only handled `TypeObject`/`TypeDictObject`/`TypeArray`/`TypeFunction`/`TypeClosure` - every other target kind fell through with `hasProperty` left at its zero value (`false`), regardless of the key or whether it actually existed.

### 1. Proxy: the `has` trap never ran

```js
const p = new Proxy([], { has(t, k) { return k === "zzz"; } });
console.log("zzz" in p, Reflect.has(p, "zzz")); // was: true false
```

New `pkg/builtins/reflect_has.go` (mirroring `reflect_delete.go`'s existing Proxy pattern) adds `proxyReflectHas`: runs the handler's `has` trap when present, validates it's callable, calls it, and on a falsy answer enforces the `[[HasProperty]]` invariants (10.5.7 steps 11-12) by reusing `reflect_delete.go`'s existing `targetOwnNonConfigurable`/`isTargetExtensible`.

### 2. Every other previously-unhandled target kind

Map/Set, Arguments, Promise, and native functions/constructors all answered `false` unconditionally before this. Two new exported `pkg/vm` helpers make this possible from `pkg/builtins`: `HasPropertyOnGivenPrototypeChain` and `HasFunctionPrototypeProperty`.

### 3. Every callable kind was missing `call`/`apply`/`bind`

```js
function f() {}
console.log("call" in f, Reflect.has(f, "call")); // was: true false
```

This also fixes `in` itself (`pkg/vm/vm.go`'s `OpIn`), not just `Reflect.has` - outside this task's stated scope, but leaving `in` wrong while `Reflect.has` was right for the exact same call would be a divergence introduced by this very change. A new shared `vm.HasOwnFunctionIntrinsic(target, name)` keeps them from drifting - and, in the process of building it, caught a real regression in my own first pass: a naive "name/length/prototype always own" check would have made `Reflect.has(Array.prototype.push, "prototype")` incorrectly `true` (a native method is never a constructor). Verified against Node across 8 variants (plain function, arrow, native method, native constructor, bound function × name/length/prototype) before landing.

One deliberate divergence from Node, not an oversight: Node's `delete f.name; "name" in f` still answers `true` (a V8-internal quirk) - `HasOwnFunctionIntrinsic` follows this codebase's own established `DeletedName`/`DeletedLength` convention instead (deleted means absent).

## Explicitly out of scope (confirmed real)

- RegExp, WeakMap/WeakSet, WeakRef/FinalizationRegistry, Generator/AsyncGenerator targets: `Reflect.has` still answers `false` unconditionally. A blanket `default:` would look like it covers these but wouldn't (`effectiveBuiltinPrototype` doesn't resolve a prototype for them) - named explicitly instead.
- Separately, pre-existing: `in` itself **throws** a `TypeError` for a RegExp right-hand side, even though a RegExp is a real object and Node handles it fine.
- Symbol keys on any callable kind stay unconditionally `false` in both `in` and `Reflect.has`.
- `Reflect.has`'s key argument doesn't run `ToPropertyKey` - noted in `reflect_has.go`'s own doc comment rather than inheriting `reflect_delete.go`'s contract wording, which doesn't hold here.

## Testing

- Verified against Node for every case above: the Proxy trap (called, result used, invariant-checked, revoked/throwing/non-callable), Map/Set/Arguments/Promise, and the full callable-intrinsic matrix.
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- `go test ./tests -run TestScripts`: green.
- New [tests/scripts/reflect_has_target_types.ts](tests/scripts/reflect_has_target_types.ts).
- test262 flip-diff (`-timeout 0.2s`, parent branch vs. this one) on `built-ins/Reflect`, `language/expressions/in`, `built-ins/Array`, `built-ins/Symbol`, `built-ins/Function`, `built-ins/Map`, `built-ins/Set`, `built-ins/Promise`, `built-ins/Proxy`, `built-ins/Object/keys`, `language/statements/for-in`: **zero regressions, one genuine new pass** - `built-ins/Reflect/has/return-abrupt-from-result.js`.
