### PR TITLE
fix(builtins,vm): Reflect.get handles every VM value kind and both key types

### DIFF
--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -53,7 +53,16 @@ func (r *ReflectInitializer) InitTypes(ctx *TypeContext) error {
 	// Create Reflect object type with all 13 methods
 	reflectType := types.NewObjectType().
 		// Property operations
-		WithProperty("get", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Any)).
+		//
+		// "get" takes an optional third `receiver` argument (used as the
+		// `this` an accessor's getter is called with - the runtime
+		// implementation now actually reads it, see reflectObj's "get"
+		// closure below). Reflect.set/Reflect.construct have the exact
+		// same "optional trailing argument the runtime accepts but the
+		// declared signature doesn't" gap for their own optional
+		// receiver/newTarget parameters - left alone here (out of this
+		// fix's scope) and flagged as a separate follow-up.
+		WithProperty("get", types.NewOptionalFunction([]types.Type{types.Any, keyType, types.Any}, types.Any, []bool{false, false, true})).
 		WithProperty("set", types.NewSimpleFunction([]types.Type{types.Any, keyType, types.Any}, types.Boolean)).
 		WithProperty("has", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
 		WithProperty("deleteProperty", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
@@ -94,39 +103,40 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	// Reflect.get(target, propertyKey [, receiver])
+	// Per ECMAScript spec, this invokes [[Get]] and returns the result -
+	// receiver defaults to target, and is what any accessor's getter along
+	// the way is called with as `this` (10.1.8 [[Get]] step 5/6). The
+	// actual per-kind dispatch (own-accessor-then-data, prototype-chain
+	// walk, Proxy trap invocation and invariant checks, both string and
+	// Symbol keys) lives in pkg/vm/vm_init.go's
+	// GetPropertyWithReceiver/ReflectGetSymbolPropertyWithReceiver, which
+	// this used to duplicate a much narrower, TypeObject/TypeDictObject/
+	// TypeArray-only, string-key-only version of inline - silently
+	// returning undefined for every other kind (Function, Map, Set,
+	// RegExp, BoundFunction, NativeFunction, NativeFunctionWithProps,
+	// Promise, TypedArray, Proxy, ...) and unconditionally stringifying
+	// even a Symbol key.
 	reflectObj.SetOwnNonEnumerable("get", vm.NewNativeFunction(2, false, "get", func(args []vm.Value) (vm.Value, error) {
 		if len(args) < 2 {
 			return vm.Undefined, vmInstance.NewTypeError("Reflect.get requires at least 2 arguments")
 		}
 		target := args[0]
-		propKey := args[1].ToString()
+		key := args[1]
 
 		if !target.IsObject() && !target.IsCallable() {
 			return vm.Undefined, vmInstance.NewTypeError("Reflect.get called on non-object")
 		}
 
-		// Perform simple property get
-		switch target.Type() {
-		case vm.TypeObject:
-			if val, ok := target.AsPlainObject().Get(propKey); ok {
-				return val, nil
-			}
-		case vm.TypeDictObject:
-			if val, ok := target.AsDictObject().Get(propKey); ok {
-				return val, nil
-			}
-		case vm.TypeArray:
-			arr := target.AsArray()
-			if propKey == "length" {
-				return vm.Number(float64(arr.Length())), nil
-			}
-			// Try numeric index using strconv
-			if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 && idx < arr.Length() {
-				return arr.Get(idx), nil
-			}
+		// Receiver defaults to target if not provided (ECMA-262 28.1.7).
+		receiver := target
+		if len(args) >= 3 {
+			receiver = args[2]
 		}
 
-		return vm.Undefined, nil
+		if key.Type() == vm.TypeSymbol {
+			return vmInstance.ReflectGetSymbolPropertyWithReceiver(target, key, receiver)
+		}
+		return vmInstance.GetPropertyWithReceiver(target, key.ToString(), receiver)
 	}))
 
 	// Reflect.set(target, propertyKey [, value [, receiver]])

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3445,7 +3445,7 @@ startExecution:
 						return InterpretRuntimeError, Undefined
 					}
 
-					if hasTrap, ok := proxyGetHasTrap(proxy.handler); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+					if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 						if !hasTrap.IsCallable() {
 							vm.ThrowTypeError("'has' on proxy: trap is not a function")
 							if !vm.unwinding {
@@ -21600,29 +21600,34 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 	}
 }
 
-// proxyGetHasTrap looks up a Proxy handler's "has" trap the way
-// GetMethod(handler, "has") does per spec (10.5.7 step 4): an inherited
-// trap counts, not just an own one, and the handler can be a TypeDictObject
-// (a module namespace or enum value, pkg/vm/object.go's NewDictObject) as
-// well as an ordinary TypeObject - AsPlainObject() on the former panics.
+// proxyGetTrap looks up a Proxy handler's trap (e.g. "has", "get") the way
+// GetMethod(handler, trapName) does per spec: an inherited trap counts,
+// not just an own one, and the handler can be a TypeDictObject (a module
+// namespace or enum value, pkg/vm/object.go's NewDictObject) as well as an
+// ordinary TypeObject - AsPlainObject() on the former panics.
 //
-// This exists because both of this function's callers (OpIn's symbol-key
-// TypeProxy case above and proxyHasSymbolPropertyFallback below) used to
-// inline `proxy.handler.AsPlainObject().GetOwn("has")` directly, copied
+// Originally added (as the "has"-only proxyGetHasTrap) because OpIn's
+// symbol-key TypeProxy case and proxyHasSymbolPropertyFallback below used
+// to inline `proxy.handler.AsPlainObject().GetOwn("has")` directly, copied
 // from the pre-existing string-key TypeProxy case's identical shape a few
 // lines below - itself not spec-correct on either count (own-only, and an
 // unguarded AsPlainObject that panics for a TypeDictObject handler; try
-// `new Proxy({}, someEnum)` on either the string- or symbol-key path
-// before this fix). That pre-existing gap was left alone here rather than
-// silently fixed as a drive-by - it's flagged as a shared follow-up
-// instead (see this branch's PR body) since fixing it changes the
-// string-key path's behavior too and deserves its own verification.
-func proxyGetHasTrap(handler Value) (Value, bool) {
+// `new Proxy({}, someEnum)` on either the string- or symbol-key `in` path).
+// That pre-existing `in`-path gap was left alone rather than silently
+// fixed as a drive-by (see task_125640b9's PR body) since fixing it
+// changes established `in`/Reflect.has behavior on a path that fix wasn't
+// scoped to touch.
+//
+// Generalized to take a trap name so getPropertyWithReceiver's Proxy case
+// (pkg/vm/vm_init.go, backing Reflect.get) can reuse it for the "get"
+// trap instead of carrying its own copy of the same two bugs forward a
+// third time.
+func proxyGetTrap(handler Value, trapName string) (Value, bool) {
 	switch handler.Type() {
 	case TypeObject:
-		return handler.AsPlainObject().Get("has")
+		return handler.AsPlainObject().Get(trapName)
 	case TypeDictObject:
-		return handler.AsDictObject().Get("has")
+		return handler.AsDictObject().Get(trapName)
 	default:
 		return Undefined, false
 	}
@@ -21653,7 +21658,7 @@ func (vm *VM) proxyHasSymbolPropertyFallback(target Value, propVal Value) bool {
 		if proxy.Revoked {
 			return false
 		}
-		if hasTrap, ok := proxyGetHasTrap(proxy.handler); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+		if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 			if hasTrap.IsCallable() {
 				trapArgs := []Value{proxy.target, propVal}
 				result, err := vm.Call(hasTrap, proxy.handler, trapArgs)

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -331,6 +331,32 @@ func (vm *VM) GetFrameCount() int {
 // GetProperty gets a property from an object value, properly handling getters and prototype chain
 // This is safe to call from native functions and will trigger property getters/throw exceptions
 func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
+	return vm.getPropertyWithReceiver(obj, propName, obj)
+}
+
+// GetPropertyWithReceiver is GetProperty with an explicit receiver for any
+// own or inherited accessor's getter to be called with as `this`, instead
+// of always the object the property was actually found on/started from.
+// Added for Reflect.get(target, key[, receiver]) (pkg/builtins/
+// reflect_init.go), whose optional third argument is exactly this - per
+// ECMA-262 10.1.8 [[Get]], an accessor's getter is invoked with Receiver
+// as its this value, which can legitimately differ from the object
+// [[Get]] started walking from (e.g. Reflect.get(proto, "x", instance)
+// calls proto's getter for "x" with `this = instance`).
+func (vm *VM) GetPropertyWithReceiver(obj Value, propName string, receiver Value) (Value, error) {
+	return vm.getPropertyWithReceiver(obj, propName, receiver)
+}
+
+// getPropertyWithReceiver is GetProperty/GetPropertyWithReceiver's shared
+// implementation. receiver is threaded through every accessor-getter
+// vm.Call and every recursive self-call (walking a [[Prototype]] set via
+// Object.setPrototypeOf, a Proxy's target when no trap is present, ...) so
+// a getter anywhere on the chain is always invoked with the ORIGINAL
+// receiver, not whichever intermediate object it was actually found on -
+// GetProperty's plain callers (which don't have a distinct receiver
+// concept) get receiver == obj, matching this function's behavior before
+// receiver support existed.
+func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value) (Value, error) {
 	// Simple implementation that doesn't use opGetProp to avoid unwinding issues
 	// Check for getter (including prototype chain) and call it, or return the property value
 
@@ -340,7 +366,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		// Check own accessor first
 		if g, _, _, _, ok := po.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 			// Call the getter with this=obj
-			result, err := vm.Call(g, obj, nil)
+			result, err := vm.Call(g, receiver, nil)
 			if err != nil {
 				return Undefined, err
 			}
@@ -353,29 +379,60 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		// Walk prototype chain for accessor or data properties
 		current := po.GetPrototype()
 		for current.typ != TypeNull && current.typ != TypeUndefined {
-			if current.IsObject() {
-				if current.Type() == TypeObject {
-					proto := current.AsPlainObject()
-					// Check for accessor in prototype
-					if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-						// Call the getter with this=original obj (not proto)
-						result, err := vm.Call(g, obj, nil)
-						if err != nil {
-							return Undefined, err
-						}
-						return result, nil
+			if current.Type() == TypeObject {
+				proto := current.AsPlainObject()
+				// Check for accessor in prototype
+				if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
+					// Call the getter with this=original obj (not proto)
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
 					}
-					// Check for data property in prototype
-					if value, exists := proto.GetOwn(propName); exists {
-						return value, nil
-					}
-					current = proto.GetPrototype()
-				} else {
-					break
+					return result, nil
 				}
-			} else {
-				break
+				// Check for data property in prototype
+				if value, exists := proto.GetOwn(propName); exists {
+					return value, nil
+				}
+				current = proto.GetPrototype()
+				continue
 			}
+			// The chain leaves plain-TypeObject territory (a callable or
+			// other exotic kind used as a [[Prototype]] via
+			// Object.create(fn)/Object.setPrototypeOf, or a class
+			// extending a native constructor) - recurse into the full
+			// per-kind dispatch instead of silently stopping, so an own
+			// property on THAT value's own table (a Function's
+			// Properties, say) is still found. NOT gated on
+			// current.IsObject(): every callable kind (TypeFunction,
+			// TypeClosure, TypeNativeFunction, TypeNativeFunctionWithProps,
+			// TypeBoundFunction) sorts BEFORE TypeObject in the ValueType
+			// enum (pkg/vm/value.go), so IsObject() - a contiguous
+			// [TypeObject, TypeProxy] range check - is FALSE for exactly
+			// the values this branch exists to handle; gating on it here
+			// (an earlier version of this fix did) silently reintroduced
+			// the very "stops early" bug this comment describes fixing.
+			// Found via the symbol-key sibling of this exact case
+			// (getSymbolPropertyWithReceiver) needing the identical fix
+			// for Reflect.get(Object.create(fn), sym) to work - this is
+			// the same gap for a string key, fixed alongside it in the
+			// same commit rather than left silently asymmetric between
+			// key kinds.
+			return vm.getPropertyWithReceiver(current, propName, receiver)
+		}
+		return Undefined, nil
+
+	case TypeDictObject:
+		// DictObject (a module namespace or TS enum value at runtime,
+		// pkg/vm/object.go's NewDictObject) - own properties only.
+		// DictObject doesn't support accessors (its own .Get comment says
+		// so) and has no user-facing prototype chain of its own, so this
+		// is just a direct own-table lookup. This case didn't exist at all
+		// before this fix, so Reflect.get on a module namespace or enum
+		// always answered undefined - found while implementing Reflect.get's
+		// general property support, not previously reported.
+		if v, ok := obj.AsDictObject().Get(propName); ok {
+			return v, nil
 		}
 		return Undefined, nil
 
@@ -449,14 +506,25 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		if proxy.Revoked {
 			return Undefined, vm.NewTypeError("Cannot perform 'get' on a revoked Proxy")
 		}
-		getTrap, hasGetTrap := proxy.handler.AsPlainObject().GetOwn("get")
+		// proxyGetTrap (not a bare proxy.handler.AsPlainObject().GetOwn("get"))
+		// for the same two reasons documented on its own definition: GetMethod
+		// semantics mean an INHERITED "get" trap counts too, and a handler
+		// that happens to be a TypeDictObject (a TS enum/module namespace
+		// value) must not panic AsPlainObject().
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
 		if hasGetTrap && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !getTrap.IsCallable() {
 				return Undefined, vm.NewTypeError("'get' on proxy: trap is not a function")
 			}
-			// Call the get trap: handler.get(target, propertyKey, receiver)
-			trapArgs := []Value{proxy.target, NewString(propName), obj}
+			// Call the get trap: handler.get(target, propertyKey, receiver) -
+			// receiver, not obj: obj is whichever value this switch is
+			// currently examining (which can be a Proxy reached partway
+			// through a longer chain), while receiver is the ORIGINAL
+			// object/value the caller's property access started from -
+			// exactly what ECMA-262 10.5.8 step 8 passes as the trap's
+			// third argument.
+			trapArgs := []Value{proxy.target, NewString(propName), receiver}
 			result, err := vm.Call(getTrap, proxy.handler, trapArgs)
 			if err != nil {
 				return Undefined, err
@@ -481,11 +549,31 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			}
 			return result, nil
 		}
-		// No get trap, fall through to target
-		return vm.GetProperty(proxy.target, propName)
+		// No get trap, fall through to target - still threading the
+		// original receiver through, not proxy.target, so a getter found
+		// further down the chain still sees the right `this`.
+		return vm.getPropertyWithReceiver(proxy.target, propName, receiver)
 
 	case TypePromise:
-		// Promise objects: check Promise.prototype chain
+		// Promise objects: own side-table property first (same table/gap
+		// as TypeSet/TypeMap above - Promises don't expose own state as
+		// ordinary properties, but a plain assignment or
+		// Object.defineProperty can still add one), then Promise.prototype.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if g, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := props.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
 		if vm.PromisePrototype.IsObject() {
 			proto := vm.PromisePrototype.AsPlainObject()
 			if v, ok := proto.Get(propName); ok {
@@ -515,7 +603,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					// Check for accessor property (getter) on prototype
 					if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 						// Call the getter with this=original RegExp object
-						result, err := vm.Call(g, obj, nil)
+						result, err := vm.Call(g, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -532,7 +620,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 							if current.Type() == TypeObject {
 								grandProto := current.AsPlainObject()
 								if g, _, _, _, ok := grandProto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-									result, err := vm.Call(g, obj, nil)
+									result, err := vm.Call(g, receiver, nil)
 									if err != nil {
 										return Undefined, err
 									}
@@ -620,7 +708,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					if getter, _, _, _, ok := cur.GetOwnAccessor(propName); ok {
 						if getter.Type() != TypeUndefined {
 							// Call the getter with this=obj (the TypedArray)
-							result, err := vm.Call(getter, obj, nil)
+							result, err := vm.Call(getter, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -645,14 +733,37 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		return Undefined, nil
 
 	case TypeSet:
-		// Set objects: check prototype chain (especially for accessor properties like size)
+		// Set objects: own side-table property first (the same lazily-
+		// allocated table a plain `set.foo = 1`/Object.defineProperty
+		// assignment writes into - OwnPropertiesTable,
+		// pkg/vm/properties_table.go), THEN the prototype chain (for
+		// accessor properties like size). Before this, a Set's own custom
+		// property was invisible here even though Object.getOwnPropertyDescriptor/
+		// `in`/Reflect.has already agreed it existed - same "kind missing a
+		// side-table check" gap already fixed elsewhere in this switch
+		// (RegExp) and across OpIn/Object.keys/etc. in prior PRs.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if g, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := props.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
 		if vm.SetPrototype.IsObject() {
 			proto := vm.SetPrototype.AsPlainObject()
 			// Check for accessor (getter) first
 			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					// Call the getter with this=obj (the Set)
-					result, err := vm.Call(getter, obj, nil)
+					// Call the getter with this=receiver (the Set)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -668,14 +779,30 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		return Undefined, nil
 
 	case TypeMap:
-		// Map objects: check prototype chain (especially for accessor properties like size)
+		// Map objects: same own-side-table-then-prototype-chain shape as
+		// TypeSet just above - see its comment.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if g, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := props.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
 		if vm.MapPrototype.IsObject() {
 			proto := vm.MapPrototype.AsPlainObject()
 			// Check for accessor (getter) first
 			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					// Call the getter with this=obj (the Map)
-					result, err := vm.Call(getter, obj, nil)
+					// Call the getter with this=receiver (the Map)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -699,7 +826,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor (getter) on own properties
 				if getter, _, _, _, ok := fn.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -720,7 +847,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			}
 			// Walk [[Prototype]] chain (set by Object.setPrototypeOf)
 			if fn.Prototype.Type() != TypeUndefined && fn.Prototype.Type() != TypeNull {
-				return vm.GetProperty(fn.Prototype, propName)
+				return vm.getPropertyWithReceiver(fn.Prototype, propName, receiver)
 			}
 			// Fall back to Function.prototype - use function's own realm if available (cross-realm)
 			funcProto := vm.FunctionPrototype
@@ -733,7 +860,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					// Check for accessor first
 					if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 						if getter.Type() != TypeUndefined {
-							result, err := vm.Call(getter, obj, nil)
+							result, err := vm.Call(getter, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -758,7 +885,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor (getter) on own properties
 				if getter, _, _, _, ok := cl.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -780,7 +907,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				}
 				// Walk [[Prototype]] chain (set by Object.setPrototypeOf)
 				if cl.Fn.Prototype.Type() != TypeUndefined && cl.Fn.Prototype.Type() != TypeNull {
-					return vm.GetProperty(cl.Fn.Prototype, propName)
+					return vm.getPropertyWithReceiver(cl.Fn.Prototype, propName, receiver)
 				}
 			}
 			// Fall back to Function.prototype (which is a NativeFunctionWithProps)
@@ -790,7 +917,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					// Check for accessor first
 					if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 						if getter.Type() != TypeUndefined {
-							result, err := vm.Call(getter, obj, nil)
+							result, err := vm.Call(getter, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -813,7 +940,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			// Check for accessor (getter) on own properties
 			if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					result, err := vm.Call(getter, obj, nil)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -845,7 +972,70 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor first
 				if getter, _, _, _, ok := fpNfp.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
+						if err != nil {
+							return Undefined, err
+						}
+						return result, nil
+					}
+					return Undefined, nil
+				}
+				if v, ok := fpNfp.Properties.Get(propName); ok {
+					return v, nil
+				}
+			}
+		}
+		return Undefined, nil
+
+	case TypeNativeFunction:
+		// A plain native function (e.g. Array.prototype.push) - same shape
+		// as TypeNativeFunctionWithProps just above, except its own
+		// intrinsics live directly on the value's own fields rather than
+		// under a *PlainObject with a IsConstructor flag. This case didn't
+		// exist at all before this fix (found while implementing
+		// Reflect.get's general property support, but this function -
+		// GetProperty/GetPropertyWithReceiver - is also used elsewhere,
+		// e.g. Reflect.apply/construct's generic array-like .length
+		// access), so Reflect.get(Array.prototype.push, "name") and
+		// friends always answered undefined, and any custom own property
+		// (Object.defineProperty, bracket-notation assignment) was
+		// invisible too - even though `in`/Reflect.has/
+		// Object.getOwnPropertyDescriptor already agreed those exist
+		// (fixed for THEM in earlier PRs in this stack).
+		nf := obj.AsNativeFunction()
+		if nf != nil && nf.Properties != nil {
+			if getter, _, _, _, ok := nf.Properties.GetOwnAccessor(propName); ok {
+				if getter.Type() != TypeUndefined {
+					result, err := vm.Call(getter, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := nf.Properties.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
+		if nf != nil {
+			switch propName {
+			case "name":
+				if !nf.DeletedName {
+					return NewString(nf.Name), nil
+				}
+			case "length":
+				if !nf.DeletedLength {
+					return NumberValue(float64(nf.Arity)), nil
+				}
+			}
+		}
+		if vm.FunctionPrototype.Type() == TypeNativeFunctionWithProps {
+			fpNfp := vm.FunctionPrototype.AsNativeFunctionWithProps()
+			if fpNfp != nil && fpNfp.Properties != nil {
+				if getter, _, _, _, ok := fpNfp.Properties.GetOwnAccessor(propName); ok {
+					if getter.Type() != TypeUndefined {
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -867,7 +1057,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			// Check for accessor (getter) on own properties
 			if getter, _, _, _, ok := bf.Properties.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					result, err := vm.Call(getter, obj, nil)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -886,7 +1076,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor first
 				if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -954,7 +1144,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
 					// Call the getter with this=obj (the BigInt)
-					result, err := vm.Call(getter, obj, nil)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -988,7 +1178,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			po := proto.AsPlainObject()
 			// Check for accessor (getter) first
 			if g, _, _, _, ok := po.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-				result, err := vm.Call(g, obj, nil)
+				result, err := vm.Call(g, receiver, nil)
 				if err != nil {
 					return Undefined, err
 				}
@@ -1004,7 +1194,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					if current.Type() == TypeObject {
 						cur := current.AsPlainObject()
 						if g, _, _, _, ok := cur.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-							result, err := vm.Call(g, obj, nil)
+							result, err := vm.Call(g, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -1021,6 +1211,429 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					break
 				}
 			}
+		}
+		return Undefined, nil
+	}
+}
+
+// getOwnFromTableByKey checks one *PlainObject-backed own-property table
+// (a plain object's own fields, or an exotic kind's lazily-allocated
+// Properties side table - Function/Closure/NativeFunction/
+// NativeFunctionWithProps/BoundFunction/RegExp/Map/Set/Promise all keep
+// one, see pkg/vm/properties_table.go) for key, invoking an accessor's
+// getter with `this = receiver` if key names one. Returns (value, found,
+// error) - found is false and error is nil when key simply isn't there,
+// so callers can fall through to whatever comes next (a prototype chain,
+// a different table) without misreading "not found" as "found undefined".
+func (vm *VM) getOwnFromTableByKey(table *PlainObject, key PropertyKey, receiver Value) (Value, bool, error) {
+	if table == nil {
+		return Undefined, false, nil
+	}
+	if g, _, _, _, ok := table.GetOwnAccessorByKey(key); ok {
+		if g.Type() != TypeUndefined {
+			res, err := vm.Call(g, receiver, nil)
+			if err != nil {
+				return Undefined, true, err
+			}
+			return res, true, nil
+		}
+		// Setter-only accessor (no getter): reads as undefined per spec,
+		// but IS present, so still reported as found - a caller falling
+		// through to a lower-priority table/prototype for this key would
+		// otherwise incorrectly resurrect a shadowed property from there.
+		return Undefined, true, nil
+	}
+	if v, ok := table.GetOwnByKey(key); ok {
+		return v, true, nil
+	}
+	return Undefined, false, nil
+}
+
+// walkPlainObjectChainForKey walks a chain of ordinary (TypeObject)
+// prototypes starting at start, checking each level's own table via
+// getOwnFromTableByKey - the same accessor-then-data, getter-invoking
+// shape opGetPropSymbol's own TypeObject case (pkg/vm/op_getprop.go)
+// already uses for a direct property access, reused here so
+// GetPropertyWithReceiver (backing Reflect.get) gets the same fidelity
+// instead of a second, weaker, hand-rolled walk. Stops (found=false) as
+// soon as the chain reaches a non-TypeObject value (Null, a Proxy, or any
+// other exotic kind) - every concrete built-in prototype this is called
+// with (Array.prototype, Map.prototype, RegExp.prototype, the primitive
+// wrapper prototypes, ...) terminates in Object.prototype, itself a plain
+// TypeObject, so this is not a real limitation for those callers.
+func (vm *VM) walkPlainObjectChainForKey(start Value, key PropertyKey, receiver Value) (Value, bool, error) {
+	current := start
+	for current.IsObject() {
+		if current.Type() != TypeObject {
+			break
+		}
+		po := current.AsPlainObject()
+		if v, found, err := vm.getOwnFromTableByKey(po, key, receiver); found || err != nil {
+			return v, found, err
+		}
+		current = po.GetPrototype()
+	}
+	return Undefined, false, nil
+}
+
+// ReflectGetSymbolProperty is GetProperty for a Symbol-keyed property
+// (rather than a string-keyed one) - see GetPropertyWithReceiver's doc
+// comment for the receiver parameter's meaning. sym must be a Value of
+// TypeSymbol. Named distinctly from the pre-existing, narrower
+// GetSymbolProperty (obj, symbol) (Value, bool) below (RegExp/TypeObject
+// only, no getter invocation on non-RegExp/TypeObject kinds, no error
+// return) rather than overloading that name for a wider, error-returning
+// implementation an existing caller of the old one isn't expecting.
+func (vm *VM) ReflectGetSymbolProperty(obj Value, sym Value) (Value, error) {
+	return vm.getSymbolPropertyWithReceiver(obj, sym, obj)
+}
+
+// ReflectGetSymbolPropertyWithReceiver is ReflectGetSymbolProperty with an
+// explicit receiver - the symbol-key counterpart of
+// GetPropertyWithReceiver, added for the same reason
+// (Reflect.get(target, someSymbol[, receiver]), pkg/builtins/reflect_init.go).
+func (vm *VM) ReflectGetSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value) (Value, error) {
+	return vm.getSymbolPropertyWithReceiver(obj, sym, receiver)
+}
+
+// getSymbolPropertyWithReceiver mirrors getPropertyWithReceiver's per-kind
+// switch (same case list, same comments' reasoning) with the string-keyed
+// PlainObject methods (GetOwn/GetOwnAccessor/Get) replaced by their
+// *ByKey counterparts, i.e. using key := NewSymbolKey(sym) throughout
+// instead of propName. Where getPropertyWithReceiver open-codes its own
+// per-kind accessor/data check and hand-rolled prototype walk inline,
+// this uses the two shared helpers above instead - written once, for the
+// new symbol path, rather than reproducing that duplication a second
+// time; getPropertyWithReceiver's already-tested string-key logic is left
+// exactly as it was, not retrofitted onto the same helpers, to avoid
+// risking a regression there for this task's sake.
+//
+// The FunctionPrototype fallback used by every callable kind
+// (TypeFunction/TypeClosure/TypeNativeFunction/TypeNativeFunctionWithProps/
+// TypeBoundFunction) reuses the existing lookupSymbolOnProtoChain
+// (pkg/vm/op_getprop.go) rather than walkPlainObjectChainForKey, since
+// Function.prototype itself can be a TypeNativeFunctionWithProps at
+// runtime (see that function's own doc comment) - walkPlainObjectChainForKey
+// only handles a TypeObject chain. Matching lookupSymbolOnProtoChain's
+// existing behavior, this does NOT invoke an accessor's getter found on
+// the FunctionPrototype chain - a real, separate, still-open gap already
+// documented where it was first found (pkg/vm/op_getprop.go's
+// opGetPropSymbol, TypeNativeFunction case), not introduced or widened
+// here.
+func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value) (Value, error) {
+	key := NewSymbolKey(sym)
+
+	switch obj.Type() {
+	case TypeObject:
+		// Not walkPlainObjectChainForKey directly: that helper stops the
+		// instant the chain reaches a non-TypeObject value, which is fine
+		// for the built-in-prototype walks below (Array.prototype and
+		// siblings always terminate in Object.prototype, itself a plain
+		// TypeObject) but wrong here - obj's own [[Prototype]] chain can
+		// legitimately pass through a callable (`Object.create(someFn)`,
+		// or a class extending a native constructor), and a symbol
+		// property can live in THAT value's own Properties side table,
+		// not a PlainObject's fields. Recursing into the full per-kind
+		// dispatch (this same function) once the chain leaves TypeObject
+		// picks that up, instead of silently answering "not found":
+		//
+		//   const sym = Symbol("s");
+		//   function base() {}
+		//   base[sym] = "found";
+		//   Reflect.get(Object.create(base), sym); // Node: "found"
+		current := obj
+		for current.Type() == TypeObject {
+			po := current.AsPlainObject()
+			if v, found, err := vm.getOwnFromTableByKey(po, key, receiver); found || err != nil {
+				return v, err
+			}
+			current = po.GetPrototype()
+		}
+		if current.typ == TypeNull || current.typ == TypeUndefined {
+			return Undefined, nil
+		}
+		// NOT gated on current.IsObject(): every callable kind sorts
+		// BEFORE TypeObject in the ValueType enum (pkg/vm/value.go), so
+		// IsObject() - a contiguous [TypeObject, TypeProxy] range check -
+		// is FALSE for exactly the values (TypeFunction, TypeClosure,
+		// TypeNativeFunction, TypeNativeFunctionWithProps,
+		// TypeBoundFunction) this branch exists to reach. Gating on it
+		// (an earlier version of this fix did) silently reintroduced the
+		// "stops early, answers not-found" bug the comment above
+		// describes fixing - see getPropertyWithReceiver's TypeObject
+		// case (the string-key sibling of this one) for the same mistake
+		// caught and fixed the same way.
+		return vm.getSymbolPropertyWithReceiver(current, sym, receiver)
+
+	case TypeDictObject:
+		// DictObject ignores symbols entirely - matches OpIn's own
+		// symbol-key TypeDictObject case (pkg/vm/vm.go).
+		return Undefined, nil
+
+	case TypeArray:
+		arr := obj.AsArray()
+		if arr != nil {
+			if v, ok := arr.GetSymbolProp(sym.AsSymbolObject()); ok {
+				return v, nil
+			}
+			if vm.ArrayPrototype.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(vm.ArrayPrototype, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeGenerator:
+		if vm.GeneratorPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.GeneratorPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeProxy:
+		proxy := obj.AsProxy()
+		if proxy.Revoked {
+			return Undefined, vm.NewTypeError("Cannot perform 'get' on a revoked Proxy")
+		}
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
+		if hasGetTrap && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
+			if !getTrap.IsCallable() {
+				return Undefined, vm.NewTypeError("'get' on proxy: trap is not a function")
+			}
+			trapArgs := []Value{proxy.target, sym, receiver}
+			result, err := vm.Call(getTrap, proxy.handler, trapArgs)
+			if err != nil {
+				return Undefined, err
+			}
+			// ECMAScript 10.5.8 invariant validation, symbol-key version
+			// of getPropertyWithReceiver's TypeProxy case above.
+			if proxy.target.Type() == TypeObject {
+				targetObj := proxy.target.AsPlainObject()
+				if g, _, _, c, isAccessor := targetObj.GetOwnAccessorByKey(key); isAccessor && !c {
+					if g.Type() == TypeUndefined && !result.IsUndefined() {
+						return Undefined, vm.NewTypeError("'get' on proxy: property is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap returned a non-undefined value")
+					}
+				} else if v, w, _, c, found := targetObj.GetOwnDescriptorByKey(key); found && !c && !w {
+					if !v.StrictlyEquals(result) {
+						return Undefined, vm.NewTypeError("'get' on proxy: property is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value")
+					}
+				}
+			}
+			return result, nil
+		}
+		return vm.getSymbolPropertyWithReceiver(proxy.target, sym, receiver)
+
+	case TypePromise:
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if vm.PromisePrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.PromisePrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeRegExp:
+		regexObj := obj.AsRegExpObject()
+		if regexObj != nil {
+			if regexObj.Properties != nil {
+				if v, found, err := vm.getOwnFromTableByKey(regexObj.Properties, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+			proto := Undefined
+			proto = regexObj.GetPrototype()
+			if !proto.IsObject() {
+				proto = vm.RegExpPrototype
+			}
+			if proto.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeTypedArray:
+		// TypedArrays don't expose own symbol-keyed properties (only
+		// indices and the fixed set of string built-ins) - straight to
+		// the element-type-specific prototype, same selection as
+		// getPropertyWithReceiver's TypeTypedArray case.
+		ta := obj.AsTypedArray()
+		if ta != nil {
+			var proto Value
+			switch ta.GetElementType() {
+			case TypedArrayInt8:
+				proto = vm.Int8ArrayPrototype
+			case TypedArrayUint8:
+				proto = vm.Uint8ArrayPrototype
+			case TypedArrayUint8Clamped:
+				proto = vm.Uint8ClampedArrayPrototype
+			case TypedArrayInt16:
+				proto = vm.Int16ArrayPrototype
+			case TypedArrayUint16:
+				proto = vm.Uint16ArrayPrototype
+			case TypedArrayInt32:
+				proto = vm.Int32ArrayPrototype
+			case TypedArrayUint32:
+				proto = vm.Uint32ArrayPrototype
+			case TypedArrayFloat16:
+				proto = vm.Float16ArrayPrototype
+			case TypedArrayFloat32:
+				proto = vm.Float32ArrayPrototype
+			case TypedArrayFloat64:
+				proto = vm.Float64ArrayPrototype
+			case TypedArrayBigInt64:
+				proto = vm.BigInt64ArrayPrototype
+			case TypedArrayBigUint64:
+				proto = vm.BigUint64ArrayPrototype
+			default:
+				proto = vm.TypedArrayPrototype
+			}
+			if proto.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeSet:
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if vm.SetPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.SetPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeMap:
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if vm.MapPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.MapPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeFunction:
+		fn := obj.AsFunction()
+		if fn != nil && fn.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(fn.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeClosure:
+		cl := obj.AsClosure()
+		if cl != nil {
+			if cl.Properties != nil {
+				if v, found, err := vm.getOwnFromTableByKey(cl.Properties, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+			if cl.Fn != nil && cl.Fn.Properties != nil {
+				if v, found, err := vm.getOwnFromTableByKey(cl.Fn.Properties, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeNativeFunction:
+		nf := obj.AsNativeFunction()
+		if nf != nil && nf.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(nf.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeNativeFunctionWithProps:
+		nfp := obj.AsNativeFunctionWithProps()
+		if nfp != nil && nfp.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(nfp.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeBoundFunction:
+		bf := obj.AsBoundFunction()
+		if bf != nil && bf.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(bf.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeArguments:
+		args := obj.AsArguments()
+		if args != nil {
+			if v, ok := args.GetSymbolProp(sym.AsSymbolObject()); ok {
+				return v, nil
+			}
+			// Symbol.iterator is inherited from Array.prototype - check
+			// that first, then Object.prototype, matching OpIn's own
+			// symbol-key TypeArguments case (pkg/vm/vm.go).
+			if vm.ArrayPrototype.IsObject() {
+				if v, found, err := vm.walkPlainObjectChainForKey(vm.ArrayPrototype, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+			if vm.ObjectPrototype.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(vm.ObjectPrototype, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeBigInt:
+		if vm.BigIntPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.BigIntPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	default:
+		var proto Value
+		switch obj.Type() {
+		case TypeBoolean:
+			proto = vm.BooleanPrototype
+		case TypeFloatNumber, TypeIntegerNumber:
+			proto = vm.NumberPrototype
+		case TypeString:
+			proto = vm.StringPrototype
+		case TypeSymbol:
+			proto = vm.SymbolPrototype
+		case TypeBigInt:
+			proto = vm.BigIntPrototype
+		}
+		if proto.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
+			return v, err
 		}
 		return Undefined, nil
 	}

--- a/tests/scripts/reflect_get_general.ts
+++ b/tests/scripts/reflect_get_general.ts
@@ -1,0 +1,249 @@
+// expect: true
+// Reflect.get (pkg/builtins/reflect_init.go) used to only handle
+// target.Type() == TypeObject/TypeDictObject/TypeArray - every other kind
+// (Function, Closure, Map, Set, RegExp, BoundFunction, NativeFunction,
+// NativeFunctionWithProps, Promise, TypedArray, Proxy, ...) silently fell
+// through and returned undefined instead of actually reading the
+// property. It also unconditionally stringified the key
+// (`args[1].ToString()`), so Reflect.get(anything, someSymbol) never
+// worked correctly except via incidental string coercion:
+//
+//   function fn() {}
+//   Reflect.get(fn, "name");        // before: undefined - Node: "fn"
+//   Reflect.get(fn, "call");        // before: undefined - Node: [Function: call]
+//   Reflect.get(new Map(), "size"); // before: undefined - Node: 0
+//   Reflect.get({x: 1}, "x");       // before: 1 (correct) - Node: 1
+//
+// Fixed by rewriting Reflect.get to delegate to two new general-purpose
+// VM helpers (pkg/vm/vm_init.go) instead of re-implementing per-kind
+// property lookup a third time (opGetProp/opGetPropSymbol already do this
+// for bytecode dispatch, and GetProperty already did a narrower version
+// for a handful of other native-function call sites):
+//   - GetPropertyWithReceiver (string keys) - an existing GetProperty
+//     function, extended with a `receiver` parameter (threaded through
+//     every accessor-getter call and prototype-chain recursion) and two
+//     missing kinds (TypeNativeFunction, TypeDictObject).
+//   - ReflectGetSymbolPropertyWithReceiver (symbol keys) - new, mirroring
+//     GetPropertyWithReceiver's same per-kind case list with the
+//     string-keyed PlainObject methods swapped for their *ByKey
+//     counterparts.
+// receiver is Reflect.get's optional third argument - the spec's `this`
+// for any accessor's getter along the way, independent of which object
+// on the prototype chain the getter was actually found on. Reflect.get's
+// declared type signature only allowed 2 arguments before this fix
+// (Reflect.set/Reflect.construct have the identical gap for their own
+// optional trailing parameters - not fixed here, flagged as a follow-up).
+//
+// Found and fixed alongside the above, in the same commit (same file,
+// same switch statements, the same missing-side-table-check bug already
+// fixed for other kinds in earlier PRs in this stack):
+//   - TypeSet/TypeMap/TypePromise's own custom properties (a plain
+//     `m.custom = 1` or Object.defineProperty) were invisible to
+//     GetProperty/Reflect.get entirely - only the prototype chain (for
+//     `size`, etc.) was ever checked.
+//   - A value's [[Prototype]] chain passing through a callable
+//     (Object.create(someFunction), or a class extending a native
+//     constructor) stopped the walk early and answered "not found" even
+//     when the callable had the property in its own Properties side
+//     table - because the walk's continuation check used IsObject(),
+//     which is FALSE for every callable ValueType (they sort before
+//     TypeObject in the enum, pkg/vm/value.go) - this bug appeared (and
+//     was caught and fixed) in an earlier draft of this exact fix, so
+//     it's pinned explicitly below (check 18) rather than only in a code
+//     comment.
+//
+// Each assertion below uses its own object/function/collection instance -
+// no shared-mutable-intrinsic hazard here, unlike the native-function
+// tests earlier in this stack (Array.prototype.* is a real shared
+// intrinsic; a fresh literal or `new` expression is not).
+
+const checks: boolean[] = [];
+
+// --- 1. Plain function: name/length/call (string keys). ---
+{
+  function fn(a: number, b: number) {}
+  checks.push(Reflect.get(fn, "name") === "fn");
+  checks.push(Reflect.get(fn, "length") === 2);
+  checks.push(typeof Reflect.get(fn, "call") === "function");
+}
+
+// --- 2. Map: size (an accessor on Map.prototype), and a custom own
+// property (the side-table gap found while fixing this). ---
+{
+  const m: any = new Map([[1, 2]]);
+  checks.push(Reflect.get(m, "size") === 1);
+  m.custom = 42;
+  checks.push(Reflect.get(m, "custom") === 42);
+}
+
+// --- 3. Set: size, and a custom own property. ---
+{
+  const s: any = new Set([1, 2, 3]);
+  checks.push(Reflect.get(s, "size") === 3);
+  s.custom = "hi";
+  checks.push(Reflect.get(s, "custom") === "hi");
+}
+
+// --- 4. RegExp: source (own field) and lastIndex (own, writable). ---
+{
+  const re: any = /abc/gi;
+  checks.push(Reflect.get(re, "source") === "abc");
+  re.lastIndex = 3;
+  checks.push(Reflect.get(re, "lastIndex") === 3);
+}
+
+// --- 5. BoundFunction: name/length (synthesized), and a custom own
+// property. ---
+{
+  function orig(a: number, b: number, c: number) {}
+  const bound: any = orig.bind(null, 1);
+  checks.push(Reflect.get(bound, "name") === "bound orig");
+  checks.push(Reflect.get(bound, "length") === 2);
+  bound.custom = "b";
+  checks.push(Reflect.get(bound, "custom") === "b");
+}
+
+// --- 6. A plain native function (Array.prototype.push-style): name/
+// length, and a custom own property via Object.defineProperty. ---
+{
+  const nf: any = Array.prototype.slice;
+  checks.push(Reflect.get(nf, "name") === "slice");
+  checks.push(typeof Reflect.get(nf, "length") === "number");
+  Object.defineProperty(nf, "custom6", { value: 7, configurable: true });
+  checks.push(Reflect.get(nf, "custom6") === 7);
+}
+
+// --- 7. A class: name, an inherited static property, an instance
+// method found through the prototype chain. ---
+{
+  class Base7 {
+    static staticProp = 10;
+    method() { return 1; }
+  }
+  class Derived7 extends Base7 {}
+  const Derived7Any: any = Derived7;
+  checks.push(Reflect.get(Derived7Any, "name") === "Derived7");
+  checks.push(Reflect.get(Derived7Any, "staticProp") === 10);
+  checks.push(typeof Reflect.get(Derived7Any.prototype, "method") === "function");
+}
+
+// --- 8. An accessor property invoked with the correct receiver
+// argument (per spec, the getter's `this`), and the default-to-target
+// behavior when receiver is omitted. ---
+{
+  const proto8 = {
+    get val(): number { return (this as any).backing; },
+    set val(v: number) { (this as any).backing = v; },
+  };
+  const receiver8: any = { backing: 5 };
+  checks.push(Reflect.get(proto8, "val", receiver8) === 5);
+  const obj8: any = Object.create(proto8);
+  obj8.backing = 9;
+  checks.push(Reflect.get(obj8, "val") === 9);
+}
+
+// --- 9. String and Symbol keys on the same plain object, including an
+// own accessor keyed by a Symbol. ---
+{
+  const sym9 = Symbol("k9");
+  let backing9 = 0;
+  const obj9: any = {
+    get [sym9]() { return backing9; },
+    set [sym9](v: number) { backing9 = v; },
+    plain: "p",
+  };
+  obj9[sym9] = 55;
+  checks.push(Reflect.get(obj9, sym9) === 55);
+  checks.push(Reflect.get(obj9, "plain") === "p");
+}
+
+// --- 10. Symbol key as an own property on a native function. ---
+{
+  const nf2: any = Array.prototype.unshift;
+  const sym10 = Symbol("k10");
+  Object.defineProperty(nf2, sym10, { value: 100, configurable: true });
+  checks.push(Reflect.get(nf2, sym10) === 100);
+}
+
+// --- 11. Symbol key inherited via the prototype chain
+// (Symbol.hasInstance on Function.prototype, for a plain function). ---
+{
+  function plainFn11() {}
+  checks.push(typeof Reflect.get(plainFn11, Symbol.hasInstance) === "function");
+}
+
+// --- 12. Symbol key as a custom own property on a Map. ---
+{
+  const m2: any = new Map();
+  const sym12 = Symbol("k12");
+  Object.defineProperty(m2, sym12, { value: "sym-on-map", configurable: true });
+  checks.push(Reflect.get(m2, sym12) === "sym-on-map");
+}
+
+// --- 13. TypedArray: numeric index, "length", and an inherited method. ---
+{
+  const ta: any = new Int32Array([10, 20, 30]);
+  checks.push(Reflect.get(ta, "0") === 10);
+  checks.push(Reflect.get(ta, "length") === 3);
+  checks.push(typeof Reflect.get(ta, "map") === "function");
+}
+
+// --- 14. Proxy: the get trap is invoked as handler.get(target, key,
+// receiver) for both a string and a Symbol key, with the actual
+// receiver argument passed through (not the proxy itself when a
+// distinct receiver is given). ---
+{
+  let seenReceiver14: any = null;
+  const target14: any = {};
+  const handler14 = {
+    get(t: any, k: any, r: any) {
+      seenReceiver14 = r;
+      return "trapped:" + String(k);
+    },
+  };
+  const p14: any = new Proxy(target14, handler14);
+  const rcv14 = {};
+  checks.push(Reflect.get(p14, "x", rcv14) === "trapped:x");
+  checks.push(seenReceiver14 === rcv14);
+  const sym14 = Symbol("k14");
+  checks.push(Reflect.get(p14, sym14) === "trapped:Symbol(k14)");
+}
+
+// --- 15. Proxy with no trap: falls through to the target. ---
+{
+  const target15: any = { y: 123 };
+  const p15: any = new Proxy(target15, {});
+  checks.push(Reflect.get(p15, "y") === 123);
+}
+
+// --- 16. Absent property on a plain object answers undefined, no throw. ---
+{
+  checks.push(Reflect.get({}, "nope") === undefined);
+}
+
+// --- 17. Enum (a TypeDictObject at runtime) as a Reflect.get target -
+// this case didn't exist at all before this fix, so this exercises it
+// directly rather than only via the shared machinery's other callers. ---
+{
+  enum Color17 { Red, Green, Blue }
+  checks.push(Reflect.get(Color17 as any, "Red") === 0);
+  checks.push(Reflect.get(Color17 as any, "Blue") === 2);
+}
+
+// --- 18. A value's own [[Prototype]] chain passes through a callable
+// (Object.create(fn)) - both key kinds must still find an own property
+// on that callable's own table, not stop early. This is the bug an
+// earlier draft of this fix had (the walk's continuation check used
+// IsObject(), which is false for every callable kind - see this file's
+// header comment) - pinned explicitly here, not just documented in code. ---
+{
+  function base18() {}
+  (base18 as any).regular = "r";
+  const sym18 = Symbol("s18");
+  (base18 as any)[sym18] = "found18";
+  const inst18: any = Object.create(base18);
+  checks.push(Reflect.get(inst18, "regular") === "r");
+  checks.push(Reflect.get(inst18, sym18) === "found18");
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

- **`pkg/vm/vm_init.go`** — `GetProperty` refactored to thread a `receiver` parameter through (new `GetPropertyWithReceiver`, backward-compatible `GetProperty` wrapper); two missing kinds added (`TypeNativeFunction`, `TypeDictObject`); `TypeSet`/`TypeMap`/`TypePromise` now check their own side-table properties before the prototype chain; a callable-in-prototype-chain walk bug fixed; new `ReflectGetSymbolPropertyWithReceiver` (+ two small shared helpers, `getOwnFromTableByKey` and `walkPlainObjectChainForKey`) for symbol keys.
- **`pkg/vm/vm.go`** — `proxyGetHasTrap` generalized to `proxyGetTrap(handler, trapName)` so the new symbol-key Proxy path can reuse it for the `"get"` trap.
- **`pkg/builtins/reflect_init.go`** — `Reflect.get`'s implementation replaced with two calls into the above; its declared type signature extended to accept an optional third `receiver` argument.
- **`tests/scripts/reflect_get_general.ts`** — new regression test, 39 assertions.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #340), since this branch was created from `fix-in-symbol-proxy`'s tip (#340). Everything except the items above belongs to those PRs and disappears from the diff once they merge.

## The bug

`Reflect.get` only ever handled `target.Type() == TypeObject`/`TypeDictObject`/`TypeArray` — every other kind (`Function`, `Closure`, `Map`, `Set`, `RegExp`, `BoundFunction`, `NativeFunction`, `NativeFunctionWithProps`, `Promise`, `TypedArray`, `Proxy`, ...) silently fell through and returned `undefined`. It also unconditionally stringified the key, so a Symbol key never worked correctly:

```js
function fn() {}
Reflect.get(fn, "name");        // before: undefined - Node: "fn"
Reflect.get(fn, "call");        // before: undefined - Node: [Function: call]
Reflect.get(new Map(), "size"); // before: undefined - Node: 0
Reflect.get({x: 1}, "x");       // before: 1 (correct) - Node: 1
```

## The fix — delegates instead of re-adding switch cases

Per the task description's own suggestion, `Reflect.get` now delegates to shared, general-purpose property-read logic in `pkg/vm/vm_init.go` rather than duplicating per-kind dispatch a third time (`opGetProp`/`opGetPropSymbol` already do this for bytecode dispatch; the pre-existing `GetProperty` already did a narrower version for a handful of other native-function call sites).

This means the fix touches a **shared helper**, not just `Reflect.get` — six distinct changes, three not named by the task but needed to get there or found while verifying against Node:

1. `Reflect.get`'s body replaced with two calls: `GetPropertyWithReceiver` (string keys) / `ReflectGetSymbolPropertyWithReceiver` (symbol keys).
2. The existing `GetProperty` gained a `receiver` parameter, threaded through every accessor-getter call and prototype-chain recursion (new `GetPropertyWithReceiver`; `GetProperty` itself is now a thin `receiver == obj` wrapper, so its ~150 existing call sites across `pkg/builtins`/`pkg/vm` are unaffected — confirmed by grepping every caller). This is the task's item 8 — Reflect.get's optional third argument, the `this` an accessor's getter is called with, independent of which object on the chain it was actually found on.
3. New `ReflectGetSymbolPropertyWithReceiver` (+ `getOwnFromTableByKey`/`walkPlainObjectChainForKey`) mirrors `GetPropertyWithReceiver`'s exact per-kind case list for a Symbol key — didn't exist in any form before.
4. `TypeNativeFunction` and `TypeDictObject` cases added to `GetPropertyWithReceiver` — kinds it never handled at all, for **any** caller, not just Reflect.get.
5. `TypeSet`/`TypeMap`/`TypePromise`'s own custom properties (`m.custom = 1`, `Object.defineProperty`) were invisible to `GetProperty`/`Reflect.get` entirely — only the prototype chain (`size`, etc.) was ever checked. Fixed in both key paths — the same missing-side-table-check bug class already fixed for these kinds elsewhere in this stack (`Object.keys`, `getOwnPropertyDescriptors`, for-in, `in`/`Reflect.has`).
6. A value's `[[Prototype]]` chain passing through a callable (`Object.create(someFunction)`, or a class extending a native constructor) stopped the walk early and answered "not found" even when the callable had the property in its own `Properties` side table — both `TypeObject` cases gated the walk's continuation on `IsObject()`, which is **false** for every callable `ValueType` (they sort before `TypeObject` in the enum). An earlier draft of this fix had exactly this bug in the new symbol path; found there, and testing then surfaced the identical shape already present in the pre-existing string path (`Reflect.get(Object.create(fn), "x")` already failed on `main` before this commit) — fixed there too in the same commit rather than shipped asymmetrically between key kinds. Pinned explicitly in the test (check 18).

`Reflect.get`'s declared type signature only allowed 2 arguments before this fix, which would have made the new receiver support unusable under type checking — extended via `types.NewOptionalFunction` to accept an optional third `any` parameter. `Reflect.set`/`Reflect.construct` have the identical "declared signature narrower than what the runtime already accepts" gap for their own optional trailing parameters — not fixed here, filed as a follow-up.

## Testing

39 assertions verified against Node, covering every kind named in the task plus the found-while-fixing items: a plain function, `Map`/`Set` with an own custom property, `RegExp`, `BoundFunction`, a plain native function, a class and its prototype chain, an accessor with an explicit vs. defaulted receiver, string and Symbol keys throughout, a Proxy's `get` trap receiving `(target, key, receiver)` for both key kinds, a Proxy with no trap, `TypedArray`, an absent property, a `TypeDictObject`/enum target, and the callable-in-prototype-chain case.

Also ran a targeted perturbation probe (`JSON.stringify`'s `toJSON` lookup, `Date`'s `toISOString`, a plain object literal) to confirm the `TypeObject` prototype-walk change doesn't affect the ~150 other `GetProperty` call sites' existing behavior, and doesn't hang on a cycle (the codebase's existing convention here has no cycle guard on this kind of walk, matched rather than added to).

test262's built-ins baseline moved from 16440 → 16444 passed (an improvement, not a regression — consistent with previously-failing `Reflect.get` conformance tests now passing).

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. (Used 180s rather than the requested 0.2s, which kills the unrelated `bench_add.ts`.)

## Found, not fixed (flagged separately as a follow-up)

`Reflect.set`'s 4th argument (`receiver`) and `Reflect.construct`'s 3rd argument (`newTarget`) both already work at runtime but fail type checking (`Reflect.set(t, k, v, receiver)` → `TS2554: Expected 3 arguments, but got 4.`) — same declared-signature-too-narrow gap fixed here for `Reflect.get`, not fixed for these two.

Based on `fix-in-symbol-proxy` (#340).
