### PR TITLE
fix(builtins): Object.getOwnPropertyNames doesn't synthesize prototype on arrow/async functions

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2794,8 +2794,19 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			}
 		}
 
-		// If no prototype was found in Properties, add it at the end
-		if !hasPrototype {
+		// If no prototype was found in Properties, only synthesize one when
+		// this function is actually constructible - an arrow function or a
+		// plain (non-generator) async function has NO "prototype" own
+		// property at all per spec, unlike an ordinary function, a
+		// generator function, or an async generator function, which all
+		// have one. This used to append "prototype" here unconditionally,
+		// which was wrong for exactly those two kinds (verified against
+		// Node: Object.getOwnPropertyNames(() => {}) is ["length","name"],
+		// no "prototype"). vm.IsConstructor already implements this exact
+		// rule for TypeFunction/TypeClosure
+		// (!IsArrowFunction && !(IsAsync && !IsGenerator)) - reused here
+		// rather than duplicated.
+		if !hasPrototype && vmInstance.IsConstructor(obj) {
 			arrObj.Append(vm.NewString("prototype"))
 		}
 	case vm.TypeClosure:
@@ -2840,7 +2851,9 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			}
 		}
 
-		if !hasPrototype {
+		// Same guard as the TypeFunction case above - see its comment for
+		// the full rationale and Node verification.
+		if !hasPrototype && vmInstance.IsConstructor(obj) {
 			arrObj.Append(vm.NewString("prototype"))
 		}
 	case vm.TypeNativeFunctionWithProps:

--- a/tests/scripts/getownpropertynames_prototype_guard.ts
+++ b/tests/scripts/getownpropertynames_prototype_guard.ts
@@ -1,0 +1,110 @@
+// expect: true
+// Object.getOwnPropertyNames's TypeFunction and TypeClosure cases both
+// unconditionally appended a synthesized "prototype" own key at the end
+// whenever "prototype" wasn't already a real, explicit own property in the
+// function's Properties table - regardless of whether the function was
+// actually constructible:
+//
+//   Object.getOwnPropertyNames(() => {});           // before: ["length","name","prototype"] - Node: ["length","name"]
+//   async function asy() {}
+//   Object.getOwnPropertyNames(asy);                // before: ["length","name","prototype"] - Node: ["length","name"]
+//
+// Per spec, a function has an own "prototype" property only when it's
+// actually constructible - an ordinary function, a generator function, and
+// an async generator function all have one; an arrow function and a plain
+// (non-generator) async function do not (verified against Node - see the
+// full matrix in the checks below).
+//
+// Fixed with a one-line guard: vm.VM.IsConstructor(obj) already implements
+// exactly this rule for TypeFunction/TypeClosure
+// (!IsArrowFunction && !(IsAsync && !IsGenerator)) - reused instead of
+// duplicated. The OTHER "prototype" branch (when "prototype" is already a
+// real, explicit own property - e.g. after a prior `.prototype` access
+// lazily created it, or user code explicitly assigned one) is untouched:
+// an explicitly-created property is always listed regardless of
+// constructibility.
+//
+// Reflect.ownKeys delegates to this same function for these two kinds
+// (task_06547fb2's fix), so the identical bug affected it too - covered
+// here as well, not just Object.getOwnPropertyNames.
+
+const checks: boolean[] = [];
+
+// --- 1. Arrow function: no "prototype" (the bug's main repro). ---
+{
+  const arrow = () => {};
+  const keys = Object.getOwnPropertyNames(arrow);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 2. Plain (non-generator) async function: no "prototype" either. ---
+{
+  async function asy() {}
+  const keys = Object.getOwnPropertyNames(asy);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 3. Generator function: HAS "prototype" - must not regress (a naive
+// "just remove the unconditional append" fix would have broken this).
+// vm.VM.IsConstructor(obj) - the predicate this fix reuses - answers
+// `true` for a generator function, which happens to be exactly the
+// has-"prototype" rule this check needs, but is NOT the same question as
+// "is this actually usable with `new`": `new (function*(){})()` throws
+// per spec, and pkg/builtins/reflect_init.go's own separate, differently-
+// named isConstructor(v) helper (used by Reflect.construct to decide
+// whether to throw) correctly returns false for a generator. This fix
+// depends on vm.IsConstructor's non-spec-constructibility answer staying
+// exactly as it is for generators/async generators - if that helper is
+// ever made spec-correct for its ACTUAL callers (e.g. OpValidateSuperclass,
+// which likely wrongly allows `class X extends function*(){}` today - see
+// the follow-up chip), this guard and check 3/4 here will need to switch
+// to a distinct has-"prototype" predicate instead. ---
+{
+  function* gen() {}
+  const keys = Object.getOwnPropertyNames(gen);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 4. Async generator function: HAS "prototype" too - the other half of
+// the same regression risk as check 3. ---
+{
+  async function* asyncGen() {}
+  const keys = Object.getOwnPropertyNames(asyncGen);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 5. A plain function declaration: HAS "prototype" - the ordinary,
+// most common case, must not regress. ---
+{
+  function fn(a: number, b: number) {
+    return a + b;
+  }
+  const keys = Object.getOwnPropertyNames(fn);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 6. A class (compiles to TypeClosure, same code path as check 5's
+// TypeFunction sibling through different surface syntax): HAS "prototype". ---
+{
+  class C {}
+  const keys = Object.getOwnPropertyNames(C);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 7. Reflect.ownKeys on an arrow function agrees with
+// Object.getOwnPropertyNames (it delegates to the same fixed function per
+// task_06547fb2) - no "prototype" here either. ---
+{
+  const arrow2 = () => {};
+  const keys = Reflect.ownKeys(arrow2 as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 8. Reflect.ownKeys on a plain async function agrees too. ---
+{
+  async function asy2() {}
+  const keys = Reflect.ownKeys(asy2 as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

This branch is stacked on #347 (`fix-reflect-set-proxy-target`); everything up to that PR's diff is inherited stack noise. The new commit on top:

`Object.getOwnPropertyNames`'s `TypeFunction` and `TypeClosure` cases both unconditionally appended a synthesized `"prototype"` own key at the end whenever `"prototype"` wasn't already a real, explicit own property in the function's `Properties` table — regardless of whether the function was actually constructible:

```js
Object.getOwnPropertyNames(() => {});
// before: ["length","name","prototype"] - Node: ["length","name"]
async function asy() {}
Object.getOwnPropertyNames(asy);
// before: ["length","name","prototype"] - Node: ["length","name"]
```

Per spec, a function has an own `"prototype"` property only when it's actually constructible: an ordinary function, a generator function, and an async generator function all have one; an arrow function and a plain (non-generator) async function do not. Full matrix verified against Node before touching anything.

**Fix:** a one-line guard in each case's final fallback — `vm.VM.IsConstructor(obj)` already computes exactly this rule for `TypeFunction`/`TypeClosure` (`!IsArrowFunction && !(IsAsync && !IsGenerator)`), reused instead of duplicated. The other `"prototype"` branch (when it's already a real, explicit own property) is untouched.

`Reflect.ownKeys` delegates to this same function for these two kinds (#345), so it inherits the fix automatically — covered by the new test.

## Deliberately not touched — a real discrepancy found while verifying

`vm.VM.IsConstructor`'s formula happens to be exactly the has-`"prototype"` rule this fix needs, but it is **not** the same question as real `[[Construct]]`-ability: it reports a generator/async-generator function as constructible (`true`), which is correct for this fix's purpose but wrong for `OpValidateSuperclass`'s actual use of the same function (`class X extends Y`). Confirmed against Node: `class X extends (function*(){}) {}` throws a `TypeError` there but does **not** throw in paserati today. `pkg/builtins/reflect_init.go` already has a separate, differently-named, spec-correct `isConstructor(v)` helper (used by `Reflect.construct`) that correctly returns `false` for a generator — the two helpers compute genuinely different things despite the similar name. This fix depends on `vm.IsConstructor`'s current, non-spec answer for generators/async-generators staying exactly as it is. Flagged as a follow-up chip (`task_3a7bbe38`) rather than fixed here, since untangling the two helpers/callers is a separate, larger change.

Also noted, not fixed (pre-existing, same branch, not a regression): `function f(){}; delete f.prototype; Object.getOwnPropertyNames(f)` still synthesizes `"prototype"` — the unconditional append did too before this fix.

## Testing

- New test: `tests/scripts/getownpropertynames_prototype_guard.ts` — 8 checks: arrow function and plain async function have no `"prototype"`; generator function, async generator function, plain function, and a class all still have one; `Reflect.ownKeys` agrees for the arrow and async-function cases. All verified against real Node.js output.
- `go test ./tests -run TestScripts -timeout 180s`: ok
- `go test ./...`: ok
- test262 baseline: 16465 → 16466 (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
