### PR TITLE
fix(vm): ordinary [[Set]] on a side-table accessor calls the setter instead of clobbering it

### DIFF
--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -337,7 +337,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			fn.Properties.DefineOwnProperty("prototype", *valueToSet, &w, &e, &c)
 			return true, InterpretOK, *valueToSet
 		}
-		return vm.setOwnChecked(fn.Properties, propName, *valueToSet)
+		return vm.setOwnChecked(fn.Properties, propName, *objVal, *valueToSet)
 	case TypeClosure:
 		closure := AsClosure(*objVal)
 		// Use closure's own Properties to avoid sharing with other closures using same FunctionObject
@@ -429,7 +429,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			closure.Properties.DefineOwnProperty("prototype", *valueToSet, &w, &e, &c)
 			return true, InterpretOK, *valueToSet
 		}
-		return vm.setOwnChecked(closure.Properties, propName, *valueToSet)
+		return vm.setOwnChecked(closure.Properties, propName, *objVal, *valueToSet)
 	case TypeNativeFunctionWithProps:
 		nfp := objVal.AsNativeFunctionWithProps()
 		if nfp != nil {
@@ -444,7 +444,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if nfp.Properties == nil {
 				nfp.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(nfp.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(nfp.Properties, propName, *objVal, *valueToSet)
 		}
 	case TypeNativeFunction:
 		nf := objVal.AsNativeFunction()
@@ -459,7 +459,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if nf.Properties == nil {
 				nf.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(nf.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(nf.Properties, propName, *objVal, *valueToSet)
 		}
 	}
 
@@ -470,7 +470,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		}
 		bf := objVal.AsBoundFunction()
 		if bf.Properties != nil {
-			return vm.setOwnChecked(bf.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(bf.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	}
@@ -951,7 +951,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if regex.Properties == nil {
 				regex.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(regex.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(regex.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypeMap:
@@ -961,7 +961,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if mapObj.Properties == nil {
 				mapObj.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(mapObj.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(mapObj.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypeSet:
@@ -971,7 +971,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if setObj.Properties == nil {
 				setObj.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(setObj.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(setObj.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypePromise:
@@ -982,7 +982,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if promiseObj.Properties == nil {
 				promiseObj.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(promiseObj.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(promiseObj.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypeArrayBuffer:
@@ -1168,7 +1168,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 			if regex.Properties == nil {
 				regex.Properties = newPropertiesTable()
 			}
-			return vm.setOwnCheckedByKey(regex.Properties, NewSymbolKey(symKey), *valueToSet)
+			return vm.setOwnCheckedByKey(regex.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	}
@@ -1179,7 +1179,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		if funcObj.Properties == nil {
 			funcObj.Properties = newPropertiesTable()
 		}
-		return vm.setOwnCheckedByKey(funcObj.Properties, NewSymbolKey(symKey), *valueToSet)
+		return vm.setOwnCheckedByKey(funcObj.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 	}
 
 	// Closure objects: store symbol properties on their Properties object
@@ -1188,7 +1188,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		if closure.Properties == nil {
 			closure.Properties = newPropertiesTable()
 		}
-		return vm.setOwnCheckedByKey(closure.Properties, NewSymbolKey(symKey), *valueToSet)
+		return vm.setOwnCheckedByKey(closure.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 	}
 
 	// Array objects: store symbol properties directly on the array
@@ -1217,7 +1217,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 	switch objVal.Type() {
 	case TypeMap, TypeSet, TypePromise, TypeBoundFunction, TypeNativeFunctionWithProps, TypeNativeFunction:
 		if props := EnsureOwnPropertiesTable(*objVal); props != nil {
-			return vm.setOwnCheckedByKey(props, NewSymbolKey(symKey), *valueToSet)
+			return vm.setOwnCheckedByKey(props, NewSymbolKey(symKey), *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	}

--- a/pkg/vm/properties_table.go
+++ b/pkg/vm/properties_table.go
@@ -110,11 +110,19 @@ func ownPropertiesSlot(v Value) **PlainObject {
 //
 // A rejection is silent in sloppy mode and a TypeError in strict mode, which is
 // what makes Object.freeze / Object.seal / Object.preventExtensions on a
-// function, RegExp, Map or Set actually bite. Accessor properties are left to
-// the callers that dispatch to setters before they get here.
+// function, RegExp, Map or Set actually bite. An existing accessor is handled
+// first, by setOwnAccessorSetter - see that function's comment for why this
+// can no longer be left to "the callers that dispatch to setters before they
+// get here", which most callers never actually did.
+//
+// receiver is the `this` an existing accessor's setter is invoked with - the
+// exotic value itself (the function, RegExp, Map, ...), not props.
 //
 // Returns the opcode-shaped triple, so call sites can `return` it directly.
-func (vm *VM) setOwnChecked(props *PlainObject, name string, v Value) (bool, InterpretResult, Value) {
+func (vm *VM) setOwnChecked(props *PlainObject, name string, receiver Value, v Value) (bool, InterpretResult, Value) {
+	if handled, ok, status, result := vm.setOwnAccessorSetter(props, keyFromString(name), name, receiver, v); handled {
+		return ok, status, result
+	}
 	if allowed, threw := vm.tableSetAllowed(props, keyFromString(name), name); !allowed {
 		if threw {
 			return false, InterpretRuntimeError, Undefined
@@ -138,7 +146,23 @@ func (vm *VM) setOwnChecked(props *PlainObject, name string, v Value) (bool, Int
 // non-configurable. Redefining an *existing* property still passes nil
 // throughout, so DefineOwnPropertyByKey's own already-correct
 // attribute-preserving behavior for that case is untouched.
-func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (bool, InterpretResult, Value) {
+//
+// receiver is the `this` an existing accessor's setter is invoked with - see
+// setOwnChecked.
+func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, receiver Value, v Value) (bool, InterpretResult, Value) {
+	// An existing accessor must go through setOwnAccessorSetter, which calls
+	// its setter (or no-ops / throws for a getter-only one) - never through
+	// the "existing property" branch below. That branch used to be reached
+	// for an accessor too (tableSetAllowed's isAccessor check reports
+	// allowed=true for one), landing on
+	// `props.DefineOwnPropertyByKey(key, v, nil, nil, nil)`, whose
+	// accessor-to-data conversion silently clobbered the accessor into a
+	// plain data property instead of calling its setter. Reproduced
+	// identically for a plain function's symbol accessor - see
+	// https://github.com/nooga/paserati/pull/333 "Found, not fixed".
+	if handled, ok, status, result := vm.setOwnAccessorSetter(props, key, key.debugName(), receiver, v); handled {
+		return ok, status, result
+	}
 	if allowed, threw := vm.tableSetAllowed(props, key, key.debugName()); !allowed {
 		if threw {
 			return false, InterpretRuntimeError, Undefined
@@ -146,20 +170,11 @@ func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (
 		return true, InterpretOK, v
 	}
 	// HasOwnByKey re-derives existence tableSetAllowed already checked
-	// (GetOwnAccessorByKey/GetOwnDescriptorByKey) - a third linear scan
-	// over the same shape, not a different question. Left as its own call
-	// rather than threading a result out of tableSetAllowed, since that
-	// function's signature is shared with the string-key path.
-	//
-	// Note: if key already names an accessor, tableSetAllowed's
-	// isAccessor check reports allowed=true, and this falls into the
-	// "existing" branch below with nil attribute pointers -
-	// DefineOwnPropertyByKey's accessor-to-data conversion then silently
-	// clobbers the accessor into a plain data property instead of calling
-	// its setter (or, getter-only, leaving it untouched). That is a
-	// distinct, pre-existing bug in its own right (reproduces identically
-	// for a plain function's symbol accessor, unaffected by this specific
-	// existence check) - not introduced or fixed here.
+	// (GetOwnDescriptorByKey, now that the accessor case above already
+	// consumed GetOwnAccessorByKey's answer) - a second linear scan over the
+	// same shape, not a different question. Left as its own call rather than
+	// threading a result out of tableSetAllowed, since that function's
+	// signature is shared with the string-key path.
 	if !props.HasOwnByKey(key) {
 		w, e, c := true, true, true
 		props.DefineOwnPropertyByKey(key, v, &w, &e, &c)
@@ -167,6 +182,75 @@ func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (
 	}
 	props.DefineOwnPropertyByKey(key, v, nil, nil, nil)
 	return true, InterpretOK, v
+}
+
+// setOwnAccessorSetter is the accessor half of ordinary [[Set]] (ECMAScript
+// OrdinarySetWithOwnDescriptor), shared by setOwnChecked and
+// setOwnCheckedByKey so every side-table kind (Function, Closure, RegExp,
+// Map, Set, Promise, BoundFunction, NativeFunction(WithProps)) gets it once
+// instead of each opSetProp/opSetPropSymbol call site reimplementing it (or,
+// for most of them, not implementing it at all - see below).
+//
+// When key names an existing accessor, this fully handles the assignment:
+// calls the setter with receiver as `this` if one exists, or - for a
+// getter-only accessor - silently no-ops in sloppy mode and throws a
+// TypeError in strict mode, per spec. It must never fall through to writing
+// a data property over an accessor. handled is false when key does not name
+// an accessor at all, in which case the caller proceeds with its own
+// data-property logic.
+//
+// Before this existed, an existing accessor's setter was only ever invoked
+// by two of the nine call sites (TypeFunction/TypeClosure in opSetProp,
+// which each pre-checked GetOwnAccessor before reaching setOwnChecked) - the
+// other seven (RegExp/Map/Set/Promise/BoundFunction/NativeFunction(WithProps),
+// for both string and symbol keys) called straight into setOwnChecked /
+// setOwnCheckedByKey, whose only accessor awareness was tableSetAllowed's
+// isAccessor check reporting the write as merely "allowed": for the
+// string-key path that reached PlainObject.SetOwn, which silently no-ops on
+// an accessor field (writable defaults to false for one) without ever
+// calling its setter; for the symbol-key path that reached
+// DefineOwnPropertyByKey with nil attributes, which clobbered the accessor
+// into a data property instead (the bug this function was written to fix).
+func (vm *VM) setOwnAccessorSetter(props *PlainObject, key PropertyKey, display string, receiver Value, v Value) (handled, ok bool, status InterpretResult, result Value) {
+	_, setter, _, _, isAccessor := props.GetOwnAccessorByKey(key)
+	if !isAccessor {
+		return false, true, InterpretOK, Undefined
+	}
+	if setter.Type() != TypeUndefined {
+		_, err := vm.Call(setter, receiver, []Value{v})
+		if err != nil {
+			if ee, eok := err.(ExceptionError); eok {
+				vm.throwException(ee.GetExceptionValue())
+				return true, false, InterpretRuntimeError, Undefined
+			}
+			var excVal Value
+			if errCtor, gok := vm.GetGlobal("Error"); gok {
+				if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+					excVal = res
+				} else {
+					eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+					eo.SetOwn("name", NewString("Error"))
+					eo.SetOwn("message", NewString(err.Error()))
+					excVal = NewValueFromPlainObject(eo)
+				}
+			} else {
+				eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+				eo.SetOwn("name", NewString("Error"))
+				eo.SetOwn("message", NewString(err.Error()))
+				excVal = NewValueFromPlainObject(eo)
+			}
+			vm.throwException(excVal)
+			return true, false, InterpretRuntimeError, Undefined
+		}
+		return true, true, InterpretOK, v
+	}
+	// Getter-only: silent no-op in sloppy mode, TypeError in strict mode -
+	// mirrors opSetProp's TypeObject prototype-chain accessor-setter check.
+	if vm.IsInStrictMode() {
+		vm.ThrowTypeError("Cannot set property '" + display + "' which has only a getter")
+		return true, false, InterpretRuntimeError, Undefined
+	}
+	return true, true, InterpretOK, v
 }
 
 // tableSetAllowed applies setOwnChecked's rejections. threw is true when a

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8783,8 +8783,21 @@ startExecution:
 				if !isValidArrayIndex {
 					// Handle Symbol keys directly
 					if indexVal.Type() == TypeSymbol {
+						frame.ip = ip
 						if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-							return status, res
+							// A thrown exception a handler caught leaves
+							// vm.unwinding false - reload the frame and keep
+							// going rather than aborting the whole run (see
+							// OpSetProp's dot-notation dispatch, and the
+							// TypeObject/callable branch below, for the same
+							// pattern). Without this check, e.g. assigning
+							// through a getter-only accessor on a Function's
+							// symbol-keyed property in strict mode threw
+							// uncatchably even from inside a try/catch.
+							if status != InterpretOK && vm.unwinding {
+								return status, res
+							}
+							goto reloadFrame
 						}
 						continue
 					}
@@ -8804,8 +8817,12 @@ startExecution:
 						}
 						// Per ECMAScript ToPropertyKey: if ToPrimitive returns a Symbol, use it directly
 						if primitiveVal.Type() == TypeSymbol {
+							frame.ip = ip
 							if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], primitiveVal, &valueVal); !ok {
-								return status, res
+								if status != InterpretOK && vm.unwinding {
+									return status, res
+								}
+								goto reloadFrame
 							}
 							continue
 						}
@@ -8813,8 +8830,9 @@ startExecution:
 					} else {
 						key = indexVal.ToString()
 					}
+					frame.ip = ip
 					if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						if status != InterpretOK {
+						if status != InterpretOK && vm.unwinding {
 							return status, res
 						}
 						goto reloadFrame
@@ -8912,8 +8930,9 @@ startExecution:
 						// Convert index to string for property key
 						key := fmt.Sprintf("%d", idx)
 						// Use opSetProp to handle property setting with accessor awareness
+						frame.ip = ip
 						if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-							if status != InterpretOK {
+							if status != InterpretOK && vm.unwinding {
 								return status, res
 							}
 							goto reloadFrame
@@ -8950,8 +8969,17 @@ startExecution:
 						// Skip setting silently (spec-incomplete structure)
 						continue
 					}
+					frame.ip = ip
 					if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-						return status, res
+						// Same unwinding check as the callable branch below -
+						// without it, a thrown exception (e.g. strict-mode
+						// assignment through a getter-only symbol-keyed
+						// accessor) aborted the whole run even from inside a
+						// try/catch that should have caught it.
+						if status != InterpretOK && vm.unwinding {
+							return status, res
+						}
+						goto reloadFrame
 					}
 					continue
 				default:
@@ -8973,8 +9001,12 @@ startExecution:
 						}
 						// Per ECMAScript ToPropertyKey: if ToPrimitive returns a Symbol, use it directly
 						if primitiveVal.Type() == TypeSymbol {
+							frame.ip = ip
 							if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], primitiveVal, &valueVal); !ok {
-								return status, res
+								if status != InterpretOK && vm.unwinding {
+									return status, res
+								}
+								goto reloadFrame
 							}
 							continue
 						}
@@ -9007,8 +9039,9 @@ startExecution:
 				} else {
 					// Route through opSetProp which handles extensibility, writable,
 					// prototype chain accessors, and global object sync
+					frame.ip = ip
 					if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						if status != InterpretOK {
+						if status != InterpretOK && vm.unwinding {
 							return status, res
 						}
 						goto reloadFrame
@@ -9025,19 +9058,33 @@ startExecution:
 					// Non-numeric index (Symbol, string, etc.) - set property via prototype chain
 					switch indexVal.Type() {
 					case TypeSymbol:
+						frame.ip = ip
 						if ok, status, value := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-							return status, value
+							// Same unwinding check as the TypeObject/callable
+							// case above - see its comment.
+							if status != InterpretOK && vm.unwinding {
+								return status, value
+							}
+							goto reloadFrame
 						}
 					case TypeString:
 						key := AsString(indexVal)
+						frame.ip = ip
 						if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-							return status, value
+							if status != InterpretOK && vm.unwinding {
+								return status, value
+							}
+							goto reloadFrame
 						}
 					default:
 						// Convert to string for property access
 						key := indexVal.ToString()
+						frame.ip = ip
 						if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-							return status, value
+							if status != InterpretOK && vm.unwinding {
+								return status, value
+							}
+							goto reloadFrame
 						}
 					}
 				}
@@ -9046,18 +9093,30 @@ startExecution:
 				// Proxy objects: route all property setting through the proxy protocol via opSetProp
 				switch indexVal.Type() {
 				case TypeSymbol:
+					frame.ip = ip
 					if ok, status, value := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-						return status, value
+						if status != InterpretOK && vm.unwinding {
+							return status, value
+						}
+						goto reloadFrame
 					}
 				case TypeString:
 					key := AsString(indexVal)
+					frame.ip = ip
 					if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						return status, value
+						if status != InterpretOK && vm.unwinding {
+							return status, value
+						}
+						goto reloadFrame
 					}
 				default:
 					key := indexVal.ToString()
+					frame.ip = ip
 					if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						return status, value
+						if status != InterpretOK && vm.unwinding {
+							return status, value
+						}
+						goto reloadFrame
 					}
 				}
 

--- a/tests/scripts/symbol_accessor_assign_no_clobber.ts
+++ b/tests/scripts/symbol_accessor_assign_no_clobber.ts
@@ -1,0 +1,247 @@
+// expect: true
+// no-typecheck
+// setOwnCheckedByKey (and, for a string key on RegExp/Map/Set/Promise/
+// BoundFunction/NativeFunction(WithProps), setOwnChecked - that call site
+// never even pre-checked for an accessor the way TypeFunction/TypeClosure's
+// callers in pkg/vm/op_setprop.go did) unconditionally wrote the assigned
+// value through DefineOwnPropertyByKey/PlainObject.SetOwn whenever the
+// target key already existed - including when it named an existing
+// ACCESSOR. Ordinary [[Set]] (obj[key] = v) must instead call the
+// accessor's setter if it has one, or - getter-only - silently no-op in
+// sloppy mode / throw a TypeError in strict mode. It must never convert
+// the accessor into a data property.
+//
+// Fixed by a new shared helper, setOwnAccessorSetter
+// (pkg/vm/properties_table.go), that both setOwnChecked and
+// setOwnCheckedByKey now consult first, mirroring the accessor-setter
+// check pkg/vm/op_setprop.go's TypeObject (plain object) case already had.
+//
+// This file needs `// no-typecheck`: the TypeScript-checked default this
+// repo's tests otherwise run under always compiles as strict mode (see
+// pkg/compiler/compiler.go's "TypeScript mode - always strict"), which
+// would make every assertion below throw instead of exercising the silent
+// sloppy-mode no-op this bug is actually about. The assertions that want
+// strict-mode throwing opt back into it locally via their own
+// "use strict" directive.
+//
+// Getting the strict-mode assertions below to work at all required a
+// second, causally-coupled fix: every OpSetIndex (bracket-notation
+// assignment) dispatch site that calls opSetPropSymbol/opSetProp
+// unconditionally did `if !ok { return status, res }` without checking
+// vm.unwinding first - so a thrown exception (this fix's new strict-mode
+// TypeError included) could never actually be caught by an enclosing
+// try/catch; it just aborted the whole VM run. Fixed by mirroring
+// OpSetProp's dot-notation dispatch (and the one already-correct
+// TypeObject/callable branch of OpSetIndex itself), which check
+// `vm.unwinding` and `goto reloadFrame` instead. See pkg/vm/vm.go's
+// OpSetIndex case.
+
+const checks = [];
+
+function hasAccessorDesc(desc, hasSetter) {
+  return (
+    desc !== undefined &&
+    typeof desc.get === "function" &&
+    (hasSetter ? typeof desc.set === "function" : desc.set === undefined)
+  );
+}
+
+// --- Function: assigning through an existing getter-only accessor must
+// leave the backing state (and the accessor itself) untouched, and must
+// not throw in sloppy mode. ---
+(function () {
+  let backing = 1;
+  function fn() {}
+  const sym = Symbol("k1");
+  Object.defineProperty(fn, sym, {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  fn[sym] = 2; // must not throw, must not touch backing, must not clobber
+  checks.push(backing === 1);
+  const desc = Object.getOwnPropertyDescriptor(fn, sym);
+  checks.push(hasAccessorDesc(desc, false));
+  checks.push(desc.get() === 1);
+})();
+
+// --- Function: assigning through an existing getter+setter accessor must
+// call the setter (whatever it does), not write a data property. ---
+(function () {
+  let backing = 0;
+  function fn() {}
+  const sym = Symbol("k2");
+  Object.defineProperty(fn, sym, {
+    get() {
+      return backing;
+    },
+    set(v) {
+      backing = v * 10;
+    },
+    configurable: true,
+  });
+  fn[sym] = 3;
+  checks.push(backing === 30);
+  const desc = Object.getOwnPropertyDescriptor(fn, sym);
+  checks.push(hasAccessorDesc(desc, true));
+  checks.push(desc.get() === 30);
+})();
+
+// --- Map (an exotic kind whose symbol-set call site, unlike Function's,
+// had no case at all before PR #333): getter-only accessor, sloppy mode. ---
+(function () {
+  let backing = "g";
+  const m = new Map();
+  const sym = Symbol("k3");
+  Object.defineProperty(m, sym, {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  m[sym] = "x";
+  checks.push(backing === "g");
+  checks.push(hasAccessorDesc(Object.getOwnPropertyDescriptor(m, sym), false));
+})();
+
+// --- Map: getter+setter accessor via a symbol key. ---
+(function () {
+  let backing = 0;
+  const m = new Map();
+  const sym = Symbol("k4");
+  Object.defineProperty(m, sym, {
+    get() {
+      return backing;
+    },
+    set(v) {
+      backing = v + 1;
+    },
+    configurable: true,
+  });
+  m[sym] = 5;
+  checks.push(backing === 6);
+  checks.push(hasAccessorDesc(Object.getOwnPropertyDescriptor(m, sym), true));
+})();
+
+// --- Map: the same getter+setter accessor via a STRING key - this call
+// site (setOwnChecked, not setOwnCheckedByKey) never even had a precheck
+// for an existing accessor, string key or symbol, so a setter was never
+// invoked at all here (a distinct, arguably worse instance of the same
+// underlying gap in the shared helper). ---
+(function () {
+  let backing = 0;
+  const m = new Map();
+  Object.defineProperty(m, "custom", {
+    get() {
+      return backing;
+    },
+    set(v) {
+      backing = v + 100;
+    },
+    configurable: true,
+  });
+  m.custom = 7;
+  checks.push(backing === 107);
+  checks.push(hasAccessorDesc(Object.getOwnPropertyDescriptor(m, "custom"), true));
+})();
+
+// --- Strict mode, symbol key: assigning through a getter-only accessor
+// must throw a TypeError instead of silently no-op'ing. Opts back into
+// strict mode locally - the rest of this file is sloppy only because of
+// the `// no-typecheck` directive above. ---
+(function () {
+  "use strict";
+  let backing = 1;
+  let threw = false;
+  function fn() {}
+  const sym = Symbol("k5");
+  Object.defineProperty(fn, sym, {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  try {
+    fn[sym] = 2;
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+  checks.push(backing === 1);
+})();
+
+// --- Strict mode, STRING key: same as above but through opSetProp's
+// TypeFunction case rather than opSetPropSymbol. Before this fix, a
+// getter-only accessor here silently no-op'd in *both* modes (PlainObject
+// SetOwn saw the accessor field's writable:false and returned without
+// ever consulting strict mode) - so this is a genuinely new throw path,
+// not just the symbol-key one becoming stricter. ---
+(function () {
+  "use strict";
+  let backing = 1;
+  let threw = false;
+  function fn() {}
+  Object.defineProperty(fn, "ro", {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  try {
+    fn.ro = 2;
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+  checks.push(backing === 1);
+})();
+
+// --- A throwing setter must propagate to an enclosing try/catch in the
+// *same* frame - exercises setOwnAccessorSetter's own exception-wrapping
+// path (the `vm.Call` error branch), which nothing above reaches since
+// every setter there returns normally. ---
+(function () {
+  let caughtMessage = null;
+  function fn() {}
+  const sym = Symbol("k6");
+  Object.defineProperty(fn, sym, {
+    set() {
+      throw new Error("boom");
+    },
+    configurable: true,
+  });
+  try {
+    fn[sym] = 1;
+  } catch (e) {
+    caughtMessage = e.message;
+  }
+  checks.push(caughtMessage === "boom");
+})();
+
+// --- Same throwing setter, but raised from *inside* a native callback
+// (Array.prototype.forEach) with the try/catch outside it. setOwnAccessorSetter
+// re-enters the VM via vm.Call for every one of these nine exotic kinds -
+// this crosses a native boundary on the way back out, the OpSetIndex
+// unwinding fix's riskiest case (see this file's header comment). ---
+(function () {
+  let caughtMessage = null;
+  function fn() {}
+  const sym = Symbol("k7");
+  Object.defineProperty(fn, sym, {
+    set() {
+      throw new Error("boom2");
+    },
+    configurable: true,
+  });
+  try {
+    [1].forEach(function () {
+      fn[sym] = 1;
+    });
+  } catch (e) {
+    caughtMessage = e.message;
+  }
+  checks.push(caughtMessage === "boom2");
+})();
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

Two coupled fixes — the unique contribution of this PR:

- **`pkg/vm/properties_table.go`** — a new shared helper, `setOwnAccessorSetter`, that `setOwnChecked` and `setOwnCheckedByKey` now consult before touching the side table.
- **`pkg/vm/vm.go`** — 13 `OpSetIndex` dispatch sites (bracket-notation assignment) that called `opSetPropSymbol`/`opSetProp` now check `vm.unwinding` before returning, instead of unconditionally aborting the whole VM run.
- **`tests/scripts/symbol_accessor_assign_no_clobber.ts`** — new regression test.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → #331 → #332 → #333 → #334), since this branch was created from `fix-getdescriptor-symbol-regexp-boundfn`'s tip. Everything except the three items above belongs to those PRs and disappears from the diff once they merge.

## Why two fixes in one commit

Shipping only the first would have made the second half's own new throw path uncatchable — the same "don't ship half a causally-coupled fix" call made on #332 (`OpGetOwnKeys` + `OpIn` for Promise).

### 1. `setOwnChecked`/`setOwnCheckedByKey` clobbered an existing accessor instead of calling its setter

```js
function fn() {}
const sym = Symbol("k");
Object.defineProperty(fn, sym, { get() { return 1; }, configurable: true });
fn[sym] = 2;
Object.getOwnPropertyDescriptor(fn, sym);
// paserati (before): { value: 2, writable: false, enumerable: false, configurable: true }
// Node:              { get: [Function], set: undefined, enumerable: false, configurable: true }
```

Ordinary `[[Set]]` on an existing accessor must call its setter if it has one, or — getter-only — silently no-op in sloppy mode / throw a `TypeError` in strict mode. It must never convert the accessor into a data property (the symbol-key path, via `DefineOwnPropertyByKey`) or silently drop the write without ever calling the setter (the string-key path, via `PlainObject.SetOwn`, which saw the accessor field's `writable: false` and just returned).

Only 2 of the 9 side-table kinds (`Function`/`Closure`) had ever invoked an existing setter at all before this fix — their `opSetProp` call sites pre-checked `GetOwnAccessor` themselves. The other 7 (`RegExp`/`Map`/`Set`/`Promise`/`BoundFunction`/`NativeFunction`/`NativeFunctionWithProps`) never did, string key or symbol.

Fixed by `setOwnAccessorSetter`, mirroring the accessor-setter check `pkg/vm/op_setprop.go`'s `TypeObject` (plain object) case already had — one call site instead of nine call sites each reimplementing it.

### 2. Its new strict-mode throw exposed: bracket-notation assignment can't be caught by try/catch

Once `setOwnAccessorSetter` could actually throw (strict mode, getter-only), every `OpSetIndex` dispatch site calling `opSetPropSymbol`/`opSetProp` did `if !ok { return status, res }` unconditionally — never checking `vm.unwinding` first. A thrown exception (mine included) therefore couldn't be caught by an enclosing try/catch; it just aborted the whole VM run silently (no error printed, exit 0). Only one of these 14 dispatch sites (the `TypeObject`/callable branch, already correctly commented "A thrown TypeError that a handler caught leaves unwinding false") had the right pattern.

Fixed the other 13 sites (across `TypeArray`'s non-index-key path, the combined `TypeObject`/.../`TypeMap`/`TypeSet`/`TypePromise` case, `TypeTypedArray`, and `TypeProxy`) to check `vm.unwinding` and `goto reloadFrame`, mirroring `OpSetProp`'s dot-notation dispatch. Added `frame.ip = ip` at each site that lacked it, so a caught exception's stack trace and the reloaded frame's resumption point are accurate.

Verified against Node: a throwing setter caught in the same frame, and the same throw raised from inside a native callback (`Array.prototype.forEach`) with the try/catch outside it — both match Node exactly. Before the fix, the first case couldn't even reach a throw; once it could, both cases silently killed the whole script instead of reaching the catch block.

**Note for future readers:** `setOwnAccessorSetter` puts `vm.Call` behind all 13 dispatch sites — a bracket assignment can now re-enter the VM (and cross a native boundary) from call sites that previously never ran JS. The frame-reload contract at each caller matters accordingly; a future 14th site needs the same `vm.unwinding` check.

## Testing

`tests/scripts/symbol_accessor_assign_no_clobber.ts` covers getter-only and getter+setter accessors on Function and Map, string and symbol keys, sloppy and strict mode, and a throwing setter caught both in-frame and across a native callback boundary. All 18 assertions verified against real Node output.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (already tracked separately)

- Reading a symbol-keyed (or, for some kinds, even string-keyed) accessor back via bracket notation (`obj[sym]`) / `Reflect.get` on these same nine kinds has its own separate, pre-existing GET-side gap — the getter is never invoked, returning `undefined`. The regression test verifies setter invocation via a captured side-effect variable instead of a bracket read-back to avoid depending on this.
- `in`'s symbol-key dispatch has no case for BoundFunction/NativeFunction/NativeFunctionWithProps.
- `Object.getOwnPropertyDescriptor` on a BoundFunction returns a data-shaped descriptor instead of an accessor-shaped one for a custom string-keyed accessor.

Based on `fix-getdescriptor-symbol-regexp-boundfn` (#334).
