### PR TITLE
chore(builtins): remove dead SetupTypedArrayToStringTag helper

### DIFF
--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -590,12 +590,3 @@ func SetupTypedArrayPrototypeProperties(proto *vm.PlainObject, vmInstance *vm.VM
 	w, e, c := false, false, false
 	proto.DefineOwnProperty("BYTES_PER_ELEMENT", vm.Number(float64(bytesPerElement)), &w, &e, &c)
 }
-
-// SetupTypedArrayToStringTag adds Symbol.toStringTag getter to a TypedArray prototype.
-// Per ECMAScript spec, %TypedArray%.prototype[@@toStringTag] is "TypedArray" and
-// each specific TypedArray prototype has its own [@@toStringTag] (e.g., "Uint8Array").
-// The property is: { writable: false, enumerable: false, configurable: true }
-func SetupTypedArrayToStringTag(proto *vm.PlainObject, typedArrayName string) {
-	e, c := false, true // not enumerable, configurable
-	proto.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolToStringTag), vm.NewString(typedArrayName), nil, &e, &c)
-}


### PR DESCRIPTION
## Summary
Removes the unused `SetupTypedArrayToStringTag` helper from [pkg/builtins/typedarray_common.go](pkg/builtins/typedarray_common.go), left over alongside the dead `SetupTypedArrayPrototype`-adjacent code removed in #312.

## Why it's dead
`grep -rn "SetupTypedArrayToStringTag(" --include="*.go" .` shows only the function's own definition — no call sites anywhere in the repo.

`Symbol.toStringTag` for concrete TypedArray prototypes (`Uint8Array`, `Int32Array`, etc.) already works via a different mechanism: [typedarray_base_init.go:126](pkg/builtins/typedarray_base_init.go#L126) installs a single **accessor-property getter** on the shared `%TypedArray%.prototype[@@toStringTag]`, inherited by every concrete typed array prototype through the prototype chain. This removed helper's per-subtype static-string-property approach was redundant from the start.

No cascading dead code: the package-level `SymbolToStringTag` var it referenced has many other live call sites across `pkg/builtins`.

## Testing
- `go build ./...` — pass
- `go vet ./...` — pass
- `gofmt -l pkg/builtins/` — no new issues (pre-existing unrelated finding in `readable_stream_init.go`)
- `go test ./tests -run TestScripts` — pass