### PR TITLE
fix(vm,builtins): `in`/Reflect.has find an inherited symbol on FunctionPrototype

### DIFF
--- a/pkg/builtins/reflect_has.go
+++ b/pkg/builtins/reflect_has.go
@@ -215,11 +215,19 @@ func reflectHas(vmInstance *vm.VM, target vm.Value, key vm.Value) (bool, error) 
 			}
 		}
 		if isSym {
-			// See HasFunctionPrototypeProperty's doc comment: a symbol
-			// key on a callable isn't handled by the string-only
-			// FunctionPrototype fallback, so it stays unconditionally
-			// false here - same as it already was before this fix.
-			return false, nil
+			// HasFunctionPrototypeSymbolProperty mirrors OpIn's own
+			// TypeFunction/TypeClosure/TypeBoundFunction/TypeNativeFunction/
+			// TypeNativeFunctionWithProps symbol-key cases (vm.go), which
+			// walk FunctionPrototype's chain for an inherited symbol
+			// property like Symbol.hasInstance. Before this, `in` and
+			// Reflect.has already disagreed here in principle (in's walk
+			// used to look for FunctionPrototype as a bare PlainObject and
+			// silently find nothing, since it's actually a
+			// TypeNativeFunctionWithProps at runtime - see that function's
+			// doc comment), but with in's walk now fixed, leaving this
+			// unconditionally false would make the disagreement real
+			// instead of masked.
+			return vmInstance.HasFunctionPrototypeSymbolProperty(propKey), nil
 		}
 		return vmInstance.HasFunctionPrototypeProperty(name), nil
 	}

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -1048,13 +1048,22 @@ func HasOwnFunctionIntrinsic(target Value, name string) bool {
 // for pkg/builtins: Reflect.has's callable cases (Function, Closure,
 // NativeFunction, NativeFunctionWithProps, BoundFunction) need the exact
 // same "own side table, then FunctionPrototype" fallback OpIn's own
-// callable cases already use internally, for a string key (this does not
-// handle a symbol key - FunctionPrototype's own representation, a
-// PlainObject in the common case but possibly a NativeFunctionWithProps,
-// needs a manual walk to support that correctly; see OpIn's
-// TypeFunction/TypeClosure symbol branches in vm.go for the pattern).
+// callable cases already use internally, for a string key.
 func (vm *VM) HasFunctionPrototypeProperty(propKey string) bool {
 	return vm.hasFunctionPrototypeProperty(propKey)
+}
+
+// HasFunctionPrototypeSymbolProperty is HasFunctionPrototypeProperty for a
+// symbol key (e.g. Symbol.hasInstance), exported for pkg/builtins so
+// Reflect.has's callable case can use the exact same walk OpIn's own
+// callable cases use internally (vm.go's hasFunctionPrototypeSymbolProperty)
+// instead of unconditionally answering false for any symbol key beyond a
+// callable's own side table - which would otherwise have `in` (which does
+// walk this chain) disagree with Reflect.has for an inherited symbol
+// property, the same "in disagrees with Reflect.has" bug class fixed
+// elsewhere in this function for string keys.
+func (vm *VM) HasFunctionPrototypeSymbolProperty(key PropertyKey) bool {
+	return vm.hasFunctionPrototypeSymbolProperty(key)
 }
 
 // handleSpecialProperties handles special properties like .length

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3364,18 +3364,8 @@ startExecution:
 						}
 					}
 					// Walk Function.prototype chain
-					if vm.FunctionPrototype.IsObject() {
-						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
-							if _, ok := cur.GetOwnByKey(symKey); ok {
-								hasProperty = true
-								break
-							}
-							pv := cur.GetPrototype()
-							if !pv.IsObject() {
-								break
-							}
-							cur = pv.AsPlainObject()
-						}
+					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
+						hasProperty = true
 					}
 				case TypeClosure:
 					// Check closure's own properties first (shadows Fn.Properties)
@@ -3395,18 +3385,8 @@ startExecution:
 						}
 					}
 					// Walk Function.prototype chain
-					if vm.FunctionPrototype.IsObject() {
-						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
-							if _, ok := cur.GetOwnByKey(symKey); ok {
-								hasProperty = true
-								break
-							}
-							pv := cur.GetPrototype()
-							if !pv.IsObject() {
-								break
-							}
-							cur = pv.AsPlainObject()
-						}
+					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
+						hasProperty = true
 					}
 				case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:
 					// Same shape as TypeFunction/TypeClosure above: all three
@@ -3433,18 +3413,8 @@ startExecution:
 							break
 						}
 					}
-					if vm.FunctionPrototype.IsObject() {
-						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
-							if _, ok := cur.GetOwnByKey(symKey); ok {
-								hasProperty = true
-								break
-							}
-							pv := cur.GetPrototype()
-							if !pv.IsObject() {
-								break
-							}
-							cur = pv.AsPlainObject()
-						}
+					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
+						hasProperty = true
 					}
 				default:
 					hasProperty = false
@@ -17724,6 +17694,55 @@ func (vm *VM) hasFunctionPrototypeProperty(propKey string) bool {
 	return false
 }
 
+// functionPrototypeOwnTable returns the PlainObject actually holding
+// FunctionPrototype's own properties - see hasFunctionPrototypeProperty's
+// doc comment for why this isn't just vm.FunctionPrototype.AsPlainObject().
+// At runtime Function.prototype is created as a callable
+// TypeNativeFunctionWithProps (pkg/builtins/function_init.go, so that
+// Function.prototype() itself is a valid no-op call per spec), and its own
+// properties - including call/apply/bind/toString and
+// Symbol.hasInstance - live in that value's Properties side table, not in
+// vm.FunctionPrototype itself. Returns nil if FunctionPrototype is neither
+// shape (shouldn't happen once initialized) or its table isn't allocated.
+func (vm *VM) functionPrototypeOwnTable() *PlainObject {
+	switch vm.FunctionPrototype.Type() {
+	case TypeObject:
+		return vm.FunctionPrototype.AsPlainObject()
+	case TypeNativeFunctionWithProps:
+		if fp := vm.FunctionPrototype.AsNativeFunctionWithProps(); fp != nil {
+			return fp.Properties
+		}
+	}
+	return nil
+}
+
+// hasFunctionPrototypeSymbolProperty is hasFunctionPrototypeProperty for a
+// symbol key, used by OpIn's TypeFunction/TypeClosure/TypeBoundFunction/
+// TypeNativeFunction/TypeNativeFunctionWithProps cases to find an inherited
+// symbol property (e.g. Function.prototype[Symbol.hasInstance]) once a
+// callable's own Properties table doesn't have it. Before this existed,
+// each of those cases open-coded `vm.FunctionPrototype.AsPlainObject()`
+// directly - which is nil whenever FunctionPrototype is (as it always is
+// at runtime) a TypeNativeFunctionWithProps rather than a TypeObject, so
+// `vm.FunctionPrototype.IsObject()` was false and the walk never even
+// started. `Symbol.hasInstance in someFunction` answered false even though
+// `Symbol.hasInstance in Function.prototype` (addressed directly, going
+// through OpIn's own TypeNativeFunctionWithProps-aware handling) correctly
+// answered true, and even though the property demonstrably exists.
+func (vm *VM) hasFunctionPrototypeSymbolProperty(key PropertyKey) bool {
+	for cur := vm.functionPrototypeOwnTable(); cur != nil; {
+		if _, ok := cur.GetOwnByKey(key); ok {
+			return true
+		}
+		pv := cur.GetPrototype()
+		if !pv.IsObject() {
+			return false
+		}
+		cur = pv.AsPlainObject()
+	}
+	return false
+}
+
 // isUnscopable checks if a property is excluded by Symbol.unscopables on the with-object.
 // This properly triggers the getter for @@unscopables per ECMAScript spec.
 // Returns (unscopable, hadError) - if hadError is true, check vm.unwinding
@@ -21437,10 +21456,11 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 				return true
 			}
 		}
-		if vm.FunctionPrototype.Type() == TypeObject {
-			return vm.FunctionPrototype.AsPlainObject().Has(propKey)
-		}
-		return false
+		// Was `if vm.FunctionPrototype.Type() == TypeObject { ... }; return
+		// false` - silently false whenever FunctionPrototype is (as it
+		// always is at runtime) TypeNativeFunctionWithProps rather than
+		// TypeObject. See hasFunctionPrototypeProperty's doc comment.
+		return vm.hasFunctionPrototypeProperty(propKey)
 	case TypeClosure:
 		cl := target.AsClosure()
 		if propKey == "name" || propKey == "length" {
@@ -21459,10 +21479,7 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 				return true
 			}
 		}
-		if vm.FunctionPrototype.Type() == TypeObject {
-			return vm.FunctionPrototype.AsPlainObject().Has(propKey)
-		}
-		return false
+		return vm.hasFunctionPrototypeProperty(propKey)
 	default:
 		return false
 	}

--- a/tests/scripts/in_symbol_boundfn_nativefn.ts
+++ b/tests/scripts/in_symbol_boundfn_nativefn.ts
@@ -66,20 +66,45 @@ checks.push("name" in bound && Reflect.has(bound, "name"));
 checks.push("name" in Arr && Reflect.has(Arr, "name"));
 checks.push("call" in nf && Reflect.has(nf, "call"));
 
-// --- Known, separately-tracked divergence risk: `in`'s new case here
-// walks vm.FunctionPrototype for an *inherited* symbol property (e.g.
-// Symbol.hasInstance), same as the pre-existing TypeFunction/TypeClosure
-// cases it mirrors - but Reflect.has (pkg/builtins/reflect_has.go)
-// unconditionally skips that walk for a symbol key on any callable. The
-// two agree today ONLY because the walk itself doesn't actually find
-// Function.prototype[Symbol.hasInstance] yet - a separate, pre-existing
-// bug (task_92b7c9d4, reproduces identically for a plain function, so
-// unrelated to this fix). Both sides are false today; this assertion
-// pins that agreement (NOT Node parity - Node has both true) so that
-// fixing the walk without also adding Reflect.has's matching
-// FunctionPrototype fallback flips this and fails loudly instead of
-// silently reintroducing the exact "in disagrees with Reflect.has" class
-// of bug this whole session has been fixing one kind at a time. ---
-checks.push((Symbol.hasInstance in bound) === Reflect.has(bound, Symbol.hasInstance));
+// --- `in`'s FunctionPrototype walk (used above by BoundFunction) also
+// correctly finds an *inherited* symbol property, e.g.
+// Function.prototype[Symbol.hasInstance], and Reflect.has agrees - both
+// now true, matching Node. (This assertion previously pinned a
+// false/false agreement caused by two compounding pre-existing bugs: the
+// walk itself couldn't find FunctionPrototype's own properties at all,
+// since vm.FunctionPrototype is a TypeNativeFunctionWithProps at runtime
+// rather than a bare PlainObject, and Reflect.has unconditionally skipped
+// the walk for any symbol key. Both are fixed now - see
+// hasFunctionPrototypeSymbolProperty's doc comment in pkg/vm/vm.go.) ---
+checks.push(Symbol.hasInstance in bound && Reflect.has(bound, Symbol.hasInstance));
+
+// --- Same inherited-symbol lookup for a plain function and a class,
+// verified to match Node (both true). ---
+function plainFn() {}
+checks.push(Symbol.hasInstance in plainFn && Reflect.has(plainFn, Symbol.hasInstance));
+
+class SomeClass {}
+checks.push(Symbol.hasInstance in SomeClass && Reflect.has(SomeClass, Symbol.hasInstance));
+
+// --- The walk doesn't stop at Function.prototype - it continues up to
+// Function.prototype's own [[Prototype]] (Object.prototype) too, for a
+// symbol property that lives there instead. Confirms the fix's shared
+// helper (hasFunctionPrototypeSymbolProperty) walks the full chain, not
+// just its first step. ---
+const inheritedFromObjectProto = Symbol("inheritedFromObjectProto");
+(Object.prototype as any)[inheritedFromObjectProto] = 1;
+checks.push(
+  inheritedFromObjectProto in plainFn && Reflect.has(plainFn, inheritedFromObjectProto)
+);
+
+// --- A class that overrides Symbol.hasInstance as its own static
+// property is still found via the own-table check, same as before -
+// unaffected by the FunctionPrototype walk fix. ---
+class OverridesHasInstance {
+  static [Symbol.hasInstance](_x: unknown) {
+    return true;
+  }
+}
+checks.push(Symbol.hasInstance in OverridesHasInstance && Reflect.has(OverridesHasInstance, Symbol.hasInstance));
 
 checks.every((c) => c === true);

--- a/tests/scripts/proxy_has_property_fallback_function_prototype.ts
+++ b/tests/scripts/proxy_has_property_fallback_function_prototype.ts
@@ -1,0 +1,52 @@
+// expect: true
+// vm.proxyHasPropertyFallback's TypeFunction/TypeClosure cases (pkg/vm/vm.go)
+// used to guard the FunctionPrototype lookup with
+// `if vm.FunctionPrototype.Type() == TypeObject { ... }; return false` -
+// silently false whenever FunctionPrototype is (as it always is at
+// runtime, per pkg/builtins/function_init.go) a TypeNativeFunctionWithProps
+// rather than a TypeObject. This fallback is what `in`/Reflect.has use for
+// a Proxy wrapping a Function/Closure with no `has` trap, so a
+// STRING-keyed property that only exists on Function.prototype (e.g.
+// "call") was invisible through such a proxy even though it's found
+// correctly on the unwrapped function itself.
+//
+// Fixed by reusing hasFunctionPrototypeProperty here too, instead of a
+// duplicated, incomplete inline check.
+//
+// This covers string keys only: OpIn's SYMBOL-key switch has no
+// `case TypeProxy` at all (a separate, much larger pre-existing gap -
+// `anySymbol in proxyObject` is unconditionally false regardless of a
+// `has` trap or the target's own properties - flagged independently, not
+// fixed here, tracked as task_42fe36b9).
+
+const checks: boolean[] = [];
+
+function fn() {}
+const proxiedFn: any = new Proxy(fn, {});
+
+// --- A string-keyed FunctionPrototype method, through the fallback
+// (no `has` trap on this proxy). `in` was the broken half before this fix
+// (unconditionally false here); Reflect.has(proxiedFn, "call") went
+// through the separate proxyReflectHas path and was already correct, so
+// it doesn't by itself exercise this fix - the first assertion below
+// does. ---
+checks.push("call" in proxiedFn);
+checks.push(Reflect.has(proxiedFn, "call"));
+checks.push("apply" in proxiedFn);
+
+// --- A genuinely absent property is still false through the fallback. ---
+checks.push(!("nonexistentMethod" in proxiedFn));
+
+// --- The same, wrapping a Closure (a function with an upvalue) instead of
+// a plain Function. ---
+function makeClosure() {
+  let captured = 1;
+  return function closureFn() {
+    return captured;
+  };
+}
+const proxiedClosure: any = new Proxy(makeClosure(), {});
+checks.push("call" in proxiedClosure);
+checks.push(!("nonexistentMethod2" in proxiedClosure));
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

Three files' logic, plus two tests — the unique contribution of this PR:

- **`pkg/vm/vm.go`** — new `functionPrototypeOwnTable()`/`hasFunctionPrototypeSymbolProperty()` helpers, replacing three duplicated inline walk loops in `OpIn`'s symbol-key switch; `vm.proxyHasPropertyFallback`'s `TypeFunction`/`TypeClosure` cases now reuse `hasFunctionPrototypeProperty` instead of a narrower inline check.
- **`pkg/vm/property_helpers.go`** — new exported `HasFunctionPrototypeSymbolProperty`; corrected `HasFunctionPrototypeProperty`'s doc comment (see below).
- **`pkg/builtins/reflect_has.go`** — the callable case's symbol-key branch now calls the new helper instead of unconditionally returning `false`.
- **`tests/scripts/in_symbol_boundfn_nativefn.ts`** — the previously-pinned "known divergence" assertion is updated to assert genuine agreement, plus new assertions.
- **`tests/scripts/proxy_has_property_fallback_function_prototype.ts`** — new regression test for the proxy-fallback fix.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #337), since this branch was created from `fix-defineproperty-nativefunction`'s tip. Everything except the items above belongs to those PRs and disappears from the diff once they merge.

## Root cause — this invalidates the task description's hypothesis

```js
function fn() {}
Symbol.hasInstance in fn;            // paserati (before): false, Node: true
Reflect.has(fn, Symbol.hasInstance); // paserati (before): false, Node: true
Symbol.hasInstance in Function.prototype; // true (correct) - addressed directly
```

The task description offered two candidates: a stale `vm.FunctionPrototype` reference, or a symbol identity/hashing mismatch. **Neither.** `vm.FunctionPrototype` is a `TypeNativeFunctionWithProps` at runtime (`pkg/builtins/function_init.go` creates `Function.prototype` as a *callable*, per spec, so `Function.prototype()` itself is a valid no-op call — its own properties, including `Symbol.hasInstance`, live in that value's `Properties` side table, not directly on it). But `OpIn`'s `TypeFunction`/`TypeClosure`/`TypeBoundFunction`/`TypeNativeFunction`/`TypeNativeFunctionWithProps` symbol-key cases each open-coded `vm.FunctionPrototype.AsPlainObject()` guarded by `vm.FunctionPrototype.IsObject()` — which is `false` for a callable-typed value, so the walk never even started.

The existing `hasFunctionPrototypeProperty` (string keys — `"call"`/`"apply"`/etc.) already handled both representations correctly, but its own doc comment had this backwards: *"FunctionPrototype can be either TypeObject or TypeNativeFunctionWithProps... a PlainObject in the common case"* — `TypeNativeFunctionWithProps` is actually the *only* case that occurs at runtime. Corrected.

## The fix

- `functionPrototypeOwnTable()` returns the `PlainObject` actually holding `FunctionPrototype`'s own properties for either representation.
- `hasFunctionPrototypeSymbolProperty(key)` walks that table's chain — replacing **three** duplicated inline walk loops in `OpIn`'s symbol switch with one call each (a deliberate dedup, not incidental churn).
- Exported as `HasFunctionPrototypeSymbolProperty` for `pkg/builtins`.
- **`reflect_has.go`'s matching fix landed in this same commit, as required**: its callable case explicitly short-circuited to `false` for any symbol key beyond a callable's own table (comment: *"stays unconditionally false here"*). Once `in`'s walk actually works, leaving this unfixed would make `in` and `Reflect.has` disagree for the first time — they only agreed before because the walk was broken on both counts.

## A third fix found while verifying, landed in the same commit

`vm.proxyHasPropertyFallback`'s `TypeFunction`/`TypeClosure` cases had the identical guard-on-`TypeObject`-only bug for **string** keys (`if vm.FunctionPrototype.Type() == TypeObject {...}; return false`) — this is what `in`/`Reflect.has` use for a Proxy wrapping a function with no `has` trap. So `"call" in someProxy` was `false` even though `"call" in someFunction` (unwrapped) was already correct. Fixed by reusing `hasFunctionPrototypeProperty` there too.

## Testing

Verified against Node: `Symbol.hasInstance` on a plain function, a class, a `BoundFunction`, a native function, and a native constructor (`Array`) — all now agree with `Reflect.has` and match Node; a class overriding `Symbol.hasInstance` as its own static property still resolves via the own-table check; the walk correctly continues past `Function.prototype` up to `Object.prototype` for a symbol property defined there (a discriminating check per review — confirms the fix isn't a one-hop shortcut); a genuinely absent symbol stays `false`; the proxy fallback finds `"call"`/`"apply"` through `Function.prototype` for both a plain function and a closure, and still correctly reports an absent method as `false`.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (flagged separately, tracked as task_42fe36b9)

`OpIn`'s symbol-key switch has no `case TypeProxy` at all — any symbol key on a Proxy is unconditionally `false` regardless of a `has` trap or the target's own properties. This is a missing trap-dispatch path (an entire case), not a walk bug like the ones fixed here, and is out of scope for this commit.

Based on `fix-defineproperty-nativefunction` (#337).
