### PR TITLE
fix(vm): OpIn's string-key TypeProxy case and both `in` fallback functions

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3553,8 +3553,19 @@ startExecution:
 						return InterpretRuntimeError, Undefined
 					}
 
-					// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-					if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+					// Check if handler has a 'has' trap. proxyGetTrap (not a
+					// bare proxy.handler.AsPlainObject().GetOwn("has")) for
+					// two reasons found while adding the symbol-key sibling
+					// of this exact case (see task_125640b9's PR body):
+					// GetMethod semantics (10.5.7 step 4) mean an INHERITED
+					// "has" trap counts too, not just an own one; and a
+					// handler that happens to be a TypeDictObject (a TS
+					// enum/module namespace value) must not panic
+					// AsPlainObject(). Both bugs were real here before this
+					// fix - confirmed via `"x" in new Proxy({}, Object.create({has(){return true}}))`
+					// (false instead of true) and `"x" in new Proxy({}, someEnum)`
+					// (a process-crashing panic, not a catchable exception).
+					if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 						// Validate trap is callable
 						if !hasTrap.IsCallable() {
 							vm.ThrowTypeError("'has' on proxy: trap is not a function")
@@ -21498,8 +21509,11 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 		if proxy.Revoked {
 			return false
 		}
-		// Check if the proxy's handler has a 'has' trap
-		if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+		// Check if the proxy's handler has a 'has' trap - proxyGetTrap, not
+		// a bare GetOwn, for the same two reasons as OpIn's own TypeProxy
+		// case above (GetMethod's inherited-trap semantics, and a
+		// TypeDictObject handler panicking AsPlainObject()).
+		if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 			if hasTrap.IsCallable() {
 				trapArgs := []Value{proxy.target, NewString(propKey)}
 				result, err := vm.Call(hasTrap, proxy.handler, trapArgs)
@@ -21517,6 +21531,18 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 	case TypeDictObject:
 		return target.AsDictObject().Has(propKey)
 	case TypeArray:
+		// NOT fixed here (pre-existing, out of this task's scope): unlike
+		// OpIn's own direct-target TypeArray case, which checks
+		// ArrayHasOwnIndex (paserati#176/#178 - a numerically-in-range
+		// index is NOT necessarily an own property, e.g. after a distant
+		// defineProperty inflates .length) before falling to the
+		// prototype chain, this still uses the simpler, wrong
+		// `index < arrayObj.Length()` test. Left alone since this task's
+		// three fixes are the trap-lookup bugs and the seven-kind
+		// fallback-coverage gap, not this unrelated pre-existing
+		// correctness issue - flagged as a third bullet on the same
+		// follow-up as the other unfixed trap-lookup sites this task's
+		// review turned up (see task's PR body).
 		arrayObj := target.AsArray()
 		if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
 			return index < arrayObj.Length()
@@ -21595,6 +21621,84 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 			}
 		}
 		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeNativeFunctionWithProps:
+		// Same own-table-then-FunctionPrototype shape as TypeFunction/
+		// TypeClosure above - mirrors OpIn's own direct-target
+		// TypeNativeFunctionWithProps case (pkg/vm/vm.go) exactly.
+		nf := target.AsNativeFunctionWithProps()
+		if HasOwnFunctionIntrinsic(target, propKey) {
+			return true
+		}
+		if nf.Properties != nil && nf.Properties.Has(propKey) {
+			return true
+		}
+		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeNativeFunction:
+		// Mirrors OpIn's own direct-target TypeNativeFunction case.
+		nf := target.AsNativeFunction()
+		if HasOwnFunctionIntrinsic(target, propKey) {
+			return true
+		}
+		if nf.Properties != nil && nf.Properties.Has(propKey) {
+			return true
+		}
+		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeBoundFunction:
+		// Mirrors OpIn's own direct-target TypeBoundFunction case.
+		bf := target.AsBoundFunction()
+		if bf.Properties != nil && bf.Properties.Has(propKey) {
+			return true
+		}
+		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeSet:
+		// Mirrors OpIn's own direct-target TypeSet case: own "size", then
+		// the side table, then Set.prototype and beyond.
+		if propKey == "size" {
+			return true
+		}
+		setObj := target.AsSet()
+		if setObj.Properties != nil && setObj.Properties.HasOwn(propKey) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), keyFromString(propKey))
+	case TypeMap:
+		// Mirrors OpIn's own direct-target TypeMap case.
+		if propKey == "size" {
+			return true
+		}
+		mapObj := target.AsMap()
+		if mapObj.Properties != nil && mapObj.Properties.HasOwn(propKey) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), keyFromString(propKey))
+	case TypePromise:
+		// Mirrors OpIn's own direct-target TypePromise case: the side
+		// table (a Promise exposes no intrinsic own state, but a plain
+		// assignment can still add one), then Promise.prototype.
+		promiseObj := target.AsPromise()
+		if promiseObj.Properties != nil && promiseObj.Properties.HasOwn(propKey) {
+			return true
+		}
+		if vm.PromisePrototype.IsObject() {
+			return vm.PromisePrototype.AsPlainObject().Has(propKey)
+		}
+		return false
+	case TypeArguments:
+		// Mirrors OpIn's own direct-target TypeArguments case.
+		argObj := target.AsArguments()
+		if propKey == "length" {
+			return true
+		}
+		if propKey == "callee" && !argObj.IsStrict() {
+			return true
+		}
+		if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
+			return index < argObj.Length()
+		}
+		if vm.ObjectPrototype.IsObject() {
+			return vm.ObjectPrototype.AsPlainObject().Has(propKey)
+		}
+		return false
 	default:
 		return false
 	}
@@ -21733,6 +21837,60 @@ func (vm *VM) proxyHasSymbolPropertyFallback(target Value, propVal Value) bool {
 			}
 		}
 		return vm.hasFunctionPrototypeSymbolProperty(key)
+	case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:
+		// Same shape as TypeFunction/TypeClosure above - mirrors OpIn's own
+		// symbol-key direct-target case for these three kinds (pkg/vm/vm.go).
+		if props := OwnPropertiesTable(target); props != nil {
+			if _, ok := props.GetOwnByKey(key); ok {
+				return true
+			}
+		}
+		return vm.hasFunctionPrototypeSymbolProperty(key)
+	case TypeSet:
+		// Mirrors OpIn's own symbol-key direct-target TypeSet case: own
+		// table, then Set.prototype and beyond.
+		setObj := target.AsSet()
+		if setObj.Properties != nil && setObj.Properties.HasOwnByKey(key) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), key)
+	case TypeMap:
+		// Mirrors OpIn's own symbol-key direct-target TypeMap case.
+		mapObj := target.AsMap()
+		if mapObj.Properties != nil && mapObj.Properties.HasOwnByKey(key) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), key)
+	case TypePromise:
+		// Mirrors OpIn's own symbol-key direct-target TypePromise case:
+		// own table first, then Promise.prototype's chain.
+		promiseObj := target.AsPromise()
+		if promiseObj.Properties != nil && promiseObj.Properties.HasOwnByKey(key) {
+			return true
+		}
+		if vm.PromisePrototype.IsObject() {
+			return vm.hasPropertyByKeyFromPrototypeChain(vm.PromisePrototype, key)
+		}
+		return false
+	case TypeArguments:
+		// Mirrors OpIn's own symbol-key direct-target TypeArguments case:
+		// Array.prototype first (for Symbol.iterator), then Object.prototype.
+		// Deliberately does NOT check argObj.HasOwnSymbolProp(...) first
+		// (every other kind's case here does check its own table before
+		// falling to a prototype) - this matches OpIn's own symbol-key
+		// TypeArguments case and reflectHas's explicit comment that "a
+		// symbol key on an Arguments object isn't handled by either" - a
+		// pre-existing, consistent gap across all three, not a new
+		// asymmetry introduced here.
+		if vm.ArrayPrototype.IsObject() {
+			if vm.hasPropertyByKeyFromPrototypeChain(vm.ArrayPrototype, key) {
+				return true
+			}
+		}
+		if vm.ObjectPrototype.IsObject() {
+			return vm.hasPropertyByKeyFromPrototypeChain(vm.ObjectPrototype, key)
+		}
+		return false
 	default:
 		return false
 	}

--- a/tests/scripts/in_symbol_proxy.ts
+++ b/tests/scripts/in_symbol_proxy.ts
@@ -17,13 +17,11 @@
 // 10.5.7 step 11 invariant checks (non-configurable own property /
 // non-extensible target), and - when no trap is present - a fallback to
 // target.[[HasProperty]] via a new proxyHasSymbolPropertyFallback,
-// mirroring the existing string-key proxyHasPropertyFallback's exact
-// type coverage (TypeProxy/TypeObject/TypeDictObject/TypeArray/TypeRegExp/
-// TypeFunction/TypeClosure, default false) rather than OpIn's fuller
-// direct-target coverage (which also handles Map/Set/Promise/
-// BoundFunction/NativeFunction/NativeFunctionWithProps/Arguments) - see
-// check 11 below for the resulting, pre-existing, shared gap this
-// intentionally leaves in place for both key kinds.
+// which at the time only mirrored the existing string-key
+// proxyHasPropertyFallback's then-narrower type coverage (TypeObject/
+// TypeArray/TypeRegExp/TypeFunction/TypeClosure) rather than OpIn's fuller
+// direct-target coverage - see check 11 below, updated by a follow-up fix
+// (task_125640b9) once that gap was closed for both key paths together.
 //
 // While implementing the trap lookup, found and fixed two spec
 // conformance bugs in the process (not present in the task description,
@@ -37,14 +35,11 @@
 //     namespace or TS enum passed as the handler - not reachable through
 //     ordinary object-literal syntax, so not itself exercised here) would
 //     otherwise panic in Value.AsPlainObject().
-// Both of these bugs equally affect the pre-existing STRING-key TypeProxy
-// case just below the new one - deliberately left alone here (fixing it
-// changes established behavior on a path this task didn't ask about) and
-// flagged as a separate follow-up task alongside check 11's fallback-
-// coverage gap (one task, three bullets: the string-key case's own-only
-// trap lookup, its unguarded AsPlainObject panic on a TypeDictObject
-// handler, and the Map/Set/Promise/callable fallback coverage gap shared
-// by both key paths).
+// Both of these bugs equally affected the pre-existing STRING-key
+// TypeProxy case just below this one at the time - flagged as a follow-up
+// (task_125640b9) rather than fixed as a drive-by here, and since fixed
+// there (same trap-lookup helper, proxyGetTrap, now shared by both key
+// paths' TypeProxy cases) - see check 11 below.
 
 const checks: boolean[] = [];
 
@@ -156,29 +151,30 @@ const checks: boolean[] = [];
   checks.push(Reflect.has(p10, Symbol("inherited")) === true);
 }
 
-// --- 11. KNOWN, PRE-EXISTING, SHARED GAP (both key kinds) - pinned, not
-// fixed here: a Proxy with no trap wrapping a Map target disagrees with
-// Reflect.has, because proxyHasSymbolPropertyFallback (and its
-// pre-existing string-key sibling, proxyHasPropertyFallback) only covers
-// TypeObject/TypeArray/TypeRegExp/TypeFunction/TypeClosure as fallback
-// target kinds, not OpIn's fuller direct-target switch (which also
-// handles Map/Set/Promise/BoundFunction/NativeFunction/
-// NativeFunctionWithProps/Arguments). Verified here for Map specifically;
-// by inspection (not individually asserted) the same fallback gap applies
-// to the other six kinds too, for the identical reason. Node agrees `in`
-// and Reflect.has here; paserati does not yet. This assertion pins
-// TODAY's divergence explicitly (matching the established pattern for a
-// still-open gap - see the history of the now-fixed pinned assertion in
-// in_symbol_boundfn_nativefn.ts) so a future fix has to touch this file
-// instead of silently leaving stale documentation.
+// --- 11. FIXED (was a known, pinned divergence): a Proxy with no trap
+// wrapping a Map target now agrees with Reflect.has. proxyHasSymbolPropertyFallback
+// (and its string-key sibling, proxyHasPropertyFallback) originally only
+// covered TypeObject/TypeArray/TypeRegExp/TypeFunction/TypeClosure as
+// fallback target kinds, unlike OpIn's fuller direct-target switch (which
+// also handles Map/Set/Promise/BoundFunction/NativeFunction/
+// NativeFunctionWithProps/Arguments) - task_125640b9 extended both
+// fallback functions with all seven of those kinds, mirroring the
+// existing own-table-then-prototype-chain logic OpIn's direct-target
+// cases already had for each. This assertion originally pinned the
+// pre-fix divergence explicitly (`inCheck === false && reflectCheck ===
+// true`) and is flipped here to assert genuine agreement instead - same
+// history as in_symbol_boundfn_nativefn.ts's own pinned-then-flipped
+// assertion (PR #338). See proxy_has_string_key_fixes.ts for per-kind
+// coverage of the other six kinds this same fix closed, plus the two
+// spec-conformance bugs shared with the string-key TypeProxy case. ---
 {
   const m: any = new Map();
   const sym = Symbol("m");
   Object.defineProperty(m, sym, { value: 1, configurable: true });
   const p11: any = new Proxy(m, {});
-  const inCheck = sym in p11; // paserati: false (gap) - Node: true
-  const reflectCheck = Reflect.has(p11, sym); // true on both
-  checks.push(inCheck === false && reflectCheck === true);
+  const inCheck = sym in p11;
+  const reflectCheck = Reflect.has(p11, sym);
+  checks.push(inCheck === true && reflectCheck === true);
 }
 
 checks.every((c) => c === true);

--- a/tests/scripts/proxy_has_string_key_fixes.ts
+++ b/tests/scripts/proxy_has_string_key_fixes.ts
@@ -1,0 +1,192 @@
+// expect: true
+// Three related, pre-existing bugs in OpIn's STRING-key TypeProxy case
+// (pkg/vm/vm.go, under `propKey := propVal.ToString()`) and its
+// supporting proxyHasPropertyFallback, found while adding the symbol-key
+// sibling of this exact case in an earlier PR in this stack (#340) and
+// deliberately left unfixed there since fixing them changes established
+// `in`/Reflect.has behavior on a path that PR wasn't scoped to touch.
+//
+//   1. Own-only trap lookup, not GetMethod-inherited. The case did
+//      `proxy.handler.AsPlainObject().GetOwn("has")` - own-only, but per
+//      ECMA-262 10.5.7 step 4 the trap comes from GetMethod(handler,
+//      "has"), which walks the handler's prototype chain. An inherited
+//      `has` trap was invisible to `in` even though Reflect.has
+//      (proxyReflectHas, pkg/builtins/reflect_has.go) already used
+//      .Get, not .GetOwn, and so already found it - see checks 1-2.
+//
+//   2. Unguarded AsPlainObject() panics on a TypeDictObject handler. The
+//      same line assumed the handler is specifically a TypeObject. A
+//      handler that happens to be a TypeDictObject (a TS enum or module
+//      namespace value at runtime - pkg/vm/object.go's NewDictObject)
+//      made Value.AsPlainObject() panic the entire process - not a
+//      catchable JS exception - instead of just answering false (an
+//      enum has no "has" member) or falling through to the trap-lookup
+//      logic correctly. See check 3.
+//
+//   3. Fallback coverage gap shared by both key paths.
+//      proxyHasPropertyFallback (string keys) and its symbol-key sibling
+//      proxyHasSymbolPropertyFallback (added in #340) both only covered
+//      TypeProxy/TypeObject/TypeDictObject/TypeArray/TypeRegExp/
+//      TypeFunction/TypeClosure as fallback target kinds when a Proxy has
+//      no `has` trap - unlike OpIn's own fuller direct-target switch,
+//      which also handles Map/Set/Promise/BoundFunction/NativeFunction/
+//      NativeFunctionWithProps/Arguments. A no-trap Proxy wrapping one of
+//      those seven kinds disagreed with Reflect.has (whose
+//      proxyReflectHas correctly recurses into the fully general
+//      reflectHas for a no-trap fallback, pkg/builtins/reflect_has.go).
+//      See checks 4-10, one per kind, both key kinds where relevant.
+//
+// Fixed via:
+//   - proxy.handler.AsPlainObject().GetOwn("has") replaced with
+//     proxyGetTrap(proxy.handler, "has") in OpIn's string-key TypeProxy
+//     case (and in proxyHasPropertyFallback's own nested TypeProxy case,
+//     for a chain of proxies with no trap anywhere) - the same helper
+//     #340 already introduced for the symbol-key path, so both key kinds
+//     now share one spec-correct trap-lookup implementation instead of
+//     two independently-bugged ones.
+//   - proxyHasPropertyFallback and proxyHasSymbolPropertyFallback both
+//     extended with TypeMap/TypeSet/TypePromise/TypeBoundFunction/
+//     TypeNativeFunction/TypeNativeFunctionWithProps/TypeArguments cases,
+//     copying the existing own-table-then-prototype-chain logic from
+//     OpIn's own direct-target switches (both key kinds, same function)
+//     for each of those kinds - not new logic, the same logic already
+//     proven correct for a non-Proxy target of each kind.
+//
+// tests/scripts/in_symbol_proxy.ts's check 11 (from #340) originally
+// pinned the Map-target divergence for a SYMBOL key explicitly; it is
+// updated in this same commit to assert the fixed (agreeing) behavior,
+// same history as in_symbol_boundfn_nativefn.ts's own pinned-then-flipped
+// assertion (PR #338).
+
+const checks: boolean[] = [];
+
+// --- 1. Inherited `has` trap (GetMethod semantics) is found for a
+// string key - matches Reflect.has, which already worked here. ---
+{
+  const base1 = { has() { return true; } };
+  const p1: any = new Proxy({}, Object.create(base1));
+  checks.push("x" in p1);
+  checks.push(Reflect.has(p1, "x") === true);
+}
+
+// --- 2. An own (non-inherited) trap still works after the fix - the
+// common case must not regress while fixing the inherited one. ---
+{
+  const p2: any = new Proxy({}, { has() { return true; } });
+  checks.push("y" in p2);
+}
+
+// --- 3. A TypeDictObject handler (a TS enum at runtime) must not panic
+// for a string key, same as the symbol-key case already fixed in #340
+// (tests/scripts/in_symbol_proxy.ts, check 9). The enum has no "has"
+// member, so this exercises the trap-lookup's TypeDictObject branch and
+// falls through to the no-trap fallback against the {} target. ---
+{
+  enum DictHandler3 { A, B }
+  const p3: any = new Proxy({}, DictHandler3 as any);
+  checks.push(("x" in p3) === false);
+}
+
+// --- 4. Map: own custom property (string key) and "size" itself, both
+// via the no-trap fallback. ---
+{
+  const m4: any = new Map();
+  Object.defineProperty(m4, "vis", { value: 1, configurable: true });
+  const p4: any = new Proxy(m4, {});
+  checks.push("vis" in p4);
+  checks.push(Reflect.has(p4, "vis") === true);
+  checks.push("size" in new Proxy(new Map([[1, 2]]), {}));
+}
+
+// --- 4b. Map: the identical own-custom-property check for a Symbol key -
+// this is the exact scenario in_symbol_proxy.ts's check 11 was pinned
+// against before this fix. ---
+{
+  const m4b: any = new Map();
+  const sym4b = Symbol("m4b");
+  Object.defineProperty(m4b, sym4b, { value: 1, configurable: true });
+  const p4b: any = new Proxy(m4b, {});
+  checks.push(sym4b in p4b);
+  checks.push(Reflect.has(p4b, sym4b) === true);
+}
+
+// --- 5. Set: own custom property and "size" through the no-trap
+// fallback, for both key kinds. ---
+{
+  const s5: any = new Set();
+  Object.defineProperty(s5, "vis", { value: 1, configurable: true });
+  const p5: any = new Proxy(s5, {});
+  checks.push("vis" in p5, Reflect.has(p5, "vis") === true);
+  const sym5 = Symbol("s5");
+  Object.defineProperty(s5, sym5, { value: 1, configurable: true });
+  const p5b: any = new Proxy(s5, {});
+  checks.push(sym5 in p5b, Reflect.has(p5b, sym5) === true);
+  checks.push("size" in new Proxy(new Set([1, 2]), {}));
+}
+
+// --- 6. Promise: an own property assigned directly onto the instance
+// (Promise has no intrinsic own state, but this is still possible), plus
+// an inherited method ("then") through the fallback's prototype walk. ---
+{
+  const pr6: any = Promise.resolve(1);
+  pr6.vis = 1;
+  const p6: any = new Proxy(pr6, {});
+  checks.push("vis" in p6, Reflect.has(p6, "vis") === true);
+  const sym6 = Symbol("pr6");
+  pr6[sym6] = 1;
+  const p6b: any = new Proxy(pr6, {});
+  checks.push(sym6 in p6b, Reflect.has(p6b, sym6) === true);
+  checks.push("then" in new Proxy(Promise.resolve(1), {}));
+}
+
+// --- 7. BoundFunction: an own custom property, for both key kinds. ---
+{
+  function orig7(a: number, b: number) {}
+  const bound7: any = orig7.bind(null, 1);
+  bound7.vis = 1;
+  const p7: any = new Proxy(bound7, {});
+  checks.push("vis" in p7, Reflect.has(p7, "vis") === true);
+  const sym7 = Symbol("bf7");
+  bound7[sym7] = 1;
+  const p7b: any = new Proxy(bound7, {});
+  checks.push(sym7 in p7b, Reflect.has(p7b, sym7) === true);
+}
+
+// --- 8. A plain native function (Array.prototype.*-style): an own
+// custom property via Object.defineProperty, for both key kinds. ---
+{
+  const nf8: any = Array.prototype.push;
+  Object.defineProperty(nf8, "vis8", { value: 1, configurable: true });
+  const p8: any = new Proxy(nf8, {});
+  checks.push("vis8" in p8, Reflect.has(p8, "vis8") === true);
+  const sym8 = Symbol("nf8");
+  Object.defineProperty(nf8, sym8, { value: 1, configurable: true });
+  const p8b: any = new Proxy(nf8, {});
+  checks.push(sym8 in p8b, Reflect.has(p8b, sym8) === true);
+}
+
+// --- 9. A native function with props (a global constructor, e.g.
+// Boolean): an own custom property, for both key kinds. ---
+{
+  Object.defineProperty(Boolean, "vis9", { value: 1, configurable: true });
+  const p9: any = new Proxy(Boolean, {});
+  checks.push("vis9" in p9, Reflect.has(p9, "vis9") === true);
+  const sym9 = Symbol("nfwp9");
+  Object.defineProperty(Boolean, sym9, { value: 1, configurable: true });
+  const p9b: any = new Proxy(Boolean, {});
+  checks.push(sym9 in p9b, Reflect.has(p9b, sym9) === true);
+}
+
+// --- 10. Arguments: "length", a numeric index, and an inherited method
+// (Object.prototype.toString), all through the no-trap fallback. ---
+{
+  function f10(a: number, b: number) {
+    const p10: any = new Proxy(arguments, {});
+    checks.push("length" in p10, Reflect.has(p10, "length") === true);
+    checks.push(0 in p10, Reflect.has(p10, 0 as any) === true);
+    checks.push("toString" in p10);
+  }
+  f10(1, 2);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

- **`pkg/vm/vm.go`** — `OpIn`'s string-key `TypeProxy` case's trap lookup replaced with `proxyGetTrap`; `proxyHasPropertyFallback`'s own nested `TypeProxy` case gets the same fix; both `proxyHasPropertyFallback` and `proxyHasSymbolPropertyFallback` extended with `TypeMap`/`TypeSet`/`TypePromise`/`TypeBoundFunction`/`TypeNativeFunction`/`TypeNativeFunctionWithProps`/`TypeArguments` cases.
- **`tests/scripts/in_symbol_proxy.ts`** — check 11's pinned divergence flipped to assert agreement now that the gap it pinned is fixed.
- **`tests/scripts/proxy_has_string_key_fixes.ts`** — new regression test, 30 assertions.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #341), since this branch was created from `fix-reflect-get-general`'s tip (#341, not the task's stated #340 — #341 introduced `proxyGetTrap`, which this PR reuses, so basing there avoids a conflict). Everything except the items above belongs to those PRs and disappears from the diff once they merge.

## Three bugs, found while adding #340's symbol-key `TypeProxy` case, deliberately left unfixed there

**This PR changes established `in`/`Reflect.has` behavior on the string-key path** — not just filling in an unfixed gap:

1. **Own-only trap lookup.** `OpIn`'s string-key `TypeProxy` case did `proxy.handler.AsPlainObject().GetOwn("has")` — own-only, but per 10.5.7 step 4 the trap comes from `GetMethod(handler, "has")`, which walks the handler's prototype chain:
   ```js
   const base = { has() { return true; } };
   const p = new Proxy({}, Object.create(base));
   console.log("x" in p);           // before: false - Node: true
   console.log(Reflect.has(p, "x")); // true on both (already used .Get)
   ```
2. **Unguarded `AsPlainObject()` panics on a `TypeDictObject` handler.** The same line assumed the handler is specifically a `TypeObject`:
   ```js
   enum E { A, B }
   "x" in new Proxy({}, E as any); // before: [VM PANIC] value is not an object - crashes the process
   ```
   Both fixed via `proxyGetTrap(proxy.handler, "has")` — the exact helper #340 already introduced for the symbol-key path — in both `OpIn`'s string-key case and `proxyHasPropertyFallback`'s own nested `TypeProxy` case (a chain of proxies with no trap anywhere hit the identical bug). Both key paths now share one spec-correct trap-lookup implementation instead of two independently-bugged ones.

3. **Fallback coverage gap shared by both key paths.** `proxyHasPropertyFallback`/`proxyHasSymbolPropertyFallback` only covered `TypeProxy`/`TypeObject`/`TypeDictObject`/`TypeArray`/`TypeRegExp`/`TypeFunction`/`TypeClosure`, unlike `OpIn`'s fuller direct-target switch:
   ```js
   const m = new Map();
   Object.defineProperty(m, "vis", { value: 1, configurable: true });
   console.log("vis" in new Proxy(m, {}));           // before: false - Node: true
   console.log(Reflect.has(new Proxy(m, {}), "vis")); // true on both
   ```
   Fixed by extending both fallback functions with all seven missing kinds — copying the existing own-table-then-prototype-chain logic already proven correct for a non-Proxy target of each kind, not new logic.

`tests/scripts/in_symbol_proxy.ts`'s check 11 (from #340) originally pinned the Map-target divergence for a symbol key explicitly; flipped here to assert genuine agreement — same history as `in_symbol_boundfn_nativefn.ts`'s own pinned-then-flipped assertion (PR #338).

## Testing

30 assertions verified against Node in the new test file: inherited and own `has` traps, a `TypeDictObject` handler no longer crashing, and all seven newly-covered fallback target kinds for both key kinds where relevant.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass. test262's built-ins baseline moved 16444 → 16445 (an improvement, not flakiness).

## Found while reviewing this fix, NOT fixed here — flagged as a follow-up

The identical `handler.AsPlainObject().GetOwn(<trapName>)` shape (unguarded cast + own-only lookup) appears at roughly two dozen more sites across `pkg/vm/vm.go`, `pkg/vm/op_getprop.go`, `pkg/vm/call.go`, `pkg/vm/vm_init.go`, and several `pkg/builtins` files, for `"has"` (several more sites beyond the ones fixed here), `"get"`, `"apply"`, `"getOwnPropertyDescriptor"`, `"defineProperty"`, and `"getPrototypeOf"` traps. Each carries the same two bugs. Far too large to fix inline here — filed as a comprehensive follow-up.

`proxyHasPropertyFallback`'s pre-existing `TypeArray` case still uses the simpler, wrong `index < arrayObj.Length()` test instead of `ArrayHasOwnIndex` (paserati#176/#178) — unrelated pre-existing correctness issue, left alone and bundled into the same follow-up.

Based on `fix-reflect-get-general` (#341).
