### PR TITLE
fix(builtins): BoundFunction descriptors and getOwnPropertySymbols on callables

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2913,6 +2913,25 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 				arrObj.Append(s)
 			}
 		}
+	} else if obj.Type() == vm.TypeNativeFunction || obj.Type() == vm.TypeNativeFunctionWithProps || obj.Type() == vm.TypeBoundFunction {
+		// These three callable kinds keep their own properties in the same
+		// lazily-allocated *PlainObject side table shape as TypeFunction/
+		// TypeClosure above (OwnPropertiesTable, pkg/vm/properties_table.go),
+		// but this function never had a case for any of them at all - so
+		// Object.getOwnPropertySymbols always answered [] even after
+		// Object.defineProperty had just added a symbol-keyed own property,
+		// even though Object.getOwnPropertyDescriptor(obj, sym) already
+		// correctly reported that same property existing (and, for
+		// TypeNativeFunction/TypeNativeFunctionWithProps,
+		// Object.getOwnPropertyDescriptors already lists it correctly too -
+		// PR #339 fixed that plural function's own equivalent gap for these
+		// same three kinds without this singular-purpose function being
+		// touched, which is what let this one lag behind unnoticed).
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			for _, s := range props.OwnSymbolKeys() {
+				arrObj.Append(s)
+			}
+		}
 	}
 	// DictObject does not support symbols; returns empty array
 	return arr, nil
@@ -5193,6 +5212,28 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 				}
 				symbolKeys = append(symbolKeys, nf.Properties.OwnSymbolKeys()...)
 			}
+		}
+	case vm.TypeBoundFunction:
+		// This case didn't exist at all before this fix, so
+		// Object.getOwnPropertyDescriptors(boundFn) always returned {}
+		// entirely - missing even "name"/"length", unlike every other
+		// callable kind's branch in this same switch (which all
+		// synthesize those two explicitly, since for THEM name/length
+		// aren't real entries in the side table). A bound function is the
+		// one callable kind where "name" ("bound " + original name) and
+		// "length" (computed at bind time) genuinely ARE real own
+		// properties set directly into bf.Properties (see
+		// pkg/vm/property_helpers.go's "Bound functions: 'name'/'length'
+		// is a real own property set at bind time" comments), so unlike
+		// TypeFunction/TypeNativeFunction*/TypeClosure above, no special
+		// synthesis is needed here - a plain OwnPropertyNames()/
+		// OwnSymbolKeys() walk already includes them alongside any other
+		// custom own property (Object.defineProperty, bracket-notation
+		// assignment).
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			stringKeys = append(stringKeys, bf.Properties.OwnPropertyNames()...)
+			symbolKeys = append(symbolKeys, bf.Properties.OwnSymbolKeys()...)
 		}
 	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
 		// These exotic kinds keep their ordinary own properties in the same

--- a/tests/scripts/boundfn_descriptors_and_native_symbols.ts
+++ b/tests/scripts/boundfn_descriptors_and_native_symbols.ts
@@ -1,0 +1,155 @@
+// expect: true
+// Two independent gaps found while verifying PR #339 (native functions'
+// custom own properties), both in pkg/builtins/object_init.go, both
+// instances of the same "exotic VM kind missing from a per-type switch"
+// bug class that's recurred throughout this stack (PRs #329-#339):
+//
+//   1. objectGetOwnPropertyDescriptorsWithVM had no `case
+//      vm.TypeBoundFunction` at all - Object.getOwnPropertyDescriptors(
+//      boundFn) returned {} entirely, missing even "name"/"length", which
+//      every other callable kind's branch in this same switch synthesizes
+//      explicitly:
+//        function fn(a, b) {}
+//        const bound = fn.bind(null);
+//        Object.getOwnPropertyDescriptors(bound); // before: {} - Node: {length: {...}, name: {...}}
+//      Fixed with a new case - but unlike TypeFunction/TypeNativeFunction/
+//      TypeNativeFunctionWithProps/TypeClosure above it (which all
+//      synthesize "name"/"length" specially, since those aren't real
+//      table entries for them), a bound function's "name" ("bound " +
+//      original) and "length" ARE real own properties written directly
+//      into bf.Properties at bind time (pkg/vm/property_helpers.go) - so
+//      a plain OwnPropertyNames()/OwnSymbolKeys() walk already includes
+//      them, no special synthesis needed.
+//
+//   2. Object.getOwnPropertySymbols had no case for TypeNativeFunction,
+//      TypeNativeFunctionWithProps, or TypeBoundFunction at all (only
+//      TypeObject/TypeFunction/TypeClosure) - checked all three against
+//      Node per the task's own instruction, all three were broken:
+//        const nf = Array.prototype.pop;
+//        const sym = Symbol("k");
+//        Object.defineProperty(nf, sym, { value: 2, configurable: true });
+//        Object.getOwnPropertySymbols(nf).length; // before: 0 - Node: 1
+//      even though Object.getOwnPropertyDescriptor(nf, sym) already
+//      correctly reported the property existing. Fixed with one shared
+//      branch for all three kinds, using the generic OwnPropertiesTable
+//      helper (pkg/vm/properties_table.go) - the same one
+//      objectGetOwnPropertyDescriptorsWithVM and objectKeysWithVM already
+//      use for the identical purpose (PR #339).
+//
+// Found while verifying, NOT fixed here (a real but larger, separate
+// bug, flagged as a follow-up): Reflect.ownKeys throws a TypeError
+// outright on ANY callable target (its object-gate never checks
+// IsCallable(), unlike Reflect.get/has/etc. in the same file), and even
+// past that gate has no case for any callable kind at all - so
+// Reflect.ownKeys(nf) disagrees with the now-fixed
+// Object.getOwnPropertySymbols(nf) above. Confirmed via:
+//   Reflect.ownKeys(Array.prototype.slice); // before: throws TypeError - Node: ["length", "name", ...]
+// Not a one-line fix like the two above - it needs real per-kind string-
+// key synthesis (name/length/prototype per callable kind), mirroring
+// objectGetOwnPropertyDescriptorsWithVM's own stringKeys collection
+// logic, which is a distinctly larger scope than this task's two gaps.
+//
+// Each assertion below uses its own function/instance (bind()/defineProperty
+// on a fresh function per check), plus distinct global constructors
+// (Number/Boolean) for the two NativeFunctionWithProps checks - these are
+// real shared intrinsics with no reset between assertions in the same
+// test file, matching the established convention (see
+// nativefunction_get_and_enumerate.ts).
+
+const checks: boolean[] = [];
+
+// --- 1. BoundFunction: name/length now present with the correct
+// attributes (writable: false, enumerable: false, configurable: true -
+// real own properties, not synthesized). ---
+{
+  function fn1(a: number, b: number) {}
+  const bound1: any = fn1.bind(null);
+  const descs: any = Object.getOwnPropertyDescriptors(bound1);
+  checks.push(
+    !!descs.length &&
+      descs.length.value === 2 &&
+      descs.length.writable === false &&
+      descs.length.enumerable === false &&
+      descs.length.configurable === true
+  );
+  checks.push(
+    !!descs.name &&
+      descs.name.value === "bound fn1" &&
+      descs.name.writable === false &&
+      descs.name.enumerable === false &&
+      descs.name.configurable === true
+  );
+}
+
+// --- 2. BoundFunction: a custom string property and a custom symbol
+// property both show up in getOwnPropertyDescriptors alongside name/length. ---
+{
+  function fn2() {}
+  const bound2: any = fn2.bind(null);
+  Object.defineProperty(bound2, "vis2", { value: 1, enumerable: true, configurable: true });
+  const sym2 = Symbol("k2");
+  Object.defineProperty(bound2, sym2, { value: 2, configurable: true });
+  const descs: any = Object.getOwnPropertyDescriptors(bound2);
+  checks.push(!!descs.vis2 && descs.vis2.value === 1);
+  checks.push(!!descs[sym2] && descs[sym2].value === 2);
+}
+
+// --- 3. BoundFunction with no custom properties: getOwnPropertyDescriptors
+// reports exactly name and length, nothing extra or missing. ---
+{
+  function fn3() {}
+  const bound3: any = fn3.bind(null);
+  checks.push(Object.keys(Object.getOwnPropertyDescriptors(bound3)).length === 2);
+}
+
+// --- 4. Object.getOwnPropertySymbols on a plain native function
+// (Array.prototype.*-style, TypeNativeFunction). ---
+{
+  const nf4: any = Array.prototype.shift;
+  const sym4 = Symbol("k4");
+  Object.defineProperty(nf4, sym4, { value: "v4", configurable: true });
+  const syms = Object.getOwnPropertySymbols(nf4);
+  checks.push(syms.length === 1 && syms[0] === sym4);
+}
+
+// --- 5. Object.getOwnPropertySymbols on a native function with props
+// (a global constructor, TypeNativeFunctionWithProps). ---
+{
+  const sym5 = Symbol("k5");
+  Object.defineProperty(Number, sym5, { value: "v5", configurable: true });
+  const syms = Object.getOwnPropertySymbols(Number);
+  checks.push(syms.includes(sym5));
+}
+
+// --- 6. Object.getOwnPropertySymbols on a BoundFunction, set via
+// bracket-notation assignment rather than defineProperty. ---
+{
+  function fn6() {}
+  const bound6: any = fn6.bind(null);
+  const sym6 = Symbol("k6");
+  bound6[sym6] = "v6";
+  const syms = Object.getOwnPropertySymbols(bound6);
+  checks.push(syms.length === 1 && syms[0] === sym6);
+}
+
+// --- 7. Regression guard: a native function with no custom symbol
+// properties still reports an empty array, not a stale leftover. ---
+{
+  const nf7: any = Array.prototype.pop;
+  checks.push(Object.getOwnPropertySymbols(nf7).length === 0);
+}
+
+// --- 8. Object.getOwnPropertySymbols on a second, distinct
+// NativeFunctionWithProps constructor (Array, not Number/Boolean used
+// above) - comparing a before/after count rather than an absolute one,
+// since this is a real shared intrinsic no other check here touches
+// directly. ---
+{
+  const before = Object.getOwnPropertySymbols(Array).length;
+  const sym8 = Symbol("k8");
+  Object.defineProperty(Array, sym8, { value: 1, configurable: true });
+  const after = Object.getOwnPropertySymbols(Array);
+  checks.push(after.length === before + 1 && after.includes(sym8));
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

- **`pkg/builtins/object_init.go`** — `objectGetOwnPropertyDescriptorsWithVM` gains a `TypeBoundFunction` case; `objectGetOwnPropertySymbolsWithVM` gains a shared case for `TypeNativeFunction`/`TypeNativeFunctionWithProps`/`TypeBoundFunction`.
- **`tests/scripts/boundfn_descriptors_and_native_symbols.ts`** — new regression test, 9 assertions.

⚠️ **The diff below also carries this stack's prior PRs** (#329 → ... → #342), since this branch was created from `fix-proxy-has-string-key-gaps`'s tip (#342, not the task's stated #339 — #342 is the current stack tip). Everything except the items above belongs to those PRs and disappears from the diff once they merge.

## Bug 1: `objectGetOwnPropertyDescriptorsWithVM` had no `TypeBoundFunction` case

```js
function fn(a, b) {}
const bound = fn.bind(null);
console.log(Object.getOwnPropertyDescriptors(bound)); // before: {} - Node: {length: {...}, name: {...}}
```

Fixed with a new case. Unlike `TypeFunction`/`TypeNativeFunction`/`TypeNativeFunctionWithProps`/`TypeClosure` above it — which all synthesize `"name"`/`"length"` specially since those aren't real table entries for them — a bound function's `"name"` and `"length"` **are** real own properties written directly into `bf.Properties` at bind time (`pkg/vm/property_helpers.go`), so a plain `OwnPropertyNames()`/`OwnSymbolKeys()` walk already includes them. No special synthesis needed, just the missing case.

## Bug 2: `Object.getOwnPropertySymbols` had no case for three callable kinds

The task named `TypeNativeFunction` specifically; per its own instruction to check `TypeNativeFunctionWithProps`/`TypeBoundFunction` too while already in that switch, all three were confirmed broken against Node:

```js
const nf = Array.prototype.pop;
const sym = Symbol("k");
Object.defineProperty(nf, sym, { value: 2, configurable: true });
console.log(Object.getOwnPropertySymbols(nf).length); // before: 0 - Node: 1
```

even though `Object.getOwnPropertyDescriptor(nf, sym)` already correctly reported the property existing. Fixed with one shared branch for all three kinds, using the generic `OwnPropertiesTable` helper (`pkg/vm/properties_table.go`) — the same one `objectGetOwnPropertyDescriptorsWithVM` and `objectKeysWithVM` already use for the identical purpose (PR #339).

## Found while verifying, NOT fixed here — flagged as a follow-up

`Reflect.ownKeys` throws a `TypeError` outright on **any** callable target (its object-gate never checks `IsCallable()`, unlike `Reflect.get`/`has`/etc. in the same file), and even past that gate has no case for any callable kind at all — so it disagrees with the now-fixed `Object.getOwnPropertySymbols` above:

```js
Reflect.ownKeys(Array.prototype.slice); // before: throws TypeError - Node: ["length", "name", ...]
```

Not a one-line fix like the two above — it needs the object-gate widened to accept callables plus real per-kind string-key synthesis (name/length/prototype per callable kind), mirroring `objectGetOwnPropertyDescriptorsWithVM`'s own `stringKeys` collection logic. A distinctly larger scope, filed as a separate follow-up.

## Testing

9 assertions verified against Node: `BoundFunction` descriptor attributes (writable/enumerable/configurable), custom string+symbol properties on a bound function, the exact key count with no custom properties, and `getOwnPropertySymbols` on all three newly-covered callable kinds (a plain native function, a native constructor, and a bound function) via both `Object.defineProperty` and bracket-notation assignment.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./...` (every package) both pass.

Based on `fix-proxy-has-string-key-gaps` (#342).
