### PR TITLE
fix(builtins): Blob.prototype.slice defaults contentType to empty string

### DIFF
--- a/pkg/builtins/blob_init.go
+++ b/pkg/builtins/blob_init.go
@@ -172,7 +172,7 @@ func createBlobObject(vmInstance *vm.VM, blob *Blob, _ *vm.PlainObject) vm.Value
 	obj.SetOwnNonEnumerable("slice", vm.NewNativeFunction(3, false, "slice", func(args []vm.Value) (vm.Value, error) {
 		start := 0
 		end := len(blob.data)
-		contentType := blob.mimeType
+		contentType := ""
 
 		if len(args) > 0 && args[0].IsNumber() {
 			start = int(args[0].ToFloat())

--- a/tests/scripts/blob_slice_content_type.ts
+++ b/tests/scripts/blob_slice_content_type.ts
@@ -1,0 +1,18 @@
+// expect: true
+
+// Omitted contentType must default to "" (empty string), not inherit the
+// parent Blob's type. See https://w3c.github.io/FileAPI/#slice-method-algo
+const withType = new Blob(["abcdef"], { type: "text/plain" });
+const sliced1 = withType.slice(0, 3);
+const check1 = sliced1.type === "";
+
+// Explicit contentType is still respected.
+const sliced2 = withType.slice(0, 3, "text/html");
+const check2 = sliced2.type === "text/html";
+
+// Parent with no type at all.
+const withoutType = new Blob(["abcdef"]);
+const sliced3 = withoutType.slice();
+const check3 = sliced3.type === "";
+
+check1 && check2 && check3;


### PR DESCRIPTION
## Summary

`Blob.prototype.slice(start?, end?, contentType?)` incorrectly defaulted an omitted `contentType` to the parent blob's own `mimeType`. Per the File API spec (and confirmed in real browsers), an omitted `contentType` must default to `""`.

```js
new Blob(['abcdef'], {type: 'text/plain'}).slice(0, 3).type === ""  // real browsers
```

This is a wrong-default-value bug, unrelated to the earlier "compiler pads omitted optional args" bug class fixed elsewhere in the codebase (array `join`, text-codec `decode`, `performance.getEntriesByName`, and the `arguments.length` inflation fix) — it's simply the wrong constant used as the default.

## Changes

- [pkg/builtins/blob_init.go](pkg/builtins/blob_init.go): `slice`'s `contentType` default changed from `blob.mimeType` to `""`.
- [tests/scripts/blob_slice_content_type.ts](tests/scripts/blob_slice_content_type.ts): regression test covering:
  - omitted `contentType` on a typed parent → `""`
  - explicit `contentType` still respected → `"text/html"`
  - no type at all on parent + no args to `slice()` → `""`

## Testing

- `go test ./tests -run TestScripts` — full suite passes, including the new test.
- Blob isn't covered by test262 (WHATWG File API type, not ECMA-262), so no test262 pass was run.