### PR TITLE
fix(vm): route every remaining Proxy trap lookup through GetMethod semantics

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -96,21 +96,21 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			return false, nil
 		}
 
-		// Get the apply trap from handler (handler can be PlainObject or DictObject)
+		// Get the apply trap from handler. GetMethod(handler, "apply") per
+		// spec: an inherited trap counts, not just an own one - proxyGetTrap
+		// (not a bare handler.AsPlainObject().GetOwn("apply")) for the same
+		// reason documented on its own definition. This also drops the
+		// `default: throw "Proxy handler is not an object"` the inline
+		// switch used to have for any handler.Type() besides TypeObject/
+		// TypeDictObject (a Map, Array, RegExp, ... - anything IsObject()
+		// besides those two, all legal per the Proxy constructor's own
+		// validation): that path disagreed with vm.Call's TypeProxy case
+		// (pkg/vm/vm_init.go, backing e.g. Reflect.apply on the same kind
+		// of proxy), which has never thrown here and instead silently
+		// falls through to "no apply trap" below - matching that instead
+		// of inventing a third answer.
 		handler := proxy.Handler()
-		var applyTrap Value
-		var hasApplyTrap bool
-
-		switch handler.Type() {
-		case TypeObject:
-			applyTrap, hasApplyTrap = handler.AsPlainObject().GetOwn("apply")
-		case TypeDictObject:
-			applyTrap, hasApplyTrap = handler.AsDictObject().GetOwn("apply")
-		default:
-			// Handler is not an object - should not happen if proxy was constructed correctly
-			vm.ThrowTypeError("Proxy handler is not an object")
-			return false, nil
-		}
+		applyTrap, hasApplyTrap := proxyGetTrap(handler, "apply")
 
 		// Check for apply trap
 		if hasApplyTrap && applyTrap.Type() != TypeUndefined && applyTrap.Type() != TypeNull {

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1186,15 +1186,11 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			return false, InterpretRuntimeError, Undefined
 		}
 
-		// Check if handler has a get trap (handler can be PlainObject or DictObject)
-		var getTrap Value
-		var hasGetTrap bool
-		switch proxy.handler.Type() {
-		case TypeObject:
-			getTrap, hasGetTrap = proxy.handler.AsPlainObject().GetOwn("get")
-		case TypeDictObject:
-			getTrap, hasGetTrap = proxy.handler.AsDictObject().GetOwn("get")
-		}
+		// Check if handler has a get trap. GetMethod(handler, "get") per
+		// spec: an inherited trap counts, not just an own one - proxyGetTrap
+		// (not a bare proxy.handler.AsPlainObject().GetOwn("get")) for the
+		// same reason documented on its own definition.
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
 		if hasGetTrap && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !getTrap.IsCallable() {

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -63,8 +63,15 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			return false, InterpretRuntimeError, Undefined
 		}
 
-		// Check if handler has a set trap (per spec: GetMethod returns undefined for null/undefined)
-		setTrap, ok := vm.getOwnGeneric(proxy.handler, "set")
+		// Check if handler has a set trap. GetMethod(handler, "set") per
+		// spec: an inherited trap counts, not just an own one -
+		// getInheritedGeneric (not getOwnGeneric) for the same reason
+		// proxyGetTrap replaced a bare handler.AsPlainObject().GetOwn(...)
+		// at the other trap call sites in this package; unlike proxyGetTrap,
+		// getInheritedGeneric also covers the full range of handler kinds
+		// getOwnGeneric already did (Array, Closure, Function, ...), not
+		// just TypeObject/TypeDictObject.
+		setTrap, ok := vm.getInheritedGeneric(proxy.handler, "set")
 		if ok && setTrap.Type() != TypeUndefined && setTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !setTrap.IsCallable() {
@@ -511,7 +518,11 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 				// Found a proxy in the chain - invoke its set trap
 				proxy := current.AsProxy()
 				if !proxy.Revoked {
-					if setTrap, ok := vm.getOwnGeneric(proxy.handler, "set"); ok && setTrap.IsCallable() {
+					// getInheritedGeneric (not getOwnGeneric): GetMethod(handler,
+					// "set") per spec counts an inherited trap too - see the
+					// other "set" trap sites in this file for the full
+					// rationale.
+					if setTrap, ok := vm.getInheritedGeneric(proxy.handler, "set"); ok && setTrap.IsCallable() {
 						// Call the set trap: trap(target, property, value, receiver)
 						// receiver is the original primitive coerced to object
 						trapArgs := []Value{proxy.Target(), NewString(propName), *valueToSet, *objVal}
@@ -1070,8 +1081,10 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 			return false, InterpretRuntimeError, Undefined
 		}
 
-		// Check if handler has a set trap
-		setTrap, ok := vm.getOwnGeneric(proxy.handler, "set")
+		// Check if handler has a set trap. getInheritedGeneric (not
+		// getOwnGeneric): GetMethod(handler, "set") per spec counts an
+		// inherited trap too.
+		setTrap, ok := vm.getInheritedGeneric(proxy.handler, "set")
 		if ok && setTrap.IsCallable() {
 			// Call the set trap: handler.set(target, propertyKey, value, receiver)
 			trapArgs := []Value{proxy.target, symKey, *valueToSet, *objVal}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4976,7 +4976,7 @@ startExecution:
 						}
 
 						// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-						if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 							if !hasTrap.IsCallable() {
 								frame.ip = ip
 								status := vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5062,7 +5062,7 @@ startExecution:
 						// For Proxy, use has trap
 						proxy := withObj.AsProxy()
 						if !proxy.Revoked {
-							if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.IsCallable() {
+							if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.IsCallable() {
 								trapArgs := []Value{proxy.target, NewString(propName)}
 								frame.ip = ip
 								vm.helperCallDepth++
@@ -5121,7 +5121,7 @@ startExecution:
 						// For Proxy, use get trap
 						proxy := withObj.AsProxy()
 						if !proxy.Revoked {
-							if getTrap, ok := proxy.handler.AsPlainObject().GetOwn("get"); ok && getTrap.IsCallable() {
+							if getTrap, ok := proxyGetTrap(proxy.handler, "get"); ok && getTrap.IsCallable() {
 								trapArgs := []Value{proxy.target, NewString(propName), withObj}
 								frame.ip = ip
 								vm.helperCallDepth++
@@ -5248,7 +5248,7 @@ startExecution:
 								// Use has trap for Proxy
 								proxy := withObj.AsProxy()
 								if !proxy.Revoked {
-									if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.IsCallable() {
+									if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.IsCallable() {
 										trapArgs := []Value{proxy.target, NewString(propName)}
 										frame.ip = ip
 										vm.helperCallDepth++
@@ -5304,7 +5304,7 @@ startExecution:
 									case TypeProxy:
 										proxy := withObj.AsProxy()
 										if !proxy.Revoked {
-											if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.IsCallable() {
+											if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.IsCallable() {
 												trapArgs := []Value{proxy.target, NewString(propName)}
 												frame.ip = ip
 												vm.helperCallDepth++
@@ -5421,7 +5421,7 @@ startExecution:
 						}
 
 						// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-						if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 							if !hasTrap.IsCallable() {
 								frame.ip = ip
 								status := vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5617,7 +5617,7 @@ startExecution:
 							return status, Undefined
 						}
 
-						if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 							if !hasTrap.IsCallable() {
 								frame.ip = ip
 								status := vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5749,7 +5749,7 @@ startExecution:
 					}
 
 					// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-					if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+					if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 						if !hasTrap.IsCallable() {
 							frame.ip = ip
 							vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5943,7 +5943,7 @@ startExecution:
 					// For Proxy, call the 'has' trap per SetMutableBinding step 2
 					proxy := withObj.AsProxy()
 					if !proxy.Revoked {
-						hasTrap, hasHasTrap := proxy.handler.AsPlainObject().GetOwn("has")
+						hasTrap, hasHasTrap := proxyGetTrap(proxy.handler, "has")
 						if hasHasTrap && hasTrap.IsCallable() {
 							trapArgs := []Value{proxy.target, NewString(propName)}
 							vm.helperCallDepth++
@@ -6066,7 +6066,7 @@ startExecution:
 					// For Proxy, call the 'has' trap per GetBindingValue step 2
 					proxy := withObj.AsProxy()
 					if !proxy.Revoked {
-						hasTrap, hasHasTrap := proxy.handler.AsPlainObject().GetOwn("has")
+						hasTrap, hasHasTrap := proxyGetTrap(proxy.handler, "has")
 						if hasHasTrap && hasTrap.IsCallable() {
 							trapArgs := []Value{proxy.target, NewString(propName)}
 							vm.helperCallDepth++
@@ -8441,7 +8441,7 @@ startExecution:
 				}
 
 				// Check if handler has a get trap (per spec: GetMethod treats null/undefined as absent)
-				getTrap, ok := proxy.handler.AsPlainObject().GetOwn("get")
+				getTrap, ok := proxyGetTrap(proxy.handler, "get")
 				if ok && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
 					// Validate trap is callable
 					if !getTrap.IsCallable() {
@@ -16450,7 +16450,7 @@ startExecution:
 				}
 
 				// Check if handler has a delete trap (per spec: GetMethod treats null/undefined as absent)
-				deleteTrap, ok := proxy.handler.AsPlainObject().GetOwn("deleteProperty")
+				deleteTrap, ok := proxyGetTrap(proxy.handler, "deleteProperty")
 				if ok && deleteTrap.Type() != TypeUndefined && deleteTrap.Type() != TypeNull {
 					// Validate trap is callable
 					if !deleteTrap.IsCallable() {
@@ -17897,7 +17897,7 @@ func (vm *VM) isUnscopable(withObj Value, propName string) (bool, bool) {
 		}
 
 		// Check if handler has a 'get' trap
-		getTrap, hasGetTrap := proxy.handler.AsPlainObject().GetOwn("get")
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
 		if hasGetTrap && getTrap.IsCallable() {
 			// Call handler.get(target, Symbol.unscopables, receiver)
 			trapArgs := []Value{proxy.target, vm.SymbolUnscopables, withObj}
@@ -21531,26 +21531,25 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 	case TypeDictObject:
 		return target.AsDictObject().Has(propKey)
 	case TypeArray:
-		// NOT fixed here (pre-existing, out of this task's scope): unlike
-		// OpIn's own direct-target TypeArray case, which checks
-		// ArrayHasOwnIndex (paserati#176/#178 - a numerically-in-range
-		// index is NOT necessarily an own property, e.g. after a distant
-		// defineProperty inflates .length) before falling to the
-		// prototype chain, this still uses the simpler, wrong
-		// `index < arrayObj.Length()` test. Left alone since this task's
-		// three fixes are the trap-lookup bugs and the seven-kind
-		// fallback-coverage gap, not this unrelated pre-existing
-		// correctness issue - flagged as a third bullet on the same
-		// follow-up as the other unfixed trap-lookup sites this task's
-		// review turned up (see task's PR body).
+		// Now fixed to match OpIn's own direct-target TypeArray case:
+		// a numerically-in-range index is NOT necessarily an own property
+		// (paserati#176/#178 - e.g. after a distant defineProperty inflates
+		// .length without that index itself ever being set), so check real
+		// presence via ArrayHasOwnIndex instead of the simpler, wrong
+		// `index < arrayObj.Length()` test - falling through to the
+		// prototype-chain check below (ArrayPrototype.Has) on a miss,
+		// same as the non-index path already did, rather than answering
+		// false outright. tryParseArrayIndex (not strconv.Atoi) also
+		// rejects non-canonical numeric strings like "007", matching
+		// OpIn's own parsing.
 		arrayObj := target.AsArray()
-		if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
-			return index < arrayObj.Length()
-		}
-		if propKey == "length" {
+		if index, ok := tryParseArrayIndex(propKey); ok {
+			if ArrayHasOwnIndex(arrayObj, index) {
+				return true
+			}
+		} else if propKey == "length" {
 			return true
-		}
-		if _, ok := arrayObj.GetOwn(propKey); ok {
+		} else if _, ok := arrayObj.GetOwn(propKey); ok {
 			return true
 		}
 		if vm.ArrayPrototype.Type() == TypeObject {
@@ -21735,6 +21734,17 @@ func proxyGetTrap(handler Value, trapName string) (Value, bool) {
 	default:
 		return Undefined, false
 	}
+}
+
+// ProxyGetTrap is proxyGetTrap exported for pkg/builtins, which imports
+// pkg/vm but not vice versa, so cannot call the unexported package-level
+// function directly - mirrors the (*VM) HasPropertyOnPrototypeChain /
+// HasFunctionPrototypeSymbolProperty pattern used elsewhere for the same
+// cross-package need. Takes no *VM state (proxyGetTrap doesn't either);
+// the method receiver exists only so callers outside this package can
+// reach it as vmInstance.ProxyGetTrap(...).
+func (vm *VM) ProxyGetTrap(handler Value, trapName string) (Value, bool) {
+	return proxyGetTrap(handler, trapName)
 }
 
 // proxyHasSymbolPropertyFallback is proxyHasPropertyFallback's symbol-key

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -2141,17 +2141,12 @@ func (vm *VM) Call(fn Value, thisValue Value, args []Value) (Value, error) {
 			return Undefined, vm.NewTypeError("Cannot perform 'apply' on a proxy that has been revoked")
 		}
 
-		// Get the apply trap from handler (handler can be PlainObject or DictObject)
+		// Get the apply trap from handler. GetMethod(handler, "apply") per
+		// spec: an inherited trap counts, not just an own one - proxyGetTrap
+		// (not a bare handler.AsPlainObject().GetOwn("apply")) for the same
+		// reason documented on its own definition.
 		handler := proxy.Handler()
-		var applyTrap Value
-		var hasApplyTrap bool
-
-		switch handler.Type() {
-		case TypeObject:
-			applyTrap, hasApplyTrap = handler.AsPlainObject().GetOwn("apply")
-		case TypeDictObject:
-			applyTrap, hasApplyTrap = handler.AsDictObject().GetOwn("apply")
-		}
+		applyTrap, hasApplyTrap := proxyGetTrap(handler, "apply")
 
 		// Check for apply trap
 		if hasApplyTrap && applyTrap.Type() != TypeUndefined && applyTrap.Type() != TypeNull {

--- a/tests/scripts/proxy_trap_lookup_fixes.ts
+++ b/tests/scripts/proxy_trap_lookup_fixes.ts
@@ -1,0 +1,161 @@
+// expect: true
+// The remaining `handler.AsPlainObject().GetOwn(<trap>)` sites turned up by
+// auditing pkg/vm and pkg/builtins for the same pattern #342 fixed for
+// OpIn's `has` lookup - the `with`-statement sites are covered separately
+// in tests/scripts/proxy_with_trap_lookup_fixes.ts. Each of these had the
+// same two bugs:
+//
+//   1. Own-only trap lookup, not GetMethod-inherited (`.GetOwn` instead of
+//      `.Get`/proxyGetTrap) - an inherited trap on the handler's own
+//      [[Prototype]] chain was invisible.
+//   2. Unguarded AsPlainObject() panics on a TypeDictObject handler (a TS
+//      enum or module namespace value at runtime).
+//
+// Fixed via proxyGetTrap (pkg/vm/vm.go), reused at every site below:
+//   - opGetProp (pkg/vm/op_getprop.go): plain property read, `obj.prop`.
+//   - OpGetIndex (pkg/vm/vm.go): computed property read, `obj[key]`.
+//   - OpDeleteProp (pkg/vm/vm.go): `delete obj.prop`.
+//   - vm.Call's TypeProxy case (pkg/vm/vm_init.go) and
+//     prepareCallWithGeneratorMode's TypeProxy case (pkg/vm/call.go): the
+//     `apply` trap for, respectively, a native call path (Reflect.apply)
+//     and a direct call expression (`proxy(...)`).
+//
+// call.go's site additionally used to have a THIRD divergent behavior:
+// a `default: throw "Proxy handler is not an object"` for any handler
+// kind besides TypeObject/TypeDictObject (e.g. a Map or Array - both
+// legal per the Proxy constructor's own validation, which only requires
+// IsObject()). vm.Call's sibling site never threw for this and instead
+// silently treated it as "no apply trap" (delegate to target) - the two
+// entry points for calling the very same proxy disagreed. Fixed by
+// dropping call.go's throw in favor of matching vm.Call (check 6).
+//
+// Also fixed in this same commit (not a trap-lookup bug, but touched
+// while reviewing the same file, pkg/vm/vm.go's proxyHasPropertyFallback):
+// the TypeArray case used `index < arrayObj.Length()` instead of
+// ArrayHasOwnIndex to decide whether a numeric index is an own property -
+// wrong per paserati#176/#178, since `.length` can be inflated by an
+// unrelated defineProperty at a distant index without this index itself
+// being set. Now matches OpIn's own TypeArray case: checks
+// ArrayHasOwnIndex first, and falls through to the prototype chain
+// (Array.prototype) on a miss instead of answering outright (checks 7-8).
+
+const checks: boolean[] = [];
+
+// --- 1. opGetProp: inherited `get` trap. ---
+{
+  const base = {
+    get(_t: any, k: string) {
+      return k === "a" ? 42 : undefined;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  checks.push(p.a === 42);
+}
+
+// --- 2. OpGetIndex: inherited `get` trap. ---
+{
+  const base = {
+    get(_t: any, k: string) {
+      return k === "b" ? 43 : undefined;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  const key = "b";
+  checks.push(p[key] === 43);
+}
+
+// --- 3. OpDeleteProp: inherited `deleteProperty` trap. ---
+{
+  const base = {
+    deleteProperty(_t: any, k: string) {
+      return k === "c";
+    },
+  };
+  const p: any = new Proxy({ c: 1 }, Object.create(base));
+  checks.push(delete p.c);
+}
+
+// --- 4. A TypeDictObject handler must not panic for opGetProp/OpGetIndex/
+// OpDeleteProp - no trap is found (an enum has no such members), so each
+// falls through to the target. ---
+{
+  enum DictHandler4 {
+    X,
+    Y,
+  }
+  const p: any = new Proxy({ v: 9 }, DictHandler4 as any);
+  checks.push(p.v === 9);
+  checks.push(p["v"] === 9);
+  checks.push(delete p.v);
+}
+
+// --- 5. apply trap, inherited: both call surfaces for the same proxy -
+// a direct call expression (call.go) and Reflect.apply (vm.Call, via
+// vm_init.go) - must agree. ---
+{
+  const base = {
+    apply(_t: any, _thisArg: any, args: any[]) {
+      return args[0] + args[1] + 1000;
+    },
+  };
+  function orig(a: number, b: number) {
+    return a + b;
+  }
+  const p: any = new Proxy(orig, Object.create(base));
+  checks.push(p(1, 2) === 1003);
+  checks.push(Reflect.apply(p, undefined, [1, 2]) === 1003);
+}
+
+// --- 6. A handler that is a legal Proxy handler (IsObject()) but neither
+// TypeObject nor TypeDictObject (here: an Array) must not throw for a
+// direct call - matches Reflect.apply on the same proxy (no apply trap
+// found either way, so both delegate to the target). ---
+{
+  function orig6(a: number) {
+    return a + 1;
+  }
+  const p: any = new Proxy(orig6, [] as any);
+  checks.push(p(4) === 5);
+  checks.push(Reflect.apply(p, undefined, [4]) === 5);
+}
+
+// --- 6b. A TypeDictObject handler must not panic for a direct call or
+// Reflect.apply either (no apply trap -> delegate to target). ---
+{
+  enum DictHandler6b {
+    X,
+    Y,
+  }
+  function orig6b(a: number) {
+    return a + 1;
+  }
+  const p: any = new Proxy(orig6b, DictHandler6b as any);
+  checks.push(p(4) === 5);
+  checks.push(Reflect.apply(p, undefined, [4]) === 5);
+}
+
+// --- 7. proxyHasPropertyFallback's TypeArray case: an in-range index
+// that isn't actually own (length inflated by a distant defineProperty)
+// must NOT be reported present through a no-trap Proxy. ---
+{
+  const arr: any = [1, 2, 3];
+  Object.defineProperty(arr, "100", { value: "x", configurable: true });
+  const p: any = new Proxy(arr, {});
+  checks.push(5 in p === false); // in range (length=101) but not own
+  checks.push(100 in p === true); // the actually-defined index
+}
+
+// --- 8. Same fallback: an inherited index on Array.prototype must still
+// be found via the prototype-chain walk on a miss (matches OpIn). ---
+{
+  (Array.prototype as any)[5] = "proto-value";
+  try {
+    const arr2: any = [1, 2, 3];
+    const p2: any = new Proxy(arr2, {});
+    checks.push(5 in p2 === true);
+  } finally {
+    delete (Array.prototype as any)[5];
+  }
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_with_trap_lookup_fixes.ts
+++ b/tests/scripts/proxy_with_trap_lookup_fixes.ts
@@ -1,0 +1,181 @@
+// expect: true
+// Two bugs shared by every `with`-statement Proxy trap lookup in the
+// run() interpreter loop (pkg/vm/vm.go), found while auditing every
+// `proxy.handler.AsPlainObject().GetOwn(<trap>)` call site after #342
+// fixed this exact pattern for OpIn's `has` lookup:
+//
+//   1. Own-only trap lookup, not GetMethod-inherited. Each site did
+//      `proxy.handler.AsPlainObject().GetOwn(<trap>)` - own-only - instead
+//      of GetMethod(handler, <trap>) per spec, which walks the handler's
+//      own [[Prototype]] chain. An inherited trap (e.g. `Object.create({
+//      has() {...} })` as a handler) was invisible on every `with`-object
+//      code path: OpGetWithProperty/OpSetWithProperty (a global variable
+//      read/write inside `with`), OpGetWithOrLocal/OpSetWithOrLocal (same,
+//      for a variable that's also a local in the current function),
+//      OpResolveWithBinding/OpGetWithByBinding/OpSetWithByBinding (a
+//      compound assignment's pre-resolved binding), and isUnscopable's own
+//      Proxy branch (checking @@unscopables on a `with`-object during any
+//      of the above).
+//
+//   2. Unguarded AsPlainObject() panics on a TypeDictObject handler. Every
+//      one of those sites assumed the handler is specifically a
+//      TypeObject. A handler that happens to be a TypeDictObject (a TS
+//      enum or module namespace value at runtime) made Value.AsPlainObject()
+//      panic the entire process - not a catchable JS exception.
+//
+// Fixed by routing every one of these sites through proxyGetTrap (the
+// helper #342 already introduced for OpIn's `has` case), which branches on
+// TypeObject/TypeDictObject and uses .Get (not .GetOwn) for both.
+//
+// checks 1-2: OpGetWithProperty / OpSetWithProperty (global variable).
+// checks 3-4: OpGetWithOrLocal / OpSetWithOrLocal (local variable, with
+//             the with-object taking priority per `with` semantics - the
+//             local must NOT be touched when the with-object claims the
+//             binding via an inherited `has`).
+// checks 5-6: compound assignment (OpResolveWithBinding + OpGetWithByBinding
+//             + OpSetWithByBinding), inherited get/set traps.
+// check 7:    a TypeDictObject handler must not panic on any `with` path.
+
+const checks: boolean[] = [];
+
+// --- 1. Global variable read inside `with`, inherited `get`/`has` traps. ---
+var wGlobal = 1;
+{
+  const base = {
+    has(_t: any, k: string) {
+      return k === "wGlobal";
+    },
+    get(_t: any, k: string) {
+      return k === "wGlobal" ? 111 : undefined;
+    },
+  };
+  const handler: any = Object.create(base);
+  function readGlobal() {
+    with (new Proxy({}, handler) as any) {
+      return wGlobal;
+    }
+  }
+  checks.push(readGlobal() === 111);
+}
+
+// --- 2. Global variable write inside `with`, inherited `has`/`set` traps. ---
+{
+  const log: string[] = [];
+  const base = {
+    has(_t: any, k: string) {
+      log.push("has:" + k);
+      return k === "wGlobal";
+    },
+    set(_t: any, k: string, v: any) {
+      log.push("set:" + k + "=" + v);
+      return true;
+    },
+  };
+  const handler: any = Object.create(base);
+  function writeGlobal() {
+    with (new Proxy({}, handler) as any) {
+      wGlobal = 222;
+    }
+  }
+  writeGlobal();
+  checks.push(log.indexOf("set:wGlobal=222") !== -1);
+}
+
+// --- 3. Local variable read inside `with` (OpGetWithOrLocal): the
+// with-object's inherited `has`/`get` traps must take priority over the
+// local, per `with` dynamic-scoping semantics. ---
+{
+  const base = {
+    has(_t: any, k: string) {
+      return k === "lx";
+    },
+    get(_t: any, k: string) {
+      return k === "lx" ? 333 : undefined;
+    },
+  };
+  const handler: any = Object.create(base);
+  function readLocal() {
+    let lx = 1;
+    with (new Proxy({}, handler) as any) {
+      return lx;
+    }
+  }
+  checks.push(readLocal() === 333);
+}
+
+// --- 4. Local variable write inside `with` (OpSetWithOrLocal): an
+// inherited `has` trap must still be found so the with-object's `set`
+// trap runs instead of silently falling back to the local. ---
+{
+  const log: string[] = [];
+  const base = {
+    has(_t: any, k: string) {
+      return k === "lx";
+    },
+  };
+  const handler: any = Object.create(base);
+  handler.set = function (_t: any, k: string, v: any) {
+    log.push("set:" + k + "=" + v);
+    return true;
+  };
+  function writeLocal() {
+    let lx = 1;
+    with (new Proxy({}, handler) as any) {
+      lx = 444;
+    }
+    return lx; // must be untouched: the with-object claimed the binding
+  }
+  checks.push(writeLocal() === 1);
+  checks.push(log.indexOf("set:lx=444") !== -1);
+}
+
+// --- 5-6. Compound assignment inside `with` (OpResolveWithBinding then
+// OpGetWithByBinding/OpSetWithByBinding), inherited get/has/set traps. ---
+{
+  const log: string[] = [];
+  const base = {
+    has(_t: any, k: string) {
+      return k === "lx";
+    },
+    get(_t: any, k: string) {
+      return k === "lx" ? 10 : undefined;
+    },
+    set(_t: any, k: string, v: any) {
+      log.push("set:" + k + "=" + v);
+      return true;
+    },
+  };
+  const handler: any = Object.create(base);
+  function compound() {
+    let lx = 1;
+    with (new Proxy({}, handler) as any) {
+      lx += 5;
+    }
+    return lx;
+  }
+  checks.push(compound() === 1); // local untouched
+  checks.push(log.indexOf("set:lx=15") !== -1); // 10 (from get) + 5
+}
+
+// --- 7. A TypeDictObject handler (a TS enum at runtime) must not panic
+// on any `with` path (global read/write, local read/write, compound). ---
+{
+  enum DictHandler7 {
+    A,
+    B,
+  }
+  function useDictHandler() {
+    let lx = 1;
+    with (new Proxy({ wGlobal: 5, lx: 6 }, DictHandler7 as any) as any) {
+      wGlobal;
+      wGlobal = 9;
+      lx;
+      lx = 9;
+      lx += 1;
+    }
+    return "no-panic";
+  }
+  checks.push(useDictHandler() === "no-panic");
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Following #342 (`fix-proxy-has-string-key-gaps`), which fixed OpIn's string-key `has` trap lookup for two bugs and introduced `proxyGetTrap` as the shared fix, a grep for `handler.AsPlainObject()` (plus the differently-shaped `getOwnGeneric`-based "set" trap lookups) turned up roughly a dozen more `pkg/vm` sites carrying the same two bugs:

1. **Own-only trap lookup, not GetMethod-inherited.** `proxy.handler.AsPlainObject().GetOwn(<trap>)` instead of `.Get(<trap>)`/`proxyGetTrap` — per ECMA-262's `GetMethod`, an inherited trap on the handler's own `[[Prototype]]` should count.
2. **Unguarded `AsPlainObject()` panics on a `TypeDictObject` handler** (a TS enum or module namespace value at runtime) — process panic, not a catchable JS exception.

Fixed every site by routing through `proxyGetTrap` (has/get/deleteProperty/apply traps) or, for "set" (looked up via `getOwnGeneric` rather than a bare `AsPlainObject().GetOwn()`), through the already-existing `getInheritedGeneric` — which preserves the wider range of legal handler kinds `getOwnGeneric` already supported (Array, Closure, Function, ...) rather than narrowing to just Object/DictObject.

Sites, grouped by feature:
- **`with`-statement dynamic scoping** (`pkg/vm/vm.go`'s `run()` loop): every trap lookup backing `OpGetWithProperty`, `OpSetWithProperty`, `OpGetWithOrLocal`, `OpSetWithOrLocal`, `OpResolveWithBinding`, `OpGetWithByBinding`, `OpSetWithByBinding`, and `isUnscopable`'s own Proxy branch; `op_setprop.go`'s three "set" trap sites back the set-half of this.
- **Plain property access**: `opGetProp`'s `obj.prop` (`op_getprop.go`), `OpGetIndex`'s `obj[key]` (`vm.go`), `OpDeleteProp`'s `delete obj.prop` (`vm.go`).
- **Calling a proxy as a function**: `vm.Call`'s `TypeProxy` case (`vm_init.go`, backs e.g. `Reflect.apply`) and `prepareCallWithGeneratorMode`'s `TypeProxy` case (`call.go`, backs a direct call expression `proxy(...)`). `call.go`'s site additionally had a third divergent behavior — a `default: throw "Proxy handler is not an object"` for any handler kind besides `TypeObject`/`TypeDictObject` (e.g. a `Map` or `Array`, both legal per the `Proxy` constructor's own `IsObject()` validation) — while `vm.Call`'s sibling site never threw there and silently fell through to "no apply trap" instead. Dropped the throw in favor of matching `vm.Call`.

**Not fixed** (documented, deliberately out of scope): `proxyGetTrap`'s own `default:` case still answers "no trap" for a handler that is `IsObject()` but neither `TypeObject` nor `TypeDictObject` (e.g. a bare function or `Array` used as a handler) rather than consulting it — a narrower, pre-existing gap in the helper itself.

**Also fixed**, found during this same review: `proxyHasPropertyFallback`'s `TypeArray` case (`vm.go`) checked `index < arrayObj.Length()` instead of `ArrayHasOwnIndex` — wrong per paserati#176/#178, since `.length` can be inflated by an unrelated `defineProperty` at a distant index without this index itself being set. Now matches `OpIn`'s own `TypeArray` case.

Added `ProxyGetTrap`, an exported wrapper around `proxyGetTrap`, for `pkg/builtins` to reuse in a follow-up PR (mirrors the `HasPropertyOnPrototypeChain`/`HasFunctionPrototypeSymbolProperty` pattern already used for the same cross-package need).

`tests/scripts/proxy_with_trap_lookup_fixes.ts` and `tests/scripts/proxy_trap_lookup_fixes.ts` cover the `with`-statement sites and the remaining sites respectively.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./pkg/...` both pass.

Based on `fix-array-getownpropertysymbols` (#350), the tip of this stack as of this writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
