### PR TITLE
fix(builtins): Object.getOwnPropertyDescriptors on RegExp/Map/Set/Promise

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -5023,6 +5023,31 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 				}
 			}
 		}
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+		// These exotic kinds keep their ordinary own properties in the same
+		// lazily-allocated side table (OwnPropertiesTable, pkg/vm/
+		// properties_table.go) as Function/Closure/NativeFunctionWithProps
+		// above - this case was missing entirely, so
+		// Object.getOwnPropertyDescriptors always returned {} for one of
+		// these four kinds even after a real own property had been defined
+		// or assigned on it, despite the single-key
+		// Object.getOwnPropertyDescriptor already answering correctly for
+		// the exact same property.
+		//
+		// RegExp's "lastIndex" is its own case: like TypeFunction's
+		// synthesized "length"/"name"/"prototype" intrinsics above, it is a
+		// real own property that isn't stored in the side table at all (a
+		// Go field on RegExpObject instead - see
+		// objectGetOwnPropertyDescriptorWithVM's TypeRegExp handling, same
+		// file), so it has to be added explicitly rather than falling out
+		// of OwnPropertyNames().
+		if obj.Type() == vm.TypeRegExp {
+			stringKeys = append(stringKeys, "lastIndex")
+		}
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			stringKeys = append(stringKeys, props.OwnPropertyNames()...)
+			symbolKeys = append(symbolKeys, props.OwnSymbolKeys()...)
+		}
 	}
 
 	// Get descriptor for each string key

--- a/tests/scripts/get_own_property_descriptors_exotic.ts
+++ b/tests/scripts/get_own_property_descriptors_exotic.ts
@@ -1,0 +1,91 @@
+// expect: true
+// Object.getOwnPropertyDescriptors collected its keys via its own local
+// switch on obj.Type() (separate from the single-key
+// Object.getOwnPropertyDescriptor) - it had no case at all for
+// TypeRegExp/TypeMap/TypeSet/TypePromise, so stringKeys/symbolKeys stayed
+// empty and it always returned {} for one of these four kinds, even after
+// a real own property had been defined or assigned on it, despite the
+// single-key getOwnPropertyDescriptor already answering correctly for the
+// exact same property (paserati#329).
+const checks: boolean[] = [];
+
+function hasDataDesc(
+  descs: any,
+  key: string,
+  value: unknown,
+  writable: boolean,
+  enumerable: boolean,
+  configurable: boolean
+): boolean {
+  const d = descs[key];
+  return (
+    d !== undefined &&
+    d.value === value &&
+    d.writable === writable &&
+    d.enumerable === enumerable &&
+    d.configurable === configurable
+  );
+}
+
+// --- RegExp with no custom property still reports "lastIndex" (a real
+// own property that lives on the RegExpObject itself, not the side
+// table - the only kind of these four with an intrinsic own property to
+// add alongside whatever the side table holds) ---
+const descsEmpty: any = Object.getOwnPropertyDescriptors(/x/g);
+checks.push(
+  Object.keys(descsEmpty).length === 1 &&
+    hasDataDesc(descsEmpty, "lastIndex", 0, true, false, false)
+);
+
+// --- RegExp with a custom property reports both ---
+const r: any = /y/g;
+r.custom = 1;
+const descsR: any = Object.getOwnPropertyDescriptors(r);
+checks.push(
+  hasDataDesc(descsR, "lastIndex", 0, true, false, false) &&
+    hasDataDesc(descsR, "custom", 1, true, true, true)
+);
+
+// --- Map/Set/Promise with a custom property ---
+const m: any = new Map();
+m.custom = 2;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(m), "custom", 2, true, true, true));
+
+const s: any = new Set();
+s.custom = 3;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(s), "custom", 3, true, true, true));
+
+const p: any = Promise.resolve(1);
+p.custom = 4;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(p), "custom", 4, true, true, true));
+
+// --- a symbol key round-trips too (via Object.defineProperty - bracket
+// assignment with a computed key on these kinds has its own, separate,
+// unrelated pre-existing gap) ---
+const m2: any = new Map();
+const sym = Symbol("k");
+Object.defineProperty(m2, sym, {
+  value: 5,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+const descsSym: any = Object.getOwnPropertyDescriptors(m2);
+checks.push(
+  descsSym[sym] !== undefined &&
+    descsSym[sym].value === 5 &&
+    descsSym[sym].writable &&
+    descsSym[sym].enumerable &&
+    descsSym[sym].configurable
+);
+
+// --- a Map/Set/Promise with nothing custom on it reports no custom keys
+// (Map/Set's own "size" isn't an own property, it's an accessor on
+// Map.prototype/Set.prototype). Object.keys on the *result* object counts
+// string keys only - fine here since none of these three fixtures carry
+// a symbol; the m2 case above is what covers symbol-key round-tripping. ---
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(new Map())).length === 0);
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(new Set())).length === 0);
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(Promise.resolve(1))).length === 0);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Stacked on [#329](https://github.com/nooga/paserati/pull/329) — this fix's per-key lookups call `objectGetOwnPropertyDescriptorWithVM`, whose `TypeMap`/`TypeSet`/`TypePromise` support only exists on that branch (RegExp's read side predates both).

`objectGetOwnPropertyDescriptorsWithVM` (plural) collects an object's own keys via its own local `switch obj.Type()` — separate from the single-key `objectGetOwnPropertyDescriptorWithVM` that #329 already fixed for these four kinds. That switch had no case at all for `TypeRegExp`/`TypeMap`/`TypeSet`/`TypePromise`, so `stringKeys`/`symbolKeys` stayed empty and the function always returned `{}` for one of these four kinds, even after a real own property had been defined or assigned on it:

```js
const m = new Map();
m.custom = 1;
console.log(Object.getOwnPropertyDescriptors(m)); // paserati: {} — Node: { custom: {...} }
```

## Fix

One case covering all four kinds via `vm.OwnPropertiesTable(obj)` (read-only is fine here) for the side table's own keys, mirroring the `TypeObject` case's `OwnPropertyNames()`/`OwnSymbolKeys()` pair. `RegExp`'s `lastIndex` needs one extra line — like `TypeFunction`'s synthesized `length`/`name`/`prototype` intrinsics, it's a real own property that isn't stored in the side table at all (a Go field on `RegExpObject`), so it's appended explicitly.

## Testing

Verified against Node: RegExp with and without a custom property (confirming `lastIndex`'s own descriptor shape), Map/Set/Promise with a custom property, a symbol key, and the no-custom-property empty case for Map/Set/Promise.

- `tests/scripts/get_own_property_descriptors_exotic.ts`
- `go test ./tests -run TestScripts` (`-timeout 180s`) and `./pkg/vm/... ./pkg/builtins/...` all pass.

## Found, not fixed (separate pre-existing bug)

While testing the symbol-key case I found bracket-notation assignment on a Map throws unconditionally — even for a plain string key:

```js
const m = new Map();
m["key"] = 1; // throws: "Cannot set index on non-array/object/typedarray type 'map'"
```

Dot-notation (`m.key = 1`) and `Object.defineProperty` both work fine — this is a different subsystem (the computed-member assignment opcode), not this file. Flagged separately; the test's symbol-key case routes around it via `Object.defineProperty`.

Based on `fix-define-property-exotic-side-table` (#329).
