### PR TITLE
fix(builtins): Object.getOwnPropertyNames/Reflect.ownKeys handle Proxy targets

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2718,18 +2718,28 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 		arrObj.Append(vm.NewString("length"))
 		return arr, nil
 	case vm.TypeObject:
-		if obj.Type() == vm.TypeObject {
-			po := obj.AsPlainObject()
-			// OwnPropertyNames returns ALL own string property names including non-enumerable
-			for _, k := range po.OwnPropertyNames() {
-				arrObj.Append(vm.NewString(k))
-			}
-		} else if obj.Type() == vm.TypeDictObject {
-			d := obj.AsDictObject()
-			// DictObject.OwnPropertyNames returns all property names
-			for _, k := range d.OwnPropertyNames() {
-				arrObj.Append(vm.NewString(k))
-			}
+		po := obj.AsPlainObject()
+		// OwnPropertyNames returns ALL own string property names including non-enumerable
+		for _, k := range po.OwnPropertyNames() {
+			arrObj.Append(vm.NewString(k))
+		}
+	case vm.TypeDictObject:
+		// This used to be an unreachable `else if` nested inside the
+		// `case vm.TypeObject:` body above (dead code - within that case,
+		// obj.Type() is always TypeObject, so the else-if branch could
+		// never run) - meaning Object.getOwnPropertyNames on a DictObject
+		// (a TypeScript `enum`, or a module namespace object - both
+		// reachable from user code, see pkg/compiler/compile_enum.go and
+		// module_bindings.go) fell all the way through to this function's
+		// `default: return arr, nil` and answered [] instead of listing
+		// the enum's real own properties. Found while adding this
+		// function's new TypeProxy case, since a Proxy wrapping a
+		// DictObject target would otherwise silently inherit the exact
+		// same bug through the new delegation.
+		d := obj.AsDictObject()
+		// DictObject.OwnPropertyNames returns all property names
+		for _, k := range d.OwnPropertyNames() {
+			arrObj.Append(vm.NewString(k))
 		}
 	case vm.TypeArray:
 		a := obj.AsArray()
@@ -2949,6 +2959,34 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 				arrObj.Append(vm.NewString(k))
 			}
 		}
+	case vm.TypeProxy:
+		// This switch never had a case for TypeProxy at all - it fell
+		// through to `default: return arr, nil` and answered [] for ANY
+		// Proxy, regardless of what its target actually has:
+		//
+		//   const target = { a: 1 };
+		//   Object.getOwnPropertyNames(new Proxy(target, {})); // before: [] - Node: ["a"]
+		//
+		// proxyOwnPropertyKeys implements the shared ECMA-262 10.5.11
+		// [[OwnPropertyKeys]] machinery (also used by
+		// objectGetOwnPropertySymbolsWithVM's own new TypeProxy case below
+		// and by Reflect.ownKeys, reflect_init.go) - one trap invocation
+		// (or delegation) producing the full mixed string+symbol key list,
+		// which each of those three callers then filters differently, per
+		// spec (they all call the same internal method and filter its
+		// result, rather than each doing its own separate trap
+		// invocation - calling a possibly-side-effecting trap twice for
+		// what should be one [[OwnPropertyKeys]] call would itself be a
+		// bug).
+		keys, err := proxyOwnPropertyKeys(vmInstance, obj)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for _, k := range keys {
+			if k.Type() != vm.TypeSymbol {
+				arrObj.Append(k)
+			}
+		}
 	default:
 		// Non-object types return empty array
 		return arr, nil
@@ -3017,9 +3055,178 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 				arrObj.Append(s)
 			}
 		}
+	} else if obj.Type() == vm.TypeProxy {
+		// Same gap, same fix, as objectGetOwnPropertyNamesWithVM's new
+		// TypeProxy case above (see its comment for the full rationale) -
+		// this function had no case for TypeProxy at all either, so
+		// Object.getOwnPropertySymbols(new Proxy(target, {})) always
+		// answered [] regardless of what symbol-keyed properties `target`
+		// actually had. Filters proxyOwnPropertyKeys's shared mixed-key
+		// result down to symbols, the mirror image of the string-only
+		// filter in objectGetOwnPropertyNamesWithVM.
+		keys, err := proxyOwnPropertyKeys(vmInstance, obj)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for _, k := range keys {
+			if k.Type() == vm.TypeSymbol {
+				arrObj.Append(k)
+			}
+		}
 	}
 	// DictObject does not support symbols; returns empty array
 	return arr, nil
+}
+
+// proxyOwnPropertyKeys implements ECMA-262 10.5.11 [[OwnPropertyKeys]] for a
+// Proxy exotic object - the single shared entry point objectGetOwnPropertyNamesWithVM,
+// objectGetOwnPropertySymbolsWithVM, and Reflect.ownKeys (reflect_init.go)
+// all delegate to and then filter differently, per spec (all three call the
+// same internal method and filter its result - not each doing its own
+// separate trap invocation, which would invoke a possibly-side-effecting
+// trap more than once for what should be a single [[OwnPropertyKeys]] call).
+//
+// Implements spec steps 1-7 (revoked check, GetMethod(handler, "ownKeys"),
+// CreateListFromArrayLike with its String|Symbol element-type restriction,
+// and the unconditional "no duplicate entries" check) plus the "no trap"
+// delegation (step 4's `return ? target.[[OwnPropertyKeys]]()`).
+//
+// Deliberately DOES NOT implement steps 8-16 (the [[Extensible]]/
+// configurable-key invariant validation a well-behaved trap must satisfy) -
+// a trap's raw result is returned as-is once past the checks above. This is
+// right for a well-behaved trap (verified against Node: a trap that simply
+// returns a different key list gets that list back verbatim) and wrong only
+// for one that violates those invariants (Node throws a TypeError there;
+// this returns the trap's result instead) - a real, narrower, deliberately
+// deferred gap (see the follow-up chip this was flagged with) rather than
+// the wrong tradeoff of delegating to the target's own keys instead, which
+// would produce an equally wrong but LESS plausible-looking answer for the
+// overwhelmingly common "trap just returns its own list" case.
+func proxyOwnPropertyKeys(vmInstance *vm.VM, proxyVal vm.Value) ([]vm.Value, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return nil, vmInstance.NewTypeError("Cannot perform 'ownKeys' on a revoked Proxy")
+	}
+	handler := proxy.Handler()
+	target := proxy.Target()
+
+	// GetMethod(handler, "ownKeys"): an inherited trap counts, undefined/
+	// null mean "no trap" - mirrors reflect_has.go's proxyReflectHas and
+	// reflect_init.go's reflectProxySet/reflectProxyDefineDataProperty,
+	// since proxyGetTrap (pkg/vm) is unexported and unreachable from this
+	// package.
+	var trap vm.Value
+	var hasTrap bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		trap, hasTrap = handler.AsPlainObject().Get("ownKeys")
+	case vm.TypeDictObject:
+		trap, hasTrap = handler.AsDictObject().Get("ownKeys")
+	}
+	if !hasTrap || trap.Type() == vm.TypeUndefined || trap.Type() == vm.TypeNull {
+		// No trap: delegate to target.[[OwnPropertyKeys]]() - concatenate
+		// the string-key and symbol-key halves, which for a plain
+		// (non-Proxy) target is exactly ECMA-262 10.1.11
+		// OrdinaryOwnPropertyKeys's required order (integer indices, then
+		// string keys, then symbol keys, all in creation order) - and
+		// recurses correctly for a nested Proxy target via this same
+		// function, through objectGetOwnPropertyNamesWithVM's own
+		// TypeProxy case calling back into this one.
+		namesVal, err := objectGetOwnPropertyNamesWithVM(vmInstance, []vm.Value{target})
+		if err != nil {
+			return nil, err
+		}
+		symsVal, err := objectGetOwnPropertySymbolsWithVM(vmInstance, []vm.Value{target})
+		if err != nil {
+			return nil, err
+		}
+		var keys []vm.Value
+		if namesVal.Type() == vm.TypeArray {
+			namesArr := namesVal.AsArray()
+			for i := 0; i < namesArr.Length(); i++ {
+				keys = append(keys, namesArr.Get(i))
+			}
+		}
+		if symsVal.Type() == vm.TypeArray {
+			symsArr := symsVal.AsArray()
+			for i := 0; i < symsArr.Length(); i++ {
+				keys = append(keys, symsArr.Get(i))
+			}
+		}
+		return keys, nil
+	}
+	if !trap.IsCallable() {
+		return nil, vmInstance.NewTypeError("'ownKeys' on proxy: trap is not a function")
+	}
+
+	trapResultArray, err := vmInstance.Call(trap, handler, []vm.Value{target})
+	if err != nil {
+		return nil, err
+	}
+
+	// CreateListFromArrayLike(trapResultArray, « String, Symbol »): accept
+	// a real array (the overwhelmingly common case) via a fast path, or
+	// any array-like object via .length + indexed access (mirrors the
+	// CreateListFromArrayLike pattern already inlined at reflect_init.go's
+	// "apply"/"construct" closures for their own argumentsList parameter).
+	var rawElements []vm.Value
+	if trapResultArray.Type() == vm.TypeArray {
+		trapArr := trapResultArray.AsArray()
+		for i := 0; i < trapArr.Length(); i++ {
+			rawElements = append(rawElements, trapArr.Get(i))
+		}
+	} else if trapResultArray.IsObject() {
+		lengthVal, err := vmInstance.GetProperty(trapResultArray, "length")
+		if err != nil {
+			return nil, err
+		}
+		length := int(lengthVal.ToFloat())
+		if length < 0 {
+			length = 0
+		}
+		for i := 0; i < length; i++ {
+			val, err := vmInstance.GetProperty(trapResultArray, strconv.Itoa(i))
+			if err != nil {
+				return nil, err
+			}
+			rawElements = append(rawElements, val)
+		}
+	} else {
+		return nil, vmInstance.NewTypeError("'ownKeys' on proxy: trap result is not an object")
+	}
+
+	// Dedup by CONTENT for a string (its `.ToString()`) and by IDENTITY for
+	// a symbol (its underlying *SymbolObject pointer) - NOT by vm.Value
+	// equality directly: two runtime-built TypeString values holding the
+	// same text are not guaranteed to compare equal via Go's `==` on
+	// vm.Value (verified: a literal "a" and a runtime-concatenated
+	// "a" + "" trap result failed to dedup when keyed on the raw Value,
+	// silently letting Node's genuine duplicate-entries TypeError through
+	// as if the list were fine).
+	type ownKeyDedupKey struct {
+		str string
+		sym *vm.SymbolObject
+	}
+	seen := make(map[ownKeyDedupKey]bool, len(rawElements))
+	trapResult := make([]vm.Value, 0, len(rawElements))
+	for _, el := range rawElements {
+		if el.Type() != vm.TypeString && el.Type() != vm.TypeSymbol {
+			return nil, vmInstance.NewTypeError(el.ToString() + " is not a valid property name")
+		}
+		var dedupKey ownKeyDedupKey
+		if el.Type() == vm.TypeSymbol {
+			dedupKey = ownKeyDedupKey{sym: el.AsSymbolObject()}
+		} else {
+			dedupKey = ownKeyDedupKey{str: el.ToString()}
+		}
+		if seen[dedupKey] {
+			return nil, vmInstance.NewTypeError("'ownKeys' on proxy: trap returned duplicate entries")
+		}
+		seen[dedupKey] = true
+		trapResult = append(trapResult, el)
+	}
+
+	return trapResult, nil
 }
 
 // reflectOwnKeysImpl returns own property keys: string names first (any enumerability), then symbols

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -867,23 +867,25 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			// Add "length"
 			arr.Append(vm.NewString("length"))
 		case vm.TypeProxy:
-			// For proxies, this should invoke the ownKeys trap
-			// For now, delegate to Object.getOwnPropertyNames + getOwnPropertySymbols
-			// This is a simplification
-			if objCtor, ok := vmInstance.GetGlobal("Object"); ok {
-				if objCtor.Type() == vm.TypeNativeFunctionWithProps {
-					nfp := objCtor.AsNativeFunctionWithProps()
-					if f, ok := nfp.Properties.GetOwn("getOwnPropertyNames"); ok {
-						if names, err := vmInstance.Call(f, vm.Undefined, []vm.Value{target}); err == nil {
-							if names.Type() == vm.TypeArray {
-								namesArr := names.AsArray()
-								for i := 0; i < namesArr.Length(); i++ {
-									arr.Append(namesArr.Get(i))
-								}
-							}
-						}
-					}
-				}
+			// This used to claim (inaccurately) to "delegate to
+			// Object.getOwnPropertyNames + getOwnPropertySymbols as a
+			// simplification" - but the delegation target itself had no
+			// TypeProxy case at all (objectGetOwnPropertyNamesWithVM,
+			// object_init.go), so the "simplification" was a complete
+			// no-op: Reflect.ownKeys on ANY Proxy, trap or no trap,
+			// always answered [] before this fix. proxyOwnPropertyKeys
+			// (object_init.go) is the real, shared ECMA-262 10.5.11
+			// [[OwnPropertyKeys]] implementation - see its own comment for
+			// what it does and doesn't validate - used here directly
+			// rather than through Object.getOwnPropertyNames, since this
+			// caller wants the FULL mixed string+symbol result, not one
+			// filtered half of it.
+			keys, err := proxyOwnPropertyKeys(vmInstance, target)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			for _, k := range keys {
+				arr.Append(k)
 			}
 		}
 

--- a/tests/scripts/getownpropertynames_proxy.ts
+++ b/tests/scripts/getownpropertynames_proxy.ts
@@ -1,0 +1,265 @@
+// expect: true
+// Object.getOwnPropertyNames had no `case vm.TypeProxy:` at all in its
+// switch - it fell to `default: return arr, nil` (empty array) for ANY
+// Proxy target, regardless of what the proxy's target actually had:
+//
+//   const target = { a: 1 };
+//   Object.getOwnPropertyNames(new Proxy(target, {})); // before: [] - Node: ["a"]
+//   Reflect.ownKeys(new Proxy(target, {}));             // before: [] - Node: ["a"]
+//
+// This was more severe than it first looked: Reflect.ownKeys's own
+// TypeProxy case already had a comment claiming it "delegate[s] to
+// Object.getOwnPropertyNames + getOwnPropertySymbols" as "a
+// simplification" (implying it was APPROXIMATELY correct, just missing
+// the real ownKeys trap's invariant checking) - but that delegation
+// target itself had no Proxy support whatsoever, so the "simplification"
+// was a complete no-op: Reflect.ownKeys on literally any Proxy, trap or
+// no trap, always returned [] before this fix.
+//
+// Fixed via proxyOwnPropertyKeys (pkg/builtins/object_init.go), a shared
+// ECMA-262 10.5.11 [[OwnPropertyKeys]] implementation that
+// Object.getOwnPropertyNames, Object.getOwnPropertySymbols, and
+// Reflect.ownKeys all delegate to and then filter differently (per spec,
+// they all call the same internal method and filter its result - not
+// each invoking a possibly-side-effecting trap separately). Implements:
+// revoked check (throws), the "ownKeys" trap if present (its result
+// validated for String|Symbol-only elements and no duplicates, per
+// CreateListFromArrayLike and step 7 - but NOT the fuller
+// extensibility/configurable-key invariant validation ECMA-262 10.5.11
+// steps 8-16 require of a well-behaved trap's result against its target -
+// deliberately deferred, see the follow-up chip this was flagged with),
+// or delegation to the proxy's own target when no trap is present.
+//
+// Fixing this also required fixing a second, independent, pre-existing
+// bug the new Proxy delegation would otherwise have silently inherited:
+// Object.getOwnPropertyNames's TypeObject case had dead code - an
+// unreachable `else if obj.Type() == vm.TypeDictObject` nested INSIDE the
+// `case vm.TypeObject:` body, where obj.Type() is always TypeObject, so
+// the DictObject branch could never run. A DictObject backs a TypeScript
+// `enum` and a module namespace object - both reachable from ordinary
+// user code - so `Object.getOwnPropertyNames(SomeEnum)` was already []
+// even with no Proxy involved at all; fixed by splitting it into its own
+// `case vm.TypeDictObject:` (see check 6 below).
+
+const checks: boolean[] = [];
+
+// --- 1. No trap, plain object target: delegates through, both
+// Object.getOwnPropertyNames and Reflect.ownKeys agree. ---
+{
+  const target: any = { a: 1, b: 2 };
+  const p = new Proxy(target, {});
+  const names = Object.getOwnPropertyNames(p);
+  const keys = Reflect.ownKeys(p);
+  checks.push(
+    names.length === 2 &&
+      names[0] === "a" &&
+      names[1] === "b" &&
+      keys.length === 2 &&
+      keys[0] === "a" &&
+      keys[1] === "b"
+  );
+}
+
+// --- 2. No trap, array target. ---
+{
+  const target2: any = [1, 2, 3];
+  const p2 = new Proxy(target2, {});
+  const names = Object.getOwnPropertyNames(p2);
+  checks.push(names.length === 4 && names[0] === "0" && names[1] === "1" && names[2] === "2" && names[3] === "length");
+}
+
+// --- 3. No trap, function target - exercises the callable-kind
+// delegation chain (task_06547fb2) through a Proxy wrapper too. ---
+{
+  function fn3(a: number) {
+    return a;
+  }
+  const p3: any = new Proxy(fn3, {});
+  const names = Object.getOwnPropertyNames(p3);
+  checks.push(names.length === 3 && names[0] === "length" && names[1] === "name" && names[2] === "prototype");
+}
+
+// --- 4. No trap, native function target (Array.prototype.slice-style,
+// non-constructor - no "prototype"). ---
+{
+  const p4: any = new Proxy(Array.prototype.slice as any, {});
+  const names = Object.getOwnPropertyNames(p4);
+  checks.push(names.length === 2 && names[0] === "length" && names[1] === "name");
+}
+
+// --- 5. No trap, bound function target. ---
+{
+  function orig5() {}
+  const bound5 = orig5.bind(null);
+  const p5: any = new Proxy(bound5, {});
+  const names = Object.getOwnPropertyNames(p5);
+  checks.push(names.length === 2 && names[0] === "length" && names[1] === "name");
+}
+
+// --- 6. The DictObject dead-code fix: a TypeScript `enum` compiles to a
+// DictObject (pkg/compiler/compile_enum.go), reachable from ordinary user
+// code with no Proxy involved at all - this is the form the bug actually
+// shipped as (Object.getOwnPropertyNames(SomeEnum) was already [] on its
+// own), checked directly first, then again through a Proxy wrapper to
+// confirm the new Proxy delegation doesn't silently reintroduce the same
+// [] answer for this one target kind while every other kind above works. ---
+{
+  enum Color6 {
+    Red,
+    Green,
+  }
+  const namesDirect = Object.getOwnPropertyNames(Color6);
+  // DictObject's own key ORDER isn't guaranteed/tested here (a
+  // pre-existing, separate limitation, not part of this fix's scope) -
+  // just that the real keys come back at all instead of [].
+  const directOk =
+    namesDirect.length === 4 &&
+    namesDirect.includes("Red") &&
+    namesDirect.includes("Green") &&
+    namesDirect.includes("0") &&
+    namesDirect.includes("1");
+
+  const p6: any = new Proxy(Color6 as any, {});
+  const namesViaProxy = Object.getOwnPropertyNames(p6);
+  const viaProxyOk =
+    namesViaProxy.length === 4 &&
+    namesViaProxy.includes("Red") &&
+    namesViaProxy.includes("Green") &&
+    namesViaProxy.includes("0") &&
+    namesViaProxy.includes("1");
+
+  checks.push(directOk && viaProxyOk);
+}
+
+// --- 7. Trap present, well-behaved: returns a completely different key
+// list than the target actually has - the trap's raw result comes back
+// verbatim (this fix does NOT validate it against the target's own
+// configurable/extensible invariants - see the follow-up chip). ---
+{
+  const target7: any = { a: 1 };
+  const p7 = new Proxy(target7, {
+    ownKeys() {
+      return ["b", "c"];
+    },
+  });
+  const keys = Reflect.ownKeys(p7);
+  checks.push(keys.length === 2 && keys[0] === "b" && keys[1] === "c");
+}
+
+// --- 8. Trap present, mixed string and symbol keys - both halves of
+// CreateListFromArrayLike's String|Symbol element restriction are
+// exercised, and Reflect.ownKeys returns the trap's result unfiltered. ---
+{
+  const sym8 = Symbol("s8");
+  const target8: any = {};
+  const p8: any = new Proxy(target8, {
+    ownKeys() {
+      return ["x", sym8];
+    },
+  });
+  const keys = Reflect.ownKeys(p8);
+  checks.push(keys.length === 2 && keys[0] === "x" && keys[1] === sym8);
+}
+
+// --- 9. Trap returns an element that is neither a string nor a symbol:
+// CreateListFromArrayLike's element-type restriction throws a TypeError. ---
+{
+  const p9: any = new Proxy(
+    {},
+    {
+      ownKeys() {
+        return ["a", 42];
+      },
+    }
+  );
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(p9);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 10. Trap returns duplicate keys: ECMA-262 10.5.11 step 7 throws a
+// TypeError unconditionally, regardless of the target's own state. ---
+{
+  const p10: any = new Proxy(
+    {},
+    {
+      ownKeys() {
+        return ["a", "a"];
+      },
+    }
+  );
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(p10);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 10a. Same as check 10, but with a RUNTIME-BUILT duplicate string
+// (`k + ""`) rather than two identical literals - dedup keyed on the raw
+// value instead of string CONTENT would miss this, since two
+// independently-constructed string values holding the same text aren't
+// guaranteed to compare equal directly (verified: this exact repro
+// initially let the duplicate through unnoticed until dedup was keyed on
+// `.ToString()` for strings / the underlying symbol pointer for symbols
+// instead). ---
+{
+  const k10a = "a" + "";
+  const p10a: any = new Proxy(
+    {},
+    {
+      ownKeys() {
+        return [k10a, "a"];
+      },
+    }
+  );
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(p10a);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 11. A revoked Proxy throws a TypeError, trap or no trap. ---
+{
+  const { proxy, revoke } = (Proxy as any).revocable({}, {});
+  revoke();
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(proxy);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 12. Object.getOwnPropertySymbols on a no-trap Proxy over a target
+// with a real symbol-keyed own property - the OTHER new TypeProxy case
+// (objectGetOwnPropertySymbolsWithVM), distinct target from check 8's
+// per this session's "distinct target per assertion" convention. ---
+{
+  const sym12 = Symbol("s12");
+  const target12: any = {};
+  target12[sym12] = 1;
+  const p12: any = new Proxy(target12, {});
+  const syms = Object.getOwnPropertySymbols(p12);
+  checks.push(syms.length === 1 && syms[0] === sym12);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

This branch is stacked on #348 (`fix-getownpropertynames-prototype-guard`); everything up to that PR's diff is inherited stack noise. The new commit on top:

**The reported bug:** `Object.getOwnPropertyNames` had no case at all for `TypeProxy` — it fell to `default: return arr, nil` (empty array) for **any** Proxy target, regardless of what the proxy's target actually had:

```js
const target = { a: 1 };
Object.getOwnPropertyNames(new Proxy(target, {})); // before: [] - Node: ["a"]
Reflect.ownKeys(new Proxy(target, {}));             // before: [] - Node: ["a"]
```

This was more severe than it first looked: `Reflect.ownKeys`'s own `TypeProxy` case already had a comment claiming it "delegate[s] to `Object.getOwnPropertyNames` + `getOwnPropertySymbols`" as "a simplification" — but the delegation target itself had no Proxy support whatsoever, so the "simplification" was a complete no-op: `Reflect.ownKeys` on literally any Proxy, trap or no trap, always returned `[]` before this fix.

## Approach

`proxyOwnPropertyKeys` is a single shared ECMA-262 10.5.11 `[[OwnPropertyKeys]]` implementation that `Object.getOwnPropertyNames`, `Object.getOwnPropertySymbols`, and `Reflect.ownKeys` all delegate to and then filter differently — matching spec, where all three call the same internal method and filter its result rather than each invoking a possibly-side-effecting trap separately. It implements:

- Revoked check (throws).
- The `ownKeys` trap if present, its result converted via `CreateListFromArrayLike` (a real array fast path, or any array-like via `.length` + indexed access) and validated for the String|Symbol element-type restriction and "no duplicate entries" (spec steps 6–7) — but **not** the fuller `[[Extensible]]`/configurable-key invariant validation steps 8–16 require of a well-behaved trap's result against its target (deliberately deferred — see follow-up chip below).
- No trap: delegates to the proxy's own target via the same two functions this is wired into, recursing correctly for a nested Proxy target.

## Two bugs found and fixed while getting there

1. **Dead code in `objectGetOwnPropertyNamesWithVM`'s `TypeObject` case:** an unreachable `else if obj.Type() == vm.TypeDictObject` nested *inside* `case vm.TypeObject:`, where `obj.Type()` is always `TypeObject` there — the `DictObject` branch could never run. A `DictObject` backs a TypeScript `enum` and a module namespace object, both reachable from ordinary user code with no Proxy involved at all, so `Object.getOwnPropertyNames(SomeEnum)` was already `[]` on its own. Fixed by splitting it into its own `case vm.TypeDictObject:`. The new Proxy delegation would otherwise have silently inherited this for a Proxy-wrapped enum.
2. **Deduping a trap's result by raw `vm.Value` equality is wrong for strings.** Two independently-constructed `TypeString` values holding the same text aren't guaranteed to compare equal via Go's `==`, so a runtime-built duplicate (`"a" + ""` alongside a literal `"a"`) slipped past the "no duplicate entries" check where Node throws. Fixed by deduping on `.ToString()` content for a string and the underlying `*SymbolObject` pointer identity for a symbol.

## Deliberately not touched — two follow-up chips

- `task_3a30b39c`: the deferred 10.5.11 steps 8–16 invariant validation. A trap that omits a target's non-configurable own key currently succeeds silently instead of throwing — pinned explicitly in the new test (check 7's comment). This needs a new generic "is this key configurable" helper spanning every realistic target kind and both key types, which none of this codebase's existing generic descriptor helpers expose.
- `task_778749f8`: `Object.getOwnPropertySymbols` has no `TypeArray` case at all — pre-existing, reproduces on a direct array with no Proxy involved (`ArrayObject` already stores symbol-keyed properties via `symbolProps`, but has no enumerator for them). A Proxy wrapping an array target inherits the same dropped-symbol-keys gap through this fix's new delegation.

## Testing

- New test: `tests/scripts/getownpropertynames_proxy.ts` — 13 checks: a no-trap Proxy over a plain object, an array, a function, a native function, a bound function, and a DictObject enum (both directly and through a Proxy); a well-behaved trap with a different key list; a trap returning mixed string/symbol keys; a trap returning an invalid element type; a trap returning duplicate keys via both literal and runtime-built strings; a revoked Proxy; and `Object.getOwnPropertySymbols` through a no-trap Proxy. All verified against real Node.js output.
- `go test ./tests -run TestScripts -timeout 180s`: ok
- `go test ./...`: ok
- test262 baseline: 16466 → 16476 (+10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
