### PR TITLE
fix(vm): make a runtime exception from eval'd code catchable by the caller

### DIFF
--- a/pkg/builtins/globals_init.go
+++ b/pkg/builtins/globals_init.go
@@ -592,7 +592,22 @@ func (g *GlobalsInitializer) InitRuntime(ctx *RuntimeContext) error {
 			result, evalErrs = driver.IndirectEvalCode(codeStr)
 		})
 		if len(evalErrs) > 0 {
-			// Error (parse/compile/runtime) - throw SyntaxError for compile errors
+			// A genuine runtime exception from the evaluated code (as opposed
+			// to a parse/compile failure) comes back wrapped so the original
+			// thrown value survives - see vm.Interpret's InterpretRuntimeError
+			// handling. Unwrap and re-throw that value as-is, so e.g. a
+			// ReferenceError thrown by eval'd code is still a ReferenceError
+			// (and catchable by the caller's try/catch) rather than every
+			// eval failure - parse, compile, or runtime alike - collapsing
+			// into a SyntaxError.
+			if unwrapper, ok := evalErrs[0].(interface{ Unwrap() error }); ok {
+				if cause := unwrapper.Unwrap(); cause != nil {
+					if exc, ok := cause.(vm.ExceptionError); ok {
+						return vm.Undefined, ctx.VM.NewExceptionError(exc.GetExceptionValue())
+					}
+				}
+			}
+			// Parse/compile error - throw SyntaxError
 			return vm.Undefined, ctx.VM.NewSyntaxError(evalErrs[0].Error())
 		}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1355,6 +1355,16 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 		vm.nextRegSlot = 0
 	}
 
+	// Remembered so the InterpretRuntimeError handling below can restore
+	// frameCount/nextRegSlot exactly, the same way executeUserFunctionSafe's
+	// frameCountAtEntry + truncateFramesTo does for its own native boundary,
+	// rather than assuming unwindException left exactly one frame (ours) to
+	// pop: some run() exit paths return InterpretRuntimeError while frames
+	// above ours are still live (e.g. OpDirectEval's reassigned-eval
+	// fallback), and a single-frame pop would silently under-restore then.
+	entryFrameCount := vm.frameCount
+	entryNextRegSlot := vm.nextRegSlot
+
 	// --- Push the new frame ---
 	frame := &vm.frames[vm.frameCount] // Get pointer to the frame slot
 	// Initialize the first frame to run the mainClosureObj
@@ -1400,6 +1410,10 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	// This ensures eval()'s script execution returns its completion value back to the native function
 	// For top-level scripts (frameCount==0 before pushing), keep isDirectCall=false to allow normal completion
 	frame.isDirectCall = (vm.frameCount > 0)
+	// Captured for the InterpretRuntimeError handling below, once run() has
+	// returned and frame.isDirectCall may no longer be trustworthy to read
+	// (the slot could in principle have been reused by then).
+	isNestedInterpretCall := frame.isDirectCall
 	frame.isSentinelFrame = false
 	frame.argCount = 0
 	frame.args = nil
@@ -1448,6 +1462,70 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	// }
 
 	if resultStatus == InterpretRuntimeError {
+		// isNestedInterpretCall is true exactly when this was a *nested*
+		// Interpret() call (frameCount > 0 before we pushed our frame above -
+		// e.g. indirect/direct eval, or any other host embedding eval'ing
+		// into an already-running VM) - see where it's captured from
+		// frame.isDirectCall above. vm.unwinding still true in that case
+		// means the exception never reached a handler at all: it ran into
+		// the top-level script frame we just pushed, which unwindException
+		// treats as a native call boundary (frame.isDirectCall ||
+		// frame.isSentinelFrame - the same mechanism executeUserFunctionSafe/
+		// vm.Call rely on to receive a catchable exception as a Go error
+		// rather than have it print as uncaught) and stops there without
+		// popping the frame or touching vm.errors - throwException only
+		// calls handleUncaughtException (which populates vm.errors, and
+		// leaves vm.unwinding=true itself, deliberately, "to signal
+		// termination") when NO frame stopped the unwind at all, i.e. a
+		// genuinely uncaught exception at frameCount==0. That top-level,
+		// non-nested case (isNestedInterpretCall==false here) must keep
+		// using vm.errors as before - it's already been populated, and
+		// re-entering this branch for it would misreport a real uncaught
+		// exception as a catchable one and, on a persistent VM, resume
+		// executing past a script that has already been fully torn down.
+		//
+		// For the nested case, a runtime exception used to return here with
+		// vm.errors empty (throwException doesn't populate it - only
+		// runtimeError/handleUncaughtException do, and neither ran) and the
+		// VM's exception state (unwinding/currentException/
+		// unwindingCrossedNative) left dangling: the caller saw an
+		// error-free result despite InterpretRuntimeError, and the stray
+		// state then corrupted whatever ran next on this VM. (A parse/
+		// compile error never reaches this point at all -
+		// IndirectEvalCode/DirectEvalCode/EvalCode return it before ever
+		// calling Interpret, which is why only genuine runtime exceptions
+		// from eval'd code showed this bug.)
+		//
+		// Take ownership of the exception here, the same way a native
+		// boundary caller does: extract it, clear the VM's unwind state, and
+		// restore frameCount/nextRegSlot to exactly what they were before we
+		// pushed - the same truncateFramesTo(frameCountAtEntry) idiom
+		// executeUserFunctionSafe uses for its own native boundary, rather
+		// than assuming unwindException left exactly our one frame to pop:
+		// some run() exit paths return InterpretRuntimeError while frames
+		// above ours are still live (e.g. OpDirectEval's reassigned-eval
+		// fallback), and popping only one frame would under-restore then.
+		// truncateFramesTo closes upvalues for every frame it drops but
+		// doesn't touch nextRegSlot (its other callers' pushed frames aren't
+		// carved from vm.registerStack), so that part is ours to do here.
+		// Report the exception via a fresh local slice rather than
+		// vm.errors: the caller's own execution keeps running after we
+		// return (this is a *nested* Interpret call), and nothing clears
+		// vm.errors again before the outer script eventually completes, so
+		// appending to it here would leak a stale error into an otherwise
+		// successful run.
+		if isNestedInterpretCall && vm.unwinding {
+			exc := vm.currentException
+			vm.unwinding = false
+			vm.currentException = Null
+			vm.truncateFramesTo(entryFrameCount)
+			vm.nextRegSlot = entryNextRegSlot
+			runtimeErr := errors.NewRuntimeError(
+				errors.Position{Line: vm.lastThrowLine, Column: vm.lastThrowColumn},
+				"Uncaught "+vm.formatExceptionDisplay(exc),
+			).CausedBy(exceptionError{exception: exc})
+			return finalValue, []errors.PaseratiError{runtimeErr}
+		}
 		// An error occurred, return the potentially partial value and the collected errors
 		// fmt.Printf("// [VM] Interpret: Returning runtime error with %d errors\n", len(vm.errors))
 		return finalValue, vm.errors
@@ -16818,23 +16896,46 @@ startExecution:
 			}
 
 			if len(evalErrs) > 0 {
-				// Compile/parse error occurred - throw as SyntaxError exception
 				// Check if we're already unwinding
 				if vm.unwinding {
 					return InterpretRuntimeError, Undefined
 				}
-				// Create a SyntaxError object and throw it
-				errMsg := evalErrs[0].Error()
+				// A genuine runtime exception from the eval'd code (as
+				// opposed to a parse/compile failure) comes back wrapped so
+				// the original thrown value survives - see vm.Interpret's
+				// InterpretRuntimeError handling. Unwrap and re-throw that
+				// value as-is, so e.g. a ReferenceError thrown by eval'd code
+				// is still a ReferenceError (and catchable here) rather than
+				// every eval failure collapsing into a SyntaxError.
 				var errObj Value
-				if ctor, ok := vm.GetGlobal("SyntaxError"); ok {
-					msg := NewString(errMsg)
-					errObj, _ = vm.Call(ctor, Undefined, []Value{msg})
-				} else {
-					// Fallback to plain error object
-					plainErr := NewObject(vm.ErrorPrototype).AsPlainObject()
-					plainErr.SetOwn("name", NewString("SyntaxError"))
-					plainErr.SetOwn("message", NewString(errMsg))
-					errObj = NewValueFromPlainObject(plainErr)
+				gotExc := false
+				if unwrapper, ok := evalErrs[0].(interface{ Unwrap() error }); ok {
+					if cause := unwrapper.Unwrap(); cause != nil {
+						if exc, ok := cause.(ExceptionError); ok {
+							// GetExceptionValue() can legitimately be
+							// Undefined (`throw undefined` inside the eval'd
+							// code) or Null (`throw null`) - gotExc, not
+							// errObj's type, is what distinguishes "found a
+							// real thrown value" from "no wrapped exception,
+							// this is a parse/compile error" below.
+							errObj = exc.GetExceptionValue()
+							gotExc = true
+						}
+					}
+				}
+				if !gotExc {
+					// Compile/parse error - create a SyntaxError object and throw it
+					errMsg := evalErrs[0].Error()
+					if ctor, ok := vm.GetGlobal("SyntaxError"); ok {
+						msg := NewString(errMsg)
+						errObj, _ = vm.Call(ctor, Undefined, []Value{msg})
+					} else {
+						// Fallback to plain error object
+						plainErr := NewObject(vm.ErrorPrototype).AsPlainObject()
+						plainErr.SetOwn("name", NewString("SyntaxError"))
+						plainErr.SetOwn("message", NewString(errMsg))
+						errObj = NewValueFromPlainObject(plainErr)
+					}
 				}
 				vm.throwException(errObj)
 				// After exception unwinding, reload frame state

--- a/tests/scripts/eval_direct_runtime_error_catchable.ts
+++ b/tests/scripts/eval_direct_runtime_error_catchable.ts
@@ -1,0 +1,56 @@
+// expect: ReferenceError:true:true:after:undefined:true
+// no-typecheck
+// Same bug as eval_indirect_runtime_error_catchable.ts, but for direct eval
+// (OpDirectEval / DirectEvalCode), which shares the vm.Interpret nested-run
+// codepath but has its own separate error-to-exception wiring in vm.go's
+// OpDirectEval handling.
+function run(): string {
+  let caughtName = "no-throw";
+  let isReferenceError = false;
+  try {
+    eval("undefinedVarInDirectEval;");
+  } catch (e) {
+    caughtName = e.name;
+    isReferenceError =
+      e instanceof ReferenceError &&
+      e.message === "undefinedVarInDirectEval is not defined";
+  }
+
+  let ranAfterCatch = false;
+  let afterMarker = "before";
+  try {
+    eval("(0, 0);");
+    ranAfterCatch = true;
+    afterMarker = "after";
+  } catch (e) {
+    afterMarker = "unexpected-throw";
+  }
+
+  // A thrown `undefined` must come through as-is, not get miscategorized as
+  // "no wrapped exception" (see OpDirectEval's gotExc handling) and
+  // rewrapped as a SyntaxError.
+  let undefThrowType = "no-throw";
+  let undefThrowIsUndefined = false;
+  try {
+    eval("throw undefined;");
+  } catch (e) {
+    undefThrowType = typeof e;
+    undefThrowIsUndefined = e === undefined;
+  }
+
+  return (
+    caughtName +
+    ":" +
+    isReferenceError +
+    ":" +
+    ranAfterCatch +
+    ":" +
+    afterMarker +
+    ":" +
+    undefThrowType +
+    ":" +
+    undefThrowIsUndefined
+  );
+}
+
+run();

--- a/tests/scripts/eval_indirect_runtime_error_catchable.ts
+++ b/tests/scripts/eval_indirect_runtime_error_catchable.ts
@@ -1,0 +1,85 @@
+// expect: ReferenceError:true:true:after:TypeError:true:undefined:true:object:true
+// no-typecheck
+// A runtime exception (e.g. ReferenceError) thrown by code passed to indirect
+// eval() must be catchable by a try/catch surrounding the eval() call, exactly
+// like a parse-time SyntaxError from indirect eval already was. It used to
+// escape and terminate the whole script as an uncaught exception instead -
+// vm.Interpret's nested run() stopped unwinding at the eval script's own
+// top-level frame (a native-call boundary) without ever surfacing that state
+// to the eval() native function, which then reported success. It also used to
+// get rewrapped as a plain SyntaxError on the way out, discarding the real
+// error type/instance.
+var indirectEval = eval;
+
+let caughtName = "no-throw";
+let isReferenceError = false;
+try {
+  indirectEval("undefinedVar1234;");
+} catch (e) {
+  caughtName = e.name;
+  isReferenceError =
+    e instanceof ReferenceError && e.message === "undefinedVar1234 is not defined";
+}
+
+// Execution must continue normally after the catch - this used to never run.
+let ranAfterCatch = false;
+let afterMarker = "before";
+try {
+  indirectEval("(0, 0);");
+  ranAfterCatch = true;
+  afterMarker = "after";
+} catch (e) {
+  afterMarker = "unexpected-throw";
+}
+
+// A different runtime exception type must also come through unwrapped.
+let caughtName2 = "no-throw";
+let isTypeError = false;
+try {
+  indirectEval("null.foo;");
+} catch (e) {
+  caughtName2 = e.name;
+  isTypeError = e instanceof TypeError;
+}
+
+// A thrown primitive that is itself falsy/nullish (as opposed to a genuine
+// parse/compile failure) must also come through as the exact value thrown,
+// not get miscategorized as "no wrapped exception, must be a SyntaxError"
+// because GetExceptionValue() happens to be Undefined/Null too.
+let undefThrowType = "no-throw";
+let undefThrowIsUndefined = false;
+try {
+  indirectEval("throw undefined;");
+} catch (e) {
+  undefThrowType = typeof e;
+  undefThrowIsUndefined = e === undefined;
+}
+
+let nullThrowType = "no-throw";
+let nullThrowIsNull = false;
+try {
+  indirectEval("throw null;");
+} catch (e) {
+  nullThrowType = typeof e;
+  nullThrowIsNull = e === null;
+}
+
+caughtName +
+  ":" +
+  isReferenceError +
+  ":" +
+  ranAfterCatch +
+  ":" +
+  afterMarker +
+  ":" +
+  caughtName2 +
+  ":" +
+  isTypeError +
+  ":" +
+  undefThrowType +
+  ":" +
+  undefThrowIsUndefined +
+  ":" +
+  nullThrowType +
+  ":" +
+  nullThrowIsNull;

--- a/tests/scripts/eval_indirect_runtime_error_uncaught.ts
+++ b/tests/scripts/eval_indirect_runtime_error_uncaught.ts
@@ -1,0 +1,10 @@
+// expect_runtime_error: Uncaught exception: ReferenceError: uncaughtFromEvalXYZ is not defined
+// no-typecheck
+// A runtime exception thrown by indirect eval'd code with no surrounding
+// try/catch must still terminate the script as a genuinely uncaught
+// exception (not print as an internal engine error, and not silently
+// succeed) - pins the message format vm.Interpret's InterpretRuntimeError
+// handling produces once the exception re-crosses into the outer script and
+// is never caught there either.
+var indirectEval = eval;
+indirectEval("uncaughtFromEvalXYZ;");


### PR DESCRIPTION
## Bug

A runtime exception (e.g. `ReferenceError`) thrown by code passed to indirect or direct `eval()` escaped any `try`/`catch` surrounding the `eval()` call and terminated the whole script as if uncaught — even though a parse-time `SyntaxError` from `eval()` was already caught correctly.

```js
var indirectEval = eval;
try {
  indirectEval("undefinedVar1234;");
  console.log("no throw");
} catch (e) {
  console.log("caught: " + e.name + " " + e.message);
}
console.log("after");
```
Expected: `caught: ReferenceError undefinedVar1234 is not defined` then `after`. Actual (before this fix): the script terminated immediately as an uncaught exception — `after` never ran, the catch block never ran.

## Root cause

`eval()` runs the evaluated code via a *nested* `vm.Interpret()` call, which pushes its own top-level `"<script>"` frame with `isDirectCall=true` (since `frameCount > 0` at that point). When the evaluated code throws, `unwindException` treats that frame as a native-call boundary and stops there without popping it or touching `vm.errors` — the same mechanism `executeUserFunctionSafe`/`vm.Call` rely on to hand a catchable exception back to native Go code as a Go `error`. `Interpret()` never performed that conversion, so it returned an empty error slice while leaving `vm.unwinding`/`vm.currentException` dangling: the caller saw a clean, error-free result despite the runtime error, and the stray VM state then corrupted whatever ran next.

`globals_init.go`'s indirect `eval()` and `vm.go`'s `OpDirectEval` also unconditionally rewrapped *any* eval error into a fresh `SyntaxError`, discarding the real exception type/value.

## Fix

- **`vm.Interpret`**: when a nested (eval-style) `Interpret` call's `run()` returns with the exception still unresolved, take ownership of it — extract the value, restore `frameCount`/`nextRegSlot` exactly (the same `truncateFramesTo` idiom `executeUserFunctionSafe` uses for its own native boundary), and return it wrapped (`RuntimeError.Cause`) so the original value survives, via a fresh local error slice rather than the shared `vm.errors` (the caller's own execution keeps running after a nested call returns, and nothing else clears `vm.errors` before it completes).
- **`globals_init.go`** (indirect eval) and **`OpDirectEval`** (direct eval): unwrap that wrapped value and re-throw the original exception instead of manufacturing a `SyntaxError`, using an explicit "found an exception" flag rather than an undefined/null sentinel so `throw undefined`/`throw null` from eval'd code aren't misclassified as parse errors.

## Testing

- Added regression tests under `tests/scripts/`: `eval_indirect_runtime_error_catchable.ts`, `eval_direct_runtime_error_catchable.ts`, `eval_indirect_runtime_error_uncaught.ts` — covering `ReferenceError`/`TypeError` from eval, continued execution after the catch, `throw undefined`/`throw null`, and the genuinely-uncaught-from-eval message format.
- `go test ./tests -run TestScripts` and `go test ./pkg/...` both pass (no regressions against the existing suite, including generator/async/finally uncaught-exception message tests that share the same `Interpret` code path).
- Manually verified indirect eval, direct eval, nested eval, and dynamic `import()` error propagation all still work correctly.

## Note

While investigating, found a related pre-existing bug (not fixed here, flagged separately): `with (obj) { undeclaredVar; }` also isn't catchable — even without eval — because that code path uses `vm.runtimeError` instead of `vm.throwException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)