### PR TITLE
fix(compiler,vm): fix array literal elision holes when mixed with a spread element

### DIFF
--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -677,18 +677,21 @@ func (c *Compiler) compileArrayLiteralWithSpread(node *parser.ArrayLiteral, hint
 
 	// Process each element, adding to the result array
 	// Free registers eagerly to avoid exhaustion with large arrays
-	for _, elem := range node.Elements {
-		switch e := elem.(type) {
-		case *parser.SpreadElement:
+	for i, elem := range node.Elements {
+		if spreadElem, isSpread := elem.(*parser.SpreadElement); isSpread {
 			// Compile the spread expression (should be an array)
 			spreadReg := c.regAlloc.Alloc()
-			_, err := c.compileNode(e.Argument, spreadReg)
+			_, err := c.compileNode(spreadElem.Argument, spreadReg)
 			if err != nil {
 				c.regAlloc.Free(spreadReg)
 				return BadRegister, err
 			}
 
-			// Use OpArraySpread to append all elements from spreadReg to hint
+			// Use OpArraySpread to append all elements from spreadReg to
+			// hint - a real spread must read its source through the
+			// iterator protocol (which resolves a hole in the SOURCE array
+			// to a present Undefined, per spec), so this is deliberately
+			// NOT OpArrayAppendRaw.
 			c.emitOpCode(vm.OpArraySpread, line)
 			c.emitByte(byte(hint))      // DestReg: result array (modified in place)
 			c.emitByte(byte(spreadReg)) // SrcReg: array to spread
@@ -696,32 +699,30 @@ func (c *Compiler) compileArrayLiteralWithSpread(node *parser.ArrayLiteral, hint
 			// Free spreadReg immediately
 			c.regAlloc.Free(spreadReg)
 
-		default:
-			// Regular element: compile and add to array
+		} else {
+			// Regular element (or an elision - see ArrayLiteral.Elisions):
+			// compile it (or load the Hole sentinel for an elision) and
+			// append the raw register value directly. This used to wrap
+			// the element in a synthetic 1-element array and OpArraySpread
+			// that in, which - for an elision - would have resolved the
+			// Hole to Undefined via OpArraySpread's iterator-based read
+			// before it ever reached the destination, silently turning
+			// `[1,,...xs,,2]`'s holes into present undefined values
+			// (paserati#300 follow-up). OpArrayAppendRaw is a plain slice
+			// append (ArrayObject.Append), so a Hole - or any other value -
+			// survives unchanged.
 			elemReg := c.regAlloc.Alloc()
-			_, err := c.compileNode(elem, elemReg)
+			_, err := c.compileArrayLiteralElement(node, i, elemReg, line)
 			if err != nil {
 				c.regAlloc.Free(elemReg)
 				return BadRegister, err
 			}
 
-			// Create a temporary single-element array and spread it
-			singleElemArrayReg := c.regAlloc.Alloc()
-			c.emitOpCode(vm.OpMakeArray, line)
-			c.emitByte(byte(singleElemArrayReg)) // DestReg: temporary array
-			c.emitByte(byte(elemReg))            // StartReg: single element
-			c.emitByte(1)                        // Count: 1 element
+			c.emitOpCode(vm.OpArrayAppendRaw, line)
+			c.emitByte(byte(hint))    // DestReg: result array (modified in place)
+			c.emitByte(byte(elemReg)) // ValueReg: value to append as-is
 
-			// Free elemReg - no longer needed after MakeArray
 			c.regAlloc.Free(elemReg)
-
-			// Spread the single-element array into the result
-			c.emitOpCode(vm.OpArraySpread, line)
-			c.emitByte(byte(hint))               // DestReg: result array (modified in place)
-			c.emitByte(byte(singleElemArrayReg)) // SrcReg: single-element array
-
-			// Free singleElemArrayReg - no longer needed after spread
-			c.regAlloc.Free(singleElemArrayReg)
 		}
 	}
 

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -303,6 +303,19 @@ const (
 	OpAllocArray OpCode = 77 // Rx Len(16bit): Preallocate array of length Len into Rx, filled with undefined
 	OpArrayCopy  OpCode = 78 // Rx DestOffset(16bit) StartReg Count: Copy Count registers starting at StartReg into Rx at DestOffset
 
+	// --- Spread-Literal Element Append ---
+	// OpArrayAppendRaw appends the raw value in Ry to the end of the array in
+	// Rx (growing .length by 1), the same plain slice-append ArrayObject.Append
+	// already does in Go - unlike OpArraySpread, it never reads Ry through the
+	// iterator protocol first, so a Hole value (an array-literal elision - see
+	// compileArrayLiteralElement, paserati#300) survives the append unchanged
+	// instead of being resolved to Undefined. compileArrayLiteralWithSpread
+	// uses this for every regular (non-spread) element in a literal that also
+	// has a spread element, since the destination array's length at that
+	// point is only known at runtime (a prior spread may have contributed a
+	// variable number of items), ruling out OpArrayCopy's compile-time offset.
+	OpArrayAppendRaw OpCode = 179 // Rx Ry: Rx.elements = append(Rx.elements, Ry); Rx.length++
+
 	// --- Accessor Property Support ---
 	OpDefineAccessor        OpCode = 80 // ObjReg GetterReg SetterReg NameIdx(16bit): Define accessor property on object
 	OpDefineAccessorDynamic OpCode = 84 // ObjReg GetterReg SetterReg NameReg: Define accessor property with dynamic name
@@ -671,6 +684,8 @@ func (op OpCode) String() string {
 		return "OpAllocArray"
 	case OpArrayCopy:
 		return "OpArrayCopy"
+	case OpArrayAppendRaw:
+		return "OpArrayAppendRaw"
 	case OpDefineAccessor:
 		return "OpDefineAccessor"
 	case OpDefineAccessorDynamic:
@@ -1170,6 +1185,8 @@ func (c *Chunk) disassembleInstruction(builder *strings.Builder, offset int) int
 	case OpArraySlice:
 		return c.registerRegisterRegisterInstruction(builder, instruction.String(), offset)
 	case OpArraySpread:
+		return c.registerRegisterInstruction(builder, instruction.String(), offset)
+	case OpArrayAppendRaw:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset)
 	case OpObjectSpread:
 		return c.registerRegisterInstruction(builder, instruction.String(), offset)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8943,6 +8943,29 @@ startExecution:
 			// Update array length
 			destArray.length = len(destArray.elements)
 
+		// --- Spread-Literal Element Append ---
+		case OpArrayAppendRaw:
+			destReg := code[ip]
+			valueReg := code[ip+1]
+			ip += 2
+
+			destVal := registers[destReg]
+			if destVal.Type() != TypeArray {
+				frame.ip = ip
+				status := vm.runtimeError("OpArrayAppendRaw: destination must be an array, got '%v'", destVal.Type())
+				return status, Undefined
+			}
+
+			// A plain raw append - unlike OpArraySpread, this never reads
+			// valueReg through the iterator/[[Get]] protocol first, so a
+			// Hole value (an array-literal elision alongside a spread
+			// element in the same literal, e.g. [1,,...xs,,2] - see
+			// compileArrayLiteralWithSpread, paserati#300) survives the
+			// append unchanged instead of being resolved to Undefined.
+			destArray := AsArray(destVal)
+			destArray.elements = append(destArray.elements, registers[valueReg])
+			destArray.length = len(destArray.elements)
+
 		// --- NEW: Object Spread Support ---
 		case OpObjectSpread:
 			destReg := code[ip]

--- a/tests/scripts/issue300_array_holes_elision_with_spread.ts
+++ b/tests/scripts/issue300_array_holes_elision_with_spread.ts
@@ -1,0 +1,80 @@
+// expect: true
+// paserati#300 follow-up: an elision that coexists with a spread element in
+// the same array literal (e.g. [1,,...xs,,2]) went through a different
+// compiler path - compileArrayLiteralWithSpread, used whenever the literal
+// contains at least one SpreadElement - which was untouched by the original
+// #300 fix (compileArrayLiteralSimple only) and still materialized those
+// elisions as a real `undefined` value instead of a hole.
+//
+// Root cause: that path builds the result incrementally, appending each
+// element via OpArraySpread (wrapping a plain element in a synthetic
+// 1-element array first). OpArraySpread reads its source through the real
+// ECMAScript iterator protocol, which resolves a Hole back into Undefined -
+// so stuffing a Hole into the synthetic carrier array and spreading it
+// would never survive the round trip. Fixed with a new opcode,
+// OpArrayAppendRaw, that appends one register's raw value directly (a
+// plain ArrayObject.Append - the same primitive `delete`/`new Array(n)`
+// already use), bypassing any iterator/property-set semantics; a genuine
+// spread element (`...xs`) still goes through OpArraySpread as before,
+// since THAT must resolve a hole in its own source array to Undefined per
+// spec - only the plain-element/elision case changed.
+const checks: boolean[] = [];
+
+const xs = [10, 20];
+const mixed: any = [1, , ...xs, , 2];
+checks.push(mixed.length === 6);
+checks.push(JSON.stringify(mixed) === "[1,null,10,20,null,2]");
+
+// Elided positions: real holes, absent everywhere.
+checks.push((1 in mixed) === false);
+checks.push((4 in mixed) === false);
+checks.push(mixed.hasOwnProperty(1) === false);
+checks.push(mixed.hasOwnProperty(4) === false);
+checks.push(Object.keys(mixed).join(",") === "0,2,3,5");
+checks.push(Object.getOwnPropertyNames(mixed).join(",") === "0,2,3,5,length");
+
+// Regular and spread-contributed positions: present, unaffected.
+checks.push((0 in mixed) === true && mixed[0] === 1);
+checks.push((2 in mixed) === true && mixed[2] === 10);
+checks.push((3 in mixed) === true && mixed[3] === 20);
+checks.push((5 in mixed) === true && mixed[5] === 2);
+
+const visited: number[] = [];
+mixed.forEach((v: any, i: number) => visited.push(i));
+checks.push(visited.join(",") === "0,2,3,5");
+
+// Elision immediately before a spread, with nothing before it.
+const leading: any = [, ...xs];
+checks.push(leading.length === 3);
+checks.push((0 in leading) === false);
+checks.push((1 in leading) === true && leading[1] === 10);
+checks.push((2 in leading) === true && leading[2] === 20);
+
+// Elision immediately after a spread, with nothing after it.
+const trailing: any = [...xs, ,];
+checks.push(trailing.length === 3);
+checks.push((0 in trailing) === true && (1 in trailing) === true);
+checks.push((2 in trailing) === false);
+
+// Multiple consecutive elisions surrounding a spread.
+const both: any = [, , ...xs, , ,];
+checks.push(both.length === 6);
+checks.push((0 in both) === false && (1 in both) === false);
+checks.push((2 in both) === true && (3 in both) === true);
+checks.push((4 in both) === false && (5 in both) === false);
+checks.push(Object.keys(both).join(",") === "2,3");
+
+// Note: a spread whose SOURCE array has its own real hole (e.g.
+// `[...[100,,300]]`) is a separate, still-open gap (spread reads its
+// source's elements raw instead of resolving a hole to undefined per the
+// iterator protocol) - untouched by this fix, which only changes how a
+// literal's OWN elision is appended, not how OpArraySpread reads a spread
+// argument. Not asserted here; tracked separately.
+
+// A real `undefined` element next to a spread must NOT become a hole.
+const real: any = [1, undefined, ...xs];
+checks.push((1 in real) === true);
+checks.push(real.hasOwnProperty(1) === true);
+checks.push(Object.keys(real).join(",") === "0,1,2,3");
+
+checks.every((c) => c === true);

--- a/tests/scripts/issue300_array_holes_literal_elision.ts
+++ b/tests/scripts/issue300_array_holes_literal_elision.ts
@@ -10,8 +10,8 @@
 // issue300_array_holes_delete_and_new_array.ts) now agree for literals too.
 //
 // Elisions mixed with a spread element in the same literal ([1,,...xs,,2])
-// are a separate, NOT-yet-fixed gap (that path still materializes them as
-// real `undefined`) - not covered here.
+// go through a different compiler path (compileArrayLiteralWithSpread) and
+// are covered separately - see issue300_array_holes_elision_with_spread.ts.
 const checks: boolean[] = [];
 
 const h: any = [1, , 3];


### PR DESCRIPTION
Re-opens #307, whose base branch (fix-300-array-holes) no longer exists after #305 merged. Rebased onto current main; no content changes.