### PR TITLE
fix(vm): for-in enumerates Map/Set/Promise own side-table properties

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3292,7 +3292,15 @@ startExecution:
 						}
 					}
 				case TypePromise:
-					// Walk Promise prototype chain for symbol properties
+					// Own side-table symbol property first (same table a
+					// plain assignment/Object.defineProperty writes into -
+					// see the non-symbol TypePromise case below), then walk
+					// the Promise.prototype chain for symbol properties.
+					promiseObj := objVal.AsPromise()
+					if promiseObj.Properties != nil && promiseObj.Properties.HasOwnByKey(NewSymbolKey(propVal)) {
+						hasProperty = true
+						break
+					}
 					proto := vm.PromisePrototype
 					if proto.IsObject() {
 						for cur := proto.AsPlainObject(); cur != nil; {
@@ -3671,9 +3679,23 @@ startExecution:
 						hasProperty = vm.ObjectPrototype.AsPlainObject().Has(propKey)
 					}
 				case TypePromise:
-					// Promise objects: check Promise.prototype chain
-					// Promises don't have user-accessible own properties, only internal state
-					if vm.PromisePrototype.IsObject() {
+					// Promise: a plain property CAN be assigned directly onto
+					// one (e.g. a subclass constructor doing `this.foo = 1`
+					// after super() - see op_setprop.go's TypePromise case,
+					// which writes into the same side table as Map/Set) even
+					// though a Promise exposes no *intrinsic* own state of its
+					// own - check that side table before falling back to
+					// Promise.prototype. This own-properties check was
+					// missing entirely (the stale comment here claimed
+					// Promises "don't have user-accessible own properties" -
+					// they do, once anything is assigned), so `in` answered
+					// false for an own property Reflect.has already found,
+					// and for-in's per-key re-verification (see
+					// TypeBoundFunction's comment above) silently dropped
+					// every such key that OpGetOwnKeys had just found.
+					if promiseObj := objVal.AsPromise(); promiseObj.Properties != nil && promiseObj.Properties.HasOwn(propKey) {
+						hasProperty = true
+					} else if vm.PromisePrototype.IsObject() {
 						hasProperty = vm.PromisePrototype.AsPlainObject().Has(propKey)
 					}
 				case TypeRegExp:
@@ -14548,6 +14570,41 @@ startExecution:
 				if regexObj != nil && regexObj.Properties != nil {
 					seen := make(map[string]bool)
 					cur := regexObj.Properties
+					for cur != nil {
+						for _, k := range cur.OwnKeys() {
+							if !seen[k] {
+								keys = append(keys, k)
+							}
+						}
+						for _, k := range cur.OwnPropertyNames() {
+							seen[k] = true
+						}
+						pv := cur.GetPrototype()
+						if !pv.IsObject() {
+							break
+						}
+						cur = pv.AsPlainObject()
+					}
+				}
+			case TypeMap, TypeSet, TypePromise:
+				// Same side table as TypeRegExp just above (OwnPropertiesTable,
+				// pkg/vm/properties_table.go) - this case was missing
+				// entirely, so `for (k in map)`/`for (k in set)`/
+				// `for (k in promise)` came back with nothing even after a
+				// plain assignment onto the value. Map/Set's own "size" is
+				// never an own property (it's a getter on Map.prototype/
+				// Set.prototype - Object.getOwnPropertyDescriptor(new Map(),
+				// "size") is undefined in Node), and Promise exposes no
+				// user-accessible own state, so only the side table matters
+				// here, same as RegExp's "lastIndex" staying excluded above.
+				// OwnPropertiesTable abstracts over the three kinds' actual
+				// field names (MapObject/SetObject/PromiseObject.Properties)
+				// via ownPropertiesSlot, so one case covers all three
+				// instead of duplicating the TypeRegExp case's body three
+				// times.
+				if props := OwnPropertiesTable(objValue); props != nil {
+					seen := make(map[string]bool)
+					cur := props
 					for cur != nil {
 						for _, k := range cur.OwnKeys() {
 							if !seen[k] {

--- a/tests/scripts/for_in_map_set_promise.ts
+++ b/tests/scripts/for_in_map_set_promise.ts
@@ -1,0 +1,62 @@
+// expect: true
+// OpGetOwnKeys (pkg/vm/vm.go) drives for-in enumeration by switching on the
+// object's type - it had cases for TypeObject, TypeDictObject, TypeArray,
+// TypeArguments, TypeFunction, TypeClosure, TypeBoundFunction, and (as of a
+// prior fix) TypeRegExp, but none at all for TypeMap/TypeSet/TypePromise.
+// `for (k in map/set/promise)` always came back with nothing, even after a
+// plain assignment onto the value.
+//
+// Fixing the enumeration alone was not enough to make for-in over a
+// Promise agree with Node: for-in's compiled bytecode re-verifies each
+// enumerated key via OpIn's HasProperty-style check before yielding it in
+// the loop body (see TypeBoundFunction's comment in OpIn, same file, for
+// the identical mechanism) - and OpIn's TypePromise case never checked its
+// own side table at all, only Promise.prototype, so every key
+// OpGetOwnKeys had just found for a Promise was silently dropped again.
+// Fixed both together: OpGetOwnKeys gained a TypeMap/TypeSet/TypePromise
+// case, and OpIn's TypePromise case (both the string-key and symbol-key
+// switches) now checks the same side table Reflect.has already did.
+const checks: boolean[] = [];
+
+function forInKeys(obj: any): string[] {
+  const keys: string[] = [];
+  for (const k in obj) {
+    keys.push(k);
+  }
+  return keys;
+}
+
+// --- Map: a custom enumerable own property is enumerated; an empty one
+// enumerates nothing; "size" (an accessor on Map.prototype, not an own
+// property) and an inherited method (get) never appear ---
+const m: any = new Map();
+m.custom = 42;
+checks.push(forInKeys(m).join(",") === "custom");
+checks.push(forInKeys(new Map()).length === 0);
+checks.push(forInKeys(m).indexOf("size") === -1);
+checks.push(forInKeys(m).indexOf("get") === -1);
+
+// --- Set: same shape ---
+const s: any = new Set();
+s.custom = 1;
+checks.push(forInKeys(s).join(",") === "custom");
+checks.push(forInKeys(new Set()).length === 0);
+checks.push(forInKeys(s).indexOf("size") === -1);
+checks.push(forInKeys(s).indexOf("add") === -1);
+
+// --- Promise: same shape, plus this is the one that also needed the
+// OpIn fix (see file comment above) - without it this enumerated empty
+// despite OpGetOwnKeys finding "custom" ---
+const p: any = Promise.resolve(1);
+p.custom = 2;
+checks.push(forInKeys(p).join(",") === "custom");
+checks.push(forInKeys(Promise.resolve(1)).length === 0);
+checks.push(forInKeys(p).indexOf("then") === -1);
+
+// --- `in` and Reflect.has on a Promise's own property now agree, the
+// concrete symptom of the OpIn gap this fix closed alongside for-in ---
+const p2: any = Promise.resolve(3);
+p2.viaAssign = 1;
+checks.push(("viaAssign" in p2) && Reflect.has(p2, "viaAssign"));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

Stacked on [#330](https://github.com/nooga/paserati/pull/330) — mirrors the `TypeRegExp` case that branch adds to `OpGetOwnKeys`.

`OpGetOwnKeys` (drives `for-in` enumeration) had cases for `TypeObject`, `TypeDictObject`, `TypeArray`, `TypeArguments`, `TypeFunction`, `TypeClosure`, `TypeBoundFunction`, and `TypeRegExp`, but none at all for `TypeMap`/`TypeSet`/`TypePromise`:

```js
const m = new Map();
m.custom = 42;
for (const k in m) { console.log(k); } // paserati: nothing — Node: "custom"
```

## The coupling I found

Fixing enumeration alone didn't make `for-in` over a **Promise** agree with Node. Debug instrumentation showed `OpGetOwnKeys` correctly finding a Promise's custom property — yet the loop still yielded nothing. `for-in`'s compiled bytecode re-verifies each enumerated key via `OpIn`'s `HasProperty`-style check before yielding it (the exact mechanism `TypeBoundFunction`'s own comment in `OpIn` already documents, from a prior fix) — and `OpIn`'s `TypePromise` case never checked its own side table at all, only `Promise.prototype`, on the stale premise that "Promises don't have user-accessible own properties" (false once anything is assigned — the same case `Reflect.has` already got right). So every key `OpGetOwnKeys` had just found for a Promise was silently dropped again.

Fixed both together: the missing `OpGetOwnKeys` case, and `OpIn`'s `TypePromise` case (string-key and symbol-key switches) now checks the side table first, same as `TypeMap`/`TypeSet` already do. The symbol-key half is verified by mirroring that already-working pattern rather than empirically — this branch has no way to set a symbol-keyed property on a Promise (`Object.defineProperty` for Promise is only fixed in the still-unmerged #329; bracket-notation assignment is a separate, also-unfixed gap).

## ⚠️ Merge-order note for #329

The concrete symptom of the `OpIn` half — `in` and `Reflect.has` disagreeing on a Promise's own property — was previously flagged and pinned as a **known-broken** assertion in #329's `define_property_exotic_side_table.ts`:
```ts
checks.push(Reflect.has(pIn, "viaAssign") && !("viaAssign" in pIn)); // known gap
```
This fix closes that gap, so that assertion goes stale once both land. I'm pushing a one-line fix to that branch as a follow-up (flip to `&& ("viaAssign" in pIn)`, drop the "known gap" comment) so `main` doesn't go red regardless of merge order.

## Testing

`tests/scripts/for_in_map_set_promise.ts`: Map/Set/Promise each enumerate a custom own property, an empty one enumerates nothing, `size`/inherited methods never appear, and `in`/`Reflect.has` agree on a Promise's own property.

`go test ./tests -run TestScripts` and `./pkg/vm/... ./pkg/builtins/...` all pass (`-timeout 180s`).

Based on `fix-forin-regexp-ownkeys` (#330).
