### PR TITLE
fix(vm): bracket-notation assignment on Map/Set/Promise, and a symbol-key attribute bug it surfaced

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2089,6 +2089,23 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 			}
 		}
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+		// Same side table as the exotic kinds above (OwnPropertiesTable,
+		// pkg/vm/properties_table.go) - this case was missing entirely, so
+		// Object.keys always came back empty for these four kinds even
+		// after a custom own property was defined on one (e.g. r.custom =
+		// 42, or Object.defineProperty once that gap is fixed too).
+		// RegExp's "lastIndex" never appears here: it's a real Go field on
+		// RegExpObject, not a side-table entry, and it's non-enumerable in
+		// any case (Object.getOwnPropertyDescriptor's TypeRegExp case,
+		// same file).
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			for _, key := range props.OwnKeys() {
+				if _, _, en, _, ok := props.GetOwnDescriptor(key); ok && en {
+					keysArray.Append(vm.NewString(key))
+				}
+			}
+		}
 	}
 
 	return keys, nil
@@ -4050,6 +4067,67 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
+	} else if obj.Type() == vm.TypeRegExp || obj.Type() == vm.TypeMap || obj.Type() == vm.TypeSet || obj.Type() == vm.TypePromise {
+		// These exotic kinds keep their ordinary own properties in the same
+		// lazily-allocated side table Function/Closure use above
+		// (OwnPropertiesTable/EnsureOwnPropertiesTable, pkg/vm/
+		// properties_table.go, shared by ownPropertiesSlot's switch) - this
+		// branch was missing entirely, so a fresh RegExp/Map/Set/Promise
+		// (no table yet - the common case, since nothing else forces one
+		// into existence first) made Object.defineProperty/
+		// Reflect.defineProperty silently do nothing while still returning
+		// the object as if it had succeeded.
+		//
+		// RegExp's "lastIndex" is excluded: it is a real Go field on
+		// RegExpObject (see reflectDeleteProperty's TypeRegExp case -
+		// {writable: true, configurable: false}), not a side-table entry -
+		// a table write here would create a second, disconnected
+		// "lastIndex" that shadows nothing real. Redefining lastIndex
+		// through defineProperty remains a pre-existing, untouched gap
+		// (still the same no-op it already was, not a new regression).
+		if obj.Type() == vm.TypeRegExp && !keyIsSymbol && propName == "lastIndex" {
+			// no-op - see comment above.
+		} else if props := vm.EnsureOwnPropertiesTable(obj); props != nil {
+			isAccessor0 := false
+			if keyIsSymbol {
+				if _, _, _, _, ok := props.GetOwnAccessorByKey(vm.NewSymbolKey(propSym)); ok {
+					isAccessor0 = true
+				}
+			} else if _, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				isAccessor0 = true
+			}
+			// Preserve the existing value when the descriptor doesn't
+			// specify one and isn't converting to/from an accessor -
+			// DefineOwnProperty otherwise overwrites an existing data
+			// property's value with the zero Value{} passed here (mirrors
+			// the TypeObject branch above).
+			if !hasValue && !isAccessor0 && !(hasGetter || hasSetter) {
+				if keyIsSymbol {
+					if existingVal, ok := props.GetOwnByKey(vm.NewSymbolKey(propSym)); ok {
+						value = existingVal
+					}
+				} else if existingVal, ok := props.GetOwn(propName); ok {
+					value = existingVal
+				}
+			}
+			var defined bool
+			if hasGetter || hasSetter {
+				if keyIsSymbol {
+					defined = props.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				} else {
+					defined = props.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				}
+			} else {
+				if keyIsSymbol {
+					defined = props.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+				} else {
+					defined = props.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
+			}
+		}
 	}
 
 	return obj, nil
@@ -4795,6 +4873,53 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 				descriptor.SetOwn("enumerable", vm.BooleanValue(e))
 				descriptor.SetOwn("configurable", vm.BooleanValue(c))
 				return vm.NewValueFromPlainObject(descriptor), nil
+			}
+		}
+	}
+
+	// Map/Set/Promise have no intrinsic own properties of their own (unlike
+	// RegExp's "lastIndex" above) - only whatever a program has defined on
+	// the same side table via Object/Reflect.defineProperty or a plain
+	// assignment (OwnPropertiesTable, pkg/vm/properties_table.go). This case
+	// was missing entirely, so Object.getOwnPropertyDescriptor always
+	// answered undefined for a custom property on one of these three kinds.
+	if obj.Type() == vm.TypeMap || obj.Type() == vm.TypeSet || obj.Type() == vm.TypePromise {
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			if keyIsSymbol {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := props.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := props.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			} else {
+				if g, s, e, c, ok := props.GetOwnAccessor(propName); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := props.GetOwnDescriptor(propName); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
 			}
 		}
 	}

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -5023,6 +5023,31 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 				}
 			}
 		}
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+		// These exotic kinds keep their ordinary own properties in the same
+		// lazily-allocated side table (OwnPropertiesTable, pkg/vm/
+		// properties_table.go) as Function/Closure/NativeFunctionWithProps
+		// above - this case was missing entirely, so
+		// Object.getOwnPropertyDescriptors always returned {} for one of
+		// these four kinds even after a real own property had been defined
+		// or assigned on it, despite the single-key
+		// Object.getOwnPropertyDescriptor already answering correctly for
+		// the exact same property.
+		//
+		// RegExp's "lastIndex" is its own case: like TypeFunction's
+		// synthesized "length"/"name"/"prototype" intrinsics above, it is a
+		// real own property that isn't stored in the side table at all (a
+		// Go field on RegExpObject instead - see
+		// objectGetOwnPropertyDescriptorWithVM's TypeRegExp handling, same
+		// file), so it has to be added explicitly rather than falling out
+		// of OwnPropertyNames().
+		if obj.Type() == vm.TypeRegExp {
+			stringKeys = append(stringKeys, "lastIndex")
+		}
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			stringKeys = append(stringKeys, props.OwnPropertyNames()...)
+			symbolKeys = append(symbolKeys, props.OwnSymbolKeys()...)
+		}
 	}
 
 	// Get descriptor for each string key

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -1203,6 +1203,25 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		return true, InterpretOK, *valueToSet
 	}
 
+	// Every remaining exotic kind that keeps its ordinary own properties in
+	// a lazily-allocated side table (OwnPropertiesTable/
+	// EnsureOwnPropertiesTable, pkg/vm/properties_table.go, via
+	// ownPropertiesSlot) shares this one branch - Map/Set/Promise here
+	// alongside BoundFunction/NativeFunctionWithProps/NativeFunction, which
+	// (unlike TypeFunction/TypeClosure/TypeRegExp just above) had no
+	// explicit case at all. A symbol-keyed bracket assignment
+	// (obj[sym] = v) on any of these silently did nothing - falling all
+	// the way through to the "ignore symbol set" branch below - even
+	// though the equivalent string-keyed assignment (opSetProp, called by
+	// OpSetIndex's outer switch) already writes into the exact same table.
+	switch objVal.Type() {
+	case TypeMap, TypeSet, TypePromise, TypeBoundFunction, TypeNativeFunctionWithProps, TypeNativeFunction:
+		if props := EnsureOwnPropertiesTable(*objVal); props != nil {
+			return vm.setOwnCheckedByKey(props, NewSymbolKey(symKey), *valueToSet)
+		}
+		return true, InterpretOK, *valueToSet
+	}
+
 	// Only PlainObject supports symbol keys for now
 	if objVal.Type() != TypeObject {
 		// DictObject or others: ignore symbol set (non-strict semantics)

--- a/pkg/vm/properties_table.go
+++ b/pkg/vm/properties_table.go
@@ -127,12 +127,42 @@ func (vm *VM) setOwnChecked(props *PlainObject, name string, v Value) (bool, Int
 
 // setOwnCheckedByKey is setOwnChecked for a symbol (or otherwise non-string)
 // key. It stores through DefineOwnPropertyByKey because that is what the
-// symbol-set paths already did.
+// symbol-set paths already did - but a plain assignment (obj[sym] = v) is
+// ordinary [[Set]], not Object.defineProperty: a brand-new property must
+// come out {writable: true, enumerable: true, configurable: true} ("regular
+// assignment semantics", per SetOwn's comment for the string-key path,
+// pkg/vm/object.go), not DefineOwnPropertyByKey's own default of false for
+// every attribute a nil pointer leaves unspecified. Passing nil for all
+// three - as this used to unconditionally do - silently created every
+// symbol property from a plain assignment as non-writable, non-enumerable,
+// non-configurable. Redefining an *existing* property still passes nil
+// throughout, so DefineOwnPropertyByKey's own already-correct
+// attribute-preserving behavior for that case is untouched.
 func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (bool, InterpretResult, Value) {
 	if allowed, threw := vm.tableSetAllowed(props, key, key.debugName()); !allowed {
 		if threw {
 			return false, InterpretRuntimeError, Undefined
 		}
+		return true, InterpretOK, v
+	}
+	// HasOwnByKey re-derives existence tableSetAllowed already checked
+	// (GetOwnAccessorByKey/GetOwnDescriptorByKey) - a third linear scan
+	// over the same shape, not a different question. Left as its own call
+	// rather than threading a result out of tableSetAllowed, since that
+	// function's signature is shared with the string-key path.
+	//
+	// Note: if key already names an accessor, tableSetAllowed's
+	// isAccessor check reports allowed=true, and this falls into the
+	// "existing" branch below with nil attribute pointers -
+	// DefineOwnPropertyByKey's accessor-to-data conversion then silently
+	// clobbers the accessor into a plain data property instead of calling
+	// its setter (or, getter-only, leaving it untouched). That is a
+	// distinct, pre-existing bug in its own right (reproduces identically
+	// for a plain function's symbol accessor, unaffected by this specific
+	// existence check) - not introduced or fixed here.
+	if !props.HasOwnByKey(key) {
+		w, e, c := true, true, true
+		props.DefineOwnPropertyByKey(key, v, &w, &e, &c)
 		return true, InterpretOK, v
 	}
 	props.DefineOwnPropertyByKey(key, v, nil, nil, nil)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8936,7 +8936,7 @@ startExecution:
 					}
 				}
 
-			case TypeObject, TypeDictObject, TypeFunction, TypeClosure, TypeRegExp, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction, TypeAsyncNativeFunction: // Functions, closures, RegExps, and native functions can have properties
+			case TypeObject, TypeDictObject, TypeFunction, TypeClosure, TypeRegExp, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction, TypeAsyncNativeFunction, TypeMap, TypeSet, TypePromise: // Functions, closures, RegExps, native functions, and Map/Set/Promise can have properties
 				var key string
 				switch indexVal.Type() {
 				case TypeString:

--- a/tests/scripts/bracket_index_set_exotic.ts
+++ b/tests/scripts/bracket_index_set_exotic.ts
@@ -1,0 +1,87 @@
+// expect: true
+// OpSetIndex's exotic-kinds case (search "can have properties" in
+// pkg/vm/vm.go) had no TypeMap/TypeSet/TypePromise at all - unlike
+// TypeFunction/TypeClosure/TypeRegExp/TypeNativeFunction(WithProps)/
+// TypeBoundFunction, which were already there - so bracket-notation
+// assignment (obj[key] = v) on a Map/Set/Promise unconditionally threw
+// "Cannot set index on non-array/object/typedarray type", even for a
+// plain string key, while dot-notation (obj.key = v) worked fine.
+//
+// Fixing that alone surfaced a second, adjacent bug: a symbol-keyed
+// bracket assignment on ANY of these exotic kinds (Map/Set/Promise, but
+// also the already-listed BoundFunction/NativeFunctionWithProps/
+// NativeFunction) routes to opSetPropSymbol, which had no case for them
+// either and silently discarded the write. And once that was added, a
+// THIRD bug turned up: opSetPropSymbol's existing helper
+// (setOwnCheckedByKey, shared by RegExp/Function/Closure's already-working
+// symbol-set paths) created every new symbol property as
+// {writable: false, enumerable: false, configurable: false} instead of
+// the true/true/true a plain assignment should produce - a pre-existing
+// bug that predates this fix, now fixed for every kind that goes through
+// it.
+const checks: boolean[] = [];
+
+function checkStringKey(obj: any): boolean {
+  obj["strkey"] = 42;
+  if (obj.strkey !== 42) return false;
+  if (!("strkey" in obj) || !Reflect.has(obj, "strkey")) return false;
+  const desc: any = Object.getOwnPropertyDescriptor(obj, "strkey");
+  return (
+    desc !== undefined &&
+    desc.value === 42 &&
+    desc.writable === true &&
+    desc.enumerable === true &&
+    desc.configurable === true
+  );
+}
+
+// checkSymbolKey verifies the write actually happened via Reflect.has
+// (always) and, when checkDesc is true, via Object.getOwnPropertyDescriptor
+// too. It deliberately does NOT check the `in` operator or the descriptor
+// for every kind: two adjacent, pre-existing gaps in OTHER functions -
+// unrelated to this bracket-assignment fix, and tracked separately - would
+// make those assertions fail even though the write this fix is responsible
+// for succeeded correctly (confirmed via Reflect.has in every case below):
+//   - `in` (OpIn)'s symbol-key dispatch has no case at all for
+//     BoundFunction/NativeFunction/NativeFunctionWithProps.
+//   - Object.getOwnPropertyDescriptor's TypeRegExp/TypeBoundFunction blocks
+//     never check a symbol key, only a string name.
+function checkSymbolKey(obj: any, checkIn: boolean, checkDesc: boolean): boolean {
+  const sym = Symbol("k");
+  obj[sym] = 99;
+  if (!Reflect.has(obj, sym)) return false;
+  if (checkIn && !(sym in obj)) return false;
+  if (!checkDesc) return true;
+  const desc: any = Object.getOwnPropertyDescriptor(obj, sym);
+  return (
+    desc !== undefined &&
+    desc.value === 99 &&
+    desc.writable === true &&
+    desc.enumerable === true &&
+    desc.configurable === true
+  );
+}
+
+// --- string key, all four kinds ---
+checks.push(checkStringKey(new Map()));
+checks.push(checkStringKey(new Set()));
+checks.push(checkStringKey(Promise.resolve(1)));
+checks.push(checkStringKey(/x/g));
+
+// --- symbol key, all four kinds ---
+checks.push(checkSymbolKey(new Map(), true, true));
+checks.push(checkSymbolKey(new Set(), true, true));
+checks.push(checkSymbolKey(Promise.resolve(1), true, true));
+checks.push(checkSymbolKey(/y/g, true, false)); // descriptor-by-symbol gap tracked separately
+
+// --- symbol key, the callable kinds the task asked to double-check ---
+function plainFn() {}
+checks.push(checkSymbolKey(plainFn.bind(null), false, false)); // both gaps above apply
+const nfp: any = Array; // NativeFunctionWithProps
+checks.push(checkSymbolKey(nfp, false, true)); // `in` gap applies, descriptor already worked
+
+// --- a genuinely absent key is still absent after all this ---
+const untouched: any = new Map();
+checks.push(!("nope" in untouched) && !Reflect.has(untouched, "nope"));
+
+checks.every((c) => c === true);

--- a/tests/scripts/define_property_exotic_side_table.ts
+++ b/tests/scripts/define_property_exotic_side_table.ts
@@ -94,16 +94,17 @@ Object.preventExtensions(m3);
 Object.defineProperty(m3, "already", { value: 2 });
 checks.push(m3.already === 2);
 
-// --- pin the known, separately-tracked `in`-on-Promise gap explicitly
-// (rather than the roundTrips helper above silently skipping it): `in`
-// never checks a Promise's own side table at all, only Reflect.has does -
-// reproduces with plain assignment too, so it's unrelated to this fix. If
-// that gap gets fixed later, this assertion should fail and point
-// whoever's fixing it at updating checkIn above instead of it going
-// unnoticed. ---
+// --- Reflect.has finds a plain own property assigned onto a Promise
+// (unrelated to defineProperty itself, but worth pinning here since the
+// roundTrips helper above skips `in` for Promise entirely). `in` used to
+// disagree with Reflect.has here - it never checked a Promise's own side
+// table at all - but that was a separate bug in the `in` operator itself
+// (OpIn, pkg/vm/vm.go), not this defineProperty fix, so it's fixed in a
+// sibling PR (#332) instead of asserted on in this file: an assertion
+// here would flip depending on merge order between the two PRs. ---
 const pIn: any = Promise.resolve(3);
 pIn.viaAssign = 1;
-checks.push(Reflect.has(pIn, "viaAssign") && !("viaAssign" in pIn));
+checks.push(Reflect.has(pIn, "viaAssign"));
 
 // --- RegExp's "lastIndex" is excluded from the generic side-table write
 // (it's a real Go field, not a table entry) - defineProperty on it stays

--- a/tests/scripts/define_property_exotic_side_table.ts
+++ b/tests/scripts/define_property_exotic_side_table.ts
@@ -1,0 +1,117 @@
+// expect: true
+// Object.defineProperty/Reflect.defineProperty on a RegExp/Map/Set/Promise
+// that has never had a property defined on it (its side table -
+// OwnPropertiesTable, pkg/vm/properties_table.go - is still nil) used to
+// silently do nothing while still returning the object as if it had
+// succeeded: definePropertyWithVM's write-path had no branch at all for
+// these four kinds (a NativeFunctionWithProps/Function/Closure-only chain),
+// so it just fell through to `return obj, nil`. Object.keys and
+// Object.getOwnPropertyDescriptor had the matching gap for Map/Set/Promise
+// (RegExp's read side already worked via a dedicated lastIndex+side-table
+// block). Plain assignment (`r.custom = 42`) was never affected - it goes
+// through EnsureOwnPropertiesTable elsewhere in the property-set path.
+const checks: boolean[] = [];
+
+function roundTrips(obj: any, useReflect: boolean, checkIn: boolean): boolean {
+  const definer = useReflect
+    ? (o: any, k: string, d: any) => Reflect.defineProperty(o, k, d)
+    : (o: any, k: string, d: any) =>
+        Object.defineProperty(o, k, d) !== undefined;
+  const ok = definer(obj, "custom", {
+    value: 42,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  if (!ok) return false;
+  const desc: any = Object.getOwnPropertyDescriptor(obj, "custom");
+  if (!desc || desc.value !== 42 || !desc.writable || !desc.enumerable || !desc.configurable) {
+    return false;
+  }
+  if (!Reflect.has(obj, "custom")) return false;
+  // `in` on a Promise has its own, separate pre-existing gap (never
+  // checks the Promise's own side table at all, reproduces with plain
+  // assignment too - unrelated to this fix, tracked separately) - skip it
+  // for that one kind so this test stays about defineProperty, not that.
+  if (checkIn && !("custom" in obj)) return false;
+  if (Object.keys(obj).indexOf("custom") === -1) return false;
+  return true;
+}
+
+// --- Object.defineProperty, virgin side table, all four kinds ---
+checks.push(roundTrips(/x/g, false, true));
+checks.push(roundTrips(new Map(), false, true));
+checks.push(roundTrips(new Set(), false, true));
+checks.push(roundTrips(Promise.resolve(1), false, false));
+
+// --- Reflect.defineProperty, virgin side table, all four kinds ---
+checks.push(roundTrips(/y/, true, true));
+checks.push(roundTrips(new Map(), true, true));
+checks.push(roundTrips(new Set(), true, true));
+checks.push(roundTrips(Promise.resolve(2), true, false));
+
+// --- redefining with a partial descriptor preserves the omitted value,
+// not the zero Value{} DefineOwnProperty would otherwise write ---
+const m: any = new Map();
+Object.defineProperty(m, "foo", {
+  value: 10,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(m, "foo", { enumerable: false });
+const fooDesc: any = Object.getOwnPropertyDescriptor(m, "foo");
+checks.push(fooDesc.value === 10 && fooDesc.enumerable === false);
+
+// --- a symbol key round-trips the same way ---
+const s: any = new Set();
+const sym = Symbol("k");
+Object.defineProperty(s, sym, { value: 7, enumerable: true, configurable: true, writable: true });
+checks.push(
+  Object.getOwnPropertyDescriptor(s, sym).value === 7 &&
+    sym in s &&
+    Reflect.has(s, sym)
+);
+
+// --- extensibility is still enforced for a brand-new property (the side
+// table gets allocated by the write path now, but Object.preventExtensions
+// already allocates its own via EnsureOwnPropertiesTable, so the check at
+// definePropertyWithVM's extensibility guard still sees it) ---
+const m2: any = new Map();
+Object.preventExtensions(m2);
+let threw = false;
+try {
+  Object.defineProperty(m2, "nope", { value: 1, configurable: true });
+} catch (e: any) {
+  threw = e instanceof TypeError;
+}
+checks.push(threw);
+
+// --- redefining an EXISTING property still works after preventExtensions ---
+const m3: any = new Map();
+m3.already = 1;
+Object.preventExtensions(m3);
+Object.defineProperty(m3, "already", { value: 2 });
+checks.push(m3.already === 2);
+
+// --- pin the known, separately-tracked `in`-on-Promise gap explicitly
+// (rather than the roundTrips helper above silently skipping it): `in`
+// never checks a Promise's own side table at all, only Reflect.has does -
+// reproduces with plain assignment too, so it's unrelated to this fix. If
+// that gap gets fixed later, this assertion should fail and point
+// whoever's fixing it at updating checkIn above instead of it going
+// unnoticed. ---
+const pIn: any = Promise.resolve(3);
+pIn.viaAssign = 1;
+checks.push(Reflect.has(pIn, "viaAssign") && !("viaAssign" in pIn));
+
+// --- RegExp's "lastIndex" is excluded from the generic side-table write
+// (it's a real Go field, not a table entry) - defineProperty on it stays
+// the same pre-existing no-op it already was, not a new divergent shadow
+// copy that would make r.lastIndex and the descriptor disagree. ---
+const r: any = /z/g;
+Object.defineProperty(r, "lastIndex", { value: 5 });
+const liDesc: any = Object.getOwnPropertyDescriptor(r, "lastIndex");
+checks.push(r.lastIndex === liDesc.value);
+
+checks.every((c) => c === true);

--- a/tests/scripts/get_own_property_descriptors_exotic.ts
+++ b/tests/scripts/get_own_property_descriptors_exotic.ts
@@ -1,0 +1,91 @@
+// expect: true
+// Object.getOwnPropertyDescriptors collected its keys via its own local
+// switch on obj.Type() (separate from the single-key
+// Object.getOwnPropertyDescriptor) - it had no case at all for
+// TypeRegExp/TypeMap/TypeSet/TypePromise, so stringKeys/symbolKeys stayed
+// empty and it always returned {} for one of these four kinds, even after
+// a real own property had been defined or assigned on it, despite the
+// single-key getOwnPropertyDescriptor already answering correctly for the
+// exact same property (paserati#329).
+const checks: boolean[] = [];
+
+function hasDataDesc(
+  descs: any,
+  key: string,
+  value: unknown,
+  writable: boolean,
+  enumerable: boolean,
+  configurable: boolean
+): boolean {
+  const d = descs[key];
+  return (
+    d !== undefined &&
+    d.value === value &&
+    d.writable === writable &&
+    d.enumerable === enumerable &&
+    d.configurable === configurable
+  );
+}
+
+// --- RegExp with no custom property still reports "lastIndex" (a real
+// own property that lives on the RegExpObject itself, not the side
+// table - the only kind of these four with an intrinsic own property to
+// add alongside whatever the side table holds) ---
+const descsEmpty: any = Object.getOwnPropertyDescriptors(/x/g);
+checks.push(
+  Object.keys(descsEmpty).length === 1 &&
+    hasDataDesc(descsEmpty, "lastIndex", 0, true, false, false)
+);
+
+// --- RegExp with a custom property reports both ---
+const r: any = /y/g;
+r.custom = 1;
+const descsR: any = Object.getOwnPropertyDescriptors(r);
+checks.push(
+  hasDataDesc(descsR, "lastIndex", 0, true, false, false) &&
+    hasDataDesc(descsR, "custom", 1, true, true, true)
+);
+
+// --- Map/Set/Promise with a custom property ---
+const m: any = new Map();
+m.custom = 2;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(m), "custom", 2, true, true, true));
+
+const s: any = new Set();
+s.custom = 3;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(s), "custom", 3, true, true, true));
+
+const p: any = Promise.resolve(1);
+p.custom = 4;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(p), "custom", 4, true, true, true));
+
+// --- a symbol key round-trips too (via Object.defineProperty - bracket
+// assignment with a computed key on these kinds has its own, separate,
+// unrelated pre-existing gap) ---
+const m2: any = new Map();
+const sym = Symbol("k");
+Object.defineProperty(m2, sym, {
+  value: 5,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+const descsSym: any = Object.getOwnPropertyDescriptors(m2);
+checks.push(
+  descsSym[sym] !== undefined &&
+    descsSym[sym].value === 5 &&
+    descsSym[sym].writable &&
+    descsSym[sym].enumerable &&
+    descsSym[sym].configurable
+);
+
+// --- a Map/Set/Promise with nothing custom on it reports no custom keys
+// (Map/Set's own "size" isn't an own property, it's an accessor on
+// Map.prototype/Set.prototype). Object.keys on the *result* object counts
+// string keys only - fine here since none of these three fixtures carry
+// a symbol; the m2 case above is what covers symbol-key round-tripping. ---
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(new Map())).length === 0);
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(new Set())).length === 0);
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(Promise.resolve(1))).length === 0);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

Three files, three causally-chained fixes — the unique contribution of this PR:

- **`pkg/vm/vm.go`** — `OpSetIndex`'s exotic-kinds case gains `TypeMap, TypeSet, TypePromise`.
- **`pkg/vm/op_setprop.go`** — `opSetPropSymbol` gains a branch for `TypeMap, TypeSet, TypePromise, TypeBoundFunction, TypeNativeFunctionWithProps, TypeNativeFunction`.
- **`pkg/vm/properties_table.go`** — `setOwnCheckedByKey` now defaults a genuinely new property's attributes to `true/true/true` instead of `false/false/false`.
- **`tests/scripts/bracket_index_set_exotic.ts`** — new regression test.

⚠️ **The diff below also contains #331's `object_init.go` changes** (this branch merges in that chain's tip so the regression test can exercise `Object.getOwnPropertyDescriptor`/`in` for Map/Set/Promise, which #329/#331 fix). Those lines belong to #329/#331, not this commit, and disappear from the diff once those merge. I also pushed a small update to #331 (`b5e89bb7`) to pick up a merge-order-independent test fix already on #329 (`dc841817`) — noting it here since #331's branch moved after that PR was opened.

## The bug

```js
const m = new Map();
m["strkey"] = 1; // throws: "Cannot set index on non-array/object/typedarray type 'map'"
```
`m.strkey = 1` (dot notation) worked fine — `OpSetIndex`'s exotic-kinds case just never listed `TypeMap`/`TypeSet`/`TypePromise`, unlike `TypeFunction`/`TypeClosure`/`TypeRegExp`/the native-function kinds, which were already there.

## Two more bugs this fix surfaced (fixed in the same commit — they're causally chained)

1. **A symbol-keyed bracket assignment silently discarded the write** on any of these kinds (and on `BoundFunction`/`NativeFunctionWithProps`/`NativeFunction`, which could never reach this path before either) — `opSetPropSymbol` had no case for any of them, falling to a "DictObject: ignore symbol set" fallback that wasn't meant for them.

2. **Once symbol keys actually reached storage, their attributes were wrong for every kind that goes through `setOwnCheckedByKey`** — including the three (`Function`/`Closure`/`RegExp`) that already worked before this PR:
   ```js
   function fn() {}
   fn[Symbol("k")] = 1;
   console.log(Object.getOwnPropertyDescriptor(fn, Symbol("k")));
   // paserati (before this fix): { value: 1, writable: false, enumerable: false, configurable: false }
   // Node: { value: 1, writable: true, enumerable: true, configurable: true }
   ```
   This was silently wrong for every existing caller, not something the Map/Set/Promise work introduced.

## Testing

`tests/scripts/bracket_index_set_exotic.ts`: string- and symbol-keyed bracket assignment on Map/Set/Promise/RegExp and the callable kinds, round-tripping via dot notation, `Reflect.has`, and (where two further adjacent gaps — flagged below, not fixed here — don't apply) `in` and `Object.getOwnPropertyDescriptor`'s exact attribute shape.

`go test ./tests -run TestScripts` and `./pkg/vm/... ./pkg/builtins/...` all pass (`-timeout 180s`).

## Found, not fixed (flagged separately — different root causes)

- `Object.getOwnPropertyDescriptor` never checks a symbol key for RegExp or BoundFunction (string-name lookup only).
- `in`'s symbol-key dispatch has no case for BoundFunction/NativeFunction/NativeFunctionWithProps (`Reflect.has` correctly finds the same property; `in` doesn't).
- Assigning through an existing symbol-keyed getter-only accessor clobbers it into a data property instead of respecting getter/setter semantics — reproduces identically for a plain function, unrelated to this fix.

This session has now turned up enough instances of "an exotic kind missing from switch N" (across `in`/`Reflect.has`, `defineProperty`, `for-in`, and now bracket-assignment) that the highest-leverage next move is a single audit of every `switch obj.Type()` in `pkg/vm/vm.go` and `pkg/builtins/object_init.go` against the nine kinds `ownPropertiesSlot` covers, rather than another one-off chip.

Based on `fix-forin-map-set-promise` (#332).
