### PR TITLE
fix(builtins,vm): widen Reflect.set/construct signatures, fix construct's newTarget prototype bug

### DIFF
--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -57,13 +57,24 @@ func (r *ReflectInitializer) InitTypes(ctx *TypeContext) error {
 		// "get" takes an optional third `receiver` argument (used as the
 		// `this` an accessor's getter is called with - the runtime
 		// implementation now actually reads it, see reflectObj's "get"
-		// closure below). Reflect.set/Reflect.construct have the exact
-		// same "optional trailing argument the runtime accepts but the
-		// declared signature doesn't" gap for their own optional
-		// receiver/newTarget parameters - left alone here (out of this
-		// fix's scope) and flagged as a separate follow-up.
+		// closure below). "set"/"construct" have the same shape of gap for
+		// their own optional trailing arguments - fixed alongside "get"
+		// here rather than left as a separate follow-up, since the runtime
+		// already accepted a 4th/3rd argument for both before this fix
+		// (Reflect.set(t, k, v, receiver) already worked under
+		// --no-typecheck; Reflect.construct(t, args, newTarget) did NOT -
+		// see the "construct" closure below for the real, causally-coupled
+		// runtime bug this surfaced and fixed in the same commit).
+		//
+		// "set"'s spec signature (ECMA-262, and lib.es2015.reflect.d.ts in
+		// the pinned TypeScript v6.0.3 tree) is
+		// `set(target, propertyKey, value, receiver?)` - only the trailing
+		// `receiver` is optional, `value` is required (it legitimately
+		// defaults to `undefined` at the VALUE level when omitted, same as
+		// any other required `any`-typed parameter given `undefined` -
+		// that's not the same as the parameter itself being optional).
 		WithProperty("get", types.NewOptionalFunction([]types.Type{types.Any, keyType, types.Any}, types.Any, []bool{false, false, true})).
-		WithProperty("set", types.NewSimpleFunction([]types.Type{types.Any, keyType, types.Any}, types.Boolean)).
+		WithProperty("set", types.NewOptionalFunction([]types.Type{types.Any, keyType, types.Any, types.Any}, types.Boolean, []bool{false, false, false, true})).
 		WithProperty("has", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
 		WithProperty("deleteProperty", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
 		// Prototype operations
@@ -79,7 +90,7 @@ func (r *ReflectInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("preventExtensions", types.NewSimpleFunction([]types.Type{types.Any}, types.Boolean)).
 		// Function operations
 		WithProperty("apply", types.NewSimpleFunction([]types.Type{types.Any, types.Any, types.Any}, types.Any)).
-		WithProperty("construct", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Any))
+		WithProperty("construct", types.NewOptionalFunction([]types.Type{types.Any, types.Any, types.Any}, types.Any, []bool{false, false, true}))
 
 	return ctx.DefineGlobal("Reflect", reflectType)
 }

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -2271,19 +2271,51 @@ func (vm *VM) ConstructWithNewTarget(constructor Value, args []Value, newTarget 
 
 		// Get prototype from newTarget (not constructor)
 		// Per ECMAScript, the prototype is determined by newTarget
-		var newTargetFn *FunctionObject
-		if newTarget.Type() == TypeClosure {
-			newTargetFn = newTarget.AsClosure().Fn
-		} else if newTarget.Type() == TypeFunction {
-			newTargetFn = newTarget.AsFunction()
-		}
-
+		//
+		// This used to unconditionally unwrap TypeClosure to its
+		// underlying, SHARED *FunctionObject (newTarget.AsClosure().Fn)
+		// and call GetOrCreatePrototypeWithVM on that directly - which
+		// creates/reads "prototype" on the function's own table, not the
+		// closure INSTANCE's table. But `someClosure.prototype = x`
+		// (op_setprop.go's TypeClosure case) writes into
+		// closure.Properties, a per-closure-instance side table that
+		// shadows the shared Fn's - exactly the same shadowing
+		// TypeFunction/TypeClosure's ordinary property-read path
+		// (getPropertyWithReceiver above) already respects. So
+		// Reflect.construct(Ctor, args, newTarget) with an explicit
+		// newTarget whose .prototype had been reassigned (or a class,
+		// which compiles to TypeClosure) silently used newTarget's
+		// stale, unshadowed default prototype instead of the real one:
+		//
+		//   function C(a) { this.a = a; }
+		//   function D() {}
+		//   D.prototype = { fromD: true };
+		//   Object.getPrototypeOf(Reflect.construct(C, [1], D)) === D.prototype; // before: false - Node: true
+		//
+		// Fixed by using ClosureObject.GetPrototypeWithVM (pkg/vm/function.go),
+		// which already gets this shadowing right - it's the same method
+		// OpValidateSuperclass (`class X extends Y`, pkg/vm/vm.go) already
+		// uses for the identical purpose. TypeNativeFunction/
+		// TypeNativeFunctionWithProps/TypeBoundFunction newTargets (a
+		// native or bound constructor) had the same bug via the same
+		// "fall back to constructor's own prototype, not newTarget's"
+		// path - handled by GetPrototypeFromConstructor below directly
+		// (their own "prototype" is a real, non-lazily-created property,
+		// so vm.GetProperty - which GetPrototypeFromConstructor calls -
+		// already reads it correctly for all three, unlike
+		// TypeFunction/TypeClosure's synthesized-on-first-access one).
 		var prototype Value
-		if newTargetFn != nil {
-			prototype = newTargetFn.GetOrCreatePrototypeWithVM(vm)
-		} else {
-			// Fallback to constructor's prototype
-			prototype = fn.GetOrCreatePrototypeWithVM(vm)
+		switch newTarget.Type() {
+		case TypeClosure:
+			prototype = newTarget.AsClosure().GetPrototypeWithVM(vm)
+		case TypeFunction:
+			prototype = newTarget.AsFunction().GetOrCreatePrototypeWithVM(vm)
+		default:
+			var gpfcErr error
+			prototype, gpfcErr = vm.GetPrototypeFromConstructor(newTarget, "%ObjectPrototype%")
+			if gpfcErr != nil {
+				return Undefined, gpfcErr
+			}
 		}
 
 		// ECMAScript spec 9.1.14 GetPrototypeFromConstructor:

--- a/tests/scripts/reflect_set_construct_optional_args.ts
+++ b/tests/scripts/reflect_set_construct_optional_args.ts
@@ -1,0 +1,166 @@
+// expect: true
+// Reflect.set and Reflect.construct were both declared with fewer
+// parameters than their runtime implementations actually accepted, so a
+// call using their spec'd optional trailing argument failed type checking
+// even though it ran fine with --no-typecheck - the same gap PR #341
+// already fixed for Reflect.get's optional third `receiver` argument:
+//
+//   const target: any = {};
+//   Reflect.set(target, "x", 1, target); // before: TS2554 "Expected 3 arguments, but got 4."
+//
+// Both fixed the same way as Reflect.get: types.NewOptionalFunction
+// instead of types.NewSimpleFunction, with the trailing argument(s)
+// marked optional.
+//
+// Fixing Reflect.construct's signature to actually ALLOW a distinct
+// newTarget argument immediately surfaced that the runtime feature behind
+// it was itself broken for almost every real newTarget - not just a type
+// declaration gap, a genuine runtime bug, found and fixed in the same
+// commit since testing the newly-typecheckable 3rd argument is what
+// caught it:
+//
+//   function C(a) { this.a = a; }
+//   function D() {}
+//   D.prototype = { fromD: true };
+//   Object.getPrototypeOf(Reflect.construct(C, [1], D)) === D.prototype; // before: false - Node: true
+//
+// Root cause: ConstructWithNewTarget (pkg/vm/vm_init.go) unwrapped a
+// TypeClosure newTarget straight to its underlying, SHARED
+// *FunctionObject (newTarget.AsClosure().Fn) and read/created "prototype"
+// there - but `someClosure.prototype = x` (op_setprop.go) writes into
+// closure.Properties, a per-CLOSURE-INSTANCE side table that shadows the
+// shared Fn's, exactly like the closure's ordinary property-read path
+// already respects. So any newTarget whose .prototype had been reassigned
+// (including a class, which compiles to TypeClosure) silently got the
+// stale, unshadowed default instead. Fixed by using
+// ClosureObject.GetPrototypeWithVM (pkg/vm/function.go) - the same method
+// `class X extends Y` (OpValidateSuperclass, pkg/vm/vm.go) already uses
+// for the identical purpose - instead of reaching past the closure
+// wrapper. A bound-function or native-constructor newTarget had the
+// identical "falls back to constructor's own prototype, not newTarget's"
+// bug via the same code path - fixed by routing those through
+// GetPrototypeFromConstructor instead, which already reads their real,
+// non-lazily-created "prototype" property correctly (unlike
+// TypeFunction/TypeClosure's synthesized-on-first-access one, which is
+// why they need the ClosureObject/FunctionObject-specific methods instead).
+//
+// Found while testing, NOT fixed here - a real, separate, pre-existing
+// runtime bug, deliberately deferred as a follow-up: Reflect.set ignores
+// a non-Proxy receiver argument distinct from target when target lacks
+// the property being set - it always writes to target regardless. Only
+// the receiver === target form (the common case, and the one this fix's
+// own type-signature change most directly unblocks) works correctly.
+// Pinned explicitly below (check 3) rather than silently left
+// undocumented - see its own comment for the repro and the reasoning for
+// deferring it. Flagged as a follow-up chip.
+
+const checks: boolean[] = [];
+
+// --- 1. Reflect.set with all 4 arguments, receiver === target (the
+// common/simple form) - already worked at runtime before this fix; this
+// confirms the type-signature change didn't perturb it. ---
+{
+  const target1: any = {};
+  const ok = Reflect.set(target1, "x", 1, target1);
+  checks.push(ok === true && target1.x === 1);
+}
+
+// --- 2. Reflect.set omitting only the trailing `receiver` (the ONLY
+// optional parameter per spec - lib.es2015.reflect.d.ts declares
+// `set(target, propertyKey, value, receiver?)`; `value` is required, so
+// passing `undefined` for it explicitly is the correct way to exercise
+// "value omitted at the value level" - a bare 2-arg call would be a type
+// error, correctly, and isn't what "receiver is optional" means). ---
+{
+  const target2: any = {};
+  const ok = Reflect.set(target2, "z", undefined);
+  checks.push(ok === true && target2.z === undefined);
+}
+
+// --- 3. KNOWN, PRE-EXISTING GAP (not fixed here, flagged as a follow-up):
+// Reflect.set with a receiver DISTINCT from target, where target lacks
+// the property, should write to the RECEIVER per ECMA-262 10.1.9.2
+// OrdinarySetWithOwnDescriptor - paserati instead writes to target. This
+// assertion pins TODAY's wrong behavior explicitly (matching the
+// established pattern for a still-open gap - see in_symbol_proxy.ts's
+// history) so a future fix has to touch this file instead of silently
+// leaving stale documentation. Node: ok === true, receiver3.y === 5,
+// "y" in target3 === false. ---
+{
+  const target3: any = {};
+  const receiver3: any = {};
+  const ok = Reflect.set(target3, "y", 5, receiver3);
+  checks.push(ok === true && target3.y === 5 && receiver3.y === undefined);
+}
+
+// --- 4. Reflect.construct with 2 arguments (newTarget defaults to
+// target) - already worked; confirms no regression. ---
+{
+  function C4(a: number) { (this as any).a = a; }
+  const inst: any = Reflect.construct(C4 as any, [3]);
+  checks.push(inst.a === 3 && inst instanceof (C4 as any));
+}
+
+// --- 5. Reflect.construct with a distinct newTarget whose .prototype was
+// reassigned to a fresh object - the exact bug this fix closes. Not
+// asserting `inst.constructor === D5`: replacing .prototype with a plain
+// object literal has no "constructor" backlink to begin with (Node
+// agrees - inst.constructor is Object there, not D5), so that would be a
+// wrong assertion, not a discriminating one. The prototype-identity check
+// is what actually distinguishes the fix. ---
+{
+  function C5(a: number) { (this as any).a = a; }
+  function D5() {}
+  (D5 as any).prototype = { fromD5: true };
+  const inst: any = Reflect.construct(C5 as any, [4], D5 as any);
+  checks.push(inst.a === 4 && Object.getPrototypeOf(inst) === (D5 as any).prototype);
+}
+
+// --- 6. Reflect.construct with a class as newTarget (classes compile to
+// TypeClosure too - same code path as check 5, different surface syntax). ---
+{
+  function C6(a: number) { (this as any).a = a; }
+  class D6 {}
+  const inst: any = Reflect.construct(C6 as any, [6], D6 as any);
+  checks.push(inst.a === 6 && Object.getPrototypeOf(inst) === (D6 as any).prototype);
+}
+
+// --- 7. Reflect.construct with a bound function as newTarget, custom
+// prototype - the TypeBoundFunction half of the same bug class. ---
+{
+  function C7(a: number) { (this as any).a = a; }
+  function E7() {}
+  const bound7: any = E7.bind(null);
+  bound7.prototype = { fromBound7: true };
+  const inst: any = Reflect.construct(C7 as any, [7], bound7);
+  checks.push(inst.a === 7 && Object.getPrototypeOf(inst) === bound7.prototype);
+}
+
+// --- 8. Reflect.construct with a fresh (never-touched) function
+// newTarget: the auto-vivified default prototype, WITH its constructor
+// backlink, must still work exactly as before this fix (a regression
+// guard - this is the one case that happened to already work, since
+// there's no divergence between the shared FunctionObject and a
+// never-created closure-instance override). ---
+{
+  function C8(a: number) { (this as any).a = a; }
+  function Fresh8() {}
+  const inst: any = Reflect.construct(C8 as any, [8], Fresh8 as any);
+  checks.push(
+    inst.a === 8 &&
+      Object.getPrototypeOf(inst) === (Fresh8 as any).prototype &&
+      inst.constructor === Fresh8
+  );
+}
+
+// --- 9. Reflect.construct omitting newTarget entirely: defaults to
+// target, constructor backlink intact - confirms the 3-arg overload
+// (added by this fix's type-signature change) doesn't disturb the
+// pre-existing 2-arg form. ---
+{
+  function C9(a: number) { (this as any).a = a; }
+  const inst: any = Reflect.construct(C9 as any, [9]);
+  checks.push(inst.a === 9 && inst.constructor === C9);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

This branch is stacked on #343 (`fix-boundfn-descriptors-and-symbols`); everything up to that PR's diff is inherited stack noise. The new commit on top:

1. **Widens `Reflect.set` and `Reflect.construct`'s declared TypeScript signatures** to actually allow their spec'd optional trailing arguments (`receiver` and `newTarget` respectively) under full type checking — the same gap #341 fixed for `Reflect.get`'s `receiver`:

   ```ts
   Reflect.set(target, "x", 1, target);   // before: TS2554 "Expected 3 arguments, but got 4."
   Reflect.construct(C, [1], D);          // before: TS2554 "Expected 2 arguments, but got 3."
   ```

   Matched each method's real spec signature (`lib.es2015.reflect.d.ts`, pinned TypeScript v6.0.3): `Reflect.set`'s `value` is **required**, only the trailing `receiver` is optional; `Reflect.construct`'s `newTarget` is the only optional parameter.

2. **Fixes a genuine runtime bug in `Reflect.construct` that widening its signature surfaced**, not just a type-declaration gap. Testing a real 3-argument call (now typecheckable) showed the feature itself was broken:

   ```js
   function C(a) { this.a = a; }
   function D() {}
   D.prototype = { fromD: true };
   Object.getPrototypeOf(Reflect.construct(C, [1], D)) === D.prototype;
   // before: false — Node: true
   ```

   Root cause (`pkg/vm/vm_init.go`, `ConstructWithNewTarget`): a `TypeClosure` `newTarget` was unwrapped straight to its underlying, **shared** `*FunctionObject`, and its `.prototype` was read/created there — bypassing the per-closure-instance `Properties` table that `D.prototype = {...}` (`op_setprop.go`) actually writes into. This is the exact same shadowing every other closure property read already respects (`ClosureObject.GetPrototypeWithVM`, already used correctly by `OpValidateSuperclass` for `class X extends Y`). A `class` newTarget hits the identical path (classes compile to `TypeClosure`); a bound-function or native-constructor newTarget had the mirrored bug via the same "falls back to the *original* constructor's prototype, not newTarget's" branch.

   Fixed by switching `TypeClosure` to `ClosureObject.GetPrototypeWithVM`, and every other kind (`TypeNativeFunction`/`TypeNativeFunctionWithProps`/`TypeBoundFunction`) to the already-correct `GetPrototypeFromConstructor`, whose `vm.GetProperty` call already reads their real, non-lazily-created `.prototype` property correctly post-#341. Verified this does **not** regress a fresh, never-touched function newTarget's lazily auto-vivified default prototype — the one case that happened to already work before this fix, since there's no divergence between the shared `FunctionObject` and a never-created closure-instance override in that case.

## Deliberately deferred (flagged as a follow-up chip, not fixed here)

While comprehensively verifying both methods against Node, found a **separate**, pre-existing `Reflect.set` bug: with a `receiver` argument distinct from `target` (plain object, not a Proxy) and the property absent everywhere, paserati writes to `target` instead of `receiver` — contrary to ECMA-262 10.1.9.2 `OrdinarySetWithOwnDescriptor`'s final `CreateDataProperty(Receiver, ...)` step. Root cause: the `"set"` closure's "Simple property set on target" fallback is receiver-aware only for `TypeProxy` receivers. This is a differently-shaped fix from the type-signature change, so it's pinned explicitly (not silently) as a known gap in the new test (check 3) and flagged as its own follow-up chip, mirroring the `in_symbol_proxy.ts` check-11 pin/flip precedent from #340/#342.

## Testing

- New test: `tests/scripts/reflect_set_construct_optional_args.ts` — 9 checks covering both methods' newly-typecheckable optional arguments, the newTarget-prototype fix across `TypeClosure`/class/`TypeBoundFunction` newTargets, a fresh-function regression guard, and the pinned `Reflect.set` receiver gap.
- `go test ./tests -run TestScripts -timeout 180s`: ok
- `go test ./...`: ok
- test262 baseline: 16445 → 16446 (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
