### PR TITLE
fix(builtins): Reflect.set implements real OrdinarySet, not just receiver===target

### DIFF
--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -41,6 +41,212 @@ func isConstructor(v vm.Value) bool {
 	}
 }
 
+// reflectGetOwnAccessorGeneric returns the getter/setter pair for v's own
+// accessor property named propKey, covering PlainObject's and
+// ArrayObject's own accessor support plus the shared side-table
+// (*PlainObject) the nine ownPropertiesSlot kinds (Function/Closure/
+// NativeFunction/NativeFunctionWithProps/BoundFunction/RegExp/Map/Set/
+// Promise) keep under OwnPropertiesTable, via the `default` branch.
+// DictObject doesn't support accessors at all (pre-existing, matches
+// every other DictObject case in this file). Any OTHER kind (e.g.
+// TypeArguments, TypeTypedArray) that OwnPropertiesTable doesn't cover
+// falls through the same `default` branch to isAccessor=false, not found
+// - reflectOrdinarySet's walk treats that as "no own property here" and
+// continues up the chain, so an exotic kind sitting as a link in a
+// prototype chain (rare, and not exercised by this fix's own tests) is
+// silently skipped rather than mishandled. Callers still need to
+// separately check for a data property when isAccessor is false.
+func reflectGetOwnAccessorGeneric(v vm.Value, propKey string) (getter vm.Value, setter vm.Value, isAccessor bool) {
+	switch v.Type() {
+	case vm.TypeObject:
+		g, s, _, _, ok := v.AsPlainObject().GetOwnAccessor(propKey)
+		return g, s, ok
+	case vm.TypeArray:
+		g, s, _, _, ok := v.AsArray().GetOwnAccessor(propKey)
+		return g, s, ok
+	case vm.TypeDictObject:
+		return vm.Undefined, vm.Undefined, false
+	default:
+		if props := vm.OwnPropertiesTable(v); props != nil {
+			g, s, _, _, ok := props.GetOwnAccessor(propKey)
+			return g, s, ok
+		}
+		return vm.Undefined, vm.Undefined, false
+	}
+}
+
+// reflectGetOwnDataDescriptorGeneric returns the value and writability of
+// v's own DATA property named propKey (call reflectGetOwnAccessorGeneric
+// first to rule out an accessor - this function doesn't check for one).
+// Mirrors reflectGetOwnAccessorGeneric's kind coverage, plus TypeArray's
+// own index/"length"/named-property shapes (an array has no side-table
+// analog for these - they're modeled directly on ArrayObject).
+func reflectGetOwnDataDescriptorGeneric(v vm.Value, propKey string) (value vm.Value, writable bool, found bool) {
+	switch v.Type() {
+	case vm.TypeObject:
+		val, w, _, _, ok := v.AsPlainObject().GetOwnDescriptor(propKey)
+		return val, w, ok
+	case vm.TypeDictObject:
+		val, w, _, _, ok := v.AsDictObject().GetOwnDescriptor(propKey)
+		return val, w, ok
+	case vm.TypeArray:
+		arr := v.AsArray()
+		if propKey == "length" {
+			return vm.Number(float64(arr.Length())), true, true
+		}
+		if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 {
+			if arr.HasOwnIndexProperty(propKey, idx) {
+				return arr.Get(idx), true, true
+			}
+			return vm.Undefined, false, false
+		}
+		if val, ok := arr.GetOwn(propKey); ok {
+			return val, true, true
+		}
+		return vm.Undefined, false, false
+	default:
+		if props := vm.OwnPropertiesTable(v); props != nil {
+			val, w, _, _, ok := props.GetOwnDescriptor(propKey)
+			return val, w, ok
+		}
+		return vm.Undefined, false, false
+	}
+}
+
+// reflectOrdinarySet implements ECMA-262 10.1.9 OrdinarySet /
+// 10.1.9.2 OrdinarySetWithOwnDescriptor for Reflect.set's non-Proxy-target
+// path: walk `target`'s own property, then its whole [[Prototype]] chain,
+// for the first applicable descriptor. An accessor's setter is invoked
+// with `receiver` as `this` regardless of where in the chain it was found
+// (accessors don't write data anywhere, so `target` vs `receiver` doesn't
+// matter for this branch). A data descriptor - found on target itself, an
+// ancestor, or nowhere at all (the implicit "value: undefined, writable:
+// true" default per 10.1.9 step 4) - always has its actual write land on
+// `receiver`, never on whichever object in the chain the descriptor was
+// found on: this is the exact distinction the pre-existing "Simple
+// property set on target" fallback got wrong, unconditionally writing to
+// `target` regardless of `receiver`.
+//
+// Before this fix, `target`'s OWN accessor wasn't invoked at all either -
+// the old fallback went straight to a raw SetOwn/Set call with no
+// descriptor awareness whatsoever, for every case including
+// receiver === target (verified against Node: Reflect.set on an object
+// with its own setter silently no-opped the setter instead of calling
+// it). Fixing the general-receiver case required walking descriptors
+// anyway, so both bugs share one fix.
+func reflectOrdinarySet(vmInstance *vm.VM, target vm.Value, propKey string, value vm.Value, receiver vm.Value) (bool, error) {
+	current := target
+	for i := 0; i < 200 && current.Type() != vm.TypeNull && current.Type() != vm.TypeUndefined; i++ {
+		if _, setter, isAccessor := reflectGetOwnAccessorGeneric(current, propKey); isAccessor {
+			// Per 10.1.9.2 step 3: an accessor descriptor with no setter
+			// means the property is effectively read-only - Set fails
+			// (verified against Node: returns false, doesn't throw here
+			// since Reflect.set never throws for an ordinary failure).
+			if setter.Type() == vm.TypeUndefined {
+				return false, nil
+			}
+			_, err := vmInstance.Call(setter, receiver, []vm.Value{value})
+			return err == nil, err
+		}
+		if _, writable, found := reflectGetOwnDataDescriptorGeneric(current, propKey); found {
+			if !writable {
+				return false, nil
+			}
+			// A writable data descriptor exists somewhere in target's own
+			// chain - per 10.1.9.2 step 4, the actual write still targets
+			// Receiver, not wherever this descriptor was found (which may
+			// be `target` itself, or an ancestor `target` inherits from).
+			return reflectCreateOrUpdateDataProperty(receiver, propKey, value)
+		}
+		current = vmInstance.PrototypeOf(current)
+	}
+	// Not found anywhere in target's chain - 10.1.9 step 4's implicit
+	// {value: undefined, writable: true, enumerable: true, configurable:
+	// true} default takes the same data-write path.
+	return reflectCreateOrUpdateDataProperty(receiver, propKey, value)
+}
+
+// reflectCreateOrUpdateDataProperty implements the receiver-side half of
+// 10.1.9.2 OrdinarySetWithOwnDescriptor once target's chain has determined
+// a data write is called for: consult receiver's OWN descriptor for the
+// same key (an accessor or non-writable data property there refuses the
+// write - verified against Node for both), and otherwise create or
+// overwrite receiver's own data property with the new value.
+func reflectCreateOrUpdateDataProperty(receiver vm.Value, propKey string, value vm.Value) (bool, error) {
+	// Per 10.1.9.2 step 4.a: if Receiver is not an object, return false -
+	// verified against Node: Reflect.set({}, "y", 5, 42) is false, not a
+	// throw.
+	if !receiver.IsObject() && !receiver.IsCallable() {
+		return false, nil
+	}
+
+	if _, _, isAccessor := reflectGetOwnAccessorGeneric(receiver, propKey); isAccessor {
+		return false, nil
+	}
+	if _, writable, found := reflectGetOwnDataDescriptorGeneric(receiver, propKey); found && !writable {
+		return false, nil
+	}
+
+	switch receiver.Type() {
+	case vm.TypeObject:
+		receiver.AsPlainObject().SetOwn(propKey, value)
+		return true, nil
+	case vm.TypeDictObject:
+		receiver.AsDictObject().SetOwn(propKey, value)
+		return true, nil
+	case vm.TypeArray:
+		arr := receiver.AsArray()
+		if propKey == "length" {
+			// The old "Simple property set on target" fallback this
+			// function replaces had an explicit "Setting length is
+			// complex, skip for now" no-op stub here - meaning
+			// Reflect.set(arr, "length", n) already silently failed to
+			// resize before this fix (verified against Node, which does
+			// resize). Since this generic data-write path would otherwise
+			// treat "length" as an ordinary named property and stash a
+			// bogus one via arr.SetOwn - worse than the prior no-op,
+			// since it'd shadow/corrupt the array's real length concept -
+			// it needs its own case, not silence, now that this path
+			// handles it at all.
+			arr.SetLength(reflectToArrayLength(value))
+			return true, nil
+		}
+		if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 {
+			arr.Set(idx, value)
+			return true, nil
+		}
+		arr.SetOwn(propKey, value)
+		return true, nil
+	default:
+		// A callable or other exotic receiver kind (Function/Closure/
+		// NativeFunction/.../Promise) - use its shared side-table, the
+		// same mechanism Object.defineProperty and friends already use
+		// for these kinds elsewhere in this codebase.
+		if props := vm.EnsureOwnPropertiesTable(receiver); props != nil {
+			props.SetOwn(propKey, value)
+			return true, nil
+		}
+		return false, nil
+	}
+}
+
+// reflectToArrayLength mirrors pkg/vm/vm_init.go's unexported
+// toLengthIntForSetProperty (ToLength clamping for an array's "length"
+// property) - duplicated rather than imported since that helper is
+// unexported and this is the one place in package builtins that needs the
+// exact same clamp.
+func reflectToArrayLength(v vm.Value) int {
+	n := v.ToFloat()
+	if n != n || n <= 0 {
+		return 0
+	}
+	const maxSafeInteger = 9007199254740991
+	if n > maxSafeInteger {
+		n = maxSafeInteger
+	}
+	return int(n)
+}
+
 type ReflectInitializer struct{}
 
 func (r *ReflectInitializer) Name() string  { return "Reflect" }
@@ -241,26 +447,28 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
-		// Simple property set on target
+		// Property set on target, implementing the real ECMA-262 10.1.9
+		// OrdinarySet / 10.1.9.2 OrdinarySetWithOwnDescriptor algorithm -
+		// see reflectOrdinarySet's own comment for the full rationale.
+		// This used to be a "just SetOwn/Set directly on target" fallback
+		// that ignored `receiver` entirely (writing to target even when a
+		// distinct receiver was given - the exact bug this fix closes)
+		// and never checked for an own or inherited accessor at all (so
+		// even the receiver === target case silently clobbered an
+		// existing setter instead of calling it - found while fixing the
+		// receiver bug, since walking descriptors is required for either
+		// fix).
 		switch target.Type() {
-		case vm.TypeObject:
-			target.AsPlainObject().SetOwn(propKey, value)
-			return vm.BooleanValue(true), nil
-		case vm.TypeDictObject:
-			target.AsDictObject().SetOwn(propKey, value)
-			return vm.BooleanValue(true), nil
-		case vm.TypeArray:
-			arr := target.AsArray()
-			if propKey == "length" {
-				// Setting length is complex, skip for now
-				return vm.BooleanValue(true), nil
-			}
-			if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 {
-				arr.Set(idx, value)
-				return vm.BooleanValue(true), nil
-			}
+		case vm.TypeObject, vm.TypeDictObject, vm.TypeArray:
+			ok, err := reflectOrdinarySet(vmInstance, target, propKey, value, receiver)
+			return vm.BooleanValue(ok), err
 		}
 
+		// target is some other kind this function doesn't model a set for
+		// (e.g. a Proxy - Reflect.set(someProxy, ...) has its own,
+		// separate, larger pre-existing gap: unrelated to the receiver
+		// bug this fix closes, not touched here). Matches this function's
+		// prior behavior for every kind it didn't have a case for.
 		return vm.BooleanValue(false), nil
 	}))
 

--- a/tests/scripts/reflect_set_construct_optional_args.ts
+++ b/tests/scripts/reflect_set_construct_optional_args.ts
@@ -44,15 +44,16 @@
 // TypeFunction/TypeClosure's synthesized-on-first-access one, which is
 // why they need the ClosureObject/FunctionObject-specific methods instead).
 //
-// Found while testing, NOT fixed here - a real, separate, pre-existing
-// runtime bug, deliberately deferred as a follow-up: Reflect.set ignores
-// a non-Proxy receiver argument distinct from target when target lacks
-// the property being set - it always writes to target regardless. Only
-// the receiver === target form (the common case, and the one this fix's
-// own type-signature change most directly unblocks) works correctly.
-// Pinned explicitly below (check 3) rather than silently left
-// undocumented - see its own comment for the repro and the reasoning for
-// deferring it. Flagged as a follow-up chip.
+// Found while testing (and flagged as a follow-up chip, task_cd1507d7) -
+// then fixed in a later PR: Reflect.set used to ignore a non-Proxy
+// receiver argument distinct from target when target lacked the property
+// being set, always writing to target regardless. Check 3 below used to
+// pin that wrong behavior explicitly; it's flipped now that
+// pkg/builtins/reflect_init.go's "set" closure implements the real
+// ECMA-262 10.1.9/10.1.9.2 OrdinarySet(WithOwnDescriptor) algorithm
+// (reflectOrdinarySet), which also fixed a second bug found in the same
+// pass: Reflect.set never invoked an own or inherited accessor's setter
+// at all, even for the common receiver === target case (see check 3a).
 
 const checks: boolean[] = [];
 
@@ -77,20 +78,45 @@ const checks: boolean[] = [];
   checks.push(ok === true && target2.z === undefined);
 }
 
-// --- 3. KNOWN, PRE-EXISTING GAP (not fixed here, flagged as a follow-up):
-// Reflect.set with a receiver DISTINCT from target, where target lacks
-// the property, should write to the RECEIVER per ECMA-262 10.1.9.2
-// OrdinarySetWithOwnDescriptor - paserati instead writes to target. This
-// assertion pins TODAY's wrong behavior explicitly (matching the
-// established pattern for a still-open gap - see in_symbol_proxy.ts's
-// history) so a future fix has to touch this file instead of silently
-// leaving stale documentation. Node: ok === true, receiver3.y === 5,
-// "y" in target3 === false. ---
+// --- 3. Reflect.set with a receiver DISTINCT from target, where target
+// lacks the property: writes to the RECEIVER per ECMA-262 10.1.9.2
+// OrdinarySetWithOwnDescriptor's final CreateDataProperty(Receiver, ...)
+// step - flipped from pinning the pre-existing wrong (writes-to-target)
+// behavior once reflectOrdinarySet fixed it (mirrors the
+// in_symbol_proxy.ts check-11 precedent: pin a known gap explicitly, flip
+// the assertion in the same test file once it closes). Verified against
+// Node: ok === true, receiver3.y === 5, "y" in target3 === false. ---
 {
   const target3: any = {};
   const receiver3: any = {};
   const ok = Reflect.set(target3, "y", 5, receiver3);
-  checks.push(ok === true && target3.y === 5 && receiver3.y === undefined);
+  checks.push(ok === true && receiver3.y === 5 && !("y" in target3));
+}
+
+// --- 3a. The second bug found alongside check 3's: Reflect.set didn't
+// invoke an own accessor's setter at all, even for the common
+// receiver === target form - it silently clobbered/no-opped instead of
+// calling the setter (verified against Node, which does call it, with
+// `this` bound to the receiver). Fixing the general-receiver case
+// required walking descriptors either way, so this shares the same fix. ---
+{
+  const obj: any = {};
+  let setterCalled = false;
+  let receivedValue: any = null;
+  let receivedThisIsObj = false;
+  Object.defineProperty(obj, "y", {
+    get() {
+      return 1;
+    },
+    set(v: any) {
+      setterCalled = true;
+      receivedValue = v;
+      receivedThisIsObj = this === obj;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(obj, "y", 99);
+  checks.push(ok === true && setterCalled && receivedValue === 99 && receivedThisIsObj);
 }
 
 // --- 4. Reflect.construct with 2 arguments (newTarget defaults to

--- a/tests/scripts/reflect_set_receiver_and_accessors.ts
+++ b/tests/scripts/reflect_set_receiver_and_accessors.ts
@@ -1,0 +1,186 @@
+// expect: true
+// Reflect.set's "set" closure (pkg/builtins/reflect_init.go) used to have
+// a "Simple property set on target" fallback that unconditionally called
+// target.AsPlainObject().SetOwn(...) / target.AsDictObject().SetOwn(...) /
+// arr.Set(idx, ...) directly, regardless of:
+//
+//  - `receiver` being distinct from `target` (a Proxy receiver was
+//    special-cased above it; any OTHER kind of distinct receiver - the
+//    common case, a plain object - fell straight through to the
+//    always-writes-to-target fallback), and
+//  - `target` (or its prototype chain) having an own or inherited
+//    accessor at all - the fallback never checked, so even the ordinary
+//    receiver === target form silently clobbered/no-opped an existing
+//    setter instead of calling it.
+//
+// Both are the same root cause (the fallback had no descriptor awareness
+// whatsoever) and are fixed together by reflectOrdinarySet, a real
+// implementation of ECMA-262 10.1.9 OrdinarySet / 10.1.9.2
+// OrdinarySetWithOwnDescriptor: walk target's own property, then its
+// whole [[Prototype]] chain, for the first applicable descriptor - an
+// accessor's setter is invoked with `receiver` as `this` wherever in the
+// chain it's found; a data descriptor's actual write always lands on
+// `receiver` (via reflectCreateOrUpdateDataProperty), never on whichever
+// object in target's chain the descriptor happened to be found on.
+//
+// Every check here was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Distinct plain-object receiver, property absent on target and
+// its whole prototype chain: per 10.1.9.2's final
+// CreateDataProperty(Receiver, ...) step, the write lands on `receiver`,
+// not `target` - the core bug this fix closes. ---
+{
+  const target: any = {};
+  const receiver: any = {};
+  const ok = Reflect.set(target, "y", 5, receiver);
+  checks.push(ok === true && receiver.y === 5 && !("y" in target));
+}
+
+// --- 2. receiver === target (the common/simple form) must not regress. ---
+{
+  const target2: any = {};
+  const ok = Reflect.set(target2, "x", 1, target2);
+  checks.push(ok === true && target2.x === 1);
+}
+
+// --- 3. receiver already has its own (writable, non-accessor) property
+// for the same key: the write updates the RECEIVER's existing property in
+// place (not the target, which still must not gain the key at all). ---
+{
+  const target3: any = {};
+  const receiver3: any = { y: 10 };
+  const ok = Reflect.set(target3, "y", 99, receiver3);
+  checks.push(ok === true && receiver3.y === 99 && !("y" in target3));
+}
+
+// --- 4. Inherited accessor (setter defined on target's prototype, not
+// target itself) with a distinct receiver: the setter still fires, and
+// `this` inside it is the RECEIVER, not target or the prototype - so the
+// side effect the setter performs (`this._z = v`) lands on the receiver. ---
+{
+  const proto: any = {};
+  Object.defineProperty(proto, "z", {
+    get() {
+      return 2;
+    },
+    set(v: any) {
+      (this as any)._z = v;
+    },
+    configurable: true,
+  });
+  const child: any = Object.create(proto);
+  const rec: any = {};
+  const ok = Reflect.set(child, "z", 42, rec);
+  checks.push(ok === true && rec._z === 42 && (child as any)._z === undefined);
+}
+
+// --- 5. Own accessor, receiver === target (the second bug found while
+// fixing check 1 - not previously covered by any test at all): the
+// setter must actually be invoked, with `this` bound to the object,
+// instead of being silently bypassed. ---
+{
+  const obj: any = {};
+  let calls = 0;
+  let lastValue: any = null;
+  Object.defineProperty(obj, "y", {
+    get() {
+      return 1;
+    },
+    set(v: any) {
+      calls++;
+      lastValue = v;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(obj, "y", 7);
+  checks.push(ok === true && calls === 1 && lastValue === 7 && obj.y === 1);
+}
+
+// --- 6. An accessor with no setter (getter-only) refuses the write and
+// returns false, rather than silently succeeding or throwing. ---
+{
+  const o: any = {};
+  Object.defineProperty(o, "y", {
+    get() {
+      return 1;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(o, "y", 5);
+  checks.push(ok === false);
+}
+
+// --- 7. A non-writable, non-accessor data property on target refuses the
+// write and returns false. ---
+{
+  const o2: any = Object.freeze({ x: 1 });
+  const ok = Reflect.set(o2, "x", 2);
+  checks.push(ok === false && o2.x === 1);
+}
+
+// --- 8. A primitive receiver (not an object) makes the data-write branch
+// fail with false, per 10.1.9.2 step 4.a - not a throw. ---
+{
+  const ok = Reflect.set({}, "y", 5, 42 as any);
+  checks.push(ok === false);
+}
+
+// --- 9. receiver has its own NON-WRITABLE property for the key: the
+// write must be refused (false), and the receiver's value must not
+// change, even though target has no such restriction at all. ---
+{
+  const target4: any = {};
+  const receiver4: any = {};
+  Object.defineProperty(receiver4, "y", { value: 1, writable: false, configurable: true });
+  const ok = Reflect.set(target4, "y", 99, receiver4);
+  checks.push(ok === false && receiver4.y === 1);
+}
+
+// --- 10. receiver has its own ACCESSOR for the key: a plain data write
+// can't overwrite an accessor, so this must be refused (false) and the
+// receiver's setter must NOT be invoked (a data write is not the same
+// operation as calling the accessor). ---
+{
+  const target5: any = {};
+  const receiver5: any = {};
+  Object.defineProperty(receiver5, "y", {
+    get() {
+      return 1;
+    },
+    set(v: any) {
+      (this as any)._y = v;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(target5, "y", 99, receiver5);
+  checks.push(ok === false && receiver5._y === undefined);
+}
+
+// --- 11. Array "length" actually resizes (the pre-existing fallback had
+// an explicit "Setting length is complex, skip for now" no-op stub here -
+// verified against Node, which does resize). ---
+{
+  const arr: any = [1, 2, 3, 4, 5];
+  const ok = Reflect.set(arr, "length", 2);
+  checks.push(ok === true && arr.length === 2 && arr[0] === 1 && arr[1] === 2 && arr[2] === undefined);
+}
+
+// --- 12. Array named (non-index) property still works, using a distinct
+// array from check 11 per this session's "distinct target per assertion"
+// convention for shared/mutable state. ---
+{
+  const arr2: any = [1, 2, 3];
+  const ok = Reflect.set(arr2, "customProp", 5);
+  checks.push(ok === true && arr2.customProp === 5);
+}
+
+// --- 13. Array numeric-index set still works. ---
+{
+  const arr3: any = [1, 2, 3];
+  const ok = Reflect.set(arr3, "1", 99);
+  checks.push(ok === true && arr3[1] === 99);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

This branch is stacked on #345 (`fix-reflect-ownkeys-callable`); everything up to that PR's diff is inherited stack noise. The new commit on top:

**The reported bug:** `Reflect.set`'s "Simple property set on target" fallback unconditionally wrote to `target` via a raw `SetOwn`/`Set` call, ignoring `receiver` entirely except for one Proxy-specific special case:

```js
const target = {}, receiver = {};
Reflect.set(target, "y", 5, receiver);
// before: target.y === 5, receiver.y === undefined
// Node:   receiver.y === 5, "y" in target === false
```

Per ECMA-262 10.1.9.2 `OrdinarySetWithOwnDescriptor`, when the property is absent on `target` and its whole prototype chain, the write's final step is `CreateDataProperty(Receiver, ...)` — it lands on `receiver`, not `target`.

**This grew past that one case while verifying it.** Fixing it correctly requires walking `target`'s own property and prototype chain for the applicable descriptor regardless of which receiver ends up being written to — and once doing that, two more bugs shared the exact same root cause (the old fallback had zero descriptor awareness at all):

- **`target`'s own or inherited accessor was never invoked**, even for the ordinary `receiver === target` case — `Reflect.set` on an object with its own setter silently no-opped instead of calling it (verified against Node, which calls it with `this` bound to the object).
- **Array `"length"` was an explicit no-op stub** (`// Setting length is complex, skip for now`) — Node actually resizes. Not new to this commit, but the old stub's silence had to become a real case here, since the generic new data-write path would otherwise treat `"length"` as an ordinary named property and stash a bogus one via `arr.SetOwn` — worse than the prior no-op.

## Approach

`reflectOrdinarySet` / `reflectCreateOrUpdateDataProperty` implement the real ECMA-262 10.1.9 `OrdinarySet` / 10.1.9.2 `OrdinarySetWithOwnDescriptor` algorithm:

1. Walk `target`'s own property, then its whole `[[Prototype]]` chain, for the first applicable descriptor.
2. An accessor's setter is invoked with `receiver` as `this` wherever in the chain it's found (a setter-less accessor returns `false`, verified against Node — `Reflect.set` never throws for an ordinary failure).
3. A writable data descriptor — found anywhere in the chain, or the implicit default when nothing is found at all — always has its actual write land on `receiver`: consult `receiver`'s own descriptor first (an accessor or non-writable data property there refuses the write; a primitive, non-object receiver refuses it too — all verified against Node), and otherwise create/overwrite `receiver`'s own data property.

## Deliberately not touched

Found but **not fixed here** (flagged as a follow-up chip, `task_18cd4923`): `Reflect.set` with `target` itself a Proxy is completely broken — it always returns `false` and never invokes the `set` trap or writes anything, for any Proxy target at all. This is distinct from `task_a32069ad` (trap *lookup* correctness across ~2 dozen sites) — it's a missing case entirely, not a lookup bug, and needs its own set-trap + invariant-checking implementation mirroring `opSetProp`'s existing `TypeProxy` handling.

## Testing

- Flips `tests/scripts/reflect_set_construct_optional_args.ts`'s check 3 (pinned as a known gap in #344) to assert the now-correct behavior, and adds check 3a for the own-accessor bug found alongside it — mirroring the `in_symbol_proxy.ts` check-11 pin/flip precedent.
- New test: `tests/scripts/reflect_set_receiver_and_accessors.ts` — 13 checks (distinct receiver, receiver===target, receiver already has an own property, inherited accessor with a distinct receiver and correct `this`, own accessor invocation, setter-less accessor, non-writable data property, primitive receiver, receiver's own non-writable/accessor property, and array length/named-property/index writes). All verified against real Node.js output.
- `go test ./tests -run TestScripts -timeout 180s`: ok
- `go test ./...`: ok
- test262 baseline: 16453 → 16462 (+9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
