### PR TITLE
fix(checker): in-narrowing on any/unknown no longer leaks its marker type

### DIFF
--- a/pkg/checker/narrowing.go
+++ b/pkg/checker/narrowing.go
@@ -705,7 +705,43 @@ func (c *Checker) applyPositiveTypeNarrowing(guard *TypeGuard) *Environment {
 	var canNarrow bool
 	var narrowedType types.Type
 
-	if originalType == types.Unknown && guard.NarrowedType != nil {
+	_, originalIsUnion := originalType.(*types.UnionType)
+	if _, isPropMarker := guard.NarrowedType.(*types.PropertyExistenceMarker); isPropMarker && !originalIsUnion {
+		// A PropertyExistenceMarker ("prop" in x, or a symbol-key `in`
+		// check - see detectTypeGuard's Pattern 4) is a filter for UNION
+		// members (consumed by the UnionType branch below via
+		// typeHasProperty/filterUnionByProperty), not a real standalone
+		// type - "x has property p" doesn't by itself refine what x IS
+		// when x isn't already a union of candidates to narrow among.
+		//
+		// Falling through to the generic types.IsAssignable(guard.
+		// NarrowedType, originalType) branch below used to let this marker
+		// get assigned as x's actual narrowed type whenever originalType
+		// was Any or Unknown - IsAssignable trivially succeeds for
+		// "anything is assignable to Any/from Unknown" - silently
+		// replacing a plain `any`/`unknown` variable's real type with the
+		// bare marker for the rest of the enclosing narrowed scope
+		// (notably the remainder of a `&&` chain - see
+		// applyTypeNarrowingFromCondition, which composes each operand's
+		// narrowing into the next). A later index/member access on that
+		// variable then type-checked against the marker's synthetic
+		// "has-property-[[Symbol]]"/"has-property-<name>" pseudo-type
+		// instead of its real one:
+		//
+		//   const arr: any = [1, 2]; const s = Symbol("x");
+		//   true && s in arr && arr[s] === 1;
+		//   // before: PS2001 "cannot apply index operator to type has-property-[[Symbol]]"
+		//   // Node:   type-checks fine (arr stays `any` throughout)
+		//
+		// For a concrete non-union, non-Any/Unknown original type (e.g. an
+		// interface), this was already effectively a no-op - IsAssignable
+		// rejects the marker against anything but Any/Unknown - so this
+		// branch doesn't change observable behavior there, only for the
+		// two universal types where it was silently wrong. canNarrow stays
+		// false, same as the "cannot narrow" fallback below.
+		debugPrintf("// [TypeNarrowing] Property-existence guard on non-union '%s' (%s) - marker has nothing to filter, leaving type unchanged\n",
+			guard.VariableName, originalType.String())
+	} else if originalType == types.Unknown && guard.NarrowedType != nil {
 		// Unknown can be narrowed to any specific type
 		canNarrow = true
 		narrowedType = guard.NarrowedType

--- a/tests/scripts/narrow_in_symbol_any.ts
+++ b/tests/scripts/narrow_in_symbol_any.ts
@@ -1,0 +1,165 @@
+// expect: true
+// The checker's `in`-based control-flow narrowing rejected type-checking a
+// symbol-key `in` check immediately followed by a symbol-key index read on
+// the same `any`-typed variable, inside one logical expression - even
+// though the variable is declared `any` and should permit any index
+// operation regardless of narrowing:
+//
+//   const arr: any = [1, 2];
+//   const s = Symbol("x");
+//   console.log(true && s in arr && arr[s] === 1);
+//   // before: PS2001 "cannot apply index operator to type has-property-[[Symbol]]"
+//   // Node:   type-checks fine, prints false (arr[s] is undefined)
+//
+// Splitting the same checks across separate statements (assigning `s in
+// arr` to a variable first, then indexing `arr[s]` later) avoided the
+// error - so the bug was specifically about narrowing applied INLINE
+// within the same `&&` chain right before a symbol-key index access, not
+// about `in`-narrowing or symbol indexing individually.
+//
+// Root cause: detectTypeGuard's Pattern 4 ("prop" in x, or a symbol-key `in`
+// check) produces a TypeGuard whose NarrowedType is a
+// *types.PropertyExistenceMarker - a synthetic marker meant only to FILTER
+// a union type's members down to the ones that have the property (see
+// applyPositiveTypeNarrowing's UnionType branch, which consumes it via
+// typeHasProperty). Outside a union, that marker isn't a real type at all.
+// But applyPositiveTypeNarrowing's generic non-union fallback branch -
+// `guard.NarrowedType != nil && types.IsAssignable(guard.NarrowedType,
+// originalType)` - fired for it anyway whenever originalType was `any` (or
+// `unknown`, handled by its own even-more-permissive branch just above),
+// since "anything is assignable to Any" trivially includes the marker.
+// That replaced `arr`'s real `any` type with the bare marker for the rest
+// of the narrowed scope (the remainder of the `&&` chain, per
+// applyTypeNarrowingFromCondition's left-to-right composition) - so
+// `arr[s]` then type-checked against the marker's synthetic
+// "has-property-[[Symbol]]" pseudo-type instead of `any`, and failed.
+//
+// Fixed in applyPositiveTypeNarrowing (pkg/checker/narrowing.go) by
+// special-casing a PropertyExistenceMarker guard on a non-union original
+// type: there's nothing for the marker to filter, so it leaves the type
+// unchanged (matches the "cannot narrow" no-op path) instead of assigning
+// the marker itself. Checks below cover both a symbol key and a string
+// key (the same marker type backs both), a missing property/symbol
+// (`false` case, not just `true`), and confirm the pre-existing use of
+// this marker to narrow a real union still works unaffected.
+//
+// Deliberately NOT touched: paserati's `typeof x === "string"` on an
+// `any`-typed x DOES narrow x to `string` (unlike real TypeScript, which
+// keeps `any` as `any` through such a check) - a separate, pre-existing,
+// much broader behavior this fix does not change. Only
+// PropertyExistenceMarker (the `in`-check guard) was special-cased, since
+// unlike a real type such as `string`, it is never itself a valid type to
+// assign to a variable - it exists purely to filter union members.
+
+type UnionA = { kind: "a"; value: number };
+type UnionB = { kind: "b" };
+function describeUnion(x: UnionA | UnionB): number {
+  if ("value" in x) {
+    return x.value;
+  }
+  return -1;
+}
+
+const checks: boolean[] = [];
+
+// --- 1. The exact reported repro: symbol-key `in` immediately followed by
+// a symbol-key index read on the same `any` variable, in one `&&` chain. ---
+{
+  const arr: any = [1, 2];
+  const s = Symbol("x");
+  checks.push((true && s in arr && arr[s] === 1) === false);
+}
+
+// --- 2. Same shape, but the symbol property actually exists - the `in`
+// check is true, and `any` still permits the index read to see the real
+// value (not just "doesn't crash"). Uses a plain object rather than an
+// array: whether an array's OWN symbol-keyed property round-trips through
+// `arr[sym]` at all is unrelated, separately-tracked work (this repo's
+// array-symbol-property support lives in its own PR stack) - this check
+// is only about the checker's narrowing, not that runtime behavior. ---
+{
+  const o2: any = {};
+  const s2 = Symbol("y");
+  o2[s2] = 42;
+  checks.push(true && s2 in o2 && o2[s2] === 42);
+}
+
+// --- 3. String-key `in` on an `any` variable, same inline-chain shape -
+// detectTypeGuard's Pattern 4 produces the identical PropertyExistenceMarker
+// for a string key, so this hit the same bug. ---
+{
+  const o: any = { foo: 1 };
+  checks.push(true && "foo" in o && o.foo === 1);
+  checks.push(true && "foo" in o && o["foo"] === 1);
+}
+
+// --- 4. `in` narrowing negated by a following `||` doesn't crash either -
+// sanity check that the fix didn't just special-case the exact `&&` shape
+// from the repro. ---
+{
+  const o2: any = { bar: 2 };
+  const result = false || ("bar" in o2 && o2.bar === 2);
+  checks.push(result === true);
+}
+
+// --- 5. Sanity: `in` narrowing on a genuine UNION still works (the marker
+// is still meaningful there - this task must not have broken the one case
+// where PropertyExistenceMarker is actually consumed as a filter). ---
+{
+  checks.push(describeUnion({ kind: "a", value: 7 }) === 7);
+  checks.push(describeUnion({ kind: "b" }) === -1);
+}
+
+// --- 6. The INVERTED (else-branch) counterpart of check 1/2, on a plain
+// identifier - applyInvertedTypeNarrowing's non-member-expression path
+// only consumes PropertyExistenceMarker inside its own UnionType branch
+// (gated on `originalType.(*types.UnionType)`), so a non-union `any`
+// already fell through to that function's final "no inverted narrowing
+// applied, return nil" path untouched - unlike the positive side, this
+// direction never had a generic Any/Unknown fallback that could leak the
+// marker in. Verified by inspection AND here: this must keep working
+// exactly as it already did, not because this task changed it. ---
+{
+  const o3: any = { foo: 1 };
+  const s3 = Symbol("z");
+  let sawUndefined = false;
+  if (s3 in o3) {
+    checks.push(false); // s3 was never set - must not reach here
+  } else {
+    sawUndefined = o3[s3] === undefined;
+  }
+  checks.push(sawUndefined);
+
+  let sawFoo = false;
+  if ("bar" in o3) {
+    checks.push(false); // "bar" was never set - must not reach here
+  } else {
+    sawFoo = o3.foo === 1;
+  }
+  checks.push(sawFoo);
+}
+
+// --- 7. A dotted member-expression base ("prop" in holder.inner), also
+// `any` - applyPositiveTypeNarrowing's separate member-expression branch
+// (isMemberExpression=true) routes a PropertyExistenceMarker through
+// filterUnionByProperty instead of the chain this task patched.
+// filterUnionByProperty's own non-union fallback already calls
+// typeHasProperty(originalType, name), which returns false for Any (Any
+// matches none of typeHasProperty's cases) - so `narrowed` comes back
+// false and this path already correctly declines to narrow, leaving
+// holder.inner as `any`. Verified by inspection AND here, both branches,
+// for the same reason as check 6: this task didn't touch it, but it
+// needs to stay covered so a future change to filterUnionByProperty
+// can't silently reintroduce the same class of bug for this call site. ---
+{
+  const holder: { inner: any } = { inner: { foo: 1 } };
+  checks.push(true && "foo" in holder.inner && holder.inner.foo === 1);
+
+  if ("bar" in holder.inner) {
+    checks.push(false); // "bar" was never set - must not reach here
+  } else {
+    checks.push(holder.inner.foo === 1);
+  }
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

A symbol-key (or string-key) `in` check immediately followed by an index read on the same `any`-typed variable, inside one logical expression, failed to type-check:

```ts
const arr: any = [1, 2];
const s = Symbol("x");
console.log(true && s in arr && arr[s] === 1);
```

```
PS2001 [ERROR]: cannot apply index operator to type has-property-[[Symbol]]
console.log(true && s in arr && arr[s] === 1);
                                    ^
```

Node type-checks this fine (it's plain JS) and prints `false`.

### Root cause

`detectTypeGuard`'s `"prop" in x` pattern produces a `TypeGuard` whose `NarrowedType` is a `*types.PropertyExistenceMarker` - a synthetic marker meant only to filter a **union** type's members down to the ones that have the property. Outside a union, it isn't a real type at all.

But `applyPositiveTypeNarrowing`'s generic non-union fallback branch (`types.IsAssignable(guard.NarrowedType, originalType)`) fired for it anyway whenever `originalType` was `Any` (or `Unknown`), since "anything is assignable to Any" trivially includes the marker. That replaced the variable's real type with the bare marker for the rest of the narrowed scope - specifically, the remainder of a `&&` chain, per `applyTypeNarrowingFromCondition`'s left-to-right composition - so the subsequent `arr[s]` type-checked against the marker's synthetic `has-property-[[Symbol]]` pseudo-type instead of `any`.

### Fix

Special-cased a `PropertyExistenceMarker` guard on a non-union original type in `applyPositiveTypeNarrowing`: there's nothing for the marker to filter outside a union, so it now leaves the type unchanged (the same no-op as the existing "cannot narrow" fallback) instead of assigning the marker itself.

**Scoped narrowly** to `PropertyExistenceMarker` rather than "never narrow `any`" - I checked, and paserati's `typeof x === "string"` on an `any`-typed `x` deliberately *does* narrow `x` to `string` (unlike real TypeScript), which is a separate, pre-existing, much broader behavior this PR does not touch. `PropertyExistenceMarker` is different in kind: unlike a real type such as `string`, it is never a valid standalone type, only a union filter, so narrowing to it outside a union is never meaningful regardless of what the original type was.

I also checked the inverted (else-branch) counterpart and the dotted-member-expression variant of this same guard (`"prop" in holder.inner`) - both were already safe by construction, since neither has a generic Any/Unknown fallback that could leak the marker in. No fix was needed there, but I added regression coverage for both so a future change can't silently reintroduce the same class of bug.

### Tests

`tests/scripts/narrow_in_symbol_any.ts` covers: the exact reported repro, a present-vs-absent symbol/string property, an `||`-chain variant, a genuine-union sanity check (the one case where the marker is still meaningfully consumed), the inverted else-branch path, and a dotted member-expression base. Every case verified against real Node.js output.

`go test ./...` passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
