### PR TITLE
fix(vm): `in` finds an own symbol property on BoundFunction/NativeFunction/NativeFunctionWithProps

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3408,6 +3408,44 @@ startExecution:
 							cur = pv.AsPlainObject()
 						}
 					}
+				case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:
+					// Same shape as TypeFunction/TypeClosure above: all three
+					// carry their own lazily-allocated Properties side table
+					// (pkg/vm/function.go - BoundFunctionObject,
+					// NativeFunctionObject, NativeFunctionObjectWithProps all
+					// have a Properties *PlainObject field), so a symbol-keyed
+					// bracket assignment (bound[sym] = v, Array[sym] = v) is
+					// findable the same way a Function's is - own table
+					// first, then walk Function.prototype for an inherited
+					// symbol property (e.g. Symbol.hasInstance).
+					//
+					// Before this case existed, these three fell to the
+					// default below and always answered false here even
+					// though Reflect.has (pkg/builtins/reflect_has.go) and
+					// the own table itself already agreed the property was
+					// there - the same "in disagrees with Reflect.has"
+					// pattern fixed for Promise (see the TypePromise case's
+					// history) and for RegExp/Map/Set's own cases above.
+					symKey := NewSymbolKey(propVal)
+					if props := OwnPropertiesTable(objVal); props != nil {
+						if _, ok := props.GetOwnByKey(symKey); ok {
+							hasProperty = true
+							break
+						}
+					}
+					if vm.FunctionPrototype.IsObject() {
+						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
+							if _, ok := cur.GetOwnByKey(symKey); ok {
+								hasProperty = true
+								break
+							}
+							pv := cur.GetPrototype()
+							if !pv.IsObject() {
+								break
+							}
+							cur = pv.AsPlainObject()
+						}
+					}
 				default:
 					hasProperty = false
 				}

--- a/tests/scripts/in_symbol_boundfn_nativefn.ts
+++ b/tests/scripts/in_symbol_boundfn_nativefn.ts
@@ -1,0 +1,85 @@
+// expect: true
+// OpIn's symbol-key switch (pkg/vm/vm.go, `if propVal.Type() == TypeSymbol`
+// then `switch objVal.Type()`) had cases for TypeObject, TypeDictObject,
+// TypeArray, TypeSet, TypeMap, TypeArguments, TypePromise, TypeRegExp,
+// TypeFunction, and TypeClosure - but nothing for TypeBoundFunction,
+// TypeNativeFunction, or TypeNativeFunctionWithProps, so a symbol-keyed `in`
+// check on any of those three fell through to `default: hasProperty =
+// false`, even for a real own symbol property that Reflect.has (and the
+// underlying Properties side table itself) already found correctly:
+//
+//   const bound = (function () {}).bind(null);
+//   bound[Symbol("k")] = 99;
+//   Reflect.has(bound, sym); // true (correct)
+//   sym in bound;            // false (WRONG) - Node: true
+//
+// Fixed by adding a case for all three, mirroring the existing
+// TypeFunction/TypeClosure cases: own Properties table first (via the
+// generic OwnPropertiesTable helper, since all three carry one - see
+// pkg/vm/properties_table.go's ownPropertiesSlot), then walk
+// vm.FunctionPrototype's chain for an inherited symbol property.
+
+const checks: boolean[] = [];
+
+// --- BoundFunction: an own symbol property set via bracket-notation
+// assignment must be found by both `in` and Reflect.has. ---
+function fn() {}
+const bound: any = fn.bind(null);
+const sym = Symbol("k");
+bound[sym] = 99;
+checks.push(sym in bound);
+checks.push(Reflect.has(bound, sym));
+
+// --- BoundFunction: a genuinely absent symbol key. ---
+checks.push(!(Symbol("absent") in bound));
+checks.push(!Reflect.has(bound, Symbol("absent")));
+
+// --- NativeFunctionWithProps (a native constructor, e.g. Array): an own
+// symbol property must be found by both. ---
+const sym2 = Symbol("k2");
+const Arr: any = Array;
+Arr[sym2] = 6;
+checks.push(sym2 in Arr);
+checks.push(Reflect.has(Arr, sym2));
+
+// --- NativeFunctionWithProps: a genuinely absent symbol key. ---
+checks.push(!(Symbol("absent2") in Arr));
+checks.push(!Reflect.has(Arr, Symbol("absent2")));
+
+// --- NativeFunction (a plain native method): its Properties table isn't
+// allocated until the first property is set on it - own symbol property
+// must still be found by both afterward. ---
+const sym3 = Symbol("k3");
+const nf: any = Array.prototype.push;
+nf[sym3] = 1;
+checks.push(sym3 in nf);
+checks.push(Reflect.has(nf, sym3));
+
+// --- NativeFunction: a genuinely absent symbol key on a function whose
+// Properties table has never been allocated at all. ---
+const nf2: any = Array.prototype.pop;
+checks.push(!(Symbol("absent3") in nf2));
+checks.push(!Reflect.has(nf2, Symbol("absent3")));
+
+// --- String keys on all three kinds are unaffected by this fix. ---
+checks.push("name" in bound && Reflect.has(bound, "name"));
+checks.push("name" in Arr && Reflect.has(Arr, "name"));
+checks.push("call" in nf && Reflect.has(nf, "call"));
+
+// --- Known, separately-tracked divergence risk: `in`'s new case here
+// walks vm.FunctionPrototype for an *inherited* symbol property (e.g.
+// Symbol.hasInstance), same as the pre-existing TypeFunction/TypeClosure
+// cases it mirrors - but Reflect.has (pkg/builtins/reflect_has.go)
+// unconditionally skips that walk for a symbol key on any callable. The
+// two agree today ONLY because the walk itself doesn't actually find
+// Function.prototype[Symbol.hasInstance] yet - a separate, pre-existing
+// bug (task_92b7c9d4, reproduces identically for a plain function, so
+// unrelated to this fix). Both sides are false today; this assertion
+// pins that agreement (NOT Node parity - Node has both true) so that
+// fixing the walk without also adding Reflect.has's matching
+// FunctionPrototype fallback flips this and fails loudly instead of
+// silently reintroducing the exact "in disagrees with Reflect.has" class
+// of bug this whole session has been fixing one kind at a time. ---
+checks.push((Symbol.hasInstance in bound) === Reflect.has(bound, Symbol.hasInstance));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

One case added to one switch, plus a new test — the unique contribution of this PR:

- **`pkg/vm/vm.go`** — `OpIn`'s symbol-key switch gains `case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:`.
- **`tests/scripts/in_symbol_boundfn_nativefn.ts`** — new regression test.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #335), since this branch was created from `fix-symbol-accessor-clobber`'s tip. Everything except the two items above belongs to those PRs and disappears from the diff once they merge.

## The bug — and a correction to the task description

```js
const bound = (function () {}).bind(null);
const sym = Symbol("k");
bound[sym] = 99;
Reflect.has(bound, sym); // true (correct)
sym in bound;            // false (WRONG) - Node: true
```

`OpIn`'s symbol-key switch had cases for `TypeFunction`/`TypeClosure` (and RegExp/Map/Set/Promise/etc. from earlier PRs in this stack) but nothing for `TypeBoundFunction`, `TypeNativeFunction`, or `TypeNativeFunctionWithProps` — falling to `default: hasProperty = false` even when the property demonstrably existed.

The task description asserted `TypeNativeFunction` "has no custom Properties field" and would need a prototype-chain-only shortcut. That's wrong — `pkg/vm/function.go`'s `NativeFunctionObject` has a `Properties *PlainObject` field exactly like the other four callable kinds do (confirmed via `pkg/vm/properties_table.go`'s `ownPropertiesSlot`, which already lists all five). All three needed the identical own-table-then-prototype-chain treatment, not a shortcut.

## The fix

One case added, mirroring the existing `TypeFunction`/`TypeClosure` cases: own `Properties` table first (via the generic `OwnPropertiesTable` helper — one call instead of three near-duplicate per-type accessor calls), then walk `vm.FunctionPrototype`'s chain for an inherited symbol property.

Verified against Node: own symbol property (BoundFunction, a native constructor like `Array`, and a plain native method like `Array.prototype.push`) found by both `in` and `Reflect.has`; absent symbol key correctly `false` on both, including a function whose `Properties` table was never allocated at all; string keys unaffected.

## Testing

`tests/scripts/in_symbol_boundfn_nativefn.ts` covers all of the above. `go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (flagged separately)

- `Object.defineProperty` throws `"called on non-object"` on a plain `TypeNativeFunction` (e.g. `Array.prototype.push`), even though bracket-notation assignment on the same value works fine.
- `Symbol.hasInstance in someFunction` / `Reflect.has(fn, Symbol.hasInstance)` both incorrectly return `false` — the `FunctionPrototype` walk this fix's new case reuses doesn't actually find an inherited symbol property (pre-existing, reproduces identically on `origin/main`), and `Reflect.has` separately skips that walk entirely for any symbol key on a callable. The test file pins today's `false`/`false` *agreement* between `in` and `Reflect.has` for this exact case, with a comment explaining that fixing the walk without also fixing `Reflect.has`'s matching gap in the same change would flip that assertion — the follow-up task is written to require both sides land together.

Based on `fix-symbol-accessor-clobber` (#335).
