### PR TITLE
fix(vm): array destructuring rest (and for-of) must call an own accessor's getter

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -3064,8 +3064,17 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 // shared index.
 func makeBuiltinIterNext(vmInstance *vm.VM, state *vm.BuiltinIterState) vm.Value {
 	nextFn := vm.NewNativeFunction(0, false, "next", func(args []vm.Value) (vm.Value, error) {
+		// StepVM (not the plain Step) so an own accessor property on the
+		// source array (IterKindArrayValues/ArrayEntries) has its getter
+		// called instead of reading the raw backing slot - see StepVM's own
+		// comment. A throwing getter propagates as this native call's error,
+		// exactly like a thrown exception from a real accessor read anywhere
+		// else the VM calls into script.
+		v, done, err := state.StepVM(vmInstance)
+		if err != nil {
+			return vm.Undefined, err
+		}
 		result := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-		v, done := state.Step()
 		result.SetOwnNonEnumerable("value", v)
 		result.SetOwnNonEnumerable("done", vm.BooleanValue(done))
 		return vm.NewValueFromPlainObject(result), nil

--- a/pkg/vm/array_iterator.go
+++ b/pkg/vm/array_iterator.go
@@ -1,6 +1,9 @@
 package vm
 
-import "strconv"
+import (
+	"strconv"
+	"unsafe"
+)
 
 // BuiltinIterState is the shared mutable state behind the built-in
 // closure-based iterators (array values/keys/entries, array-likes,
@@ -75,6 +78,21 @@ func resolveFastIterState(iterVal, nextVal Value) *BuiltinIterState {
 	}
 	st := nf.IterState
 	if st.Kind != IterKindStateOnIterator {
+		if (st.Kind == IterKindArrayValues || st.Kind == IterKindArrayEntries) && st.Arr != nil && st.Arr.HasAccessors() {
+			// An own accessor property on the source array (get/set installed
+			// via Object.defineProperty) must have its getter called - ordinary
+			// [[Get]] semantics, same as plain property access. Step() can't do
+			// that: it has no VM to call the getter with and no channel to
+			// report a thrown exception, which is exactly why it stays the fast,
+			// error-free primitive OpFastIterNext depends on. So bail to the
+			// generic iterator.next() call path here instead, which goes
+			// through the native `next` closure and StepVM (below) - that path
+			// already has both. Checked once per for-of loop (OpIterFastCheck
+			// runs before the loop, not per iteration), matching the "checked
+			// once, cached" semantics this whole fast-path scheme already uses
+			// for the next-method identity check itself.
+			return nil
+		}
 		return st
 	}
 	if iterVal.typ == TypeObject {
@@ -301,4 +319,93 @@ func (st *BuiltinIterState) Step() (Value, bool) {
 		return Undefined, true
 	}
 	return Undefined, true
+}
+
+// getOwnIndexed reads the array's index i via ordinary [[Get]]: an own
+// accessor property at that index (get/set installed via
+// Object.defineProperty, at any index - DefineAccessorProperty never touches
+// `elements`, so an accessor index's raw slot is stale or a leftover Hole,
+// not the value [[Get]] must produce) has its getter called with the array
+// itself as `this` (a setter-only accessor reads as undefined, matching
+// ordinary [[Get]] on an accessor with no getter, without calling anything);
+// otherwise falls back to the raw element via Get, which is already
+// bounds/hole safe. Mirrors the accessor-first-then-raw-element precedence
+// arrayLikeGet (pkg/builtins/array_generic.go) uses for the generic
+// Array.prototype methods, applied here for the shared array values/entries
+// iterator state that backs for-of, spread's generic iterator-protocol
+// fallback, and iterator-protocol destructuring - including rest
+// (`const [x, ...rest] = arr`), which always takes the full generic path
+// since a rest element disables the destructuring fast path
+// (arrayDeclPatternFastEligible).
+func (a *ArrayObject) getOwnIndexed(vmInstance *VM, i int) (Value, error) {
+	key := strconv.Itoa(i)
+	if getter, _, _, _, ok := a.GetOwnAccessor(key); ok {
+		if getter.Type() == TypeUndefined {
+			return Undefined, nil
+		}
+		return vmInstance.Call(getter, Value{typ: TypeArray, obj: unsafe.Pointer(a)}, nil)
+	}
+	return a.Get(i), nil
+}
+
+// StepVM behaves exactly like Step, except for IterKindArrayValues and
+// IterKindArrayEntries when the source array has at least one own accessor
+// property: those two kinds read an element via getOwnIndexed instead of
+// Step()'s raw Arr.Get, so an own accessor's getter runs. Step() itself
+// can't do this - it has no VM to call the getter with and no way to report
+// a thrown exception - which is exactly why callers that can only tolerate
+// the fast, error-free Step() (the OpFastIterNext dispatch-loop opcode) bail
+// to the generic iterator-protocol call path up front instead, via
+// resolveFastIterState's own HasAccessors check. StepVM is for the one
+// caller that already goes through a real call and has an error channel to
+// use: the native `next` closure (makeBuiltinIterNext).
+//
+// A getter is arbitrary script: it can shrink the array's own backing
+// storage mid-loop (`a.length = 0`, `a.pop()`, ...). No extra guard is
+// needed for that here, the same way Step()'s own IterKindArrayValues case
+// needs none - Length() and getOwnIndexed's Get fallback are both re-read
+// live on every step, so a shrunk array simply reports done sooner instead
+// of a Go slice-bounds panic.
+func (st *BuiltinIterState) StepVM(vmInstance *VM) (Value, bool, error) {
+	switch st.Kind {
+	case IterKindArrayValues:
+		if st.Arr == nil || !st.Arr.HasAccessors() {
+			v, done := st.Step()
+			return v, done, nil
+		}
+		if st.Index >= st.Arr.Length() {
+			return Undefined, true, nil
+		}
+		idx := st.Index
+		st.Index++
+		v, err := st.Arr.getOwnIndexed(vmInstance, idx)
+		if err != nil {
+			return Undefined, false, err
+		}
+		return v, false, nil
+
+	case IterKindArrayEntries:
+		if st.Arr == nil || !st.Arr.HasAccessors() {
+			v, done := st.Step()
+			return v, done, nil
+		}
+		if st.Index >= st.Arr.Length() {
+			return Undefined, true, nil
+		}
+		idx := st.Index
+		st.Index++
+		elem, err := st.Arr.getOwnIndexed(vmInstance, idx)
+		if err != nil {
+			return Undefined, false, err
+		}
+		pair := NewArray()
+		pairArr := pair.AsArray()
+		pairArr.Append(Number(float64(idx)))
+		pairArr.Append(elem)
+		return pair, false, nil
+
+	default:
+		v, done := st.Step()
+		return v, done, nil
+	}
 }

--- a/tests/scripts/destructure_rest_accessor_getter.ts
+++ b/tests/scripts/destructure_rest_accessor_getter.ts
@@ -1,0 +1,71 @@
+// Array destructuring's rest element (`const [x, ...rest] = arr`, and the
+// assignment-pattern form `[x, ...rest] = arr`) must honor an own accessor
+// property (get/set installed via Object.defineProperty) on the source array
+// exactly like plain property access already does - the rest binding always
+// goes through the generic iterator protocol (a rest element disables the
+// array-destructuring fast path, see destructure_array_fast_path.ts), whose
+// element reads previously bypassed accessors (found while testing PR
+// "fix(vm): array spread must call an own accessor's getter, not read raw
+// storage"). Covers: a plain getter, a setter-only accessor (reads as
+// undefined), a throwing getter (propagates as a catchable exception), a
+// getter that shrinks the array's own backing storage mid-rest (must not
+// panic), the assignment-pattern form, the plain no-accessor path
+// (regression guard), and for-of over the same kind of array (same shared
+// iterator state backs both). Values are read back via JSON.stringify
+// (rather than Array.prototype.join, which has its own unrelated bug
+// rendering undefined/null elements as the literal word instead of empty -
+// out of scope here) and cross-checked against Node.
+// expect: [42,3]|[2,null]|caught:boom|[99]|[7,3]|[2,3]|[1,99,3]
+let out: string[] = [];
+
+// 1. Plain getter at an in-bounds index
+const a = [1, 2, 3];
+Object.defineProperty(a, "1", { get() { return 42; }, enumerable: true, configurable: true });
+const [, ...restA] = a;
+out.push(JSON.stringify(restA));
+
+// 2. Setter-only accessor reads as undefined (JSON.stringify renders it as null)
+const b = [1, 2, 3];
+Object.defineProperty(b, "2", { set(_v: number) {}, enumerable: true, configurable: true });
+const [, ...restB] = b;
+out.push(JSON.stringify(restB));
+
+// 3. A throwing getter propagates as a catchable exception
+const c = [1, 2, 3];
+Object.defineProperty(c, "1", { get() { throw new Error("boom"); }, enumerable: true, configurable: true });
+try {
+  const [, ...restC] = c;
+  out.push("no throw:" + JSON.stringify(restC));
+} catch (e: any) {
+  out.push("caught:" + e.message);
+}
+
+// 4. A getter that shrinks the array's own backing storage mid-rest must not
+// panic - Length() and the raw-element fallback are both re-read live, so
+// the rest simply stops early (matches Node).
+const d = [1, 2, 3, 4, 5];
+Object.defineProperty(d, "1", { get() { (d as any).length = 0; return 99; }, enumerable: true, configurable: true });
+const [, ...restD] = d;
+out.push(JSON.stringify(restD));
+
+// 5. Assignment-pattern rest (not a declaration)
+let p: number, restE: number[];
+const e = [1, 2, 3];
+Object.defineProperty(e, "1", { get() { return 7; }, enumerable: true, configurable: true });
+[p, ...restE] = e;
+out.push(JSON.stringify(restE));
+
+// 6. No-accessor path is unaffected (regression guard)
+const f = [1, 2, 3];
+const [, ...restF] = f;
+out.push(JSON.stringify(restF));
+
+// 7. for-of over the same kind of array (blast radius: the array's default
+// iterator is shared between for-of and rest destructuring)
+const g = [1, 2, 3];
+Object.defineProperty(g, "1", { get() { return 99; }, enumerable: true, configurable: true });
+let forOfOut: number[] = [];
+for (const v of g) forOfOut.push(v);
+out.push(JSON.stringify(forOfOut));
+
+out.join("|");


### PR DESCRIPTION
## Premise correction

The task that motivated this fix named `OpArraySlice`'s `TypeArray` fast path (`pkg/vm/vm.go`) as the bug site for `const [x, ...rest] = arr` not honoring an own accessor property. That's not reachable from the current compiler: its only two callers (`compileArrayDestructuringFastPath`, `compileArrayDestructuringDeclarationWithValueReg`) have zero callers anywhere in the repo. A rest element always disables the destructuring fast path, so `const [x, ...rest] = arr` takes the full generic iterator protocol — it calls the source's real `next()`, the same one `for...of` uses.

The actual bug is in the shared array iterator state (`BuiltinIterState.Step()`, `pkg/vm/array_iterator.go`): `IterKindArrayValues`/`IterKindArrayEntries` read `st.Arr.Get(st.Index)` — the raw backing slot — unconditionally, bypassing any own accessor property installed via `Object.defineProperty`.

```js
const a = [1, 2, 3];
Object.defineProperty(a, "1", { get() { return 42; }, enumerable: true, configurable: true });
const [, ...rest] = a;
console.log(JSON.stringify(rest));   // was [2,3], should be [42,3]
for (const v of a) {}                // same bug — for-of shares the iterator
```

## Fix

- `BuiltinIterState.Step()` has no VM and no error channel, so it stays the fast primitive `OpFastIterNext` depends on. Added `StepVM(vm)`: for `IterKindArrayValues`/`IterKindArrayEntries` when `Arr.HasAccessors()`, reads each index via a new `ArrayObject.getOwnIndexed` — accessor-first-then-raw-element, mirroring `arrayLikeGet`'s precedence for the generic `Array.prototype` methods.
- `makeBuiltinIterNext`'s `next` closure now calls `StepVM` and propagates a thrown getter's error as the call's own error.
- `resolveFastIterState` now refuses steppable state for those two kinds when the array has accessors, forcing `for...of`'s fast path (`OpFastIterNext`) onto the generic call path instead — checked once per loop, matching the existing "checked once" caching this fast-path scheme already relies on for the next-method identity check.
- A getter is arbitrary script and can shrink the array mid-iteration; `Length()`/`Get()` are re-read live every step (unchanged from `Step()`), so a shrinking getter reports `done` sooner instead of panicking — verified against Node.

## Explicitly NOT covered

- `[...arr]` spread's own `TypeArray` fast path (`extractSpreadArguments`) — separate bug, `fix-array-spread-accessor-getter`'s territory.
- `OpArrayRawGetInt`, the fast path for non-rest patterns (`const [a, b] = arr`).
- `Array.from(arr)`.
- An accessor installed after a for-of loop's `OpIterFastCheck` already ran (checked once, by design).

Also found and spun off as its own follow-up (not folded in here): `Array.prototype.join` renders `undefined`/`null` elements as the literal words instead of the spec's empty string. The regression test below uses `JSON.stringify` instead of `join` to avoid depending on that unrelated bug.

## Verification

- Repro above, setter-only accessor, throwing getter, shrinking-getter, assignment-pattern rest, no-accessor path, for-of, and a `class S extends Array {}` subclass `this`-binding check — all cross-checked against Node.
- `go build ./...`, `go vet ./...`: clean.
- `go test ./...`: all packages pass.
- New test `tests/scripts/destructure_rest_accessor_getter.ts`: fails on pre-fix source (stash-verified), passes after.
- test262 before/after `-dump` diff (`-timeout 0.2s`) on `language/statements/const`, `language/statements/let`, `language/expressions/assignment`, `built-ins/Array`: identical pass/fail sets, zero regressions. On `language/statements/for-of`: one new pass (`array-key-get-error.js` — exactly this bug), zero new failures (744→745 of 751).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
