### PR TITLE
fix(vm): make ReferenceError from with-property lookup catchable

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -5021,13 +5021,39 @@ startExecution:
 						registers[destReg] = val
 					} else {
 						frame.ip = ip
-						status := vm.runtimeError("%s is not defined", propName)
-						return status, Undefined
+						vm.ThrowReferenceError(fmt.Sprintf("%s is not defined", propName))
+						if vm.handlerFound {
+							vm.handlerFound = false
+							goto reloadFrame
+						}
+						if !vm.unwinding {
+							// Exception was caught by a handler, reload frame and continue
+							frame = &vm.frames[vm.frameCount-1]
+							closure = frame.closure
+							function = closure.Fn
+							registers = frame.registers
+							ip = frame.ip
+							goto reloadFrame
+						}
+						return InterpretRuntimeError, Undefined
 					}
 				} else {
 					frame.ip = ip
-					status := vm.runtimeError("%s is not defined", propName)
-					return status, Undefined
+					vm.ThrowReferenceError(fmt.Sprintf("%s is not defined", propName))
+					if vm.handlerFound {
+						vm.handlerFound = false
+						goto reloadFrame
+					}
+					if !vm.unwinding {
+						// Exception was caught by a handler, reload frame and continue
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						registers = frame.registers
+						ip = frame.ip
+						goto reloadFrame
+					}
+					return InterpretRuntimeError, Undefined
 				}
 			}
 

--- a/tests/scripts/with_undefined_property_catchable.ts
+++ b/tests/scripts/with_undefined_property_catchable.ts
@@ -1,0 +1,28 @@
+// expect: ReferenceError:true:after
+// no-typecheck
+// A `with` block reading an identifier that exists neither on the with-object
+// nor at global scope must raise a normal, catchable ReferenceError - not an
+// uncatchable internal error that aborts the whole script. The OpGetWithProperty
+// handler used to call vm.runtimeError(...) directly for this "not found
+// anywhere" fallback case, which appends to vm.errors and returns
+// InterpretRuntimeError without going through vm.throwException/unwindException,
+// so no surrounding try/catch (even one directly wrapping the with block) could
+// ever catch it.
+let caughtName = "no-throw";
+let isReferenceError = false;
+try {
+  with ({}) {
+    undefinedInsideWithXYZ;
+  }
+} catch (e) {
+  caughtName = e.name;
+  isReferenceError =
+    e instanceof ReferenceError &&
+    e.message === "undefinedInsideWithXYZ is not defined";
+}
+
+// Execution must continue normally after the catch.
+let afterMarker = "before";
+afterMarker = "after";
+
+caughtName + ":" + isReferenceError + ":" + afterMarker;


### PR DESCRIPTION
## Summary

`OpGetWithProperty`'s fallback path — reached when an identifier read inside a `with (obj) { ... }` block is found on neither the with-object nor the global scope — called `vm.runtimeError(...)` directly at both of its "not defined" call sites. That helper appends to `vm.errors` and returns `InterpretRuntimeError` directly, bypassing `vm.throwException`/`vm.unwindException` entirely. As a result the ReferenceError was **uncatchable** by any surrounding `try/catch`, even one wrapping the `with` block in the same non-nested, non-eval script — the whole script aborted instead.

A few lines above, the strict-mode branch for the analogous "not found in any with-object scope" case already does this correctly via `vm.ThrowReferenceError(...)` followed by the standard `handlerFound`/`unwinding` checks and frame-reload dance. This PR converts the two `vm.runtimeError(...)` sites to that same pattern.

## Repro

```js
try {
  with ({}) { undefinedInsideWithXYZ; }
  console.log("no throw");
} catch (e) {
  console.log("caught: " + e.name);
}
console.log("after");
```

- Before: script aborts as an uncaught internal error; `"after"` never runs.
- After: prints `caught: ReferenceError` then `after`.

## Testing

- Added `tests/scripts/with_undefined_property_catchable.ts` (modeled on `eval_indirect_runtime_error_catchable.ts`), asserting the error is a catchable `ReferenceError` with the correct message and that execution continues after the `catch`.
- `go build ./...` passes.
- `go test ./tests -run TestScripts` — full smoke suite green, no regressions.

Note: the identical bug pattern also exists in `OpGetWithByBinding`'s analogous fallback (the inline-cache/binding-resolved variant of with-property lookup). Left out of scope for this PR since it wasn't part of the reported issue, but worth a follow-up.