### PR TITLE
fix(builtins): Reflect.ownKeys accepts and correctly handles callable targets

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2864,6 +2864,78 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 				arrObj.Append(vm.NewString(k))
 			}
 		}
+	case vm.TypeNativeFunction:
+		// A plain (non-Props) native function - this switch never had a case
+		// for it at all, so Object.getOwnPropertyNames fell to the
+		// default/"non-object types" branch and answered [] even for a
+		// function with real own properties (Object.defineProperty already
+		// let you add one - Object.getOwnPropertyDescriptor(s) already
+		// listed it correctly, PR #339). Mirrors the
+		// TypeNativeFunctionWithProps case above - "length"/"name" are
+		// synthesized (not real own properties for this kind either), and
+		// "prototype" is included only when this native function is
+		// actually a constructor (checked here since, unlike
+		// TypeFunction/TypeClosure below, every TypeNativeFunction defined
+		// in this codebase today is IsConstructor==false in practice, so
+		// this guard is what correctly keeps "prototype" OFF a plain
+		// native function like Array.prototype.slice - verified against
+		// Node, which agrees: no "prototype" there).
+		nf := obj.AsNativeFunction()
+		var propNames []string
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			propNames = props.OwnPropertyNames()
+		}
+
+		for _, k := range propNames {
+			if isIntegerIndex(k) {
+				arrObj.Append(vm.NewString(k))
+			}
+		}
+
+		arrObj.Append(vm.NewString("length"))
+		arrObj.Append(vm.NewString("name"))
+
+		hasPrototype := false
+		for _, k := range propNames {
+			if k == "prototype" {
+				hasPrototype = true
+				break
+			}
+		}
+		if hasPrototype {
+			arrObj.Append(vm.NewString("prototype"))
+		}
+
+		for _, k := range propNames {
+			if k != "length" && k != "name" && k != "prototype" && !isIntegerIndex(k) {
+				arrObj.Append(vm.NewString(k))
+			}
+		}
+
+		if !hasPrototype && nf.IsConstructor {
+			arrObj.Append(vm.NewString("prototype"))
+		}
+	case vm.TypeBoundFunction:
+		// Another kind this switch never had a case for at all - fell to
+		// the default/empty branch. Unlike every other callable kind
+		// above, a bound function needs NO synthesis whatsoever: "name"
+		// (bound " + original) and "length" are REAL own properties
+		// written directly into bf.Properties at bind time (PR #343's
+		// "Bound functions: 'name'/'length' is a real own property set at
+		// bind time" precedent - re-synthesizing them here would just
+		// duplicate them), and a bound function exotic object never has
+		// its own "prototype" property at all, regardless of whether its
+		// target is a constructor (verified against Node:
+		// `Reflect.ownKeys(SomeClass.bind(null))` is `["length","name"]`,
+		// no "prototype", even though SomeClass itself has one). So the
+		// stored table's own names, already integer-indices-first per
+		// OwnPropertyNames(), are the complete, correctly-ordered answer.
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			for _, k := range bf.Properties.OwnPropertyNames() {
+				arrObj.Append(vm.NewString(k))
+			}
+		}
 	default:
 		// Non-object types return empty array
 		return arr, nil

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -391,7 +391,15 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		target := args[0]
 
-		if !target.IsObject() {
+		// Every sibling Reflect method in this file (get/set/has/apply/
+		// construct/...) gates on "!IsObject() && !IsCallable()" - this one
+		// used to gate on "!IsObject()" alone, so it threw a TypeError
+		// outright for a plain function, a class, a native function, a
+		// native constructor, or a bound function - values every other
+		// Reflect method here already accepts. Confirmed against Node:
+		// Reflect.ownKeys(Array.prototype.slice) is ["length","name"]
+		// there, not a throw.
+		if !target.IsObject() && !target.IsCallable() {
 			return vm.Undefined, vmInstance.NewTypeError("Reflect.ownKeys called on non-object")
 		}
 
@@ -400,6 +408,55 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		arr := keysArray.AsArray()
 
 		switch target.Type() {
+		case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+			// Fixing the gate above just made these five kinds reach this
+			// switch instead of throwing - but the switch itself had no
+			// case for any of them, so they'd have fallen through to
+			// "return keysArray, nil" and answered [] instead of actually
+			// throwing OR actually working (silently wrong either way).
+			//
+			// Rather than hand-rolling a THIRD independent per-kind
+			// name/length/prototype synthesis switch alongside
+			// objectGetOwnPropertyNamesWithVM's (Object.getOwnPropertyNames)
+			// and objectGetOwnPropertySymbolsWithVM's (Object.
+			// getOwnPropertySymbols) own already-correct ones - the exact
+			// "N independent copies of the same per-kind dispatch slowly
+			// drift apart" pattern behind most of this session's bug
+			// fixes - delegate straight to those two for these five kinds
+			// only (TypeObject/TypeDictObject/TypeArray/TypeProxy below
+			// keep their own existing, already-correct logic exactly as
+			// it was; TypeNativeFunction/TypeBoundFunction were just added
+			// to objectGetOwnPropertyNamesWithVM as part of this same fix,
+			// since it had no case for either of them either - the same
+			// gap, just one level down).
+			//
+			// Per ECMAScript 10.1.11 OrdinaryOwnPropertyKeys, Reflect.
+			// ownKeys's required order - integer indices ascending, then
+			// string keys in creation order, then symbol keys in creation
+			// order - is exactly what concatenating these two functions'
+			// own outputs already produces, so no reordering is needed
+			// here.
+			namesVal, err := objectGetOwnPropertyNamesWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if namesVal.Type() == vm.TypeArray {
+				namesArr := namesVal.AsArray()
+				for i := 0; i < namesArr.Length(); i++ {
+					arr.Append(namesArr.Get(i))
+				}
+			}
+			symsVal, err := objectGetOwnPropertySymbolsWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if symsVal.Type() == vm.TypeArray {
+				symsArr := symsVal.AsArray()
+				for i := 0; i < symsArr.Length(); i++ {
+					arr.Append(symsArr.Get(i))
+				}
+			}
+			return keysArray, nil
 		case vm.TypeObject:
 			obj := target.AsPlainObject()
 			// 1. String keys (all, including non-enumerable)

--- a/tests/scripts/reflect_ownkeys_callable.ts
+++ b/tests/scripts/reflect_ownkeys_callable.ts
@@ -1,0 +1,169 @@
+// expect: true
+// Reflect.ownKeys had two independent problems, found while verifying
+// paserati PR #343:
+//
+// 1. Its object-gate threw on any callable target. Unlike every other
+//    Reflect method in this file (get/set/has/apply/construct/...), which
+//    all correctly gate on `!target.IsObject() && !target.IsCallable()`,
+//    ownKeys gated on `!target.IsObject()` alone - so it threw a TypeError
+//    outright for a plain function, a native function, a bound function,
+//    or a class, even though every other Reflect method here already
+//    accepts them:
+//
+//      Reflect.ownKeys(Array.prototype.slice); // before: threw - Node: ["length", "name"]
+//
+// 2. Even past that gate, the switch had no case at all for any callable
+//    kind (TypeFunction/TypeClosure/TypeNativeFunction/
+//    TypeNativeFunctionWithProps/TypeBoundFunction) - so fixing (1) alone
+//    would just fall through and answer [] instead of throwing.
+//
+// Rather than hand-rolling a third independent per-kind name/length/
+// prototype synthesis switch (this codebase's dominant recurring bug
+// class this whole multi-PR effort has been chasing down - N independent
+// copies of the same per-kind dispatch slowly drifting apart), these five
+// kinds now delegate straight to Object.getOwnPropertyNames +
+// Object.getOwnPropertySymbols (concatenated - which is exactly the
+// ECMA-262 10.1.11 OrdinaryOwnPropertyKeys order Reflect.ownKeys itself
+// requires: integer indices, then string keys, then symbol keys, all in
+// creation order). TypeObject/TypeDictObject/TypeArray/TypeProxy keep
+// their own pre-existing, already-correct logic untouched.
+//
+// Object.getOwnPropertyNames itself had no case at all for
+// TypeNativeFunction (a plain, non-Props native function like
+// Array.prototype.slice) or TypeBoundFunction either - the same "kind
+// missing from a switch" gap, one level down, fixed in the same commit
+// since Reflect.ownKeys's delegation depends on it for exactly those two
+// kinds.
+//
+// Found while verifying, NOT fixed here - a real, narrower, pre-existing
+// bug in the untouched TypeFunction/TypeClosure cases, deliberately
+// deferred as a follow-up: they synthesize "prototype" unconditionally
+// whenever it isn't already a real, explicit own property - even for an
+// arrow function or a plain (non-generator) async function, neither of
+// which has a "prototype" own property at all per spec (verified against
+// Node). Not touched here since it's unrelated to the callable-kind gate/
+// switch bug this task is about, and none of Node, this task's stated
+// scope, or its listed test targets involve arrow/async functions.
+
+const checks: boolean[] = [];
+
+// --- 1. A plain function: length, name, prototype (the gate no longer
+// throws, and TypeFunction/TypeClosure already had correct per-kind
+// synthesis via Object.getOwnPropertyNames). ---
+{
+  function fn(a: number, b: number) { return a + b; }
+  const keys = Reflect.ownKeys(fn as any);
+  checks.push(
+    keys.length === 3 &&
+      keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype"
+  );
+}
+
+// --- 2. A class (compiles to TypeClosure, same shape as check 1 through
+// a different surface syntax). ---
+{
+  class C {}
+  const keys = Reflect.ownKeys(C as any);
+  checks.push(
+    keys.length === 3 &&
+      keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype"
+  );
+}
+
+// --- 3. A native function that is NOT a constructor
+// (TypeNativeFunction) - no "prototype" (Node agrees: Array.prototype.slice
+// has none). This is one of the two kinds that had NO case at all in
+// Object.getOwnPropertyNames before this fix - previously silently []. ---
+{
+  const keys = Reflect.ownKeys(Array.prototype.slice as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 4. A native constructor (TypeNativeFunctionWithProps,
+// IsConstructor === true) - HAS "prototype", unlike check 3's non-
+// constructor native function. Not asserting the full key list here:
+// paserati's own Array bootstrap registers its statics in a different
+// order than Node's (isArray/from/of/fromAsync vs Node's isArray/from/
+// fromAsync/of) - an engine implementation detail, not a spec
+// requirement, and not something this fix controls (it only touches
+// synthesis of length/name/prototype, not the order user code registers
+// its own statics in). Asserting the length/name/prototype prefix and
+// that more keys follow is what's actually spec-fixed and
+// engine-independent. ---
+{
+  const keys = Reflect.ownKeys(Array as any);
+  checks.push(
+    keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype" &&
+      keys.length > 3
+  );
+}
+
+// --- 5. A bound function (TypeBoundFunction) - the OTHER kind that had
+// no case at all in Object.getOwnPropertyNames before this fix. Per PR
+// #343, "name"/"length" are REAL own properties set at bind time (not
+// synthesized), and a bound function never has its own "prototype"
+// regardless of whether its target is a constructor - verified against
+// Node for both a bound plain function AND a bound class. ---
+{
+  function orig() {}
+  const bound = orig.bind(null);
+  const keys = Reflect.ownKeys(bound as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+{
+  class D {}
+  const boundClass = (D as any).bind(null);
+  const keys = Reflect.ownKeys(boundClass);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 6. The symbol half of the delegation actually fires: a symbol
+// property added to a plain function (own local function, not a shared
+// intrinsic, so this can't collide with any other test file's own
+// mutations of a real global) shows up in Reflect.ownKeys, positioned
+// after every string key per ECMA-262 10.1.11 OrdinaryOwnPropertyKeys.
+// Not comparing this against Object.getOwnPropertyNames +
+// getOwnPropertySymbols the way checks 1-5 implicitly do (via the fixed
+// implementation itself calling exactly those two functions) - doing so
+// here would just be asserting the delegation agrees with itself. This
+// checks an actual value: the symbol is present, and it comes last. ---
+{
+  function fn6(a: number) { return a; }
+  const sym6 = Symbol("custom6");
+  Object.defineProperty(fn6, sym6, {
+    value: 1,
+    enumerable: false,
+    configurable: true,
+  });
+  const keys = Reflect.ownKeys(fn6 as any);
+  checks.push(
+    keys.length === 4 &&
+      keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype" &&
+      keys[3] === sym6
+  );
+}
+
+// --- 7. The gate itself: before this fix, ALL of the calls above would
+// have thrown a TypeError instead of returning key lists - explicitly
+// confirm a callable target no longer throws, and a genuinely
+// non-object, non-callable primitive still correctly does (per spec,
+// Reflect.ownKeys's target must be an object). ---
+{
+  let threw = false;
+  try {
+    Reflect.ownKeys(42 as any);
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

This branch is stacked on #344 (`fix-reflect-set-construct-optional-args`); everything up to that PR's diff is inherited stack noise. The new commit on top fixes `Reflect.ownKeys`'s two independent gaps for callable targets:

1. **The object-gate threw on any callable target.** Unlike every other `Reflect` method in this file (`get`/`set`/`has`/`apply`/`construct`/...), which all correctly gate on `!target.IsObject() && !target.IsCallable()`, `ownKeys` gated on `!target.IsObject()` alone:

   ```js
   Reflect.ownKeys(Array.prototype.slice); // before: threw TypeError - Node: ["length", "name"]
   ```

2. **Even past that gate, the switch had no case at all for any callable kind** (`TypeFunction`/`TypeClosure`/`TypeNativeFunction`/`TypeNativeFunctionWithProps`/`TypeBoundFunction`) — fixing (1) alone would just fall through and answer `[]`.

## Approach

Rather than hand-rolling a third independent per-kind name/length/prototype synthesis switch — this codebase's dominant recurring bug class (N independent copies of the same per-kind dispatch slowly drifting apart) — these five kinds now **delegate to `Object.getOwnPropertyNames` + `Object.getOwnPropertySymbols`, concatenated**. That's exactly the order ECMA-262 10.1.11 `OrdinaryOwnPropertyKeys` requires (integer indices, then string keys, then symbol keys, all in creation order), so no reordering is needed. `TypeObject`/`TypeDictObject`/`TypeArray`/`TypeProxy` keep their own pre-existing logic untouched — an earlier version of this fix considered delegating those too, but `Object.getOwnPropertyNames` has real per-kind edge-case differences from `Reflect.ownKeys` there (primitives, Proxy) that would have been a regression, not a cleanup — see "Deliberately not touched" below.

`Object.getOwnPropertyNames` itself had no case at all for `TypeNativeFunction` (a plain, non-`Props` native function like `Array.prototype.slice`) or `TypeBoundFunction` either — the identical "kind missing from a switch" gap, one level down — fixed in the same commit since `Reflect.ownKeys`'s delegation depends on it for exactly those two kinds:
- `TypeNativeFunction` gets `"prototype"` only when actually a constructor (every `TypeNativeFunction` in this codebase today is non-constructor in practice, matching Node's `Array.prototype.slice`).
- `TypeBoundFunction` needs **no synthesis at all** — `"name"`/`"length"` are real own properties set at bind time (#343), and a bound function never has its own `"prototype"` regardless of its target's constructibility (verified against Node for both a bound plain function and a bound class).

## Deliberately not touched

- **`TypeNativeFunctionWithProps`'s own-statics order** (e.g. Array's `isArray`/`from`/`fromAsync`/`of`) is this engine's bootstrap insertion order, not a spec requirement — it already differs slightly from Node's own order and this PR doesn't touch or normalize it. The new test asserts the length/name/prototype prefix, not the full static-property ordering.
- **Two real, pre-existing bugs found while verifying, deferred as follow-up chips** (not from the original task, not fixed here):
  - `TypeFunction`/`TypeClosure` unconditionally synthesize `"prototype"` even for an arrow function or a plain (non-generator) async function, neither of which has one per spec (`Object.getOwnPropertyNames(() => {})` → paserati `["length","name","prototype"]`, Node `["length","name"]`). Unrelated to the callable-kind gap this PR closes, and doesn't affect any kind this PR's own tests exercise.
  - `Object.getOwnPropertyNames`/`Reflect.ownKeys` return `[]` unconditionally for **any** Proxy target — more severe than `Reflect.ownKeys`'s own existing "simplification" comment implies, since that comment's delegation target (`Object.getOwnPropertyNames`) has no `TypeProxy` case at all either. A real fix needs the `ownKeys` trap + ECMA-262 10.5.11's invariant-checking machinery — a larger, differently-shaped fix.

## Testing

- New test: `tests/scripts/reflect_ownkeys_callable.ts` — 8 checks covering a plain function, a class, a native function, a native constructor, a bound function, a bound class, the symbol half of the delegation, and the gate's throw/no-throw boundary. All verified against real Node.js output.
- `go test ./tests -run TestScripts -timeout 180s`: ok
- `go test ./...`: ok
- test262 baseline: 16446 → 16453 (+7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
