### PR TITLE
fix(vm): for-in enumerates a RegExp's own side-table properties

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14519,6 +14519,51 @@ startExecution:
 						cur = pv.AsPlainObject()
 					}
 				}
+			case TypeRegExp:
+				// Enumerate own enumerable properties on the RegExp's side
+				// table (OwnPropertiesTable, pkg/vm/properties_table.go -
+				// the same lazily-allocated PlainObject Function/Closure/
+				// Map/Set/Promise use) - mirrors the identical TypeFunction/
+				// TypeClosure/TypeBoundFunction cases above. This case was
+				// missing entirely, so `for (k in regex)` came back with
+				// nothing even after `regex.x = 1`. "lastIndex" never
+				// appears here: it's a real Go field on RegExpObject, not a
+				// side-table entry, and it's {enumerable: false} in any
+				// case (see reflectDeleteProperty's TypeRegExp case and
+				// Object.getOwnPropertyDescriptor's TypeRegExp handling,
+				// both in pkg/builtins). Nothing from RegExp.prototype
+				// surfaces either - its own methods are all non-enumerable,
+				// same as Function.prototype's for the cases above. The
+				// `cur.GetPrototype()` walk below only *looks* like it
+				// continues into the real prototype chain: a side table's
+				// own prototype field is always Undefined (see
+				// newPropertiesTable's doc comment), so the loop never
+				// actually advances past the table itself - an enumerable
+				// property defined directly on a RegExp subclass's
+				// prototype (rather than RegExp.prototype, which has none)
+				// is therefore not enumerated, same pre-existing structural
+				// gap the TypeFunction/TypeClosure/TypeBoundFunction cases
+				// above already have for a subclassed callable.
+				regexObj := objValue.AsRegExpObject()
+				if regexObj != nil && regexObj.Properties != nil {
+					seen := make(map[string]bool)
+					cur := regexObj.Properties
+					for cur != nil {
+						for _, k := range cur.OwnKeys() {
+							if !seen[k] {
+								keys = append(keys, k)
+							}
+						}
+						for _, k := range cur.OwnPropertyNames() {
+							seen[k] = true
+						}
+						pv := cur.GetPrototype()
+						if !pv.IsObject() {
+							break
+						}
+						cur = pv.AsPlainObject()
+					}
+				}
 			default:
 				// For primitive types, return empty array
 				keys = []string{}

--- a/tests/scripts/for_in_regexp.ts
+++ b/tests/scripts/for_in_regexp.ts
@@ -1,0 +1,56 @@
+// expect: true
+// OpGetOwnKeys (pkg/vm/vm.go) drives for-in enumeration by switching on the
+// object's type - it had no `case TypeRegExp:` at all, so `for (k in regex)`
+// always came back with nothing, even after `regex.x = 1`, while the
+// identical TypeFunction/TypeClosure/TypeBoundFunction cases already
+// enumerated their own side table's own enumerable keys correctly.
+const checks: boolean[] = [];
+
+function forInKeys(obj: any): string[] {
+  const keys: string[] = [];
+  for (const k in obj) {
+    keys.push(k);
+  }
+  return keys;
+}
+
+// --- a custom enumerable own property assigned directly onto the
+// instance is enumerated ---
+const r: any = /x/g;
+r.custom = 42;
+checks.push(forInKeys(r).join(",") === "custom");
+
+// --- a RegExp with no custom properties enumerates nothing ---
+const r2: any = /y/;
+checks.push(forInKeys(r2).length === 0);
+
+// --- "lastIndex" (own, but {enumerable: false} - it's a real Go field on
+// RegExpObject, not a side-table entry) never appears ---
+const r3: any = /z/g;
+checks.push(forInKeys(r3).indexOf("lastIndex") === -1);
+
+// --- inherited RegExp.prototype methods (test/exec/...) are all
+// non-enumerable, so none of them appear either ---
+checks.push(forInKeys(r3).indexOf("test") === -1);
+checks.push(forInKeys(r3).indexOf("exec") === -1);
+
+// --- a non-enumerable custom property (via Object.defineProperty) is
+// correctly excluded, while an enumerable one alongside it still shows ---
+const r4: any = /w/g;
+Object.defineProperty(r4, "hidden", {
+  value: 1,
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+r4.visible = 2;
+checks.push(forInKeys(r4).join(",") === "visible");
+
+// --- a symbol-keyed own property never appears (for-in is string-keys
+// only, per spec) ---
+const r5: any = /v/g;
+r5[Symbol.iterator] = function () {};
+r5.named = 1;
+checks.push(forInKeys(r5).join(",") === "named");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

`for-in` never enumerated a RegExp's own properties, even a plain enumerable one assigned directly onto the instance:

```js
const r = /x/g;
r.custom = 42;
for (const k in r) { console.log(k); } // paserati: nothing — Node: "custom"
```

Third instance of the same class of bug surfacing in this session (an exotic kind missing from a switch that dispatches per `objValue.Type()`, following the `in`/`Reflect.has` fix in [#323](https://github.com/nooga/paserati/pull/323) and the `Object`/`Reflect.defineProperty` fix in [#329](https://github.com/nooga/paserati/pull/329)) — `OpGetOwnKeys`, which drives `for-in` enumeration, has cases for `TypeObject`, `TypeDictObject`, `TypeArray`, `TypeArguments`, `TypeFunction`, `TypeClosure`, and `TypeBoundFunction`, but none at all for `TypeRegExp`.

## Fix

Added a `TypeRegExp` case mirroring the identical `TypeFunction`/`TypeClosure`/`TypeBoundFunction` cases exactly — enumerate the RegExp's side table (`OwnPropertiesTable`) own enumerable keys. `lastIndex` never appears: it's a real Go field on `RegExpObject`, not a side-table entry, and it's non-enumerable regardless. Nothing from `RegExp.prototype` surfaces either, since its own methods are all non-enumerable.

**Noted, not fixed:** the `cur.GetPrototype()` walk in all four of these cases only ever runs once in practice — a side table's own prototype field is always `Undefined` (not the value's real `[[Prototype]]`), so an enumerable property defined directly on a RegExp (or Function/Closure/BoundFunction) *subclass's* prototype isn't enumerated. Confirmed against Node this diverges, but it's a pre-existing structural limitation shared by all four cases, not something this fix introduces — documented in the new case's comment rather than fixed here.

## Testing

- `tests/scripts/for_in_regexp.ts`: a custom enumerable own property is enumerated; a RegExp with none enumerates empty; `lastIndex` and inherited prototype methods (`test`/`exec`) never appear; a non-enumerable custom property (via `Object.defineProperty`) is excluded while an enumerable one alongside it still shows; a symbol-keyed own property never appears.
- `go test ./tests -run TestScripts` and `./pkg/vm/...` both pass (`-timeout 180s`).
- Verified against Node throughout, including the subclass-prototype edge case noted above.

## Out of scope (flagged separately)

The identical gap exists for `TypeMap`/`TypeSet`/`TypePromise` in the same `OpGetOwnKeys` switch — not fixed here, flagged as a follow-up.

Based on `main` at 472148b7.
