### PR TITLE
fix(vm,builtins): array symbol-keyed properties - read, enumerate, describe

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3016,6 +3016,26 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 		for _, s := range po.OwnSymbolKeys() {
 			arrObj.Append(s)
 		}
+	} else if obj.Type() == vm.TypeArray {
+		// ArrayObject already stores symbol-keyed properties
+		// (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp - that's how
+		// `arr[sym] = v` works at all), but this function never had a
+		// case for TypeArray at all, so Object.getOwnPropertySymbols on
+		// an array with a real symbol property silently answered []
+		// (verified against Node, which lists it):
+		//
+		//   const arr = [1, 2, 3];
+		//   arr[Symbol("s")] = 42;
+		//   Object.getOwnPropertySymbols(arr).length; // before: 0 - Node: 1
+		//
+		// ArrayObject.OwnSymbolKeys() (pkg/vm/value.go) is the new
+		// enumerator this case needed - it didn't exist at all before
+		// this fix, unlike PlainObject's own OwnSymbolKeys the TypeObject
+		// case above already used.
+		a := obj.AsArray()
+		for _, s := range a.OwnSymbolKeys() {
+			arrObj.Append(s)
+		}
 	} else if obj.Type() == vm.TypeFunction {
 		// Functions store properties in their Properties field
 		fn := obj.AsFunction()
@@ -4830,6 +4850,51 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	// Check arrays first before plainObj (arrays can also be AsPlainObject but their indices are stored separately)
 	if obj.Type() == vm.TypeArray {
 		arrObj := obj.AsArray()
+		// Symbol-keyed own properties (arr[sym] = v) live in ArrayObject's
+		// own symbolProps map (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp,
+		// pkg/vm/value.go) - completely separate from the propName-based
+		// index/"length"/named-property checks below, all of which are
+		// meaningless for a symbol key (propName is "" here). This function
+		// never had a symbol-key branch for TypeArray at all, so it fell
+		// through the propName checks (none matched an empty propName) and
+		// then the switch below (which also has no TypeArray case), landing
+		// on the final default and reporting undefined even for a symbol
+		// property that demonstrably exists - Object.getOwnPropertySymbols
+		// lists it (task_778749f8) and `arr[sym]`/Reflect.get both read it
+		// back correctly, but Object.getOwnPropertyDescriptor claimed no
+		// such property existed:
+		//
+		//   const arr = [1, 2, 3]; const s = Symbol("x"); arr[s] = 42;
+		//   Object.getOwnPropertyDescriptor(arr, s);
+		//   // before: undefined
+		//   // Node:   {value: 42, writable: true, enumerable: true, configurable: true}
+		//
+		// Symbol properties on arrays have no separate attribute-override
+		// tracking (unlike named string properties' propertyDesc map), so -
+		// verified against Node - the descriptor is always the plain
+		// ordinary-property default: writable/enumerable/configurable all
+		// true. This is only safe because Object.defineProperty(arr, sym,
+		// {...}) is ITSELF currently a no-op for arrays (verified: it
+		// neither stores into symbolProps nor throws, so no non-default
+		// attribute combination or accessor can exist to misreport here) -
+		// a separate, pre-existing gap, not fixed by this branch. If a
+		// future fix adds symbol-keyed defineProperty support for arrays,
+		// this hardcoded true/true/true (and the early `return
+		// vm.Undefined, nil` for an absent key just below) will need to
+		// consult whatever attribute storage that fix introduces instead.
+		if keyIsSymbol {
+			if sym := propSym.AsSymbolObject(); sym != nil {
+				if v, ok := arrObj.GetSymbolProp(sym); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(true))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(true))
+					descriptor.SetOwn("configurable", vm.BooleanValue(true))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+			return vm.Undefined, nil
+		}
 		isFrozen := arrObj.IsFrozen()
 		// An index (or named key) explicitly turned into an accessor via
 		// Object.defineProperty takes priority over the plain-element read

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -842,30 +842,51 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 				arr.Append(vm.NewString(key))
 			}
 		case vm.TypeArray:
-			arrayObj := target.AsArray()
-			// Add numeric indices - skipping holes (paserati#300): a hole
-			// from `delete arr[i]`, a literal elision, or `new Array(n)` is
-			// not an own property at all.
-			for i := 0; i < arrayObj.DenseLength(); i++ {
-				key := strconv.Itoa(i)
-				if !arrayObj.HasOwnIndexProperty(key, i) {
-					continue
+			// This used to hand-roll its own index/sparse-index/"length"
+			// logic - byte-for-byte identical to
+			// objectGetOwnPropertyNamesWithVM's own TypeArray case except
+			// for one thing: it never appended NAMED (non-index) string
+			// properties at all, so an array with an ad-hoc property like
+			// `arr.foo = "bar"` was missing "foo" from Reflect.ownKeys even
+			// though Object.getOwnPropertyNames(arr) correctly included it
+			// (verified against Node, which lists it in both). It also had
+			// no symbol-key coverage whatsoever - ArrayObject.OwnSymbolKeys
+			// (pkg/vm/value.go) is a brand-new method this exact fix added,
+			// since Object.getOwnPropertySymbols had no TypeArray case
+			// either before this.
+			//
+			// Rather than hand-rolling BOTH gaps' worth of duplicate logic
+			// a second time in a second independent switch - the "N
+			// independent copies of the same per-kind dispatch slowly
+			// drift apart" pattern behind most of this session's bug
+			// fixes, and exactly how this array case ended up missing
+			// named properties while its sibling function didn't - this
+			// now delegates to objectGetOwnPropertyNamesWithVM +
+			// objectGetOwnPropertySymbolsWithVM, mirroring the five
+			// callable kinds' own delegation above (task_06547fb2). Their
+			// index/sparse-index/"length" handling is already identical to
+			// what this case had, so this is a pure superset: same output
+			// for everything that already worked, plus the two gaps closed.
+			namesVal, err := objectGetOwnPropertyNamesWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if namesVal.Type() == vm.TypeArray {
+				namesArr := namesVal.AsArray()
+				for i := 0; i < namesArr.Length(); i++ {
+					arr.Append(namesArr.Get(i))
 				}
-				arr.Append(vm.NewString(key))
 			}
-			// A sparse index beyond the dense range (paserati#176/#178 -
-			// see arraySparseIndices in object_init.go) is an integer-
-			// indexed own key too, so per OrdinaryOwnPropertyKeys it
-			// belongs here, in ascending numeric order, before "length" -
-			// not visited by iterating up to it, which is exactly the
-			// multi-billion-iteration hang this fixes. Reflect.ownKeys
-			// wants every own key regardless of enumerability, hence
-			// enumerableOnly=false.
-			for _, idx := range arraySparseIndices(arrayObj, false) {
-				arr.Append(vm.NewString(strconv.Itoa(idx)))
+			symsVal, err := objectGetOwnPropertySymbolsWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
 			}
-			// Add "length"
-			arr.Append(vm.NewString("length"))
+			if symsVal.Type() == vm.TypeArray {
+				symsArr := symsVal.AsArray()
+				for i := 0; i < symsArr.Length(); i++ {
+					arr.Append(symsArr.Get(i))
+				}
+			}
 		case vm.TypeProxy:
 			// This used to claim (inaccurately) to "delegate to
 			// Object.getOwnPropertyNames + getOwnPropertySymbols as a

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1482,9 +1482,33 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		*dest = Undefined
 		return true, InterpretOK, *dest
 	case TypeArray:
+		// Arrays: consult the array's OWN symbol-keyed properties first -
+		// opSetPropSymbol's TypeArray case (pkg/vm/op_setprop.go) already
+		// writes `arr[sym] = v` into ArrayObject.symbolProps via
+		// SetSymbolProp, but this case used to skip straight to the
+		// prototype chain without ever checking it, so the read half of
+		// the exact same feature silently returned undefined - or, worse,
+		// a same-named symbol property inherited from Array.prototype -
+		// instead of the array's own value:
+		//
+		//   const arr = [1, 2, 3];
+		//   const sym = Symbol("s");
+		//   arr[sym] = 42;
+		//   arr[sym]; // before: undefined - Node: 42
+		//
+		// GetSymbolProp already existed and worked (that's how
+		// HasOwnSymbolProp/Object.getOwnPropertySymbols's new TypeArray
+		// case can see it) - this case just never called it.
+		arrObj := base.AsArray()
+		if sym := symKey.AsSymbolObject(); sym != nil {
+			if v, ok := arrObj.GetSymbolProp(sym); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+		}
 		// Arrays: consult the per-instance prototype override (subclassing)
 		// before falling back to the realm's intrinsic Array.prototype.
-		proto := base.AsArray().prototype
+		proto := arrObj.prototype
 		if !proto.IsObject() {
 			proto = vm.ArrayPrototype
 		}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -219,10 +219,18 @@ type ArrayObject struct {
 	properties   map[string]Value        // Named properties (e.g., "index", "input" for match results)
 	propertyDesc map[string]PropertyDesc // Property descriptors for named properties
 	symbolProps  map[*SymbolObject]Value // Symbol-keyed properties (e.g., Symbol.iterator override)
-	getters      map[string]Value        // Accessor getters for named properties
-	setters      map[string]Value        // Accessor setters for named properties
-	extensible   bool                    // When false, no new properties can be added (for Object.freeze/seal)
-	frozen       bool                    // When true, elements are also non-writable and non-configurable
+	// symbolPropOrder tracks symbolProps' keys in creation order - a Go map
+	// has none, but ECMA-262 10.1.11 OrdinaryOwnPropertyKeys requires
+	// symbol-keyed own properties to enumerate in the order they were
+	// created (verified against Node: two symbols added to an array
+	// enumerate in insertion order via Object.getOwnPropertySymbols and
+	// Reflect.ownKeys, and stay after every string key regardless of when
+	// each was added relative to the symbols). See OwnSymbolKeys.
+	symbolPropOrder []*SymbolObject
+	getters         map[string]Value // Accessor getters for named properties
+	setters         map[string]Value // Accessor setters for named properties
+	extensible      bool             // When false, no new properties can be added (for Object.freeze/seal)
+	frozen          bool             // When true, elements are also non-writable and non-configurable
 	// lengthNonWritable tracks Object.defineProperty(arr, "length",
 	// {writable: false}) - stored inverted (zero value = writable, the ES
 	// default) so every existing ArrayObject construction site, which
@@ -2844,6 +2852,12 @@ func (a *ArrayObject) SetSymbolProp(sym *SymbolObject, val Value) {
 	if a.symbolProps == nil {
 		a.symbolProps = make(map[*SymbolObject]Value)
 	}
+	if _, existed := a.symbolProps[sym]; !existed {
+		// New key - record its creation-order position. An overwrite of an
+		// already-present key keeps its original position, matching
+		// ordinary property semantics (redefining a value doesn't move it).
+		a.symbolPropOrder = append(a.symbolPropOrder, sym)
+	}
 	a.symbolProps[sym] = val
 }
 
@@ -2854,6 +2868,21 @@ func (a *ArrayObject) HasOwnSymbolProp(sym *SymbolObject) bool {
 	}
 	_, ok := a.symbolProps[sym]
 	return ok
+}
+
+// OwnSymbolKeys returns every symbol this array has an own property for, in
+// creation order - mirrors PlainObject.OwnSymbolKeys's shape/contract
+// (pkg/vm/object.go), used by Object.getOwnPropertySymbols and
+// Reflect.ownKeys (pkg/builtins). Array symbol-keyed properties previously
+// had no enumerator at all despite genuinely being stored (GetSymbolProp/
+// SetSymbolProp/HasOwnSymbolProp already worked) - Object.getOwnPropertySymbols
+// on an array with a real symbol property silently answered [] before this.
+func (a *ArrayObject) OwnSymbolKeys() []Value {
+	symbols := make([]Value, 0, len(a.symbolPropOrder))
+	for _, sym := range a.symbolPropOrder {
+		symbols = append(symbols, Value{typ: TypeSymbol, obj: unsafe.Pointer(sym)})
+	}
+	return symbols
 }
 
 // DefineAccessorProperty defines an accessor property on the array object
@@ -3663,5 +3692,17 @@ func (a *ArrayObject) DeleteSymbolProp(sym *SymbolObject) bool {
 	}
 	_, existed := a.symbolProps[sym]
 	delete(a.symbolProps, sym)
+	if existed {
+		// Keep symbolPropOrder in sync - a re-added key after deletion
+		// gets a fresh, later creation-order position via SetSymbolProp's
+		// own "not already present" check, matching how deleting then
+		// redefining an ordinary property moves it to the end too.
+		for i, s := range a.symbolPropOrder {
+			if s == sym {
+				a.symbolPropOrder = append(a.symbolPropOrder[:i], a.symbolPropOrder[i+1:]...)
+				break
+			}
+		}
+	}
 	return existed
 }

--- a/tests/scripts/array_getownpropertysymbols.ts
+++ b/tests/scripts/array_getownpropertysymbols.ts
@@ -1,0 +1,221 @@
+// expect: true
+// THE BIGGEST-BLAST-RADIUS FIX HERE: opGetPropSymbol's TypeArray case
+// (pkg/vm/op_getprop.go) - the VM READ PATH for `arr[sym]` - used to skip
+// straight to the Array.prototype chain without ever consulting the
+// array's OWN symbolProps at all, even though opSetPropSymbol's sibling
+// TypeArray case (pkg/vm/op_setprop.go) already wrote `arr[sym] = v`
+// there correctly:
+//
+//   const arr = [1, 2, 3]; const sym = Symbol("s"); arr[sym] = 42;
+//   arr[sym]; // before: undefined (or a same-named Array.prototype
+//             //         value, if one existed) - Node: 42
+//
+// This was found while verifying that `Reflect.get(arr, sym)` (which
+// already worked, via a different Go-side code path) agreed with
+// `arr[sym]` (the bytecode path, which didn't) - the exact "N call sites
+// for the same operation slowly drift apart" bug class this whole
+// session keeps finding. Left unfixed, this would have made
+// Object.getOwnPropertySymbols's own new TypeArray case (below) report a
+// symbol key that user code could never actually read back through
+// ordinary `arr[sym]` syntax - a dishonest half of a fix.
+//
+// A third, sibling gap found the same way:
+// Object.getOwnPropertyDescriptor(arr, sym) (objectGetOwnPropertyDescriptorWithVM,
+// pkg/builtins/object_init.go) had no symbol-key branch for TypeArray
+// either - it fell through the (propName-based, meaningless for a
+// symbol) index/length checks and then a switch with no TypeArray case,
+// landing on undefined even though the property demonstrably exists:
+//
+//   Object.getOwnPropertyDescriptor(arr, sym);
+//   // before: undefined
+//   // Node:   {value: 42, writable: true, enumerable: true, configurable: true}
+//
+// Object.getOwnPropertySymbols had no case at all for TypeArray - its
+// if/else-if chain covered TypeObject/TypeFunction/TypeClosure/
+// TypeNativeFunction/TypeNativeFunctionWithProps/TypeBoundFunction/
+// TypeProxy and fell through for everything else, silently returning []:
+//
+//   const arr = [1, 2, 3];
+//   arr[Symbol("s")] = 42;
+//   Object.getOwnPropertySymbols(arr).length; // before: 0 - Node: 1
+//
+// ArrayObject (pkg/vm/value.go) already stored symbol-keyed properties -
+// GetSymbolProp/SetSymbolProp/HasOwnSymbolProp already worked, that's how
+// `arr[sym] = v` and `sym in arr` worked at all - but had no enumerator
+// for them at all. Fixed by adding ArrayObject.OwnSymbolKeys(), backed by
+// a new symbolPropOrder []*SymbolObject field that SetSymbolProp appends
+// to (only on first insertion) and DeleteSymbolProp splices out of, so
+// symbols enumerate in creation order per ECMA-262 10.1.11
+// OrdinaryOwnPropertyKeys (verified against Node: insertion order, and
+// symbols always sort after every string key regardless of when each was
+// added relative to the other).
+//
+// Reflect.ownKeys's own TypeArray case had a SEPARATE, independent bug:
+// it hand-rolled its own index/sparse-index/"length" logic and never
+// included named (non-index) string properties at all, on top of having
+// no symbol coverage either. Rather than bolting a third independent
+// symbol-enumeration call site onto that hand-rolled logic, it was
+// rewritten to delegate to Object.getOwnPropertyNamesWithVM +
+// Object.getOwnPropertySymbolsWithVM instead - mirroring the delegation
+// already used for the five callable kinds (task_06547fb2) - which is a
+// verified pure superset of the old logic (identical index/sparse-index/
+// length handling) plus both gaps closed at once.
+//
+// NOTE on named (non-symbol) property ordering: this task deliberately
+// does NOT assert an order between multiple named string properties like
+// `arr.foo` and `arr.baz` on an array. ArrayObject.NamedPropertyKeys()
+// (pkg/vm/value.go) enumerates its `properties` map with a plain,
+// untracked `for k := range a.properties`, which is Go-map-iteration-
+// order (i.e. genuinely randomized per run) rather than creation order -
+// a separate, pre-existing bug already present in
+// Object.getOwnPropertyNames before this task touched anything, merely
+// newly SURFACED in Reflect.ownKeys by this task's delegation choice
+// (Reflect.ownKeys's old TypeArray case never included named properties
+// at all, so it couldn't previously expose this). Filed as a follow-up
+// chip rather than fixed here, since it's unrelated to symbol handling.
+// Checks below only assert symbol-keyed ordering/positioning and named-
+// property MEMBERSHIP, never named-property ORDER.
+
+const checks: boolean[] = [];
+
+// --- 1. Single symbol property on a plain array. ---
+{
+  const arr: any = [1, 2, 3];
+  const sym = Symbol("s");
+  arr[sym] = 42;
+  const syms = Object.getOwnPropertySymbols(arr);
+  checks.push(syms.length === 1 && syms[0] === sym && arr[sym] === 42);
+}
+
+// --- 2. Multiple symbol properties enumerate in creation order (the
+// symbolPropOrder mechanism this fix added - the one check that actually
+// discriminates "has an enumerator" from "has an ORDERED enumerator"). ---
+{
+  const arr2: any = [1, 2, 3];
+  const s1 = Symbol("s1");
+  const s2 = Symbol("s2");
+  arr2[s1] = "a";
+  arr2[s2] = "b";
+  const syms2 = Object.getOwnPropertySymbols(arr2);
+  checks.push(syms2.length === 2 && syms2[0] === s1 && syms2[1] === s2);
+}
+
+// --- 3. Reflect.ownKeys on an array with a symbol property: the symbol
+// comes after every string key (indices + "length"), per ECMA-262
+// 10.1.11 OrdinaryOwnPropertyKeys. ---
+{
+  const arr3: any = [1, 2, 3];
+  const sym3 = Symbol("s3");
+  arr3[sym3] = 99;
+  const keys3 = Reflect.ownKeys(arr3);
+  checks.push(
+    keys3.length === 5 &&
+      keys3[0] === "0" &&
+      keys3[1] === "1" &&
+      keys3[2] === "2" &&
+      keys3[3] === "length" &&
+      keys3[4] === sym3
+  );
+}
+
+// --- 4. Named string property + symbol together: membership only for
+// the named key (order between multiple named keys is a separate,
+// pre-existing, deliberately-not-fixed-here bug - see header comment),
+// but the symbol's POSITION (always last, after every string key) is
+// asserted since that ordering guarantee doesn't depend on the broken
+// map iteration at all. ---
+{
+  const arr4: any = [1, 2];
+  arr4.foo = "bar";
+  const sym4 = Symbol("s4");
+  arr4[sym4] = "c";
+  const keys4 = Reflect.ownKeys(arr4);
+  const stringKeys = keys4.slice(0, keys4.length - 1);
+  checks.push(
+    keys4.length === 5 &&
+      keys4[keys4.length - 1] === sym4 &&
+      stringKeys.indexOf("0") !== -1 &&
+      stringKeys.indexOf("1") !== -1 &&
+      stringKeys.indexOf("length") !== -1 &&
+      stringKeys.indexOf("foo") !== -1
+  );
+}
+
+// --- 5. Proxy wrapping an array with a symbol property, no trap: the
+// no-trap delegation (proxyOwnPropertyKeys, task_3c1fe018) picks up the
+// array's symbol via the newly-fixed Object.getOwnPropertySymbols path
+// transitively. ---
+{
+  const target5: any = [1, 2, 3];
+  const sym5 = Symbol("s5");
+  target5[sym5] = 5;
+  const p5 = new Proxy(target5, {});
+  const keys5 = Reflect.ownKeys(p5);
+  const syms5 = Object.getOwnPropertySymbols(p5);
+  checks.push(
+    keys5.length === 5 &&
+      keys5[keys5.length - 1] === sym5 &&
+      syms5.length === 1 &&
+      syms5[0] === sym5
+  );
+}
+
+// --- 6. A symbol property does not leak into Object.getOwnPropertyNames
+// or show up as an enumerable string key (sanity: the two enumerators
+// stay properly partitioned by key type). ---
+{
+  const arr6: any = [1, 2];
+  const sym6 = Symbol("s6");
+  arr6[sym6] = "hidden";
+  const names6 = Object.getOwnPropertyNames(arr6);
+  checks.push(names6.indexOf(sym6 as any) === -1 && names6.length === 3);
+}
+
+// --- 7. Object.getOwnPropertyDescriptor agrees with `arr[sym]` and
+// Reflect.get for the same array symbol property - all three read paths
+// (bytecode opGetPropSymbol, Reflect.get's Go-side property lookup, and
+// this function's own TypeArray branch) had independently drifted before
+// this fix; this pins all three at once so they can't silently
+// re-diverge. ---
+{
+  const arr7a: any = [1, 2, 3];
+  const sym7a = Symbol("x");
+  arr7a[sym7a] = 42;
+  const desc = Object.getOwnPropertyDescriptor(arr7a, sym7a) as any;
+  checks.push(
+    arr7a[sym7a] === 42 &&
+      Reflect.get(arr7a, sym7a) === 42 &&
+      sym7a in arr7a &&
+      desc !== undefined &&
+      desc.value === 42 &&
+      desc.writable === true &&
+      desc.enumerable === true &&
+      desc.configurable === true
+  );
+}
+
+// --- 8. Reading an array's own symbol property takes precedence over an
+// identically-keyed property on Array.prototype (opGetPropSymbol's
+// TypeArray case used to skip straight to the prototype chain without
+// ever consulting the array's own symbolProps at all, so this would have
+// found the prototype's value, or undefined, instead of the array's
+// own). ---
+{
+  const sym7 = Symbol("s7");
+  (Array.prototype as any)[sym7] = "from-prototype";
+  const arr7: any = [1, 2];
+  arr7[sym7] = "own-value";
+  const readBack = arr7[sym7];
+  // Array.prototype is a PlainObject, not an ArrayObject - its
+  // DeleteSymbolProp actually removes the entry (verified against Node;
+  // this is unrelated to ArrayObject.DeleteSymbolProp's own bug, which
+  // is never reached from the `delete` opcode at all - see the deferred
+  // follow-up chip), so cleaning up this way doesn't leak the symbol
+  // onto the shared intrinsic for later scripts. Assert the cleanup
+  // itself worked, not just trust it.
+  delete (Array.prototype as any)[sym7];
+  const cleanedUp = !(sym7 in (Array.prototype as any));
+  checks.push(readBack === "own-value" && cleanedUp);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## What's actually new here

This branch is stacked on #349 (`fix-getownpropertynames-proxy`); everything up to that PR's diff is inherited stack noise. The new commit on top:

**The reported bug:** `Object.getOwnPropertySymbols` had no case at all for `TypeArray` - its if/else-if chain covered `TypeObject`/`TypeFunction`/`TypeClosure`/`TypeNativeFunction`/`TypeNativeFunctionWithProps`/`TypeBoundFunction`/`TypeProxy` and fell through for everything else, silently returning `[]`:

```js
const arr = [1, 2, 3];
arr[Symbol("s")] = 42;
Object.getOwnPropertySymbols(arr).length; // before: 0 - Node: 1
```

`ArrayObject` already stored symbol-keyed properties (`GetSymbolProp`/`SetSymbolProp`/`HasOwnSymbolProp` - that's how `arr[sym] = v` and `sym in arr` worked at all) but had no enumerator for them.

## The bigger find: the VM read path was also broken

While verifying `Reflect.get(arr, sym)` agreed with `arr[sym]` (a check I ran specifically because this codebase keeps having "N call sites for the same operation drift apart" bugs), I found `opGetPropSymbol`'s `TypeArray` case - what actually runs for `arr[sym]` - skipped straight to the `Array.prototype` chain without ever consulting the array's own `symbolProps`, even though `opSetPropSymbol`'s sibling case already wrote there correctly:

```js
const arr = [1, 2, 3]; const sym = Symbol("s"); arr[sym] = 42;
arr[sym]; // before: undefined (or a same-named Array.prototype value, if one existed) - Node: 42
```

Left unfixed, this would have made `Object.getOwnPropertySymbols`'s new `TypeArray` case report a key that user code could never actually read back - a dishonest half of a fix. Fixed by checking `GetSymbolProp` before falling back to the prototype chain.

A third, sibling read path had the identical gap: `Object.getOwnPropertyDescriptor(arr, sym)` had no symbol-key branch for `TypeArray` at all, landing on `undefined` for a property that demonstrably exists. Fixed the same way - reads `GetSymbolProp` and reports the plain ordinary-property default (`writable`/`enumerable`/`configurable` all `true`), which is correct only because `Object.defineProperty(arr, sym, {...})` is itself currently a no-op for arrays (see follow-up chip below) - there's no way yet for a non-default attribute combination to exist.

## Approach for enumeration and ordering

Added `ArrayObject.OwnSymbolKeys() []Value`, backed by a new `symbolPropOrder []*SymbolObject` field that `SetSymbolProp` appends to (only on first insertion) and `DeleteSymbolProp` splices out of, so symbols enumerate in creation order per ECMA-262 10.1.11 `OrdinaryOwnPropertyKeys` (verified against Node: insertion order, symbols always sort after every string key).

`Reflect.ownKeys`'s own `TypeArray` case had a fourth, independent bug: it hand-rolled index/sparse-index/"length" logic and never included named (non-index) string properties at all, on top of no symbol coverage. Rather than bolting a third independent symbol-enumeration call site onto that hand-rolled logic, it now delegates to `objectGetOwnPropertyNamesWithVM` + `objectGetOwnPropertySymbolsWithVM` - mirroring the delegation already used for the five callable kinds (task_06547fb2). Verified this is a pure superset of the old logic (identical index/sparse-index/length handling) with both gaps closed.

## Found while verifying, NOT fixed here - three follow-up chips

- `task_991e3da2`: `delete arr[sym]` claims success (`true`) but never actually removes the property - `ArrayObject.DeleteSymbolProp` (hardened by this commit for `symbolPropOrder` consistency) is never called from the delete opcode's array handling at all.
- `task_7fdd49ad`: `ArrayObject.NamedPropertyKeys()` enumerates its `properties` map via plain `for k := range`, which is genuinely randomized per run - pre-existing in `Object.getOwnPropertyNames`, newly surfaced in `Reflect.ownKeys` by this PR's delegation choice (confirmed flaky by running the same script 8x in a row and seeing the order flip).
- `task_90f68f41`: `Object.defineProperty(arr, sym, {...})` is a silent no-op - no error, nothing stored - for both data and accessor descriptors, unlike the string-keyed equivalent which already works.

## Testing

- New test: `tests/scripts/array_getownpropertysymbols.ts` - single symbol property (also exercising the `opGetPropSymbol` read-path fix and `getOwnPropertyDescriptor`), multiple symbols in creation order, `Reflect.ownKeys` ordering symbols after every string key, named-property membership alongside a symbol (deliberately not asserting order between multiple named string properties, per the deferred chip above), a Proxy wrapping a symbol-bearing array with no trap, symbol/string enumerator partitioning, all three read paths (bracket access, `Reflect.get`, `getOwnPropertyDescriptor`) agreeing on value and attributes, and an array's own symbol property taking precedence over an identically-keyed `Array.prototype` property (with an explicit assertion that the test's own prototype cleanup actually succeeded). All verified against real Node.js output.
- `go test ./tests -run TestScripts -timeout 180s`: ok
- `go test ./...`: ok
- test262 baseline: 16476 → 16477 (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
