### PR TITLE
fix(vm,builtins): Object.defineProperty on arrays supports symbol keys

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -4195,6 +4195,26 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		}
 	}
 
+	// Array objects, symbol key: ES 10.4.2.1 Array exotic [[DefineOwnProperty]]
+	// defers to OrdinaryDefineOwnProperty for any key that "length" doesn't
+	// intercept - true for every symbol key, since a symbol can never equal
+	// the string "length". This used to have no branch at all: a symbol key
+	// on an array fell through every propName-gated check above (all of them
+	// meaningless for a symbol, since propName is "" here) and reached the
+	// `obj.Type() == vm.TypeObject` block below, which a TypeArray value
+	// never satisfies - so Object.defineProperty(arr, sym, {...}) silently
+	// did nothing: it neither stored anything nor threw, for both data and
+	// accessor descriptors alike.
+	if obj.Type() == vm.TypeArray && keyIsSymbol {
+		arr := obj.AsArray()
+		if arr != nil && propSym.AsSymbolObject() != nil {
+			if err := vmInstance.ArrayDefineOwnSymbolProperty(arr, propSym.AsSymbolObject(), hasValue, value, writablePtr, enumerablePtr, configurablePtr, hasGetter, getter, hasSetter, setter); err != nil {
+				return vm.Undefined, err
+			}
+			return obj, nil
+		}
+	}
+
 	// Define the property with attributes (on plain objects only for now)
 	if obj.Type() == vm.TypeObject {
 		if obj.Type() == vm.TypeObject {
@@ -4850,46 +4870,40 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	// Check arrays first before plainObj (arrays can also be AsPlainObject but their indices are stored separately)
 	if obj.Type() == vm.TypeArray {
 		arrObj := obj.AsArray()
-		// Symbol-keyed own properties (arr[sym] = v) live in ArrayObject's
-		// own symbolProps map (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp,
-		// pkg/vm/value.go) - completely separate from the propName-based
-		// index/"length"/named-property checks below, all of which are
-		// meaningless for a symbol key (propName is "" here). This function
-		// never had a symbol-key branch for TypeArray at all, so it fell
-		// through the propName checks (none matched an empty propName) and
-		// then the switch below (which also has no TypeArray case), landing
-		// on the final default and reporting undefined even for a symbol
-		// property that demonstrably exists - Object.getOwnPropertySymbols
-		// lists it (task_778749f8) and `arr[sym]`/Reflect.get both read it
-		// back correctly, but Object.getOwnPropertyDescriptor claimed no
-		// such property existed:
+		// Symbol-keyed own properties (arr[sym] = v, or an explicit
+		// Object.defineProperty(arr, sym, {...})) live in ArrayObject's own
+		// symbol-keyed storage (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp
+		// for a plain value; symbolPropertyDesc/symbolGetters/symbolSetters
+		// for an explicit descriptor - see ArrayDefineOwnSymbolProperty,
+		// pkg/vm/array_props.go) - completely separate from the
+		// propName-based index/"length"/named-property checks below, all of
+		// which are meaningless for a symbol key (propName is "" here). This
+		// function used to have no symbol-key branch for TypeArray at all
+		// (task_778749f8's fix here only handled the plain-value case, since
+		// Object.defineProperty on a symbol key was itself still a no-op at
+		// the time - see ArrayDefineOwnSymbolProperty's doc comment):
 		//
-		//   const arr = [1, 2, 3]; const s = Symbol("x"); arr[s] = 42;
+		//   const arr = [1, 2]; const s = Symbol("d");
+		//   Object.defineProperty(arr, s, {value: 7, writable: false, enumerable: false, configurable: false});
 		//   Object.getOwnPropertyDescriptor(arr, s);
-		//   // before: undefined
-		//   // Node:   {value: 42, writable: true, enumerable: true, configurable: true}
-		//
-		// Symbol properties on arrays have no separate attribute-override
-		// tracking (unlike named string properties' propertyDesc map), so -
-		// verified against Node - the descriptor is always the plain
-		// ordinary-property default: writable/enumerable/configurable all
-		// true. This is only safe because Object.defineProperty(arr, sym,
-		// {...}) is ITSELF currently a no-op for arrays (verified: it
-		// neither stores into symbolProps nor throws, so no non-default
-		// attribute combination or accessor can exist to misreport here) -
-		// a separate, pre-existing gap, not fixed by this branch. If a
-		// future fix adds symbol-keyed defineProperty support for arrays,
-		// this hardcoded true/true/true (and the early `return
-		// vm.Undefined, nil` for an absent key just below) will need to
-		// consult whatever attribute storage that fix introduces instead.
+		//   // before: {value: 7, writable: true, enumerable: true, configurable: true} (hardcoded default)
+		//   // Node:   {value: 7, writable: false, enumerable: false, configurable: false}
 		if keyIsSymbol {
 			if sym := propSym.AsSymbolObject(); sym != nil {
-				if v, ok := arrObj.GetSymbolProp(sym); ok {
+				if g, s, e, c, ok := arrObj.GetOwnSymbolAccessor(sym); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, desc, ok := arrObj.GetSymbolPropertyDescriptor(sym); ok {
 					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 					descriptor.SetOwn("value", v)
-					descriptor.SetOwn("writable", vm.BooleanValue(true))
-					descriptor.SetOwn("enumerable", vm.BooleanValue(true))
-					descriptor.SetOwn("configurable", vm.BooleanValue(true))
+					descriptor.SetOwn("writable", vm.BooleanValue(desc.Writable))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(desc.Enumerable))
+					descriptor.SetOwn("configurable", vm.BooleanValue(desc.Configurable))
 					return vm.NewValueFromPlainObject(descriptor), nil
 				}
 			}
@@ -5488,6 +5502,15 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 			stringKeys = append(stringKeys, strconv.Itoa(i))
 		}
 		stringKeys = append(stringKeys, "length")
+		// This case never collected symbol keys at all, so
+		// Object.getOwnPropertyDescriptors(arr) silently dropped a symbol
+		// property entirely (whether a plain `arr[sym] = v` or one defined
+		// via Object.defineProperty - see ArrayDefineOwnSymbolProperty,
+		// pkg/vm/array_props.go) despite the single-key
+		// Object.getOwnPropertyDescriptor already answering correctly for
+		// the exact same property - same gap this switch's other
+		// branches' doc comments describe fixing for their own kinds.
+		symbolKeys = append(symbolKeys, arr.OwnSymbolKeys()...)
 	case vm.TypeFunction:
 		fn := obj.AsFunction()
 		// Function intrinsics: length, name, prototype

--- a/pkg/builtins/reflect_delete.go
+++ b/pkg/builtins/reflect_delete.go
@@ -79,8 +79,12 @@ func reflectDeleteProperty(vmInstance *vm.VM, target vm.Value, key vm.Value) (bo
 	case vm.TypeArray:
 		arr := target.AsArray()
 		if isSym {
-			arr.DeleteSymbolProp(key.AsSymbolObject())
-			return true, nil
+			// A symbol property can now be explicitly non-configurable via
+			// Object.defineProperty (see ArrayDefineOwnSymbolProperty,
+			// pkg/vm/array_props.go) - propagate DeleteSymbolProp's actual
+			// result instead of hardcoding success, matching every other
+			// case in this function.
+			return arr.DeleteSymbolProp(key.AsSymbolObject()), nil
 		}
 		if idx, isIndex := vm.ParseArrayIndex(name); isIndex {
 			return arr.DeleteIndex(idx), nil

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -282,6 +282,105 @@ func (vm *VM) ArrayDefineOwnProperty(
 	return nil
 }
 
+// ArrayDefineOwnSymbolProperty implements the Array exotic object's
+// [[DefineOwnProperty]] (ECMA-262 10.4.2.1 -> OrdinaryDefineOwnProperty
+// 10.1.6.3) for a symbol-keyed property. This is the symbol-keyed
+// counterpart of ArrayDefineOwnProperty above, backing
+// Object.defineProperty(arr, sym, {...}) - previously a silent no-op for
+// arrays: a symbol key never matched any of ArrayDefineOwnProperty's
+// callers' branches (all gated on a non-symbol propName), and there was no
+// storage to hold a non-default attribute combination or an accessor even if
+// one had been dispatched here. A symbol key never aliases a numeric index
+// or "length" the way a named key can, so none of ArrayDefineOwnProperty's
+// index/length-specific machinery (dense-element growth, sparse-index
+// tracking, tryParseArrayIndex) applies - this mirrors only that function's
+// plain named-property tail (the non-index path).
+func (vm *VM) ArrayDefineOwnSymbolProperty(
+	a *ArrayObject, sym *SymbolObject,
+	hasValue bool, value Value,
+	writablePtr, enumerablePtr, configurablePtr *bool,
+	hasGetter bool, getter Value,
+	hasSetter bool, setter Value,
+) error {
+	becomingAccessor := hasGetter || hasSetter
+
+	var exists, isAccessor, curWritable, curEnumerable, curConfigurable bool
+	if _, _, e, c, ok := a.GetOwnSymbolAccessor(sym); ok {
+		exists, isAccessor, curEnumerable, curConfigurable = true, true, e, c
+	} else if _, desc, ok := a.GetSymbolPropertyDescriptor(sym); ok {
+		exists, curWritable, curEnumerable, curConfigurable = true, desc.Writable, desc.Enumerable, desc.Configurable
+	}
+
+	// OrdinaryDefineOwnProperty 10.1.6.3 steps 3-4: reject on a
+	// non-configurable existing property whose descriptor the caller is
+	// trying to widen or whose kind/writability it's trying to narrow.
+	if exists && !curConfigurable {
+		if configurablePtr != nil && *configurablePtr {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if enumerablePtr != nil && *enumerablePtr != curEnumerable {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if isAccessor && (hasValue || writablePtr != nil) {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if !isAccessor && becomingAccessor {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if !isAccessor && !becomingAccessor && !curWritable && writablePtr != nil && *writablePtr {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		// NOT checked here, matching ArrayDefineOwnProperty's identical
+		// pre-existing gap for named keys (10.1.6.3 step 4e-ii): redefining
+		// a non-configurable, non-writable data property with a *different*
+		// [[Value]] should also throw, but doesn't - it's silently accepted
+		// as a no-op-that-isn't since the write below still updates the
+		// value if hasValue is true. Left this way for parity with the
+		// named-key path rather than fixing only the symbol-key side.
+	} else if !exists && !a.IsExtensible() {
+		return vm.NewTypeError("Cannot define property Symbol(), object is not extensible")
+	}
+
+	enumerable := curEnumerable
+	if !exists {
+		enumerable = false
+	}
+	if enumerablePtr != nil {
+		enumerable = *enumerablePtr
+	}
+	configurable := curConfigurable
+	if !exists {
+		configurable = false
+	}
+	if configurablePtr != nil {
+		configurable = *configurablePtr
+	}
+
+	if becomingAccessor {
+		a.DefineSymbolAccessorProperty(sym, getter, hasGetter, setter, hasSetter, &enumerable, &configurable)
+		return nil
+	}
+
+	writable := curWritable
+	if !exists {
+		writable = false
+	}
+	if writablePtr != nil {
+		writable = *writablePtr
+	}
+	newValue := value
+	if !hasValue {
+		if v, ok := a.GetSymbolProp(sym); ok {
+			newValue = v
+		} else {
+			newValue = Undefined
+		}
+	}
+
+	a.DefineSymbolProperty(sym, newValue, writable, enumerable, configurable)
+	return nil
+}
+
 // DeleteIndex implements [[Delete]] (ECMA-262 10.4.2.1 -> OrdinaryDelete
 // 10.1.7) for a numeric array index, clearing the slot (and any tracked
 // accessor/descriptor state for it) and reporting success. A plain element

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1501,6 +1501,31 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		// case can see it) - this case just never called it.
 		arrObj := base.AsArray()
 		if sym := symKey.AsSymbolObject(); sym != nil {
+			// A symbol-keyed accessor defined via Object.defineProperty(arr,
+			// sym, {get, set}) takes priority over the plain symbolProps
+			// value, mirroring the named-property read path (GetOwnAccessor
+			// consulted before a plain element/property) - see
+			// ArrayObject.GetOwnSymbolAccessor and
+			// ArrayDefineOwnSymbolProperty (array_props.go).
+			if arrObj.HasSymbolAccessors() {
+				if getter, _, _, _, ok := arrObj.GetOwnSymbolAccessor(sym); ok {
+					if getter.Type() == TypeUndefined {
+						*dest = Undefined
+						return true, InterpretOK, *dest
+					}
+					res, err := vm.Call(getter, base, nil)
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							vm.throwException(ee.GetExceptionValue())
+							return false, InterpretRuntimeError, Undefined
+						}
+						vm.ThrowTypeError(err.Error())
+						return false, InterpretRuntimeError, Undefined
+					}
+					*dest = res
+					return true, InterpretOK, *dest
+				}
+			}
 			if v, ok := arrObj.GetSymbolProp(sym); ok {
 				*dest = v
 				return true, InterpretOK, *dest

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -1191,12 +1191,36 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		return vm.setOwnCheckedByKey(closure.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 	}
 
-	// Array objects: store symbol properties directly on the array
+	// Array objects: store symbol properties directly on the array. A
+	// symbol-keyed accessor defined via Object.defineProperty(arr, sym,
+	// {get, set}) takes priority over the plain symbolProps slot, mirroring
+	// the named-property write path and this function's own RegExp/Proxy
+	// branches above - see ArrayObject.GetOwnSymbolAccessor and
+	// ArrayDefineOwnSymbolProperty (array_props.go).
 	if objVal.Type() == TypeArray {
 		arr := objVal.AsArray()
 		if arr != nil {
 			sym := symKey.AsSymbolObject()
 			if sym != nil {
+				if arr.HasSymbolAccessors() {
+					if _, setter, _, _, ok := arr.GetOwnSymbolAccessor(sym); ok {
+						if setter.Type() != TypeUndefined {
+							_, err := vm.Call(setter, *objVal, []Value{*valueToSet})
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+									return false, InterpretRuntimeError, Undefined
+								}
+								vm.ThrowTypeError(err.Error())
+								return false, InterpretRuntimeError, Undefined
+							}
+						}
+						// A getter-only accessor silently swallows the write in
+						// sloppy mode, matching ArrayPrototypeSetterFor's
+						// identical rule for a named-property accessor.
+						return true, InterpretOK, *valueToSet
+					}
+				}
 				arr.SetSymbolProp(sym, *valueToSet)
 			}
 		}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -227,10 +227,23 @@ type ArrayObject struct {
 	// Reflect.ownKeys, and stay after every string key regardless of when
 	// each was added relative to the symbols). See OwnSymbolKeys.
 	symbolPropOrder []*SymbolObject
-	getters         map[string]Value // Accessor getters for named properties
-	setters         map[string]Value // Accessor setters for named properties
-	extensible      bool             // When false, no new properties can be added (for Object.freeze/seal)
-	frozen          bool             // When true, elements are also non-writable and non-configurable
+	// symbolPropertyDesc/symbolGetters/symbolSetters are the symbol-keyed
+	// counterparts of propertyDesc/getters/setters above, backing
+	// Object.defineProperty(arr, sym, {...}) - previously a silent no-op for
+	// arrays (paserati task_778749f8 follow-up): symbolProps only ever held a
+	// bare value with no attribute tracking and no accessor storage at all, so
+	// a non-default writable/enumerable/configurable combination, or a
+	// get/set pair, defined via Object.defineProperty on a symbol key
+	// couldn't be represented and defineProperty quietly dropped it. See
+	// DefineSymbolProperty/DefineSymbolAccessorProperty/GetOwnSymbolAccessor
+	// and ArrayDefineOwnSymbolProperty (array_props.go).
+	symbolPropertyDesc map[*SymbolObject]PropertyDesc
+	symbolGetters      map[*SymbolObject]Value
+	symbolSetters      map[*SymbolObject]Value
+	getters            map[string]Value // Accessor getters for named properties
+	setters            map[string]Value // Accessor setters for named properties
+	extensible         bool             // When false, no new properties can be added (for Object.freeze/seal)
+	frozen             bool             // When true, elements are also non-writable and non-configurable
 	// lengthNonWritable tracks Object.defineProperty(arr, "length",
 	// {writable: false}) - stored inverted (zero value = writable, the ES
 	// default) so every existing ArrayObject construction site, which
@@ -2847,27 +2860,46 @@ func (a *ArrayObject) GetSymbolProp(sym *SymbolObject) (Value, bool) {
 	return v, ok
 }
 
-// SetSymbolProp sets a symbol-keyed property on the array object
+// SetSymbolProp sets a symbol-keyed property on the array object. Uses
+// noteSymbolPropOrder (which checks all of symbolProps/symbolGetters/
+// symbolSetters via HasOwnSymbolProp) rather than a bare `_, existed :=
+// a.symbolProps[sym]` check: since DefineSymbolAccessorProperty added a
+// second place a symbol key can already "exist" without an entry in
+// symbolProps (an accessor-only symbol has its data entry deleted - see
+// that method), the bare check alone would have missed that case and
+// appended a second symbolPropOrder entry for the same symbol, making
+// Object.getOwnPropertySymbols list it twice.
 func (a *ArrayObject) SetSymbolProp(sym *SymbolObject, val Value) {
 	if a.symbolProps == nil {
 		a.symbolProps = make(map[*SymbolObject]Value)
 	}
-	if _, existed := a.symbolProps[sym]; !existed {
-		// New key - record its creation-order position. An overwrite of an
-		// already-present key keeps its original position, matching
-		// ordinary property semantics (redefining a value doesn't move it).
-		a.symbolPropOrder = append(a.symbolPropOrder, sym)
-	}
+	a.noteSymbolPropOrder(sym)
 	a.symbolProps[sym] = val
 }
 
-// HasOwnSymbolProp checks if the array object has an own symbol property
+// HasOwnSymbolProp checks if the array object has an own symbol property -
+// either a plain data value (symbolProps) or an accessor defined via
+// Object.defineProperty (symbolGetters/symbolSetters). Callers like `in`,
+// Reflect.has, and hasOwnProperty must see an accessor-only symbol (one
+// whose value was replaced entirely by DefineSymbolAccessorProperty, which
+// deletes the symbolProps entry) as present too.
 func (a *ArrayObject) HasOwnSymbolProp(sym *SymbolObject) bool {
-	if a.symbolProps == nil {
-		return false
+	if a.symbolProps != nil {
+		if _, ok := a.symbolProps[sym]; ok {
+			return true
+		}
 	}
-	_, ok := a.symbolProps[sym]
-	return ok
+	if a.symbolGetters != nil {
+		if _, ok := a.symbolGetters[sym]; ok {
+			return true
+		}
+	}
+	if a.symbolSetters != nil {
+		if _, ok := a.symbolSetters[sym]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // OwnSymbolKeys returns every symbol this array has an own property for, in
@@ -2883,6 +2915,157 @@ func (a *ArrayObject) OwnSymbolKeys() []Value {
 		symbols = append(symbols, Value{typ: TypeSymbol, obj: unsafe.Pointer(sym)})
 	}
 	return symbols
+}
+
+// noteSymbolPropOrder records sym's creation-order position the first time
+// it becomes an own property by any means (plain value, attributed data
+// property, or accessor) - shared by SetSymbolProp and
+// DefineSymbolAccessorProperty so a symbol that starts as one kind and is
+// later redefined as the other (Object.defineProperty converting a data
+// property to an accessor or back) keeps its original position instead of
+// moving to the end, matching ordinary property semantics (redefining a key
+// doesn't move it) - the same rule ArrayDefineOwnProperty's named-property
+// path already follows.
+func (a *ArrayObject) noteSymbolPropOrder(sym *SymbolObject) {
+	if a.HasOwnSymbolProp(sym) {
+		return
+	}
+	a.symbolPropOrder = append(a.symbolPropOrder, sym)
+}
+
+// DefineSymbolProperty sets a symbol-keyed data property with an explicit
+// writable/enumerable/configurable combination - the symbol-keyed
+// counterpart of DefineOwnProperty, backing
+// Object.defineProperty(arr, sym, {value, writable, enumerable, configurable}).
+// Converts an existing accessor at this key back into a data property,
+// mirroring DefineOwnProperty's/ArrayDefineOwnProperty's handling of the
+// same conversion for named keys.
+func (a *ArrayObject) DefineSymbolProperty(sym *SymbolObject, value Value, writable, enumerable, configurable bool) {
+	if a.symbolGetters != nil {
+		delete(a.symbolGetters, sym)
+	}
+	if a.symbolSetters != nil {
+		delete(a.symbolSetters, sym)
+	}
+	a.noteSymbolPropOrder(sym)
+	if a.symbolProps == nil {
+		a.symbolProps = make(map[*SymbolObject]Value)
+	}
+	a.symbolProps[sym] = value
+	if a.symbolPropertyDesc == nil {
+		a.symbolPropertyDesc = make(map[*SymbolObject]PropertyDesc)
+	}
+	a.symbolPropertyDesc[sym] = PropertyDesc{
+		Writable:     writable,
+		Enumerable:   enumerable,
+		Configurable: configurable,
+	}
+}
+
+// GetSymbolPropertyDescriptor returns the descriptor for a symbol-keyed data
+// property - the symbol-keyed counterpart of GetOwnPropertyDescriptor. A
+// symbol whose value was set via the plain SetSymbolProp path (`arr[sym] =
+// v`, never touched by Object.defineProperty) has no entry in
+// symbolPropertyDesc and reports the ES ordinary-property default
+// (writable/enumerable/configurable all true), same as GetOwnPropertyDescriptor
+// does for a plain named property.
+func (a *ArrayObject) GetSymbolPropertyDescriptor(sym *SymbolObject) (Value, PropertyDesc, bool) {
+	v, ok := a.GetSymbolProp(sym)
+	if !ok {
+		return Undefined, PropertyDesc{}, false
+	}
+	if a.symbolPropertyDesc != nil {
+		if desc, hasDesc := a.symbolPropertyDesc[sym]; hasDesc {
+			return v, desc, true
+		}
+	}
+	return v, PropertyDesc{Writable: true, Enumerable: true, Configurable: true}, true
+}
+
+// DefineSymbolAccessorProperty defines a symbol-keyed accessor property - the
+// symbol-keyed counterpart of DefineAccessorProperty, backing
+// Object.defineProperty(arr, sym, {get, set, ...}).
+func (a *ArrayObject) DefineSymbolAccessorProperty(sym *SymbolObject, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+	a.noteSymbolPropOrder(sym)
+	if a.symbolGetters == nil {
+		a.symbolGetters = make(map[*SymbolObject]Value)
+	}
+	if a.symbolSetters == nil {
+		a.symbolSetters = make(map[*SymbolObject]Value)
+	}
+	if hasGetter {
+		a.symbolGetters[sym] = getter
+	}
+	if hasSetter {
+		a.symbolSetters[sym] = setter
+	}
+
+	desc := PropertyDesc{
+		Writable:     false, // accessors don't have writable
+		Enumerable:   false,
+		Configurable: true,
+	}
+	if enumerable != nil {
+		desc.Enumerable = *enumerable
+	}
+	if configurable != nil {
+		desc.Configurable = *configurable
+	}
+	if a.symbolPropertyDesc == nil {
+		a.symbolPropertyDesc = make(map[*SymbolObject]PropertyDesc)
+	}
+	a.symbolPropertyDesc[sym] = desc
+
+	// Converting a data property into an accessor: drop the plain value,
+	// mirroring DefineAccessorProperty's delete(a.properties, name).
+	if a.symbolProps != nil {
+		delete(a.symbolProps, sym)
+	}
+}
+
+// HasSymbolAccessors reports whether this array has ever had a symbol-keyed
+// accessor property defined on it - the symbol-keyed counterpart of
+// HasAccessors, letting hot per-symbol paths (opGetPropSymbol/opSetPropSymbol)
+// skip the GetOwnSymbolAccessor map probe on the overwhelmingly common array
+// that has never had one.
+func (a *ArrayObject) HasSymbolAccessors() bool {
+	return a.symbolGetters != nil || a.symbolSetters != nil
+}
+
+// GetOwnSymbolAccessor returns the getter and setter for a symbol-keyed
+// accessor property - the symbol-keyed counterpart of GetOwnAccessor.
+// Returns (getter, setter, enumerable, configurable, isAccessor).
+func (a *ArrayObject) GetOwnSymbolAccessor(sym *SymbolObject) (Value, Value, bool, bool, bool) {
+	hasGetter := a.symbolGetters != nil && a.symbolGetters[sym].Type() != 0
+	hasSetter := a.symbolSetters != nil && a.symbolSetters[sym].Type() != 0
+
+	if !hasGetter && !hasSetter {
+		return Undefined, Undefined, false, false, false
+	}
+
+	getter := Undefined
+	setter := Undefined
+	if a.symbolGetters != nil {
+		if g, ok := a.symbolGetters[sym]; ok {
+			getter = g
+		}
+	}
+	if a.symbolSetters != nil {
+		if s, ok := a.symbolSetters[sym]; ok {
+			setter = s
+		}
+	}
+
+	enumerable := false
+	configurable := true
+	if a.symbolPropertyDesc != nil {
+		if desc, ok := a.symbolPropertyDesc[sym]; ok {
+			enumerable = desc.Enumerable
+			configurable = desc.Configurable
+		}
+	}
+
+	return getter, setter, enumerable, configurable, true
 }
 
 // DefineAccessorProperty defines an accessor property on the array object
@@ -3683,26 +3866,47 @@ func formatDateTimestamp(timestamp float64) string {
 	return t.Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
 }
 
-// DeleteSymbolProp removes a symbol-keyed own property from the array object
-// and reports whether it was present. Symbol-keyed array properties are
-// ordinary configurable properties, so removal always succeeds.
+// DeleteSymbolProp removes a symbol-keyed own property from the array
+// object and reports whether the delete succeeded. A symbol with no own
+// property at all trivially succeeds (OrdinaryDelete 10.1.7 step 2: nothing
+// to reject). A symbol-keyed property with no tracked descriptor (a plain
+// `arr[sym] = v` assignment, never touched by Object.defineProperty) is an
+// ordinary configurable property and always comes off; one explicitly
+// defined non-configurable via Object.defineProperty(arr, sym,
+// {configurable: false, ...}) - now representable via symbolPropertyDesc,
+// see ArrayDefineOwnSymbolProperty (array_props.go) - must be left alone and
+// report failure instead, matching OrdinaryDelete's [[Configurable]] check
+// the same way DeleteOwn already does for named properties.
 func (a *ArrayObject) DeleteSymbolProp(sym *SymbolObject) bool {
-	if a.symbolProps == nil {
-		return false
+	if !a.HasOwnSymbolProp(sym) {
+		return true
 	}
-	_, existed := a.symbolProps[sym]
-	delete(a.symbolProps, sym)
-	if existed {
-		// Keep symbolPropOrder in sync - a re-added key after deletion
-		// gets a fresh, later creation-order position via SetSymbolProp's
-		// own "not already present" check, matching how deleting then
-		// redefining an ordinary property moves it to the end too.
-		for i, s := range a.symbolPropOrder {
-			if s == sym {
-				a.symbolPropOrder = append(a.symbolPropOrder[:i], a.symbolPropOrder[i+1:]...)
-				break
-			}
+	if a.symbolPropertyDesc != nil {
+		if desc, ok := a.symbolPropertyDesc[sym]; ok && !desc.Configurable {
+			return false
 		}
 	}
-	return existed
+	if a.symbolProps != nil {
+		delete(a.symbolProps, sym)
+	}
+	if a.symbolGetters != nil {
+		delete(a.symbolGetters, sym)
+	}
+	if a.symbolSetters != nil {
+		delete(a.symbolSetters, sym)
+	}
+	if a.symbolPropertyDesc != nil {
+		delete(a.symbolPropertyDesc, sym)
+	}
+	// Keep symbolPropOrder in sync - a re-added key after deletion gets a
+	// fresh, later creation-order position via noteSymbolPropOrder's own
+	// "not already present" check, matching how deleting then redefining an
+	// ordinary property moves it to the end too.
+	for i, s := range a.symbolPropOrder {
+		if s == sym {
+			a.symbolPropOrder = append(a.symbolPropOrder[:i], a.symbolPropOrder[i+1:]...)
+			break
+		}
+	}
+	return true
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17096,13 +17096,24 @@ startExecution:
 				// numeric index's configurability comes from the array-wide
 				// `frozen` flag rather than a per-element bit.
 				arr := obj.AsArray()
-				keyStr := key.ToString()
-				if idx, isNumeric := tryParseArrayIndex(keyStr); isNumeric {
-					success = arr.DeleteIndex(idx)
-				} else if key.Type() != TypeSymbol {
-					success = arr.DeleteOwn(keyStr)
+				if key.Type() == TypeSymbol {
+					// Symbol-keyed properties can now be explicitly defined
+					// non-configurable via Object.defineProperty (see
+					// ArrayDefineOwnSymbolProperty, array_props.go) - route
+					// through DeleteSymbolProp so a `delete arr[sym]` both
+					// respects that and actually removes the entry (data,
+					// accessor, and descriptor alike) rather than
+					// unconditionally reporting success while leaving the
+					// property in place, which used to be safe only because
+					// every symbol property was implicitly configurable.
+					success = arr.DeleteSymbolProp(key.AsSymbolObject())
 				} else {
-					success = true
+					keyStr := key.ToString()
+					if idx, isNumeric := tryParseArrayIndex(keyStr); isNumeric {
+						success = arr.DeleteIndex(idx)
+					} else {
+						success = arr.DeleteOwn(keyStr)
+					}
 				}
 			} else if obj.Type() == TypeString {
 				// String primitives: indices within length are non-configurable

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1373,7 +1373,25 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 	case TypeArray:
 		arr := obj.AsArray()
 		if arr != nil {
-			if v, ok := arr.GetSymbolProp(sym.AsSymbolObject()); ok {
+			symObj := sym.AsSymbolObject()
+			// A symbol-keyed accessor defined via Object.defineProperty(arr,
+			// sym, {get, set}) takes priority over the plain symbolProps
+			// value - mirrors getOwnFromTableByKey's accessor-then-data
+			// order just above, and opGetPropSymbol's own TypeArray case
+			// (pkg/vm/op_getprop.go), which this function must agree with
+			// per PR #350's own invariant (arr[sym] === Reflect.get(arr,
+			// sym)) - Object.defineProperty on a symbol key was itself
+			// still a no-op when that invariant was written, so this
+			// couldn't yet be tested there. See ArrayObject.GetOwnSymbolAccessor.
+			if arr.HasSymbolAccessors() {
+				if g, _, _, _, ok := arr.GetOwnSymbolAccessor(symObj); ok {
+					if g.Type() == TypeUndefined {
+						return Undefined, nil
+					}
+					return vm.Call(g, receiver, nil)
+				}
+			}
+			if v, ok := arr.GetSymbolProp(symObj); ok {
 				return v, nil
 			}
 			if vm.ArrayPrototype.IsObject() {

--- a/tests/scripts/array_defineproperty_symbol.ts
+++ b/tests/scripts/array_defineproperty_symbol.ts
@@ -1,0 +1,297 @@
+// expect: true
+// Object.defineProperty(arr, sym, {...}) was a silent no-op for arrays: it
+// neither threw nor stored anything, for both data and accessor
+// descriptors, on any array-typed target:
+//
+//   const arr = [1, 2]; const s = Symbol("d");
+//   Object.defineProperty(arr, s, {value: 7, writable: false, enumerable: false, configurable: false});
+//   arr[s];                                    // before: undefined - Node: 7
+//   Object.getOwnPropertyDescriptor(arr, s);    // before: undefined - Node: {value:7,writable:false,enumerable:false,configurable:false}
+//   Object.getOwnPropertySymbols(arr).length;   // before: 0 - Node: 1
+//
+//   const a2 = [1, 2]; const s2 = Symbol("g");
+//   Object.defineProperty(a2, s2, { get() { return 99; } });
+//   a2[s2];                                     // before: undefined - Node: 99
+//
+// Root cause: ArrayObject's existing accessor/attribute-override storage
+// (getters/setters/propertyDesc, pkg/vm/value.go) is keyed by string only -
+// unlike symbolProps (map[*SymbolObject]Value), which stores a bare value
+// with no attribute tracking at all. objectDefinePropertyWithVM
+// (pkg/builtins/object_init.go) never had a symbol-key branch for TypeArray
+// either - a symbol key fell through every propName-gated check (all
+// meaningless for a symbol, since propName is "" for one) and landed on the
+// TypeObject-only block below, which a TypeArray value never satisfies.
+//
+// Fixed by adding symbol-keyed counterparts of the existing string-keyed
+// storage - symbolPropertyDesc/symbolGetters/symbolSetters on ArrayObject -
+// plus ArrayDefineOwnSymbolProperty (pkg/vm/array_props.go, mirroring
+// ArrayDefineOwnProperty's non-index tail) to implement
+// [[DefineOwnProperty]] for a symbol key, and wiring it into
+// objectDefinePropertyWithVM, Object.getOwnPropertyDescriptor's TypeArray
+// branch, and the read (opGetPropSymbol) / write (opSetPropSymbol) bytecode
+// paths so an accessor's getter/setter actually fires.
+//
+// This also surfaced (and fixes) a second, independent gap: `delete
+// arr[sym]` (OpDeleteIndex's TypeArray case, pkg/vm/vm.go) unconditionally
+// reported success without ever calling ArrayObject.DeleteSymbolProp,
+// relying on the old invariant that every symbol property was implicitly
+// configurable (true before this fix, since Object.defineProperty could
+// never make one otherwise). Now that a symbol property can be
+// non-configurable, or an accessor, `delete` is routed through
+// DeleteSymbolProp so it both respects configurability and actually clears
+// accessor/descriptor state on success - see checks 5-6 below. Same gap,
+// same fix, for Reflect.deleteProperty (pkg/builtins/reflect_delete.go).
+//
+// Every check below (including exact attribute values, TypeError on an
+// illegal redefinition, and delete's success/failure split) was verified
+// against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Data descriptor, all attributes false: round-trips through
+// arr[sym], Object.getOwnPropertyDescriptor, and Object.getOwnPropertySymbols. ---
+{
+  const arr: any = [1, 2];
+  const s = Symbol("d");
+  Object.defineProperty(arr, s, {
+    value: 7,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  const desc = Object.getOwnPropertyDescriptor(arr, s) as any;
+  const syms = Object.getOwnPropertySymbols(arr);
+  checks.push(
+    arr[s] === 7 &&
+      desc !== undefined &&
+      desc.value === 7 &&
+      desc.writable === false &&
+      desc.enumerable === false &&
+      desc.configurable === false &&
+      syms.length === 1 &&
+      syms[0] === s
+  );
+}
+
+// --- 2. Data descriptor, all attributes true (the ordinary-property
+// default) - distinguishes "attributes are tracked at all" from "tracked
+// attributes happen to read back as their zero value". ---
+{
+  const arr2: any = [1, 2];
+  const s2 = Symbol("all-true");
+  Object.defineProperty(arr2, s2, {
+    value: "v",
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  const desc2 = Object.getOwnPropertyDescriptor(arr2, s2) as any;
+  checks.push(
+    arr2[s2] === "v" &&
+      desc2.writable === true &&
+      desc2.enumerable === true &&
+      desc2.configurable === true
+  );
+}
+
+// --- 3. Data descriptor, a mixed combination (writable, non-enumerable,
+// configurable) - the two attributes above aren't just being ORed/ANDed
+// together into one bit. ---
+{
+  const arr3: any = [1, 2];
+  const s3 = Symbol("mixed");
+  Object.defineProperty(arr3, s3, {
+    value: 1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  const desc3 = Object.getOwnPropertyDescriptor(arr3, s3) as any;
+  checks.push(
+    desc3.writable === true &&
+      desc3.enumerable === false &&
+      desc3.configurable === true
+  );
+}
+
+// --- 4. Accessor property: `arr[sym]` invokes the getter (not a stored
+// value), and the getter is called freshly on every read. ---
+{
+  const arr4: any = [1, 2];
+  const s4 = Symbol("g");
+  let calls = 0;
+  Object.defineProperty(arr4, s4, {
+    get() {
+      calls++;
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const first = arr4[s4];
+  const second = arr4[s4];
+  const desc4 = Object.getOwnPropertyDescriptor(arr4, s4) as any;
+  checks.push(
+    first === 99 &&
+      second === 99 &&
+      calls === 2 &&
+      typeof desc4.get === "function" &&
+      desc4.set === undefined &&
+      desc4.enumerable === true &&
+      desc4.configurable === true &&
+      !("value" in desc4) &&
+      !("writable" in desc4)
+  );
+}
+
+// --- 5. Accessor property with both get and set: assignment invokes the
+// setter (not overwriting a plain data slot), and the getter reflects
+// whatever the setter stored. ---
+{
+  const arr5: any = [1, 2];
+  const s5 = Symbol("gs");
+  let backing = 0;
+  Object.defineProperty(arr5, s5, {
+    get() {
+      return backing;
+    },
+    set(v: number) {
+      backing = v * 2;
+    },
+    configurable: true,
+  });
+  arr5[s5] = 21;
+  checks.push(arr5[s5] === 42 && backing === 42);
+}
+
+// --- 6. Object.getOwnPropertySymbols / Reflect.ownKeys include a symbol
+// defined via Object.defineProperty (not just via a plain `arr[sym] = v`
+// assignment - the array_getownpropertysymbols.ts test already covers that
+// path; this one exercises the descriptor-based path added by this fix). ---
+{
+  const arr6: any = [1, 2, 3];
+  const s6 = Symbol("via-define");
+  Object.defineProperty(arr6, s6, { value: "x", enumerable: true });
+  const syms6 = Object.getOwnPropertySymbols(arr6);
+  const keys6 = Reflect.ownKeys(arr6);
+  checks.push(
+    syms6.length === 1 &&
+      syms6[0] === s6 &&
+      keys6[keys6.length - 1] === s6
+  );
+}
+
+// --- 7. A non-configurable symbol property rejects a defineProperty call
+// that tries to widen configurable/enumerable or change writable - and
+// `delete arr[sym]` reports failure and leaves the property in place
+// (exercises the OpDeleteIndex fix: it used to unconditionally report
+// success without even checking, back when every symbol property was
+// implicitly configurable). ---
+{
+  const arr7: any = [1, 2];
+  const s7 = Symbol("locked");
+  Object.defineProperty(arr7, s7, {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  let threw = false;
+  try {
+    Object.defineProperty(arr7, s7, { configurable: true });
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  const deleteResult = delete arr7[s7];
+  const stillHasIt = s7 in arr7;
+  const stillReadsAsOne = arr7[s7] === 1;
+  checks.push(threw && deleteResult === false && stillHasIt && stillReadsAsOne);
+}
+
+// --- 8. A configurable accessor property CAN be deleted, and deleting it
+// actually removes the property (not just reporting success while leaving
+// the getter/setter behind) - `sym in arr` and getOwnPropertyDescriptor
+// both agree it's gone afterward. ---
+{
+  const arr8: any = [1, 2];
+  const s8 = Symbol("removable");
+  Object.defineProperty(arr8, s8, {
+    get() {
+      return 5;
+    },
+    configurable: true,
+  });
+  const deleteResult = delete arr8[s8];
+  checks.push(
+    deleteResult === true &&
+      !(s8 in arr8) &&
+      Object.getOwnPropertyDescriptor(arr8, s8) === undefined &&
+      Object.getOwnPropertySymbols(arr8).length === 0
+  );
+}
+
+// --- 9. Reflect.deleteProperty agrees with the `delete` operator for a
+// non-configurable symbol property on an array (same underlying
+// DeleteSymbolProp fix, different call site - pkg/builtins/reflect_delete.go). ---
+{
+  const arr9: any = [1, 2];
+  const s9 = Symbol("reflect-locked");
+  Object.defineProperty(arr9, s9, { value: 1, configurable: false });
+  const result9 = Reflect.deleteProperty(arr9, s9);
+  checks.push(result9 === false && s9 in arr9);
+}
+
+// --- 10. Reflect.get(arr, sym) agrees with `arr[sym]` for a symbol
+// accessor - the accessor's getter must fire either way, and both with a
+// default receiver and an explicit one (called as `this`). A sibling read
+// path (getSymbolPropertyWithReceiver, pkg/vm/vm_init.go) backs
+// Reflect.get and had its own, independent no-accessor-check gap - the
+// same class of bug array_getownpropertysymbols.ts's header describes
+// (opGetPropSymbol vs. Reflect.get drifting apart), just for the
+// accessor case this fix newly makes possible. ---
+{
+  const arr10: any = [1, 2];
+  const s10 = Symbol("g10");
+  const receiverProbe = { tag: "probe" };
+  Object.defineProperty(arr10, s10, {
+    get() {
+      return (this as any) === receiverProbe ? "receiver" : "self";
+    },
+    configurable: true,
+  });
+  checks.push(
+    arr10[s10] === "self" &&
+      Reflect.get(arr10, s10) === "self" &&
+      Reflect.get(arr10, s10, receiverProbe) === "receiver"
+  );
+}
+
+// --- 11. Object.getOwnPropertyDescriptors (plural) includes a symbol
+// property on an array, agreeing with the singular
+// Object.getOwnPropertyDescriptor for the same key - the plural function
+// collects its own key list per source kind and had no symbol-key
+// collection for TypeArray at all, so it silently dropped every array
+// symbol property regardless of how it was defined. ---
+{
+  const arr11: any = [1, 2];
+  const s11 = Symbol("plural");
+  Object.defineProperty(arr11, s11, {
+    value: 3,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  const all = Object.getOwnPropertyDescriptors(arr11) as any;
+  const single = Object.getOwnPropertyDescriptor(arr11, s11) as any;
+  checks.push(
+    all[s11] !== undefined &&
+      all[s11].value === 3 &&
+      all[s11].writable === false &&
+      all[s11].enumerable === false &&
+      all[s11].configurable === false &&
+      all[s11].value === single.value &&
+      all[s11].writable === single.writable
+  );
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

`Object.defineProperty(arr, sym, {...})` was a silent no-op for arrays - it neither stored anything nor threw, for both data and accessor descriptors:

```js
const arr = [1, 2];
const s = Symbol("d");
Object.defineProperty(arr, s, {value: 7, writable: false, enumerable: false, configurable: false});
console.log(arr[s]);                                    // before: undefined - Node: 7
console.log(Object.getOwnPropertyDescriptor(arr, s));    // before: undefined - Node: {value: 7, writable: false, enumerable: false, configurable: false}
console.log(Object.getOwnPropertySymbols(arr).length);   // before: 0 - Node: 1
```

### Root cause

`ArrayObject`'s existing accessor/attribute-override storage (`getters`/`setters`/`propertyDesc`, `pkg/vm/value.go`) is keyed by `string` only - unlike `symbolProps` (`map[*SymbolObject]Value`), which stores a bare value with no attribute tracking or accessor support at all. `objectDefinePropertyWithVM` (`pkg/builtins/object_init.go`) also had no symbol-key branch for `TypeArray` at all - a symbol key fell through every propName-gated array check (meaningless for a symbol, since propName is `""`) and landed on the `TypeObject`-only block, which a `TypeArray` value never satisfies.

### Fix

Added symbol-keyed counterparts of the existing string-keyed storage (`symbolPropertyDesc`/`symbolGetters`/`symbolSetters` on `ArrayObject`) plus `ArrayDefineOwnSymbolProperty` (mirroring `ArrayDefineOwnProperty`'s non-index tail), and wired it into every call site that needs to agree on this behavior:

- `objectDefinePropertyWithVM` - the actual `Object.defineProperty` entry point
- `Object.getOwnPropertyDescriptor`'s `TypeArray` branch - previously hardcoded `writable`/`enumerable`/`configurable` to `true`, only safe because `defineProperty` was itself a no-op
- `Object.getOwnPropertyDescriptors` (plural) - never collected array symbol keys at all
- `opGetPropSymbol`/`opSetPropSymbol` (the bracket-access bytecode read/write paths) - now invoke the accessor's getter/setter
- `getSymbolPropertyWithReceiver` (backs `Reflect.get`) - same accessor wiring, so a bracket read and `Reflect.get` agree, per the cross-path invariant #350 established
- `ArrayObject.DeleteSymbolProp` - now respects configurability and clears accessor/descriptor state, instead of assuming every symbol property is configurable (true before this fix, since `defineProperty` could never say otherwise)
- `OpDeleteIndex`'s `TypeArray` case and `Reflect.deleteProperty` - route a symbol-keyed delete through the above instead of unconditionally reporting success

Also fixed a latent bug surfaced by review: `SetSymbolProp` checked only `symbolProps` for "does this key already have an order position", which stopped being sufficient once an accessor-only symbol (no `symbolProps` entry) could exist - could have appended a duplicate `symbolPropOrder` entry, making `getOwnPropertySymbols` list a symbol twice.

### Tests

`tests/scripts/array_defineproperty_symbol.ts` covers: data descriptors (multiple attribute combinations, including all-false and all-true), accessor descriptors (getter/setter invocation), `getOwnPropertySymbols`/`Reflect.ownKeys` inclusion, delete semantics (configurable vs non-configurable, data vs accessor, both `delete` and `Reflect.deleteProperty`), and `Reflect.get`/receiver handling for accessors. Every case verified against real Node.js output.

`go test ./tests -run TestScripts -timeout 180s` passes with no regressions.

### Known, deliberately unfixed gap (documented in code)

Redefining a non-configurable, non-writable symbol-keyed data property with a *different* value should throw (10.1.6.3 step 4e-ii) but doesn't - this mirrors an identical, pre-existing gap in the named-key path (`ArrayDefineOwnProperty`), so it's left as-is for parity rather than fixed only for symbols.

Three unrelated gaps found during review were filed as separate follow-ups rather than folded into this PR (each has its own broader scope: checker `in`-narrowing on `any`, `Reflect.set` never handling symbol keys at all, and `Object.assign`/spread never copying an array's named or symbol properties).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
