### PR TITLE
fix(vm,builtins,checker): RegExp is an object for in/Reflect.has

### DIFF
--- a/pkg/builtins/reflect_has.go
+++ b/pkg/builtins/reflect_has.go
@@ -116,6 +116,46 @@ func reflectHas(vmInstance *vm.VM, target vm.Value, key vm.Value) (bool, error) 
 		}
 		return false, nil
 
+	case vm.TypeRegExp:
+		// RegExp: "lastIndex" lives on the RegExpObject itself (writable,
+		// non-configurable - see reflectDeleteProperty's TypeRegExp case),
+		// not in the side table. Then the side table (OwnPropertiesTable -
+		// user-assigned own properties), then this instance's own
+		// [[Prototype]] chain - a subclass's RegExp.prototype
+		// (RegExpObject.prototype, set "for subclassing" per its field
+		// comment) when overridden, or vmInstance.RegExpPrototype itself
+		// otherwise - for inherited methods (test/exec) and accessors
+		// (source/flags/global/...), and (for a symbol key)
+		// @@match/@@matchAll/@@replace/@@search/@@split (pkg/builtins/
+		// regexp_init.go) - mirrors OpIn's TypeRegExp case (pkg/vm/vm.go).
+		re := target.AsRegExpObject()
+		if !isSym && name == "lastIndex" {
+			return true, nil
+		}
+		if props := vm.OwnPropertiesTable(target); props != nil {
+			if isSym {
+				if props.HasOwnByKey(propKey) {
+					return true, nil
+				}
+			} else if props.HasOwn(name) {
+				return true, nil
+			}
+		}
+		proto := vm.Undefined
+		if re != nil {
+			proto = re.GetPrototype()
+		}
+		if !proto.IsObject() {
+			proto = vmInstance.RegExpPrototype
+		}
+		if !proto.IsObject() {
+			return false, nil
+		}
+		if isSym {
+			return vmInstance.HasPropertyOnGivenPrototypeChain(proto, propKey), nil
+		}
+		return proto.AsPlainObject().Has(name), nil
+
 	case vm.TypeArguments:
 		// Mirrors OpIn's own TypeArguments case (pkg/vm/vm.go) exactly -
 		// including its non-symbol-only scope; a symbol key on an
@@ -184,9 +224,7 @@ func reflectHas(vmInstance *vm.VM, target vm.Value, key vm.Value) (bool, error) 
 		return vmInstance.HasFunctionPrototypeProperty(name), nil
 	}
 
-	// Not (yet) handled: RegExp (an own side-table property exists via
-	// OwnPropertiesTable, but RegExpPrototype's fallback isn't wired up
-	// here), WeakMap/WeakSet/WeakRef/FinalizationRegistry,
+	// Not (yet) handled: WeakMap/WeakSet/WeakRef/FinalizationRegistry,
 	// Generator/AsyncGenerator. Each answers false unconditionally, same
 	// as before this fix - a real gap, not silently implied covered by a
 	// blanket default (effectiveBuiltinPrototype, the obvious-looking

--- a/pkg/checker/expressions.go
+++ b/pkg/checker/expressions.go
@@ -2782,8 +2782,13 @@ func (c *Checker) isObjectType(t types.Type) bool {
 		// Type parameters could be objects, allow them (this might need refinement)
 		return true
 	default:
-		// Check for any type that could represent an object
-		return t == types.Any
+		// RegExp is a real ordinary object at runtime, but the checker
+		// models it as a distinct *types.Primitive marker (see
+		// pkg/types/primitive.go) rather than an *types.ObjectType, so it
+		// needs its own case here - otherwise `"test" in /x/` was rejected
+		// at check time before the 'in' operator's own object-ness fix in
+		// the VM (OpIn, pkg/vm/vm.go) ever ran.
+		return t == types.Any || t == types.RegExp
 	}
 }
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3124,7 +3124,8 @@ startExecution:
 			if objType != TypeObject && objType != TypeDictObject && objType != TypeArray &&
 				objType != TypeFunction && objType != TypeNativeFunctionWithProps && objType != TypeProxy &&
 				objType != TypeClosure && objType != TypeNativeFunction && objType != TypeBoundFunction &&
-				objType != TypeSet && objType != TypeMap && objType != TypeArguments && objType != TypePromise {
+				objType != TypeSet && objType != TypeMap && objType != TypeArguments && objType != TypePromise &&
+				objType != TypeRegExp {
 				frame.ip = ip
 				vm.ThrowTypeError(fmt.Sprintf("Cannot use 'in' operator to search for '%s' in %s", propVal.ToString(), objVal.Type().String()))
 				if vm.frameCount == 0 || vm.unwindingCrossedNative {
@@ -3218,6 +3219,44 @@ startExecution:
 					if proto.IsObject() {
 						for cur := proto.AsPlainObject(); cur != nil; {
 							if _, ok := cur.GetOwnByKey(NewSymbolKey(propVal)); ok {
+								hasProperty = true
+								break
+							}
+							pv := cur.GetPrototype()
+							if !pv.IsObject() {
+								break
+							}
+							cur = pv.AsPlainObject()
+						}
+					}
+				case TypeRegExp:
+					// Own side-table symbol property first, then walk the
+					// prototype chain starting from this instance's own
+					// [[Prototype]] (a subclass's RegExp.prototype, set via
+					// RegExpObject.prototype - "Per-instance [[Prototype]]
+					// override for subclassing" per its field comment - or
+					// vm.RegExpPrototype itself when unset). RegExp.prototype
+					// carries @@match/@@matchAll/@@replace/@@search/@@split
+					// (pkg/builtins/regexp_init.go), so `Symbol.match in /x/`
+					// must find them the same way Node does.
+					symKey := NewSymbolKey(propVal)
+					regexObj := objVal.AsRegExpObject()
+					if regexObj != nil && regexObj.Properties != nil {
+						if _, ok := regexObj.Properties.GetOwnByKey(symKey); ok {
+							hasProperty = true
+							break
+						}
+					}
+					proto := Undefined
+					if regexObj != nil {
+						proto = regexObj.GetPrototype()
+					}
+					if !proto.IsObject() {
+						proto = vm.RegExpPrototype
+					}
+					if proto.IsObject() {
+						for cur := proto.AsPlainObject(); cur != nil; {
+							if _, ok := cur.GetOwnByKey(symKey); ok {
 								hasProperty = true
 								break
 							}
@@ -3558,6 +3597,35 @@ startExecution:
 					// Promises don't have user-accessible own properties, only internal state
 					if vm.PromisePrototype.IsObject() {
 						hasProperty = vm.PromisePrototype.AsPlainObject().Has(propKey)
+					}
+				case TypeRegExp:
+					// RegExp: "lastIndex" is a real own property that lives on
+					// the RegExpObject itself (writable, non-configurable - see
+					// reflectDeleteProperty's TypeRegExp case), not in the
+					// side table. Then the side table (user-assigned own
+					// properties, the same one Object.freeze/seal use), then
+					// this instance's own [[Prototype]] chain - a subclass's
+					// RegExp.prototype (RegExpObject.prototype, set "for
+					// subclassing" per its field comment) when overridden, or
+					// vm.RegExpPrototype itself otherwise - for inherited
+					// methods (test/exec) and accessors (source/flags/
+					// global/...).
+					regexObj := objVal.AsRegExpObject()
+					if propKey == "lastIndex" {
+						hasProperty = true
+					} else if regexObj != nil && regexObj.Properties != nil && regexObj.Properties.HasOwn(propKey) {
+						hasProperty = true
+					} else {
+						proto := Undefined
+						if regexObj != nil {
+							proto = regexObj.GetPrototype()
+						}
+						if !proto.IsObject() {
+							proto = vm.RegExpPrototype
+						}
+						if proto.IsObject() {
+							hasProperty = proto.AsPlainObject().Has(propKey)
+						}
 					}
 				default:
 					// Non-object RHS - shouldn't reach here due to check above
@@ -21026,8 +21094,24 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 				return true
 			}
 		}
-		if vm.RegExpPrototype.Type() == TypeObject {
-			return vm.RegExpPrototype.AsPlainObject().Has(propKey)
+		// Walk this instance's own [[Prototype]] chain - a subclass's
+		// RegExp.prototype (RegExpObject.prototype, "for subclassing" per
+		// its field comment) when overridden, or vm.RegExpPrototype
+		// otherwise - matching OpIn's TypeRegExp case above and
+		// reflectHas's (pkg/builtins/reflect_has.go), which recurses back
+		// into this same fallback via proxyReflectHas. Hardcoding
+		// vm.RegExpPrototype here (as this used to) made a Proxy wrapping
+		// a RegExp subclass disagree with a direct `in`/Reflect.has on the
+		// same subclass instance for a method the subclass itself adds.
+		proto := Undefined
+		if regexObj != nil {
+			proto = regexObj.GetPrototype()
+		}
+		if !proto.IsObject() {
+			proto = vm.RegExpPrototype
+		}
+		if proto.IsObject() {
+			return proto.AsPlainObject().Has(propKey)
 		}
 		return false
 	case TypeFunction:

--- a/tests/scripts/regexp_in_reflect_has.ts
+++ b/tests/scripts/regexp_in_reflect_has.ts
@@ -1,0 +1,94 @@
+// expect: true
+// `in` (OpIn, pkg/vm/vm.go) unconditionally threw a TypeError for a RegExp
+// right-hand side - TypeRegExp was simply missing from OpIn's allowed-type
+// list, even though a RegExp is an ordinary object in ECMAScript
+// ("test" in /x/ is true in Node). The static checker rejected the same
+// expression before it ever reached the VM (isObjectType, pkg/checker/
+// expressions.go, had no case for the *types.Primitive RegExp marker type -
+// see pkg/types/primitive.go) - a plain (non-`any`) `/x/` literal hit this,
+// so a typed case is included below, not just `any`-typed ones. Reflect.has
+// (regexp, key) had the matching gap: no TypeRegExp case in reflectHas's
+// switch (pkg/builtins/reflect_has.go), acknowledged in its own
+// default-case comment, so it answered false unconditionally regardless of
+// the key.
+const checks: boolean[] = [];
+
+// --- a plain, statically-typed RegExp (not `any`) - exercises the checker
+// fix, not just the VM/Reflect.has one ---
+const typed = /x/;
+checks.push("test" in typed && Reflect.has(typed, "test"));
+if ("test" in typed) {
+  checks.push(true);
+} else {
+  checks.push(false);
+}
+
+const r: any = /x/g;
+
+// --- own "lastIndex" (lives on the RegExpObject itself, not the side
+// table - see reflectDeleteProperty's TypeRegExp case) ---
+checks.push("lastIndex" in r && Reflect.has(r, "lastIndex"));
+
+// --- inherited methods from RegExp.prototype ---
+checks.push("test" in r && Reflect.has(r, "test"));
+checks.push("exec" in r && Reflect.has(r, "exec"));
+
+// --- inherited accessors on RegExp.prototype (source/flags are getters,
+// not own data properties on the instance) ---
+checks.push("source" in r && Reflect.has(r, "source"));
+checks.push("flags" in r && Reflect.has(r, "flags"));
+checks.push("global" in r && Reflect.has(r, "global"));
+
+// --- a genuinely absent key ---
+checks.push(!("nope" in r) && !Reflect.has(r, "nope"));
+
+// --- a plain own property assigned directly onto the instance (the
+// side table OwnPropertiesTable/EnsureOwnPropertiesTable manages) ---
+r.custom = 42;
+checks.push("custom" in r && Reflect.has(r, "custom"));
+
+// --- a RegExp with no `g` flag behaves the same way ---
+const r2: any = /y/;
+checks.push("lastIndex" in r2 && Reflect.has(r2, "lastIndex"));
+checks.push("test" in r2 && Reflect.has(r2, "test"));
+checks.push(!("nope" in r2) && !Reflect.has(r2, "nope"));
+
+// --- well-known symbols RegExp.prototype defines (@@match/@@matchAll/
+// @@replace/@@search/@@split - pkg/builtins/regexp_init.go): the
+// symbol-key switch in OpIn/reflectHas used to fall to `false`
+// unconditionally for a RegExp target, even though Node finds these. A
+// symbol RegExp.prototype does NOT define (@@iterator) still correctly
+// answers false. ---
+checks.push(Symbol.match in r && Reflect.has(r, Symbol.match));
+checks.push(Symbol.matchAll in r && Reflect.has(r, Symbol.matchAll));
+checks.push(Symbol.replace in r && Reflect.has(r, Symbol.replace));
+checks.push(Symbol.search in r && Reflect.has(r, Symbol.search));
+checks.push(Symbol.split in r && Reflect.has(r, Symbol.split));
+checks.push(!(Symbol.iterator in r) && !Reflect.has(r, Symbol.iterator));
+
+// --- a RegExp subclass instance: RegExpObject.prototype ("per-instance
+// [[Prototype]] override for subclassing") must be walked instead of
+// unconditionally using the intrinsic RegExp.prototype, or an own method
+// added on the subclass's prototype (not found on RegExp.prototype
+// itself) would incorrectly report absent. ---
+class MyRegExp extends RegExp {
+  mine() {
+    return 1;
+  }
+}
+const sub: any = new MyRegExp("z");
+checks.push("mine" in sub && Reflect.has(sub, "mine"));
+checks.push("test" in sub && Reflect.has(sub, "test")); // still inherited beyond the subclass
+checks.push(!("nope" in sub) && !Reflect.has(sub, "nope"));
+
+// --- a Proxy wrapping a RegExp subclass instance, with no `has` trap:
+// `in` (via proxyHasPropertyFallback) and Reflect.has (which recurses
+// back into reflectHas for the target) must agree with each other, and
+// both must still see the subclass's own prototype method - not just
+// the intrinsic RegExp.prototype either fallback used to hardcode. ---
+const proxied: any = new Proxy(sub, {});
+checks.push("mine" in proxied && Reflect.has(proxied, "mine"));
+checks.push("test" in proxied && Reflect.has(proxied, "test"));
+checks.push(!("nope" in proxied) && !Reflect.has(proxied, "nope"));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Two related dispatch gaps, same root cause — RegExp was never wired into either function:

- **`in` throws for a RegExp right-hand side.** `OpIn`'s allowed-type list (`pkg/vm/vm.go`) was missing `TypeRegExp`, so `"test" in /x/` unconditionally threw a `TypeError` even though a RegExp is an ordinary object in ECMAScript (Node: `true`).
- **`Reflect.has` answers `false` unconditionally for a RegExp target** (`pkg/builtins/reflect_has.go`, added in #317 — acknowledged as a gap in its own default-case comment).

A third gap surfaced while fixing the above: the static checker's `isObjectType` (`pkg/checker/expressions.go`) had no case for the `*types.Primitive` RegExp marker type (`pkg/types/primitive.go` models RegExp as a distinct primitive-like singleton rather than an `ObjectType`), so `"test" in /x/` was rejected at check time before the expression ever reached the VM's `OpIn` fix. Without this fix the other two are unreachable in normal (non-`any`) typed code.

## What both new dispatch cases check, in order

1. An own property that lives directly on the `RegExpObject` (`lastIndex`).
2. The lazily-created side table (`OwnPropertiesTable` — user-assigned own properties, the same table `Object.freeze`/`seal` use).
3. This instance's own `[[Prototype]]` chain — a subclass's `RegExp.prototype` (`RegExpObject.prototype`, set "for subclassing" per its field comment) when overridden, or the intrinsic `RegExpPrototype` otherwise — covering inherited methods (`test`/`exec`), inherited accessors (`source`/`flags`/`global`/...), and the well-known symbols `RegExp.prototype` defines (`@@match`/`@@matchAll`/`@@replace`/`@@search`/`@@split`).

`proxyHasPropertyFallback`'s existing (pre-#297) `TypeRegExp` case hardcoded `vm.RegExpPrototype`, which would have made `in` on a Proxy-wrapped RegExp subclass disagree with `Reflect.has` on the same target (`reflectHas`'s proxy path recurses back into `reflectHas` itself, which does honor the per-instance override) — fixed to match.

## Testing

- `tests/scripts/regexp_in_reflect_has.ts`: own `lastIndex`, inherited methods/accessors/symbols, a genuinely absent key, a user-assigned own property, a RegExp subclass instance, and a Proxy wrapping one — confirming `in`/`Reflect.has` agree with each other and with Node throughout.
- `go test ./tests -run TestScripts` and `./pkg/vm/... ./pkg/builtins/... ./pkg/checker/...` all pass.
- test262 sanity: `built-ins/RegExp` (1202/1879, within the established ~1199–1204 flake band at `-timeout 0.2s`, confirmed via repeated before/after runs on unchanged code) and `language/expressions/in` (36/36) — no regressions.

## Out of scope (flagged separately)

While investigating I found two adjacent, pre-existing bugs that are *not* fixed here since they're a different root cause:
- `Object.defineProperty` silently no-ops on a RegExp (and other exotic objects) with no side table yet — `definePropertyTarget` uses the non-allocating `OwnPropertiesTable` instead of `EnsureOwnPropertiesTable`.
- `for...in` never enumerates a RegExp's own properties at all — `OpGetOwnKeys` has no `case TypeRegExp:`.

Based on `fix-reflect-has-target-dispatch` (#317), the current tip of the #315→#316→#317 stack.