### PR TITLE
fix(builtins): Object.getOwnPropertyDescriptor honors symbol keys for RegExp/BoundFunction

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -4822,9 +4822,37 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 		}
 	case vm.TypeBoundFunction:
 		bf := obj.AsBoundFunction()
-		// Bound function name/length are real own properties in bf.Properties
-		// They can be deleted (configurable:true) or redefined via Object.defineProperty
 		if bf.Properties != nil {
+			// A symbol key never names the synthesized "name"/"length"
+			// intrinsics above, so it skips straight to the side-table
+			// lookup - mirroring the TypeMap/TypeSet/TypePromise block
+			// below (accessor first, then data), which this case never
+			// had at all: it only ever looked up `propName`, a string, so
+			// `Object.getOwnPropertyDescriptor(boundFn, sym)` answered
+			// undefined even for a real own symbol property that
+			// Reflect.has/`in` already found correctly.
+			if keyIsSymbol {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := bf.Properties.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := bf.Properties.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				return vm.Undefined, nil
+			}
+			// Bound function name/length are real own properties in bf.Properties
+			// They can be deleted (configurable:true) or redefined via Object.defineProperty
 			if propName == "name" || propName == "length" {
 				if val, ok := bf.Properties.GetOwn(propName); ok {
 					_, w, e, c, _ := bf.Properties.GetOwnDescriptor(propName)
@@ -4854,6 +4882,38 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	// Handle RegExp intrinsic property: lastIndex
 	// Per ECMAScript spec: {value: 0, writable: true, enumerable: false, configurable: false}
 	if obj.Type() == vm.TypeRegExp {
+		// A symbol key is never "lastIndex" (a symbol never equals a
+		// string), so that intrinsic check stays string-only and this
+		// skips straight to the side-table lookup - mirroring the
+		// TypeMap/TypeSet/TypePromise block above (accessor first, then
+		// data), which the "custom properties on the regex" check just
+		// below never had at all: it only ever looked up `propName`, a
+		// string, so `Object.getOwnPropertyDescriptor(regex, sym)`
+		// answered undefined even for a real own symbol property that
+		// Reflect.has/`in` already found correctly.
+		if keyIsSymbol {
+			regexObj := obj.AsRegExpObject()
+			if regexObj != nil && regexObj.Properties != nil {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := regexObj.Properties.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := regexObj.Properties.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+			return vm.Undefined, nil
+		}
 		if propName == "lastIndex" {
 			regexObj := obj.AsRegExpObject()
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()

--- a/tests/scripts/get_own_property_descriptor_symbol_regexp_boundfn.ts
+++ b/tests/scripts/get_own_property_descriptor_symbol_regexp_boundfn.ts
@@ -1,0 +1,109 @@
+// expect: true
+// objectGetOwnPropertyDescriptorWithVM's TypeBoundFunction case and its
+// TypeRegExp block (pkg/builtins/object_init.go) both looked up an own
+// property by string name only (propName), never checking keyIsSymbol or
+// using propSym - unlike the sibling TypeMap/TypeSet/TypePromise block in
+// the same function, which correctly branches on keyIsSymbol and uses
+// GetOwnAccessorByKey/GetOwnDescriptorByKey for a symbol key. So
+// Object.getOwnPropertyDescriptor(regexOrBoundFn, sym) always answered
+// undefined for a real own symbol property, even though `in`/Reflect.has
+// already found it correctly.
+const checks: boolean[] = [];
+
+function hasDataDesc(
+  desc: any,
+  value: unknown,
+  writable: boolean,
+  enumerable: boolean,
+  configurable: boolean
+): boolean {
+  return (
+    desc !== undefined &&
+    desc.value === value &&
+    desc.writable === writable &&
+    desc.enumerable === enumerable &&
+    desc.configurable === configurable
+  );
+}
+
+// --- RegExp: an own symbol property set via bracket-notation assignment ---
+const sym = Symbol("k");
+const r: any = /x/g;
+r[sym] = 4;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(r, sym), 4, true, true, true));
+checks.push(sym in r && Reflect.has(r, sym));
+
+// --- RegExp: a genuinely absent symbol key ---
+checks.push(Object.getOwnPropertyDescriptor(r, Symbol("absent")) === undefined);
+
+// --- RegExp: "lastIndex" (a real own property, but never a symbol) is
+// unaffected by routing symbol keys to the side table first ---
+const lastIndexDesc: any = Object.getOwnPropertyDescriptor(r, "lastIndex");
+checks.push(hasDataDesc(lastIndexDesc, 0, true, false, false));
+
+// --- RegExp: a symbol-keyed accessor (set via Object.defineProperty,
+// since bracket-assignment through an accessor has its own separate,
+// unrelated pre-existing gap) ---
+const r2: any = /y/g;
+Object.defineProperty(r2, sym, {
+  get() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const r2Desc: any = Object.getOwnPropertyDescriptor(r2, sym);
+checks.push(
+  r2Desc !== undefined &&
+    typeof r2Desc.get === "function" &&
+    r2Desc.get() === 42 &&
+    r2Desc.set === undefined &&
+    r2Desc.enumerable === true &&
+    r2Desc.configurable === true
+);
+
+// --- BoundFunction: an own symbol property set via bracket-notation
+// assignment. Only Reflect.has is checked (not `in`): the `in` operator's
+// symbol-key dispatch has its own, separate, still-open gap for
+// BoundFunction (tracked independently) - unrelated to this
+// getOwnPropertyDescriptor fix, which this test is actually about. ---
+function fn() {}
+const bound: any = fn.bind(null);
+bound[sym] = 5;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(bound, sym), 5, true, true, true));
+checks.push(Reflect.has(bound, sym));
+
+// --- BoundFunction: a genuinely absent symbol key ---
+checks.push(Object.getOwnPropertyDescriptor(bound, Symbol("absent")) === undefined);
+
+// --- BoundFunction: "name"/"length" (real own properties, but never a
+// symbol) are unaffected ---
+const boundNameDesc: any = Object.getOwnPropertyDescriptor(bound, "name");
+checks.push(
+  boundNameDesc !== undefined &&
+    boundNameDesc.value === "bound fn" &&
+    boundNameDesc.writable === false &&
+    boundNameDesc.enumerable === false &&
+    boundNameDesc.configurable === true
+);
+
+// --- BoundFunction: a symbol-keyed accessor ---
+const bound2: any = fn.bind(null);
+Object.defineProperty(bound2, sym, {
+  get() {
+    return 43;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const bound2Desc: any = Object.getOwnPropertyDescriptor(bound2, sym);
+checks.push(
+  bound2Desc !== undefined &&
+    typeof bound2Desc.get === "function" &&
+    bound2Desc.get() === 43 &&
+    bound2Desc.set === undefined &&
+    bound2Desc.enumerable === true &&
+    bound2Desc.configurable === true
+);
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

One file's logic change plus a new test — the unique contribution of this PR:

- **`pkg/builtins/object_init.go`** — `objectGetOwnPropertyDescriptorWithVM`'s `case vm.TypeBoundFunction:` block and its `if obj.Type() == vm.TypeRegExp {` block both now check `keyIsSymbol` and, when true, look the key up in the side table via `GetOwnAccessorByKey`/`GetOwnDescriptorByKey` (accessor first, then data) before falling back to the existing string-only logic — mirroring the sibling `TypeMap`/`TypeSet`/`TypePromise` block already in the same function.
- **`tests/scripts/get_own_property_descriptor_symbol_regexp_boundfn.ts`** — new regression test.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → #331 → #332 → #333), since this branch was created from `fix-bracket-index-exotic`'s tip. Everything except the two files above belongs to those PRs and disappears from the diff once they merge.

## The bug

```js
const sym = Symbol("k");
const r = /x/g;
r[sym] = 4;
Object.getOwnPropertyDescriptor(r, sym); // undefined (should describe the symbol property)
sym in r; // true - in/Reflect.has already found it correctly
```

Both `objectGetOwnPropertyDescriptorWithVM`'s `TypeBoundFunction` case and its `TypeRegExp` block looked a property up by string name only (`propName`), never checking `keyIsSymbol`/using `propSym`. So `Object.getOwnPropertyDescriptor(regexOrBoundFn, sym)` always answered `undefined` for a real own symbol property, even though `in`/`Reflect.has` (fixed earlier in this stack) already found it.

## The fix

Both blocks now branch on `keyIsSymbol` first, using the exact `GetOwnAccessorByKey`/`GetOwnDescriptorByKey` pattern the `TypeMap`/`TypeSet`/`TypePromise` block already used, and return early. RegExp's `"lastIndex"` intrinsic check stays string-only (a symbol is never `"lastIndex"`). The two new early `return vm.Undefined, nil` statements for an unmatched symbol key are equivalent-by-construction to the previous fall-through path: every block below in the same function gates on a different `obj.Type()` and would never have matched a `TypeRegExp`/`TypeBoundFunction` value anyway.

Verified against Node for both RegExp and BoundFunction: a symbol data property set via bracket assignment, a symbol-keyed accessor defined via `Object.defineProperty`, a genuinely absent symbol key, and the pre-existing string-keyed intrinsics (`"lastIndex"`, `"name"`) all match exactly.

## Testing

`tests/scripts/get_own_property_descriptor_symbol_regexp_boundfn.ts` covers all of the above for both RegExp and BoundFunction. One assertion intentionally checks `Reflect.has(bound, sym)` instead of `sym in bound`: the `in` operator's symbol-key dispatch has its own separate, still-open gap for BoundFunction (tracked independently, not fixed here) — unrelated to this `getOwnPropertyDescriptor` fix.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./pkg/vm/... ./pkg/builtins/... -timeout 180s` both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (already tracked separately)

- `in`'s symbol-key dispatch has no case for BoundFunction/NativeFunction/NativeFunctionWithProps.
- Assigning through an existing symbol-keyed getter-only accessor clobbers it into a data property instead of respecting getter/setter semantics.

This stack (#329 → #331 → #332 → #333 → this PR) is now five deep, each PR's diff showing every ancestor's commits until the earlier ones merge. As noted on #333, a single audit of every `switch obj.Type()` in `pkg/vm/vm.go` and `pkg/builtins/object_init.go` against the nine kinds `ownPropertiesSlot` covers would likely be higher-leverage than continuing to fix these one at a time.

Based on `fix-bracket-index-exotic` (#333).
