### PR TITLE
fix(vm,builtins): native functions expose custom own properties to GET and enumeration

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2089,16 +2089,19 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 			}
 		}
-	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps:
 		// Same side table as the exotic kinds above (OwnPropertiesTable,
 		// pkg/vm/properties_table.go) - this case was missing entirely, so
-		// Object.keys always came back empty for these four kinds even
+		// Object.keys always came back empty for these six kinds even
 		// after a custom own property was defined on one (e.g. r.custom =
 		// 42, or Object.defineProperty once that gap is fixed too).
 		// RegExp's "lastIndex" never appears here: it's a real Go field on
 		// RegExpObject, not a side-table entry, and it's non-enumerable in
 		// any case (Object.getOwnPropertyDescriptor's TypeRegExp case,
-		// same file).
+		// same file). TypeNativeFunction/TypeNativeFunctionWithProps'
+		// "name"/"length" intrinsics are non-enumerable synthesized
+		// properties, not side-table entries either, so they're correctly
+		// excluded here the same way.
 		if props := vm.OwnPropertiesTable(obj); props != nil {
 			for _, key := range props.OwnKeys() {
 				if _, _, en, _, ok := props.GetOwnDescriptor(key); ok && en {
@@ -5166,6 +5169,29 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 						stringKeys = append(stringKeys, k)
 					}
 				}
+				// Symbol keys were missing here too (e.g. a symbol property
+				// defined on a native constructor like Boolean/Number) -
+				// same gap as the TypeNativeFunction branch below, fixed
+				// alongside it since it's the identical one-line fix on the
+				// identical *PlainObject side table.
+				symbolKeys = append(symbolKeys, nfp.Properties.OwnSymbolKeys()...)
+			}
+		} else {
+			// TypeNativeFunction: a plain native method's own custom
+			// properties - this branch never existed at all, so
+			// Object.getOwnPropertyDescriptors(nf) only ever reported
+			// "length"/"name", silently dropping anything just defined via
+			// Object.defineProperty or bracket-notation assignment (the
+			// single-key Object.getOwnPropertyDescriptor already answered
+			// correctly for the exact same property).
+			nf := obj.AsNativeFunction()
+			if nf.Properties != nil {
+				for _, k := range nf.Properties.OwnPropertyNames() {
+					if k != "length" && k != "name" {
+						stringKeys = append(stringKeys, k)
+					}
+				}
+				symbolKeys = append(symbolKeys, nf.Properties.OwnSymbolKeys()...)
 			}
 		}
 	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -102,6 +102,62 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 	if objVal.Type() == TypeNativeFunction {
 		nf := objVal.AsNativeFunction()
 		if nf != nil && nf.Properties != nil {
+			// Check for an accessor property first (getters/setters) -
+			// mirrors TypeBoundFunction's equivalent check in
+			// handleCallableProperty (property_helpers.go). Without this,
+			// an accessor defined via Object.defineProperty(nf, "custom",
+			// {get(){...}}) fell straight to GetOwn below, which - for an
+			// accessor field - returns (Undefined, true) (DefineAccessorProperty
+			// appends a placeholder Undefined properties slot for it), so
+			// `nf.custom` silently answered undefined instead of calling
+			// the getter, even though the same accessor's *setter* already
+			// ran correctly via `nf.custom = v` (pkg/vm/op_setprop.go).
+			if g, _, _, _, ok := nf.Properties.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					res, err := vm.Call(g, *objVal, nil)
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							if frame != nil && !frameWasNil {
+								frame.ip = ip - 4
+							}
+							vm.throwException(ee.GetExceptionValue())
+							if !vm.unwinding {
+								return false, InterpretOK, Undefined
+							}
+							return false, InterpretRuntimeError, Undefined
+						}
+						var excVal Value
+						if errCtor, ok := vm.GetGlobal("Error"); ok {
+							if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+								excVal = res
+							} else {
+								eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+								eo.SetOwn("name", NewString("Error"))
+								eo.SetOwn("message", NewString(err.Error()))
+								excVal = NewValueFromPlainObject(eo)
+							}
+						} else {
+							eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+							eo.SetOwn("name", NewString("Error"))
+							eo.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(eo)
+						}
+						if frame != nil && !frameWasNil {
+							frame.ip = ip - 4
+						}
+						vm.throwException(excVal)
+						if !vm.unwinding {
+							return false, InterpretOK, Undefined
+						}
+						return false, InterpretRuntimeError, Undefined
+					}
+					*dest = res
+					return true, InterpretOK, *dest
+				}
+				// Setter-only accessor (no getter): reads as undefined per spec.
+				*dest = Undefined
+				return true, InterpretOK, *dest
+			}
 			if prop, exists := nf.Properties.GetOwn(propName); exists {
 				*dest = prop
 				return true, InterpretOK, *dest
@@ -2182,6 +2238,91 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 				*dest = v
 				return true, InterpretOK, *dest
 			}
+		}
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+
+	// NativeFunction: check own symbol properties (accessor first, mirroring
+	// TypeObject's GetOwnAccessorByKey-then-GetOwnByKey pattern above and
+	// this same TypeNativeFunction kind's string-key equivalent in
+	// opGetProp's block 3b), then Function.prototype chain.
+	//
+	// This case didn't exist at all before this fix, so a symbol-keyed own
+	// property - even a plain data one - set via bracket-notation
+	// assignment or Object.defineProperty always fell through to the
+	// DictObject default below and read back as undefined, even though
+	// Object.getOwnPropertyDescriptor already showed it existed correctly.
+	//
+	// The accessor check specifically was added after review flagged an
+	// asymmetry a first pass introduced: opGetProp's block 3b (string keys,
+	// same TypeNativeFunction kind) invokes an own accessor's getter, so
+	// leaving this symbol-key sibling without one would have made
+	// `nf.custom` call the getter while `nf[sym]` did not, on the very
+	// same value in the same commit - worse than the pre-fix state of
+	// "symbol keys don't work at all". TypeFunction/TypeClosure/
+	// TypeBoundFunction/TypeNativeFunctionWithProps above still lack this
+	// (none of those four invoke a symbol-key accessor's getter; TypeObject,
+	// separately, already does - see its own case earlier in this
+	// function), so that remains a real, separate, still-open gap.
+	if base.Type() == TypeNativeFunction {
+		nf := base.AsNativeFunction()
+		key := NewSymbolKey(symKey)
+		if nf.Properties != nil {
+			if g, _, _, _, ok := nf.Properties.GetOwnAccessorByKey(key); ok {
+				if g.Type() != TypeUndefined {
+					res, err := vm.Call(g, base, nil)
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							if frame != nil && !frameWasNil {
+								frame.ip = ip - 4
+							}
+							vm.throwException(ee.GetExceptionValue())
+							if !vm.unwinding {
+								return false, InterpretOK, Undefined
+							}
+							return false, InterpretRuntimeError, Undefined
+						}
+						var excVal Value
+						if errCtor, ok := vm.GetGlobal("Error"); ok {
+							if res2, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+								excVal = res2
+							} else {
+								eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+								eo.SetOwn("name", NewString("Error"))
+								eo.SetOwn("message", NewString(err.Error()))
+								excVal = NewValueFromPlainObject(eo)
+							}
+						} else {
+							eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+							eo.SetOwn("name", NewString("Error"))
+							eo.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(eo)
+						}
+						if frame != nil && !frameWasNil {
+							frame.ip = ip - 4
+						}
+						vm.throwException(excVal)
+						if !vm.unwinding {
+							return false, InterpretOK, Undefined
+						}
+						return false, InterpretRuntimeError, Undefined
+					}
+					*dest = res
+					return true, InterpretOK, *dest
+				}
+				// Setter-only accessor (no getter): reads as undefined per spec.
+				*dest = Undefined
+				return true, InterpretOK, *dest
+			}
+			if v, ok := nf.Properties.GetOwnByKey(key); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			*dest = v
+			return true, InterpretOK, *dest
 		}
 		*dest = Undefined
 		return true, InterpretOK, *dest

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14666,21 +14666,23 @@ startExecution:
 						cur = pv.AsPlainObject()
 					}
 				}
-			case TypeMap, TypeSet, TypePromise:
+			case TypeMap, TypeSet, TypePromise, TypeNativeFunction, TypeNativeFunctionWithProps:
 				// Same side table as TypeRegExp just above (OwnPropertiesTable,
 				// pkg/vm/properties_table.go) - this case was missing
 				// entirely, so `for (k in map)`/`for (k in set)`/
-				// `for (k in promise)` came back with nothing even after a
-				// plain assignment onto the value. Map/Set's own "size" is
-				// never an own property (it's a getter on Map.prototype/
-				// Set.prototype - Object.getOwnPropertyDescriptor(new Map(),
-				// "size") is undefined in Node), and Promise exposes no
-				// user-accessible own state, so only the side table matters
+				// `for (k in promise)`/`for (k in nativeFn)` came back with
+				// nothing even after a plain assignment onto the value.
+				// Map/Set's own "size" is never an own property (it's a
+				// getter on Map.prototype/Set.prototype -
+				// Object.getOwnPropertyDescriptor(new Map(), "size") is
+				// undefined in Node), Promise exposes no user-accessible own
+				// state, and TypeNativeFunction/TypeNativeFunctionWithProps'
+				// "name"/"length" are non-enumerable synthesized intrinsics,
+				// not side-table entries - so only the side table matters
 				// here, same as RegExp's "lastIndex" staying excluded above.
-				// OwnPropertiesTable abstracts over the three kinds' actual
-				// field names (MapObject/SetObject/PromiseObject.Properties)
-				// via ownPropertiesSlot, so one case covers all three
-				// instead of duplicating the TypeRegExp case's body three
+				// OwnPropertiesTable abstracts over all five kinds' actual
+				// field names via ownPropertiesSlot, so one case covers them
+				// instead of duplicating the TypeRegExp case's body five
 				// times.
 				if props := OwnPropertiesTable(objValue); props != nil {
 					seen := make(map[string]bool)

--- a/tests/scripts/nativefunction_get_and_enumerate.ts
+++ b/tests/scripts/nativefunction_get_and_enumerate.ts
@@ -1,0 +1,199 @@
+// expect: true
+// Following the fix to Object.defineProperty (and OpIn/getOwnPropertyDescriptor)
+// for plain TypeNativeFunction values (defineproperty_native_function.ts),
+// several more places still didn't see a native function's custom own
+// properties. All three are fixed here:
+//
+//   1. opGetPropSymbol (pkg/vm/op_getprop.go) had no `case TypeNativeFunction`
+//      at all - reading any symbol-keyed own property via `nf[sym]` (or
+//      Reflect.get, though that has its own separate, much larger gap -
+//      see below) returned undefined even though
+//      Object.getOwnPropertyDescriptor already showed it existed.
+//
+//      Fixing this surfaced an asymmetry a first pass introduced: the
+//      sibling string-key fix below (opGetProp's TypeNativeFunction block)
+//      invokes an own accessor's getter, so this symbol-key case invokes
+//      it too - otherwise `nf.custom` would call the getter while `nf[sym]`
+//      would not, on the very same value. TypeFunction/TypeClosure/
+//      TypeBoundFunction/TypeNativeFunctionWithProps's symbol-key cases
+//      still do NOT invoke an own accessor's getter (none of the four
+//      ever have) - that remains a real, separate, still-open gap.
+//
+//   2. opGetProp's existing TypeNativeFunction block (string keys) only
+//      ever called Properties.GetOwn, which never detects or invokes an
+//      accessor's getter - PlainObject.DefineAccessorProperty appends a
+//      placeholder Undefined properties slot for an accessor field, so
+//      GetOwn(name) returns (Undefined, true) for one instead of
+//      (_, false). This silently made `nf.custom` read as undefined
+//      instead of calling the getter, even though the very same
+//      accessor's *setter* already ran correctly via `nf.custom = v`.
+//
+//   3. Object.keys, Object.getOwnPropertyDescriptors, and OpGetOwnKeys
+//      (for-in, pkg/vm/vm.go) all skipped a native function's own
+//      enumerable custom properties entirely - their switches never had a
+//      TypeNativeFunction case. TypeNativeFunctionWithProps (e.g. `Boolean`,
+//      `Number`) had the identical gap in the same switches, found and
+//      fixed alongside it since the case bodies already used the generic
+//      OwnPropertiesTable/`nfp.Properties` machinery and needed no new code,
+//      only the additional case label.
+//
+// Each assertion below uses its own Array.prototype method (or, for the
+// NativeFunctionWithProps checks, a distinct global constructor) - these
+// are real shared intrinsics with no reset between assertions in the same
+// test file, so reusing one across assertions would let one mutation leak
+// into another's expectations. The three NativeFunctionWithProps checks
+// (6, 8, 13) deliberately use three different constructors (Boolean,
+// Number, String) for the same reason - consolidating them onto one
+// constructor would silently couple those three checks together.
+//
+// While fixing (3), found the TypeNativeFunctionWithProps branch of
+// Object.getOwnPropertyDescriptors also dropped symbol keys entirely
+// (only the new TypeNativeFunction branch collected them) - fixed
+// alongside it, same one-line fix on the identical *PlainObject side
+// table (check 13 below).
+//
+// Found but NOT fixed here (flagged as separate follow-ups):
+//   - Reflect.get is almost entirely non-functional beyond TypeObject/
+//     TypeDictObject/TypeArray, and unconditionally stringifies its key
+//     even for a Symbol - a large, pre-existing, unrelated gap.
+//   - Object.getOwnPropertyDescriptors has no TypeBoundFunction case at
+//     all (returns {} - missing even name/length).
+//   - Object.getOwnPropertySymbols has no TypeNativeFunction case (misses
+//     a symbol property that getOwnPropertyDescriptor already reports).
+
+const checks: boolean[] = [];
+
+// --- 1. Symbol-keyed data property read back via bracket notation ---
+{
+  const nf: any = Array.prototype.shift;
+  const sym = Symbol("k1");
+  Object.defineProperty(nf, sym, { value: 2, enumerable: true, configurable: true });
+  checks.push(nf[sym] === 2);
+}
+
+// --- 2. Symbol-keyed data property set via bracket notation, read back ---
+{
+  const nf: any = Array.prototype.pop;
+  const sym = Symbol("k2");
+  nf[sym] = 5;
+  checks.push(nf[sym] === 5);
+}
+
+// --- 3. String-keyed accessor: getter invoked via direct property access ---
+{
+  const nf: any = Array.prototype.unshift;
+  let backing = 0;
+  Object.defineProperty(nf, "custom", {
+    get() { return backing; },
+    set(v: number) { backing = v; },
+    configurable: true,
+  });
+  nf.custom = 100;
+  checks.push(backing === 100);
+  checks.push(nf.custom === 100);
+}
+
+// --- 4. Symbol-keyed accessor: getter invoked via bracket access. This is
+// the case that would have been silently inconsistent with #3 above (same
+// kind, same commit) had the accessor check been added only on the
+// string-key path. ---
+{
+  const nf: any = Array.prototype.slice;
+  let backing = 0;
+  const sym = Symbol("k4");
+  Object.defineProperty(nf, sym, {
+    get() { return backing; },
+    set(v: number) { backing = v; },
+    configurable: true,
+  });
+  nf[sym] = 200;
+  checks.push(backing === 200);
+  checks.push(nf[sym] === 200);
+}
+
+// --- 5. Object.keys sees an enumerable custom property (string key) ---
+{
+  const nf: any = Array.prototype.concat;
+  Object.defineProperty(nf, "vis", { value: 1, enumerable: true, configurable: true });
+  checks.push(JSON.stringify(Object.keys(nf)) === JSON.stringify(["vis"]));
+}
+
+// --- 6. Object.keys on TypeNativeFunctionWithProps (a native constructor) ---
+{
+  Object.defineProperty(Boolean, "visCtor", { value: 1, enumerable: true, configurable: true });
+  checks.push(Object.keys(Boolean).includes("visCtor"));
+}
+
+// --- 7. for-in enumerates the same enumerable custom property ---
+{
+  const nf: any = Array.prototype.indexOf;
+  Object.defineProperty(nf, "vis2", { value: 1, enumerable: true, configurable: true });
+  const seen: string[] = [];
+  for (const k in nf) seen.push(k);
+  checks.push(JSON.stringify(seen) === JSON.stringify(["vis2"]));
+}
+
+// --- 8. for-in on TypeNativeFunctionWithProps ---
+{
+  Object.defineProperty(Number, "visCtor2", { value: 1, enumerable: true, configurable: true });
+  const seen: string[] = [];
+  for (const k in Number) seen.push(k);
+  checks.push(seen.includes("visCtor2"));
+}
+
+// --- 9. Object.getOwnPropertyDescriptors reports the same custom property ---
+{
+  const nf: any = Array.prototype.lastIndexOf;
+  Object.defineProperty(nf, "vis3", { value: 1, enumerable: true, configurable: true });
+  const descs: any = Object.getOwnPropertyDescriptors(nf);
+  checks.push(!!descs.vis3 && descs.vis3.value === 1);
+}
+
+// --- 10. A non-enumerable custom property is correctly excluded from
+// Object.keys/for-in but still present in getOwnPropertyDescriptors ---
+{
+  const nf: any = Array.prototype.includes;
+  Object.defineProperty(nf, "hidden", { value: 1, enumerable: false, configurable: true });
+  checks.push(!Object.keys(nf).includes("hidden"));
+  let seenHidden = false;
+  for (const k in nf) if (k === "hidden") seenHidden = true;
+  checks.push(!seenHidden);
+  checks.push((Object.getOwnPropertyDescriptors(nf) as any).hidden !== undefined);
+}
+
+// --- 11. name/length are still correctly excluded from Object.keys/for-in
+// (non-enumerable synthesized intrinsics, not side-table entries) ---
+{
+  const nf: any = Array.prototype.join;
+  checks.push(!Object.keys(nf).includes("name"));
+  checks.push(!Object.keys(nf).includes("length"));
+}
+
+// --- 12. Repeated string-key accessor read at the same call site: opGetProp's
+// TypeNativeFunction accessor check runs before the normal inline-cache path
+// used for plain objects, so a monomorphic repeated read must still call the
+// getter every time, not just once. ---
+{
+  const nf: any = Array.prototype.reverse;
+  let n = 0;
+  Object.defineProperty(nf, "counter", {
+    get() { return ++n; },
+    configurable: true,
+  });
+  const seenVals: number[] = [];
+  for (let i = 0; i < 3; i++) seenVals.push(nf.counter);
+  checks.push(JSON.stringify(seenVals) === JSON.stringify([1, 2, 3]));
+}
+
+// --- 13. Object.getOwnPropertyDescriptors reports a symbol-keyed property
+// on TypeNativeFunctionWithProps too (found while fixing (3)'s
+// TypeNativeFunction sibling - the WithProps branch collected string keys
+// but never symbol keys, from the same *PlainObject side table). ---
+{
+  const sym = Symbol("k13");
+  Object.defineProperty(String, sym, { value: 9, enumerable: true, configurable: true });
+  const descs: any = Object.getOwnPropertyDescriptors(String);
+  checks.push(!!descs[sym] && descs[sym].value === 9);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

- **`pkg/vm/op_getprop.go`** — new `TypeNativeFunction` case in `opGetPropSymbol` (with own-accessor getter invocation); `opGetProp`'s existing `TypeNativeFunction` block (string keys) now checks `GetOwnAccessor` before `GetOwn`.
- **`pkg/vm/vm.go`** — `OpGetOwnKeys` (for-in) switch gains `TypeNativeFunction, TypeNativeFunctionWithProps`.
- **`pkg/builtins/object_init.go`** — `objectKeysWithVM` switch gains the same two cases; `objectGetOwnPropertyDescriptorsWithVM` gains a `TypeNativeFunction` else-branch (string + symbol keys) and adds the missing symbol-key collection to the pre-existing `TypeNativeFunctionWithProps` branch.
- **`tests/scripts/nativefunction_get_and_enumerate.ts`** — new regression test, 13 assertions, each using a distinct `Array.prototype.*` method or global constructor (these are real shared intrinsics with no reset between assertions in the same file).

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #338), since this branch was created from `fix-in-symbol-hasinstance-walk`'s tip (#338). Everything except the items above belongs to those PRs and disappears from the diff once they merge.

## Root cause — this invalidates part of the task description's premise

The task asked to mirror "already-working `TypeBoundFunction`/`TypeMap`/`TypeSet`/`TypePromise` symbol-key GET cases (accessor-getter-invocation included)." That's not what the code does. None of those existing cases in `opGetPropSymbol` invoke an accessor's getter for a symbol key — and `Map`/`Set`'s symbol-key GET path doesn't even check their own property table at all, only the prototype chain. Verified by reading the code, not assumed.

```js
const nf = Array.prototype.shift;
let backing = 0;
Object.defineProperty(nf, "custom", { get() { return backing; }, set(v) { backing = v; }, configurable: true });
nf.custom = 100;
console.log(nf.custom); // paserati (before): undefined - Node: 100

const nf2 = Array.prototype.pop;
const sym = Symbol("k");
Object.defineProperty(nf2, sym, { value: 2, configurable: true });
console.log(nf2[sym]); // paserati (before): undefined - Node: 2

const nf3 = Array.prototype.push;
Object.defineProperty(nf3, "vis", { value: 1, enumerable: true, configurable: true });
console.log(Object.keys(nf3)); // paserati (before): [] - Node: ["vis"]
```

## The fix

1. **`opGetPropSymbol`'s new `TypeNativeFunction` case** does invoke an own accessor's getter — not because a sibling case already does, but because leaving it out would have created a same-commit inconsistency: fix (2) below makes `nf.custom` (string key) call the getter, so `nf[sym]` (symbol key, same value) not doing the same would be a regression in internal consistency, not just an unfixed gap. This was caught in review before shipping — the first pass left the symbol case without accessor invocation, reasoning (correctly, at the time) that no sibling case had it either; that reasoning stopped holding once the string-key sibling in the same commit gained it. `TypeFunction`/`TypeClosure`/`TypeBoundFunction`/`TypeNativeFunctionWithProps` still lack symbol-key accessor invocation — a real, separate, still-open gap, intentionally not touched here.

2. **`opGetProp`'s `TypeNativeFunction` block** now checks `Properties.GetOwnAccessor` before `Properties.GetOwn`. Root cause: `PlainObject.DefineAccessorProperty` appends a placeholder `Undefined` properties slot for an accessor field, so plain `GetOwn(name)` returns `(Undefined, true)` for an accessor field, not `(_, false)` — so it silently looked like a data property with value `undefined` instead of triggering a getter call.

3. **`Object.keys`, `Object.getOwnPropertyDescriptors`, `OpGetOwnKeys` (for-in)** all gain a `TypeNativeFunction` case where the case body already used generic `OwnPropertiesTable`/`Properties` machinery — no new logic needed beyond the case itself.

## Found while fixing (3), not requested by the task, fixed in the same commit

`TypeNativeFunctionWithProps` (e.g. `Boolean`, `Number`, `String`) had the identical missing-case gap in `Object.keys` and `OpGetOwnKeys`, and its pre-existing `Object.getOwnPropertyDescriptors` branch collected string keys but never symbol keys — all fixed alongside the `TypeNativeFunction` work since it's the same switch statements and the same *PlainObject side table, zero new logic.

## Testing

17-assertion draft verified byte-identical between Node and paserati before being narrowed into the final 13-assertion test file (some scratch checks were folded together). Includes a discriminating check (test #12) that the new `opGetProp` accessor path isn't stale-cached on a repeated monomorphic read — `for (let i=0;i<3;i++) nf.counter` invokes the getter all three times, confirming the accessor branch (which sits ahead of the normal inline-cache path) isn't accidentally read once and cached.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (flagged separately as follow-up tasks)

- `Reflect.get` is almost entirely non-functional beyond `TypeObject`/`TypeDictObject`/`TypeArray`, and unconditionally stringifies its key even for a `Symbol` — a large, pre-existing, unrelated gap deserving its own task.
- `Object.getOwnPropertyDescriptors` has no `TypeBoundFunction` case at all (returns `{}` — missing even `name`/`length`).
- `Object.getOwnPropertySymbols` has no `TypeNativeFunction` case (misses a symbol property that `getOwnPropertyDescriptor` already reports).

Based on `fix-in-symbol-hasinstance-walk` (#338).
