### PR TITLE
fix(builtins,vm): Object.defineProperty accepts a plain TypeNativeFunction target

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3454,7 +3454,8 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		obj.Type() == vm.TypeFunction ||
 		obj.Type() == vm.TypeClosure ||
 		obj.Type() == vm.TypeNativeFunctionWithProps ||
-		obj.Type() == vm.TypeBoundFunction
+		obj.Type() == vm.TypeBoundFunction ||
+		obj.Type() == vm.TypeNativeFunction
 	if !isObjectLike {
 		return vm.Undefined, vmInstance.NewTypeError("Object.defineProperty called on non-object")
 	}
@@ -4009,6 +4010,39 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 					defined = nfp.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
 					defined = nfp.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
+			}
+		}
+	} else if obj.Type() == vm.TypeNativeFunction {
+		// Plain native functions (e.g. Array.prototype.push) store additional
+		// properties in Properties exactly like TypeNativeFunctionWithProps
+		// above - the isObjectLike gate near the top of this function used to
+		// exclude TypeNativeFunction entirely, so Object.defineProperty on
+		// one of these threw "called on non-object" even though a
+		// bracket-notation assignment on the exact same value already wrote
+		// into this same table fine (pkg/vm/properties_table.go's
+		// ownPropertiesSlot has always listed TypeNativeFunction alongside
+		// the other four callable kinds).
+		nf := obj.AsNativeFunction()
+		if nf != nil {
+			if nf.Properties == nil {
+				nf.Properties = vm.EnsureOwnPropertiesTable(obj)
+			}
+			var defined bool
+			if hasGetter || hasSetter {
+				if keyIsSymbol {
+					defined = nf.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				} else {
+					defined = nf.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				}
+			} else {
+				if keyIsSymbol {
+					defined = nf.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+				} else {
+					defined = nf.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
 			}
 			if !defined {
@@ -4786,6 +4820,36 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 		}
 	case vm.TypeNativeFunction:
 		nf := obj.AsNativeFunction()
+		// A symbol key is never "name"/"length" (a symbol never equals a
+		// string), so it skips straight to the side-table lookup - mirroring
+		// the TypeBoundFunction block below (accessor first, then data).
+		// Before this, TypeNativeFunction never checked nf.Properties at
+		// all here, symbol or string key: Object.defineProperty on a plain
+		// native function (e.g. Array.prototype.push) now writes into that
+		// table (a separate, sibling fix), but this getter still answered
+		// undefined for what it had just written.
+		if keyIsSymbol {
+			if nf.Properties != nil {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := nf.Properties.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := nf.Properties.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+			return vm.Undefined, nil
+		}
 		if propName == "name" && !nf.DeletedName {
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 			descriptor.SetOwn("value", vm.NewString(nf.Name))
@@ -4801,6 +4865,27 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			descriptor.SetOwn("enumerable", vm.BooleanValue(false))
 			descriptor.SetOwn("configurable", vm.BooleanValue(true))
 			return vm.NewValueFromPlainObject(descriptor), nil
+		}
+		// Any other own property (set via bracket-notation assignment or
+		// Object.defineProperty on this same table) - accessor first, then
+		// data, mirroring the symbol-key check above.
+		if nf.Properties != nil {
+			if g, s, e, c, ok := nf.Properties.GetOwnAccessor(propName); ok {
+				descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+				descriptor.SetOwn("get", g)
+				descriptor.SetOwn("set", s)
+				descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+				descriptor.SetOwn("configurable", vm.BooleanValue(c))
+				return vm.NewValueFromPlainObject(descriptor), nil
+			}
+			if v, w, e, c, ok := nf.Properties.GetOwnDescriptor(propName); ok {
+				descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+				descriptor.SetOwn("value", v)
+				descriptor.SetOwn("writable", vm.BooleanValue(w))
+				descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+				descriptor.SetOwn("configurable", vm.BooleanValue(c))
+				return vm.NewValueFromPlainObject(descriptor), nil
+			}
 		}
 	case vm.TypeNativeFunctionWithProps:
 		nfp := obj.AsNativeFunctionWithProps()

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3660,13 +3660,26 @@ startExecution:
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
 					}
 				case TypeNativeFunction:
-					// Native functions don't have custom properties, but do
-					// carry the same "name"/"length" own intrinsics as any
-					// other callable (see TypeFunction's comment above,
-					// and TypeNativeFunctionWithProps's for why "prototype"
-					// is correctly excluded - a native method is never a
-					// constructor) before falling back to FunctionPrototype.
+					// A plain native function CAN have custom own properties -
+					// set via bracket-notation assignment, or (as of a recent
+					// fix to Object.defineProperty's target-type gate) via
+					// Object.defineProperty - stored in nf.Properties exactly
+					// like TypeBoundFunction below. This case used to claim
+					// "native functions don't have custom properties" and
+					// skip straight to FunctionPrototype, so `"x" in nf` was
+					// false right after `nf.x = 1`/`Object.defineProperty(nf,
+					// "x", ...)` even though Reflect.has(nf, "x") (and the
+					// table itself) already agreed it existed - the same
+					// "in disagrees with Reflect.has" gap already fixed here
+					// for TypeFunction/TypeNativeFunctionWithProps/TypeClosure/
+					// TypeBoundFunction above. Also carries the same
+					// "name"/"length" own intrinsics as any other callable
+					// (see TypeFunction's comment above) before falling back
+					// to FunctionPrototype.
+					nf := objVal.AsNativeFunction()
 					if HasOwnFunctionIntrinsic(objVal, propKey) {
+						hasProperty = true
+					} else if nf.Properties != nil && nf.Properties.Has(propKey) {
 						hasProperty = true
 					} else {
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)

--- a/tests/scripts/defineproperty_native_function.ts
+++ b/tests/scripts/defineproperty_native_function.ts
@@ -1,0 +1,145 @@
+// expect: true
+// Object.defineProperty threw "Object.defineProperty called on non-object"
+// on a plain TypeNativeFunction value (e.g. Array.prototype.push), even
+// though the exact same value already accepted a bracket-notation
+// assignment fine, and every other callable kind (TypeFunction,
+// TypeClosure, TypeBoundFunction, TypeNativeFunctionWithProps) was already
+// accepted - pkg/builtins/object_init.go's isObjectLike gate near the top
+// of objectDefinePropertyWithVM simply never listed TypeNativeFunction,
+// even though its Properties *PlainObject side table (pkg/vm/function.go)
+// is identical in shape to the other four callable kinds.
+//
+// Fixing the write side surfaced two read-side siblings that also never
+// checked a plain native function's Properties table at all:
+//   - objectGetOwnPropertyDescriptorWithVM's TypeNativeFunction case only
+//     ever answered "name"/"length" - defining anything else was invisible
+//     to Object.getOwnPropertyDescriptor.
+//   - OpIn's non-symbol TypeNativeFunction case (pkg/vm/vm.go) carried a
+//     comment claiming "native functions don't have custom properties" and
+//     skipped straight to the FunctionPrototype fallback, so `"x" in nf`
+//     disagreed with Reflect.has(nf, "x") right after defining "x".
+// All three are fixed here, in the same commit as the write-side fix -
+// same "don't ship half a causally-coupled fix" reasoning as PR #332.
+//
+// Each assertion below uses its own function (Array.prototype methods are
+// real shared intrinsics - a distinct one per check keeps one assertion's
+// mutation from being observable by another).
+
+const checks: boolean[] = [];
+
+function hasDataDesc(desc: any, value: unknown, writable: boolean, enumerable: boolean, configurable: boolean): boolean {
+  return (
+    desc !== undefined &&
+    desc.value === value &&
+    desc.writable === writable &&
+    desc.enumerable === enumerable &&
+    desc.configurable === configurable
+  );
+}
+
+// --- A data property via Object.defineProperty on a plain native function,
+// read back via Object.getOwnPropertyDescriptor (singular) and direct
+// property access. ---
+{
+  const nf: any = Array.prototype.push;
+  Object.defineProperty(nf, "tag", { value: 1, writable: true, enumerable: true, configurable: true });
+  checks.push(nf.tag === 1);
+  checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(nf, "tag"), 1, true, true, true));
+}
+
+// --- A symbol-keyed data property, same as above. Verified only via
+// Object.getOwnPropertyDescriptor, not `nf[sym]`: reading a symbol-keyed
+// property back via bracket notation on a plain native function has its
+// own separate, pre-existing GET-side gap (opGetPropSymbol has no
+// TypeNativeFunction case at all) - flagged independently, not fixed
+// here. ---
+{
+  const nf: any = Array.prototype.pop;
+  const sym = Symbol("k");
+  Object.defineProperty(nf, sym, { value: 2, writable: true, enumerable: true, configurable: true });
+  checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(nf, sym), 2, true, true, true));
+}
+
+// --- An accessor property: the setter actually runs (verified via a
+// captured side-effect variable, not a read-back). The getter is
+// confirmed callable via the descriptor's own `get` function, not via
+// `nf.custom` direct read - invoking an own accessor's getter through
+// ordinary property access on a plain native function is a second,
+// separate pre-existing GET-side gap (opGetProp's TypeNativeFunction
+// case only ever calls Properties.GetOwn, which doesn't return an
+// accessor's value) - also flagged independently, not fixed here. ---
+{
+  const nf: any = Array.prototype.shift;
+  let backing = 0;
+  Object.defineProperty(nf, "custom", {
+    get() {
+      return backing;
+    },
+    set(v: number) {
+      backing = v;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  nf.custom = 100;
+  checks.push(backing === 100);
+  const desc: any = Object.getOwnPropertyDescriptor(nf, "custom");
+  checks.push(typeof desc.get === "function" && desc.get() === 100 && typeof desc.set === "function");
+}
+
+// --- name/length intrinsics are preserved: still their synthesized
+// {writable: false, enumerable: false, configurable: true} shape, and
+// redefining name's *value* (permitted since it's configurable) works. ---
+{
+  const nf: any = Array.prototype.unshift;
+  checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(nf, "name"), "unshift", false, false, true));
+  checks.push(
+    hasDataDesc(Object.getOwnPropertyDescriptor(nf, "length"), Array.prototype.unshift.length, false, false, true)
+  );
+  Object.defineProperty(nf, "name", { value: "renamed" });
+  checks.push(nf.name === "renamed");
+}
+
+// --- `in`/Reflect.has agree for a property just defined via
+// Object.defineProperty, both string- and symbol-keyed. ---
+{
+  const nf: any = Array.prototype.slice;
+  Object.defineProperty(nf, "strkey", { value: 1, configurable: true });
+  checks.push("strkey" in nf && Reflect.has(nf, "strkey"));
+  const sym2 = Symbol("k2");
+  Object.defineProperty(nf, sym2, { value: 1, configurable: true });
+  checks.push(sym2 in nf && Reflect.has(nf, sym2));
+}
+
+// --- Reflect.defineProperty (delegates to the same fixed gate). ---
+{
+  const nf: any = Array.prototype.concat;
+  const ok = Reflect.defineProperty(nf, "viaReflect", { value: "v", writable: true, enumerable: true, configurable: true });
+  checks.push(ok === true);
+  checks.push(nf.viaReflect === "v");
+}
+
+// --- A genuinely absent property still answers undefined/false
+// everywhere. ---
+{
+  const nf: any = Array.prototype.indexOf;
+  checks.push(Object.getOwnPropertyDescriptor(nf, "absent") === undefined);
+  checks.push(!("absent" in nf) && !Reflect.has(nf, "absent"));
+}
+
+// --- Non-extensible rejects a new property (must be the LAST assertion
+// touching this particular function, since preventExtensions is permanent
+// for the life of this VM instance). ---
+{
+  const nf: any = Array.prototype.lastIndexOf;
+  Object.preventExtensions(nf);
+  let threw = false;
+  try {
+    Object.defineProperty(nf, "z", { value: 1, configurable: true });
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

Three files, three causally-linked fixes — the unique contribution of this PR:

- **`pkg/builtins/object_init.go`** — `objectDefinePropertyWithVM`'s `isObjectLike` gate and write-dispatch switch both gain `TypeNativeFunction`; its `objectGetOwnPropertyDescriptorWithVM`'s `case vm.TypeNativeFunction:` gains an accessor-then-data side-table lookup.
- **`pkg/vm/vm.go`** — `OpIn`'s non-symbol `case TypeNativeFunction:` now checks `nf.Properties` before falling back to `FunctionPrototype`.
- **`tests/scripts/defineproperty_native_function.ts`** — new regression test.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #336), since this branch was created from `fix-in-symbol-boundfn-nativefn`'s tip. Everything except the items above belongs to those PRs and disappears from the diff once they merge.

## The bug

```js
const nf = Array.prototype.push;
Object.defineProperty(nf, Symbol("k"), { value: 1, configurable: true });
// paserati: TypeError: Object.defineProperty called on non-object
// Node: succeeds
```

`objectDefinePropertyWithVM`'s `isObjectLike` gate explicitly listed `TypeFunction`/`TypeClosure`/`TypeBoundFunction`/`TypeNativeFunctionWithProps` as valid targets, but never `TypeNativeFunction` — even though the same value already accepts a bracket-notation assignment fine, since `pkg/vm/properties_table.go`'s `ownPropertiesSlot` has always listed `TypeNativeFunction` alongside the other four callable kinds (identical lazily-allocated `Properties *PlainObject` side table). `Reflect.defineProperty` delegates to the same function, so it threw identically.

## Two more bugs this fix surfaced (fixed in the same commit — necessary for a real regression test)

Writing the fix alone would only prove `defineProperty` stops throwing — not that it actually stored anything observable. Reading it back hit two more instances of the same "type missing from switch N" class this session has been fixing all along:

1. **`objectGetOwnPropertyDescriptorWithVM`'s `TypeNativeFunction` case only ever answered `"name"`/`"length"`** — it never checked `nf.Properties` at all, so `Object.getOwnPropertyDescriptor` answered `undefined` for anything just defined. Fixed with the same accessor-then-data side-table lookup `TypeBoundFunction`/`TypeRegExp` already have in the same function.
2. **`OpIn`'s non-symbol `TypeNativeFunction` case carried a comment claiming "native functions don't have custom properties"** and skipped straight to the `FunctionPrototype` fallback — so `"x" in nf` disagreed with `Reflect.has(nf, "x")` right after defining `"x"`. Same bug class fixed for RegExp/Map/Set/Promise/BoundFunction/NativeFunctionWithProps earlier this session (most recently for *symbol* keys on this exact type, #336, three commits back) — this is its string-key sibling. Fixed by checking `nf.Properties.Has(propKey)` before the fallback, mirroring `TypeBoundFunction`'s case immediately below it.

## Testing

`tests/scripts/defineproperty_native_function.ts` covers: a data property (string and symbol key), an accessor property (setter's side effect confirmed; getter confirmed callable via the returned descriptor — see below), name/length intrinsics preserved including a permitted redefinition of `name`'s value, `in`/`Reflect.has` agreement for both key types, `Reflect.defineProperty`, a genuinely absent property, and `Object.preventExtensions` correctly rejecting a new property. Each assertion uses its own `Array.prototype.*` method, since these are real shared intrinsics with no reset between assertions in one file.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (flagged separately)

Three more pre-existing gaps turned up while verifying — same "stays broken until its own chip lands" boundary as #336's enumeration note:

- `opGetPropSymbol` has no `TypeNativeFunction` case at all — a symbol-keyed property (even a plain data one) reads back as `undefined` via bracket notation/`Reflect.get`, even though the descriptor correctly shows it exists.
- `opGetProp`'s `TypeNativeFunction` case never invokes an own accessor's getter — only plain data properties. The setter already runs correctly (an earlier PR fixed that half). The test verifies the getter is callable via the descriptor's own `get` function instead of `nf.custom` direct read.
- `Object.keys`/`Object.getOwnPropertyDescriptors`/`for-in` all skip a native function's own enumerable custom properties entirely.

Based on `fix-in-symbol-boundfn-nativefn` (#336).
