### PR TITLE
fix(builtins): arrayLikeGet must check own properties map for sparse indices beyond dense storage

### DIFF
--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -221,10 +221,12 @@ func arrayIndexGetFromProto(vmInstance *vm.VM, arr *vm.ArrayObject, receiver vm.
 // every/filter/forEach/etc. Real Arrays check for an own accessor at that
 // index first (set via Object.defineProperty - see ArrayDefineOwnProperty)
 // before falling back to the exact hole-checking the previous fast path
-// did; PlainObjects go through getOwnPlainObjectProperty for correct
-// accessor handling (see its comment); every other type (TypedArray,
-// Arguments, Proxy, boxed primitives, Map/Set/...) has no holes to speak
-// of, so a plain Get is both correct and simpler.
+// did, then arr.GetOwn for a plain data property tracked past the dense
+// elements slice (see maxDenseArrayDefineIndex); PlainObjects go through
+// getOwnPlainObjectProperty for correct accessor handling (see its
+// comment); every other type (TypedArray, Arguments, Proxy, boxed
+// primitives, Map/Set/...) has no holes to speak of, so a plain Get is
+// both correct and simpler.
 func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, error) {
 	switch thisVal.Type() {
 	case vm.TypeArray:
@@ -244,12 +246,27 @@ func arrayLikeGet(vmInstance *vm.VM, thisVal vm.Value, i int) (vm.Value, bool, e
 		if arr.HasIndex(i) {
 			return arr.Get(i), true, nil
 		}
-		// Own slot is a hole (or absent, or was `delete`d): [[HasProperty]]
-		// (7.3.11 -> OrdinaryHasProperty 9.1.7) doesn't stop at "no own
-		// property" - it walks the prototype chain. Array.prototype[i] is
-		// rarely set, so only pay for the walk once the fast own-value path
-		// above has already missed.
-		return arrayIndexGetFromProto(vmInstance, arr, thisVal, strconv.Itoa(i))
+		// Own slot is a hole (or absent, or was `delete`d, or never
+		// materialized): everything past this point needs the string key,
+		// computed once and shared by both checks below.
+		key := strconv.Itoa(i)
+		// Beyond the dense elements slice (or never grown into it) is not
+		// automatically a hole: an index past maxDenseArrayDefineIndex
+		// (see pkg/vm/array_props.go) that was set via
+		// Object.defineProperty is tracked as a plain named property in
+		// arr.properties instead of materializing `elements` up to idx -
+		// still a genuine own data property, just one HasIndex/Get can't
+		// see. Check it before falling through to the prototype chain (an
+		// own property always shadows one inherited from Array.prototype,
+		// same as the dense-element case just above).
+		if v, ok := arr.GetOwn(key); ok {
+			return v, true, nil
+		}
+		// [[HasProperty]] (7.3.11 -> OrdinaryHasProperty 9.1.7) doesn't
+		// stop at "no own property" - it walks the prototype chain.
+		// Array.prototype[i] is rarely set, so only pay for the walk once
+		// the fast own-value paths above have already missed.
+		return arrayIndexGetFromProto(vmInstance, arr, thisVal, key)
 	case vm.TypeObject:
 		return getOwnPlainObjectProperty(vmInstance, thisVal.AsPlainObject(), thisVal, strconv.Itoa(i))
 	case vm.TypeProxy:

--- a/tests/scripts/array_sparse_index_generic_methods.ts
+++ b/tests/scripts/array_sparse_index_generic_methods.ts
@@ -1,0 +1,136 @@
+// expect: true
+// Same bug family as paserati#176/#178 and array_sparse_index_read.ts, one
+// level up: arrayLikeGet (pkg/builtins/array_generic.go) - the shared
+// (value, exists, error) accessor every Array.prototype generic method
+// (forEach/map/filter/some/every/at/indexOf/lastIndexOf/slice/...) uses to
+// read element i - checked an own accessor first, then arr.HasIndex(i)
+// (bounds-checks the dense .elements slice), and on a miss fell straight
+// through to arrayIndexGetFromProto, which *only* walks the prototype
+// chain. It never consulted the array's own .properties map, where
+// ArrayDefineOwnProperty tracks a data property defined at an index past
+// maxDenseArrayDefineIndex (2^24) - too large to grow .elements into (see
+// array_props.go) - instead of materializing it there. That index is a
+// perfectly genuine own property (arr[idx] and hasOwnProperty both see it
+// fine - see array_sparse_index_read.ts), but every generic method backed
+// by arrayLikeGet silently treated it as a hole.
+//
+// forEach/map/filter/some/every are all O(length), and the bug is only
+// reachable past maxDenseArrayDefineIndex, so this necessarily costs a few
+// seconds of wall time no matter how it's written - SPARSE_IDX is kept at
+// exactly that bound (rather than some rounder, larger number), and the
+// array is built once and reused (read-only) across those five checks, to
+// keep it to one pass each rather than five separate arrays. at/indexOf/
+// lastIndexOf/slice are included too since, called the way they are below,
+// they exercise the same fixed code path in O(1) - cheap insurance for
+// broader call-site coverage.
+const checks: boolean[] = [];
+
+const SPARSE_IDX = 16777217; // maxDenseArrayDefineIndex (16777216) + 1
+
+const a: any[] = [1, 2, 3];
+Object.defineProperty(a, String(SPARSE_IDX), {
+  value: "sparse-val",
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+
+// Sanity: direct indexing and hasOwnProperty already worked (paserati#176).
+checks.push(a[SPARSE_IDX] === "sparse-val");
+checks.push((a as any).hasOwnProperty(String(SPARSE_IDX)));
+
+// forEach must visit the sparse index with its real value, and must NOT
+// visit a genuine hole below it (this fix must not turn every miss into a
+// properties-map probe that invents a value that isn't there) - checked
+// together in one pass since forEach is O(length) regardless.
+//
+// The callback is typed/returns `undefined` explicitly (rather than a
+// plain arrow function) because Array.prototype.forEach's declared
+// parameter type here is `(v, i?, arr?) => undefined`, and this checker
+// does not currently accept a `void`-returning callback in its place -
+// unlike real TypeScript, which allows that. Not this bug; a separate,
+// narrower checker gap.
+let found: any = "not-visited";
+let visitedHole = false;
+a.forEach(function (v: any, i?: number): undefined {
+  if (i === SPARSE_IDX) found = v;
+  if (i === 10) visitedHole = true;
+  return undefined;
+});
+checks.push(found === "sparse-val");
+checks.push(visitedHole === false);
+
+// map must carry the value through at the same index.
+const mapped = a.map(function (v) {
+  return v;
+});
+checks.push(mapped[SPARSE_IDX] === "sparse-val");
+
+// filter must see the element as present and matching.
+const filtered = a.filter(function (v) {
+  return v === "sparse-val";
+});
+checks.push(filtered.length === 1);
+checks.push(filtered[0] === "sparse-val");
+
+// some must find it.
+checks.push(
+  a.some(function (v) {
+    return v === "sparse-val";
+  }) === true
+);
+
+// every must see it (and so report false for a predicate it fails).
+checks.push(
+  a.every(function (v) {
+    return v !== "sparse-val";
+  }) === false
+);
+
+// at(-1): O(1) - resolves to exactly SPARSE_IDX since it's also the last
+// index (length - 1).
+checks.push(a.at(-1) === "sparse-val");
+
+// lastIndexOf with no fromIndex starts scanning at length - 1, i.e.
+// SPARSE_IDX itself: O(1), hits on the first step.
+checks.push(a.lastIndexOf("sparse-val") === SPARSE_IDX);
+
+// indexOf with fromIndex = SPARSE_IDX starts scanning there directly:
+// O(1), hits on the first step.
+checks.push(a.indexOf("sparse-val", SPARSE_IDX) === SPARSE_IDX);
+
+// slice(SPARSE_IDX) copies exactly one element: O(1).
+const sliced = a.slice(SPARSE_IDX);
+checks.push(sliced.length === 1);
+checks.push(sliced[0] === "sparse-val");
+
+// Own-vs-prototype precedence: the new arr.GetOwn check must sit between
+// the dense-element check and the prototype walk, not replace or bypass
+// either. Uses a second, distinct index so mutating Array.prototype here
+// can't affect the checks above. Both directions matter: an own property
+// past maxDenseArrayDefineIndex must still shadow an identically-indexed
+// inherited one (the new check could wrongly skip straight to the proto
+// walk), and an index with no own property there must still fall through
+// to find one on Array.prototype (the new check must not report a false
+// negative that swallows the walk).
+{
+  const PROTO_IDX = 16777218; // maxDenseArrayDefineIndex + 2
+  const key = String(PROTO_IDX);
+  (Array.prototype as any)[key] = "proto-val";
+  try {
+    const own: any[] = [];
+    Object.defineProperty(own, key, {
+      value: "own-val",
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    checks.push(own.at(-1) === "own-val"); // own shadows inherited
+    delete own[PROTO_IDX];
+    checks.push(own.at(-1) === "proto-val"); // falls through to Array.prototype
+  } finally {
+    delete (Array.prototype as any)[key];
+  }
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

`arrayLikeGet` (`pkg/builtins/array_generic.go`) is the shared `(value, exists, error)` accessor every `Array.prototype` generic method — `forEach`/`map`/`filter`/`some`/`every`/`at`/`indexOf`/`lastIndexOf`/`slice`/... — uses to read element `i` of an array-like `this`. For a real `Array`, it checked an own accessor first, then `arr.HasIndex(i)` (a bounds check against the dense `.elements` slice), and on a miss fell straight through to `arrayIndexGetFromProto`, which *only* walks the prototype chain.

It never consulted the array's own `.properties` map — where `ArrayDefineOwnProperty` tracks a data property defined via `Object.defineProperty` at an index past `maxDenseArrayDefineIndex` (2^24), since that index is too large to grow `.elements` into (see `pkg/vm/array_props.go`). That index is a genuine own property — `arr[idx]` and `hasOwnProperty` already saw it correctly (paserati#176) — but every generic method backed by `arrayLikeGet` silently treated it as a hole.

## Fix

Check `arr.GetOwn(key)` between the dense-element check and the prototype-chain walk, same pattern `Object.prototype.hasOwnProperty`'s own array-index handling already uses (`object_init.go`). The string key is computed once and shared between that check and the proto walk, to avoid a redundant `strconv.Itoa` on the (already rare) miss path.

**Note on the original bug report:** it referenced a shared `arraySparseIndexValue` helper (PR #313) as prior art — that function does not exist on `main` (confirmed via grep). This PR inlines the equivalent `GetOwnAccessor`/`GetOwn` logic directly instead.

## Testing

- New regression test: [tests/scripts/array_sparse_index_generic_methods.ts](tests/scripts/array_sparse_index_generic_methods.ts) — covers `forEach`, `map`, `filter`, `some`, `every` (the methods called out in the bug report), plus the O(1) call sites `at`, `indexOf`, `lastIndexOf`, `slice`, plus own-vs-prototype precedence in both directions (an own property at the sparse index must shadow an identically-indexed inherited one, and vice versa when there's no own property).
- Verified the test actually catches the bug: temporarily reverted the fix (via stash) and confirmed the test fails; reapplied and confirmed it passes.
- `go test ./tests -run TestScripts` passes (full suite, ~14s).
- `test262` `built-ins/Array/**` results are **byte-identical** before and after (2607/3079 passing) — the 2^24 boundary this bug lives past is a paserati implementation detail, not something test262 probes for plain arrays (it tests near the 2^32-2 array-index bound instead, which a different, already-fixed code path handles — see paserati#176/#178).

**Known cost, called out explicitly:** `forEach`/`map`/`filter`/`some`/`every` are all O(length) by spec, and the bug is only reachable past `maxDenseArrayDefineIndex`, so exercising it for real makes this one test take ~9-10s wall time and transiently allocate on the order of a few hundred MB (`map` builds a real ~16.7M-element result array). This is inherent to testing the actual bug rather than a mock of it; kept to exactly one array built once and reused (read-only) across the five O(length) checks rather than five separate huge arrays, and using the smallest valid index that triggers it (`maxDenseArrayDefineIndex + 1`) rather than a larger round number.

Filed a separate, out-of-scope observation as a follow-up task: the checker currently rejects a plain `void`-returning arrow function as a callback argument where the declared parameter type returns a specific type (here `undefined`, in `forEach`'s builtin signature) — real TypeScript special-cases `void`-returning callbacks as assignable there. Worked around here with an explicit `function(...): undefined { ...; return undefined; }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)