### PR TITLE
fix(builtins): complete AbortSignal/AbortController abort(reason?) typing

### DIFF
--- a/pkg/builtins/abort_controller_init.go
+++ b/pkg/builtins/abort_controller_init.go
@@ -31,7 +31,7 @@ func (a *AbortControllerInitializer) InitTypes(ctx *TypeContext) error {
 
 	// AbortSignal static methods
 	abortSignalConstructorType := types.NewObjectType().
-		WithProperty("abort", types.NewSimpleFunction([]types.Type{}, abortSignalType)).
+		WithProperty("abort", types.NewOptionalFunction([]types.Type{types.Any}, abortSignalType, []bool{true})).
 		WithProperty("timeout", types.NewSimpleFunction([]types.Type{types.Number}, abortSignalType)).
 		WithProperty("any", types.NewSimpleFunction([]types.Type{types.Any}, abortSignalType)). // signals array
 		WithProperty("prototype", abortSignalType)
@@ -43,7 +43,7 @@ func (a *AbortControllerInitializer) InitTypes(ctx *TypeContext) error {
 	// AbortController type
 	abortControllerType := types.NewObjectType().
 		WithProperty("signal", abortSignalType).
-		WithProperty("abort", types.NewSimpleFunction([]types.Type{}, types.Undefined))
+		WithProperty("abort", types.NewOptionalFunction([]types.Type{types.Any}, types.Undefined, []bool{true}))
 
 	// AbortController constructor
 	abortControllerConstructorType := types.NewObjectType().
@@ -65,7 +65,7 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// AbortSignal.abort(reason?) - creates an already-aborted signal
 	signalConstructor.SetOwnNonEnumerable("abort", vm.NewNativeFunction(1, false, "abort", func(args []vm.Value) (vm.Value, error) {
 		var reason vm.Value
-		if len(args) > 0 {
+		if len(args) > 0 && !args[0].IsUndefined() {
 			reason = args[0]
 		} else {
 			// Default reason is DOMException with name "AbortError"
@@ -245,7 +245,7 @@ func createAbortControllerObject(vmInstance *vm.VM, controller *AbortController,
 	// abort(reason?) method
 	obj.SetOwnNonEnumerable("abort", vm.NewNativeFunction(1, false, "abort", func(args []vm.Value) (vm.Value, error) {
 		var reason vm.Value
-		if len(args) > 0 {
+		if len(args) > 0 && !args[0].IsUndefined() {
 			reason = args[0]
 		} else {
 			reason = vm.NewString("AbortError: signal is aborted without reason")

--- a/tests/scripts/abort_controller_reason_default.ts
+++ b/tests/scripts/abort_controller_reason_default.ts
@@ -1,0 +1,34 @@
+// expect: true
+// AbortController.prototype.abort(reason?) and AbortSignal.abort(reason?) must
+// treat an explicit `undefined` reason the same as an omitted one (DOM spec:
+// "If reason is undefined, set reason to a new 'AbortError' DOMException"),
+// not just an absent argument. Once the type signatures declared `reason` as
+// an optional parameter, the compiler pads an omitted call with an explicit
+// `undefined` argument, so a bare `len(args) > 0` check would wrongly treat
+// `abort()` as if a real reason had been supplied.
+const checks: boolean[] = [];
+
+// AbortController.prototype.abort
+const c1 = new AbortController();
+c1.abort();
+checks.push(String(c1.signal.reason).includes("AbortError"));
+
+const c2 = new AbortController();
+c2.abort(undefined);
+checks.push(String(c2.signal.reason).includes("AbortError"));
+
+const c3 = new AbortController();
+c3.abort("custom reason");
+checks.push(c3.signal.reason === "custom reason");
+
+// AbortSignal.abort (static)
+const s1 = AbortSignal.abort();
+checks.push(String(s1.reason).includes("AbortError"));
+
+const s2 = AbortSignal.abort(undefined);
+checks.push(String(s2.reason).includes("AbortError"));
+
+const s3 = AbortSignal.abort("custom sig reason");
+checks.push(s3.reason === "custom sig reason");
+
+checks.every((v) => v === true);


### PR DESCRIPTION
## Summary

`AbortSignal.abort()` and `AbortController.prototype.abort()` were declared as zero-parameter functions in their type signatures, even though their runtime implementations already accepted an optional `reason` argument via a bare `len(args) > 0` check.

That check is a *presence* check, but the DOM spec's default-reason step ("if reason is undefined, set reason to a new `AbortError` DOMException") is a *value* check — so the existing code was only correct by accident, because the type checker never let a call site pass an explicit `undefined` through to it (the signature declared zero parameters, so `reason` wasn't type-checked at all). Completing the signature to the technically-correct `abort(reason?: any)` would have silently reintroduced the "omitted argument arrives as an explicit `undefined`, `len(args) > 0` treats it as provided" bug that's been fixed across several other `pkg/builtins/*.go` files.

## Changes

- `pkg/builtins/abort_controller_init.go`:
  - Complete the type signatures for `AbortSignal.abort` and `AbortController.prototype.abort` to `abort(reason?: any)` per the DOM spec (previously zero-parameter).
  - Guard both runtime call sites with `!args[0].IsUndefined()` so an explicit `undefined` (from a real call site, or from the compiler's optional-argument padding) is treated the same as an omitted argument.
- `tests/scripts/abort_controller_reason_default.ts`: regression test covering `abort()`, `abort(undefined)`, and `abort("custom reason")` for both `AbortController.prototype.abort` and the static `AbortSignal.abort`, checked against `.signal.reason` / `.reason`.

## Testing

- `go build ./...`
- `go test ./tests -run TestScripts -timeout 180s` — all pass, including the new test.
- Manually verified `abort()`, `abort(undefined)`, and `abort("custom reason")` behavior via a scratch script before writing the regression test.