### PR TITLE
fix(builtins,vm): Object.assign and spread copy an array's named/symbol properties

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3368,6 +3368,64 @@ func setObjectAssignTargetProperty(vmInstance *vm.VM, target vm.Value, key strin
 	return nil
 }
 
+// setObjectAssignTargetPropertyByKey is setObjectAssignTargetProperty for a
+// symbol key - backing Object.assign's own symbol-key copy loops below
+// (previously nonexistent: no source branch ever walked a symbol key at
+// all, so there was nothing to write here either - see objectAssignWithVM's
+// doc comment). Mirrors the string-key version's exact per-target-kind
+// scope: an accessor is only checked for a TypeObject target (the
+// string-key version doesn't check one for TypeArray or the callable
+// side-table kinds either - a separate, narrower, pre-existing limitation
+// this function deliberately doesn't widen).
+//
+// There is no PlainObject.SetOwnByKey (only the string-keyed SetOwn, which
+// itself implements "preserve existing writable/enumerable/configurable,
+// default a brand-new key to true/true/true"), so the TypeObject and
+// callable-side-table branches reproduce that same rule explicitly via
+// HasOwnByKey + DefineOwnPropertyByKey, matching vm.setOwnCheckedByKey's
+// identical pattern (pkg/vm/properties_table.go) for the same "ordinary
+// [[Set]], not Object.defineProperty" distinction that function's own doc
+// comment explains - and the identical pattern this session's Reflect.set
+// symbol-key fix (reflectCreateOrUpdateDataPropertyByKey) already used for
+// the same reason.
+func setObjectAssignTargetPropertyByKey(vmInstance *vm.VM, target vm.Value, sym vm.Value, value vm.Value) error {
+	key := vm.NewSymbolKey(sym)
+	switch target.Type() {
+	case vm.TypeObject:
+		plainTarget := target.AsPlainObject()
+		if _, setter, _, _, isAccessor := plainTarget.GetOwnAccessorByKey(key); isAccessor {
+			if setter.Type() == vm.TypeUndefined {
+				return nil // accessor with no setter: [[Set]] silently no-ops (non-strict)
+			}
+			_, err := vmInstance.Call(setter, target, []vm.Value{value})
+			return err
+		}
+		if plainTarget.HasOwnByKey(key) {
+			plainTarget.DefineOwnPropertyByKey(key, value, nil, nil, nil)
+		} else {
+			w, e, c := true, true, true
+			plainTarget.DefineOwnPropertyByKey(key, value, &w, &e, &c)
+		}
+	case vm.TypeDictObject:
+		// DictObjects have no symbol-keyed storage at all - matches every
+		// other DictObject-and-symbols case in this codebase.
+	case vm.TypeArray:
+		if symObj := sym.AsSymbolObject(); symObj != nil {
+			target.AsArray().SetSymbolProp(symObj, value)
+		}
+	case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+		if props := vm.EnsureOwnPropertiesTable(target); props != nil {
+			if props.HasOwnByKey(key) {
+				props.DefineOwnPropertyByKey(key, value, nil, nil, nil)
+			} else {
+				w, e, c := true, true, true
+				props.DefineOwnPropertyByKey(key, value, &w, &e, &c)
+			}
+		}
+	}
+	return nil
+}
+
 func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
@@ -3439,6 +3497,49 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 					return vm.Undefined, err
 				}
 			}
+			// Symbol-keyed own properties - this loop never existed at all,
+			// so Object.assign silently dropped every symbol property a
+			// TypeObject source had, plain or accessor, regardless of
+			// enumerability (verified against Node, which copies an
+			// enumerable one and skips a non-enumerable one, exactly like
+			// the string-key loop just above):
+			//
+			//   const o = {}; const s = Symbol("x"); o[s] = "v";
+			//   Object.assign({}, o)[s]; // before: undefined - Node: "v"
+			//
+			// Same accessor-invokes-getter rule as the string-key loop
+			// (paserati#274) - OwnSymbolKeys() (unlike OwnKeys()) isn't
+			// pre-filtered to enumerable-only, since a symbol key can only
+			// become non-enumerable via an explicit Object.defineProperty,
+			// which is comparatively rare - so this filters explicitly per
+			// key instead.
+			for _, symVal := range plainObj.OwnSymbolKeys() {
+				symKey := vm.NewSymbolKey(symVal)
+				var value vm.Value
+				if getter, _, enumerable, _, isAccessor := plainObj.GetOwnAccessorByKey(symKey); isAccessor {
+					if !enumerable {
+						continue
+					}
+					if getter.Type() == vm.TypeUndefined {
+						value = vm.Undefined
+					} else {
+						var err error
+						value, err = vmInstance.Call(getter, source, nil)
+						if err != nil {
+							return vm.Undefined, err
+						}
+					}
+				} else {
+					v, _, enumerable, _, ok := plainObj.GetOwnDescriptorByKey(symKey)
+					if !ok || !enumerable {
+						continue
+					}
+					value = v
+				}
+				if err := setObjectAssignTargetPropertyByKey(vmInstance, target, symVal, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
 		} else if source.Type() == vm.TypeDictObject {
 			dictObj := source.AsDictObject()
 			for _, key := range dictObj.OwnKeys() {
@@ -3478,6 +3579,113 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 				key := strconv.Itoa(idx)
 				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// Named (non-index) accessor properties, e.g.
+			// Object.defineProperty(arr, "foo", {get, set, enumerable}) -
+			// stored in getters/setters, never in `properties` (see
+			// ArrayObject.DefineAccessorProperty's own doc comment), so the
+			// named-data loop just below can't see these at all. This whole
+			// branch - named string properties on an array source, accessor
+			// or plain - never existed prior to this fix: Object.assign(
+			// {}, arr) only ever copied indexed elements, silently dropping
+			// anything set via `arr.foo = ...` or Object.defineProperty:
+			//
+			//   const arr = [1, 2]; arr.foo = "bar";
+			//   Object.assign({}, arr).foo; // before: undefined - Node: "bar"
+			//
+			// AccessorKeys() can also report a numeric-index key (an
+			// accessor installed AT an array index via Object.defineProperty
+			// - ParseArrayIndex skips those here since the dense/sparse
+			// index loops above already own that key space (though neither
+			// of those loops actually invokes an index accessor's getter
+			// today - a separate, narrower, pre-existing gap not touched by
+			// this fix; see arraySparseIndexValue's own accessor handling
+			// for the sparse-index case, which DOES get this right - the
+			// gap is specific to the DENSE-range loop above, whose
+			// arrObj.Get(i) reads straight from `elements` with no accessor
+			// check at all). Deliberately vm.ParseArrayIndex, NOT
+			// vm.LooksLikeArrayIndex: the latter has no upper bound, so a key
+			// like "4294967295" (past the 2^32-2 array-index ceiling) would
+			// look like an index here and get skipped, while arraySparseIndices'
+			// own vm.ParseArrayIndex-based filter (used below) also rejects it
+			// as too big - the two filters must use the SAME predicate or a
+			// key can fall in the gap between them and vanish entirely.
+			for _, name := range arrObj.AccessorKeys() {
+				if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+					continue
+				}
+				getter, _, enumerable, _, isAccessor := arrObj.GetOwnAccessor(name)
+				if !isAccessor || !enumerable {
+					continue
+				}
+				var value vm.Value
+				if getter.Type() == vm.TypeUndefined {
+					value = vm.Undefined
+				} else {
+					var err error
+					value, err = vmInstance.Call(getter, source, nil)
+					if err != nil {
+						return vm.Undefined, err
+					}
+				}
+				if err := setObjectAssignTargetProperty(vmInstance, target, name, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// Named (non-index) plain data properties, e.g. `arr.foo = "bar"`.
+			// NamedPropertyKeys() (despite its doc comment) also returns any
+			// sparse-index key sharing the same `properties` map - already
+			// handled above via arraySparseIndices - so vm.ParseArrayIndex
+			// filters those back out here, the exact same predicate
+			// arraySparseIndices itself uses to find only the ones that ARE
+			// indices (not vm.LooksLikeArrayIndex, which has no upper bound
+			// and would leave an out-of-range numeric key like
+			// "4294967295" matched by neither filter - see the AccessorKeys
+			// loop above for the full explanation).
+			for _, name := range arrObj.NamedPropertyKeys() {
+				if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+					continue
+				}
+				value, enumerable, ok := arrObj.GetNamedPropertyDescriptor(name)
+				if !ok || !enumerable {
+					continue
+				}
+				if err := setObjectAssignTargetProperty(vmInstance, target, name, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// Symbol-keyed properties, plain or accessor (see
+			// ArrayDefineOwnSymbolProperty, pkg/vm/array_props.go) - same
+			// gap and same fix shape as the TypeObject source branch's own
+			// symbol loop above, just against ArrayObject's own symbol
+			// storage (GetOwnSymbolAccessor/GetSymbolPropertyDescriptor)
+			// instead of PlainObject's.
+			for _, symVal := range arrObj.OwnSymbolKeys() {
+				symObj := symVal.AsSymbolObject()
+				var value vm.Value
+				if getter, _, enumerable, _, isAccessor := arrObj.GetOwnSymbolAccessor(symObj); isAccessor {
+					if !enumerable {
+						continue
+					}
+					if getter.Type() == vm.TypeUndefined {
+						value = vm.Undefined
+					} else {
+						var err error
+						value, err = vmInstance.Call(getter, source, nil)
+						if err != nil {
+							return vm.Undefined, err
+						}
+					}
+				} else {
+					v, desc, ok := arrObj.GetSymbolPropertyDescriptor(symObj)
+					if !ok || !desc.Enumerable {
+						continue
+					}
+					value = v
+				}
+				if err := setObjectAssignTargetPropertyByKey(vmInstance, target, symVal, value); err != nil {
 					return vm.Undefined, err
 				}
 			}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -9541,8 +9541,10 @@ startExecution:
 				continue
 			}
 
-			// Only process actual objects (non-Proxy)
-			if sourceVal.Type() != TypeObject && sourceVal.Type() != TypeDictObject {
+			// Only process actual objects (non-Proxy). TypeArray used to be
+			// excluded here too - see the TypeArray case in the switch
+			// below for what that silently dropped.
+			if sourceVal.Type() != TypeObject && sourceVal.Type() != TypeDictObject && sourceVal.Type() != TypeArray {
 				// For other primitive types, they should be converted to objects first
 				// But for now, skip them as they typically have no enumerable properties
 				continue
@@ -9678,6 +9680,231 @@ startExecution:
 									destObj.DefineOwnPropertyByKey(key, value, &w, &e, &c)
 								}
 							}
+						}
+					}
+					// DictObject doesn't support symbol keys, so skip for DictObject destination
+				}
+			case TypeArray:
+				// A TypeArray source used to fall straight into the
+				// `sourceVal.Type() != TypeObject && sourceVal.Type() !=
+				// TypeDictObject` skip above and contribute NOTHING to the
+				// destination - not just missing named/symbol properties
+				// (the gap this case exists to close), but missing even the
+				// array's own indexed elements:
+				//
+				//   const arr = [1, 2, 3]; arr.foo = "bar";
+				//   const s = Symbol("s"); arr[s] = "v";
+				//   ({...arr});
+				//   // before: {} (nothing copied at all)
+				//   // Node:   {0: 1, 1: 2, 2: 3, foo: "bar"} (plus the
+				//   //         symbol, invisible to a plain {} print but
+				//   //         present - see this file's Object.assign
+				//   //         equivalent, pkg/builtins/object_init.go,
+				//   //         which this case is built to match: object
+				//   //         spread and Object.assign both implement
+				//   //         ECMAScript's CopyDataProperties abstract
+				//   //         operation, so they must copy the same set of
+				//   //         properties).
+				//
+				// Mirrors the TypeObject case just above: dense indices,
+				// then sparse indices beyond DenseLength() (paserati#176/
+				// #178 - see arraySparseIndices's own doc comment for why a
+				// naive 0..Length() loop would hang), then named (non-index)
+				// properties - accessor first since DefineAccessorProperty
+				// removes a converted key from `properties` entirely, then
+				// plain data - then symbol-keyed properties, accessor or
+				// plain, via ArrayObject's own symbol storage (see
+				// ArrayDefineOwnSymbolProperty, array_props.go).
+				arr := AsArray(sourceVal)
+				denseLen := arr.DenseLength()
+				for i := 0; i < denseLen; i++ {
+					key := strconv.Itoa(i)
+					if getter, _, enumerable, _, isAccessor := arr.GetOwnAccessor(key); isAccessor {
+						if !enumerable {
+							continue
+						}
+						var value Value
+						if getter.Type() != TypeUndefined {
+							frame.ip = ip
+							res, err := vm.Call(getter, sourceVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("Error calling getter for index '%s': %v", key, err)
+								}
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									registers = frame.registers
+									ip = frame.ip
+									goto reloadFrame
+								}
+								return InterpretRuntimeError, Undefined
+							}
+							value = res
+						} else {
+							value = Undefined
+						}
+						if destVal.Type() == TypeDictObject {
+							AsDictObject(destVal).SetOwn(key, value)
+						} else {
+							AsPlainObject(destVal).SetOwn(key, value)
+						}
+						continue
+					}
+					if !arr.HasIndex(i) {
+						continue // hole - not an own property at all (paserati#300)
+					}
+					value := arr.Get(i)
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(key, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(key, value)
+					}
+				}
+				for _, idx := range arraySparseIndices(arr, true) {
+					key := strconv.Itoa(idx)
+					var value Value
+					if getter, _, _, _, isAccessor := arr.GetOwnAccessor(key); isAccessor {
+						if getter.Type() != TypeUndefined {
+							frame.ip = ip
+							res, err := vm.Call(getter, sourceVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("Error calling getter for index '%s': %v", key, err)
+								}
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									registers = frame.registers
+									ip = frame.ip
+									goto reloadFrame
+								}
+								return InterpretRuntimeError, Undefined
+							}
+							value = res
+						} else {
+							value = Undefined
+						}
+					} else if v, ok := arr.GetOwn(key); ok {
+						value = v
+					}
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(key, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(key, value)
+					}
+				}
+				for _, name := range arr.AccessorKeys() {
+					// tryParseArrayIndex, not LooksLikeArrayIndex: the latter has
+					// no upper bound, so an out-of-range numeric key like
+					// "4294967295" would look like an index here and get
+					// skipped, while the dense/sparse loops above (which use
+					// tryParseArrayIndex, via arraySparseIndices) would also
+					// reject it as too big to be an index - leaving it matched
+					// by neither loop and silently dropped. Both filters must
+					// use the same predicate so they partition the key space
+					// exactly.
+					if _, isIndex := tryParseArrayIndex(name); isIndex {
+						continue // an index accessor - already handled above
+					}
+					getter, _, enumerable, _, isAccessor := arr.GetOwnAccessor(name)
+					if !isAccessor || !enumerable {
+						continue
+					}
+					var value Value
+					if getter.Type() != TypeUndefined {
+						frame.ip = ip
+						res, err := vm.Call(getter, sourceVal, nil)
+						if err != nil {
+							if ee, ok := err.(ExceptionError); ok {
+								vm.throwException(ee.GetExceptionValue())
+							} else {
+								vm.runtimeError("Error calling getter for property '%s': %v", name, err)
+							}
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								registers = frame.registers
+								ip = frame.ip
+								goto reloadFrame
+							}
+							return InterpretRuntimeError, Undefined
+						}
+						value = res
+					} else {
+						value = Undefined
+					}
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(name, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(name, value)
+					}
+				}
+				for _, name := range arr.NamedPropertyKeys() {
+					// tryParseArrayIndex - see the matching comment on the
+					// AccessorKeys loop above for why this can't be
+					// LooksLikeArrayIndex.
+					if _, isIndex := tryParseArrayIndex(name); isIndex {
+						continue // a sparse index sharing this map - already handled above
+					}
+					value, enumerable, ok := arr.GetNamedPropertyDescriptor(name)
+					if !ok || !enumerable {
+						continue
+					}
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(name, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(name, value)
+					}
+				}
+				for _, sym := range arr.OwnSymbolKeys() {
+					symKey := NewSymbolKey(sym)
+					symObj := sym.AsSymbolObject()
+					if getter, _, enumerable, _, isAccessor := arr.GetOwnSymbolAccessor(symObj); isAccessor {
+						if !enumerable {
+							continue
+						}
+						var value Value
+						if getter.Type() != TypeUndefined {
+							frame.ip = ip
+							res, err := vm.Call(getter, sourceVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("Error calling getter for symbol property: %v", err)
+								}
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									registers = frame.registers
+									ip = frame.ip
+									goto reloadFrame
+								}
+								return InterpretRuntimeError, Undefined
+							}
+							value = res
+						} else {
+							value = Undefined
+						}
+						if destVal.Type() == TypeObject {
+							destObj := AsPlainObject(destVal)
+							w, e, c := true, true, true
+							destObj.DefineOwnPropertyByKey(symKey, value, &w, &e, &c)
+						}
+					} else if value, desc, ok := arr.GetSymbolPropertyDescriptor(symObj); ok && desc.Enumerable {
+						if destVal.Type() == TypeObject {
+							destObj := AsPlainObject(destVal)
+							w, e, c := true, true, true
+							destObj.DefineOwnPropertyByKey(symKey, value, &w, &e, &c)
 						}
 					}
 					// DictObject doesn't support symbol keys, so skip for DictObject destination

--- a/tests/scripts/object_assign_spread_array_named_symbol_props.ts
+++ b/tests/scripts/object_assign_spread_array_named_symbol_props.ts
@@ -1,0 +1,225 @@
+// expect: true
+// Object.assign(target, arr) only ever copied an array's indexed elements
+// (dense + sparse, paserati#176/#178) plus (for an object/dict target)
+// "length" - it never copied a named string property (`arr.foo = ...`,
+// plain or an accessor via Object.defineProperty) or ANY symbol-keyed
+// property at all (plain or accessor), regardless of enumerability.
+// Object-literal spread (`{...arr}`) had an even broader version of the
+// same gap: a TypeArray source was excluded entirely, before the
+// string-key/symbol-key copying loops even started, so it contributed
+// NOTHING - not even the indexed elements:
+//
+//   const arr = [1, 2, 3]; arr.foo = "bar";
+//   const sym = Symbol("s"); arr[sym] = "sym-val";
+//
+//   Object.assign({}, arr);
+//   // before: {0: 1, 1: 2, 2: 3}                      - missing foo AND the symbol
+//   // Node:   {0: 1, 1: 2, 2: 3, foo: "bar"} plus the symbol (verified below)
+//
+//   ({...arr});
+//   // before: {}                                       - missing everything, even the indices
+//   // Node:   {0: 1, 1: 2, 2: 3, foo: "bar"} plus the symbol
+//
+// Fixed by adding named-property (accessor-then-plain, mirroring how
+// DefineAccessorProperty removes a converted key from the plain-data
+// store entirely) and symbol-property (via ArrayObject's own symbol
+// storage - ArrayDefineOwnSymbolProperty, pkg/vm/array_props.go) copy
+// loops to Object.assign's TypeArray source branch
+// (pkg/builtins/object_init.go), and a whole new TypeArray case to
+// object-literal spread's bytecode handler (pkg/vm/vm.go) covering the
+// same set of properties - the two must stay in sync, since ECMAScript
+// defines both operations in terms of the same CopyDataProperties
+// abstract operation.
+//
+// Both fixes call an accessor's getter (never copy the bare data slot
+// underneath it - paserati#274's rule, already applied elsewhere) and
+// skip a non-enumerable property entirely (own-enumerable-properties is
+// CopyDataProperties' own filter, not a data/accessor distinction).
+//
+// Every check below was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. A plain enumerable named string property (`arr.foo = ...`) is
+// copied by both operations. ---
+{
+  const arr: any = [1, 2];
+  arr.foo = "bar";
+  const viaAssign = Object.assign({}, arr);
+  const viaSpread: any = { ...arr };
+  checks.push(viaAssign.foo === "bar" && viaSpread.foo === "bar");
+}
+
+// --- 2. A non-enumerable named string property (defined via
+// Object.defineProperty) is NOT copied by either operation. ---
+{
+  const arr2: any = [1, 2];
+  Object.defineProperty(arr2, "hidden", {
+    value: "h",
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign2 = Object.assign({}, arr2);
+  const viaSpread2: any = { ...arr2 };
+  checks.push(
+    !("hidden" in viaAssign2) &&
+      !("hidden" in viaSpread2) &&
+      viaAssign2.hidden === undefined &&
+      viaSpread2.hidden === undefined
+  );
+}
+
+// --- 3. A named ENUMERABLE ACCESSOR property invokes its getter exactly
+// once per operation - the value copied is what the getter returns, not
+// a stale/absent data slot (accessors are stored separately from plain
+// data - see DefineAccessorProperty's own doc comment). ---
+{
+  const arr3: any = [1, 2];
+  let calls = 0;
+  Object.defineProperty(arr3, "computed", {
+    get() {
+      calls++;
+      return 42;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const viaAssign3 = Object.assign({}, arr3);
+  const viaSpread3: any = { ...arr3 };
+  checks.push(
+    viaAssign3.computed === 42 && viaSpread3.computed === 42 && calls === 2
+  );
+}
+
+// --- 4. A named NON-enumerable accessor property is not copied, and its
+// getter is never invoked (no observable side effect from skipping it). ---
+{
+  const arr4: any = [1, 2];
+  let calls4 = 0;
+  Object.defineProperty(arr4, "hiddenAcc", {
+    get() {
+      calls4++;
+      return 99;
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign4 = Object.assign({}, arr4);
+  const viaSpread4: any = { ...arr4 };
+  checks.push(
+    !("hiddenAcc" in viaAssign4) && !("hiddenAcc" in viaSpread4) && calls4 === 0
+  );
+}
+
+// --- 5. A plain enumerable symbol-keyed property (`arr[sym] = v`) is
+// copied by both operations - the exact shape of the originally reported
+// bug. ---
+{
+  const arr5: any = [1, 2, 3];
+  const sym5 = Symbol("plain");
+  arr5[sym5] = "sym-val";
+  const viaAssign5 = Object.assign({}, arr5);
+  const viaSpread5: any = { ...arr5 };
+  checks.push(viaAssign5[sym5] === "sym-val" && viaSpread5[sym5] === "sym-val");
+}
+
+// --- 6. A non-enumerable symbol-keyed data property (defined via
+// Object.defineProperty) is NOT copied by either operation. ---
+{
+  const arr6: any = [1, 2];
+  const sym6 = Symbol("hidden");
+  Object.defineProperty(arr6, sym6, {
+    value: "hv",
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign6 = Object.assign({}, arr6);
+  const viaSpread6: any = { ...arr6 };
+  checks.push(
+    !(sym6 in viaAssign6) &&
+      !(sym6 in viaSpread6) &&
+      viaAssign6[sym6] === undefined &&
+      viaSpread6[sym6] === undefined
+  );
+}
+
+// --- 7. A symbol-keyed ENUMERABLE ACCESSOR property (get/set via
+// Object.defineProperty) invokes its getter, exactly once per operation. ---
+{
+  const arr7: any = [1, 2];
+  const sym7 = Symbol("symacc");
+  let calls7 = 0;
+  Object.defineProperty(arr7, sym7, {
+    get() {
+      calls7++;
+      return "sav";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const viaAssign7 = Object.assign({}, arr7);
+  const viaSpread7: any = { ...arr7 };
+  checks.push(
+    viaAssign7[sym7] === "sav" && viaSpread7[sym7] === "sav" && calls7 === 2
+  );
+}
+
+// --- 8. A symbol-keyed NON-enumerable accessor property is not copied,
+// and its getter is never invoked. ---
+{
+  const arr8: any = [1, 2];
+  const sym8 = Symbol("hiddensymacc");
+  let calls8 = 0;
+  Object.defineProperty(arr8, sym8, {
+    get() {
+      calls8++;
+      return "nope";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign8 = Object.assign({}, arr8);
+  const viaSpread8: any = { ...arr8 };
+  checks.push(!(sym8 in viaAssign8) && !(sym8 in viaSpread8) && calls8 === 0);
+}
+
+// --- 9. Sanity: the array's own indexed elements are still copied
+// alongside its named/symbol properties (spread's TypeArray case is
+// brand new - it must not have dropped the basic indexed-copy behavior
+// while adding named/symbol coverage). ---
+{
+  const arr9: any = [10, 20, 30];
+  arr9.tag = "meta";
+  const viaAssign9 = Object.assign({}, arr9);
+  const viaSpread9: any = { ...arr9 };
+  checks.push(
+    viaAssign9[0] === 10 &&
+      viaAssign9[1] === 20 &&
+      viaAssign9[2] === 30 &&
+      viaAssign9.tag === "meta" &&
+      viaSpread9[0] === 10 &&
+      viaSpread9[1] === 20 &&
+      viaSpread9[2] === 30 &&
+      viaSpread9.tag === "meta"
+  );
+}
+
+// --- 10. A named string key that LOOKS numeric but is beyond the
+// canonical array-index bound (2^32 - 2, ECMA-262 6.1.7's definition of
+// an array index) is an ordinary named property, not an index - and must
+// land in the named-property copy loop, not the sparse-index loop, which
+// rejects it as too big. Both loops filter with the same "is this a
+// canonical array index" predicate the sparse-index loop itself uses, so
+// a key like this can't fall in the gap between the two and vanish. ---
+{
+  const arr10: any = [1, 2];
+  arr10["4294967295"] = "past-bound";
+  const viaAssign10 = Object.assign({}, arr10);
+  const viaSpread10: any = { ...arr10 };
+  checks.push(
+    viaAssign10["4294967295"] === "past-bound" &&
+      viaSpread10["4294967295"] === "past-bound"
+  );
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Bug

`Object.assign(target, arr)` only ever copied an array source's indexed elements (dense + sparse). It never copied a named string property (`arr.foo = ...`, plain or accessor) or any symbol-keyed property (plain or accessor via `Object.defineProperty`) at all:

```js
const arr = [1, 2, 3];
arr.foo = "bar";
const sym = Symbol("s");
arr[sym] = "sym-val";

Object.assign({}, arr);
// before: {0: 1, 1: 2, 2: 3}                                    - missing foo AND the symbol
// Node:   {0: 1, 1: 2, 2: 3, foo: "bar", [sym]: "sym-val"}
```

Object-literal spread (`{...arr}`) had a broader version of the same gap: a `TypeArray` source was excluded before the copy loop even started, so it contributed **nothing** — not even the indices:

```js
({...arr});
// before: {}
// Node:   {0: 1, 1: 2, 2: 3, foo: "bar", [sym]: "sym-val"}
```

## Fix

- `pkg/builtins/object_init.go`: `objectAssignWithVM`'s `TypeArray` source branch gained named-accessor, named-plain-data, and symbol-property copy loops (enumerable-only, invoking a getter for an accessor — same pattern already used for the `TypeObject` source branch, `paserati#274`, and this function's own sparse-index handling, `paserati#300`). While building the symbol loop, found `Object.assign` was *also* missing symbol-key copying for a plain-**object** source — a broader pre-existing gap than what was reported. Fixed with a matching symbol loop on the `TypeObject` branch too, via a new `setObjectAssignTargetPropertyByKey` helper covering every target kind `Object.assign` already supports.
- `pkg/vm/vm.go`: the object-literal-spread bytecode handler's early skip now lets `TypeArray` sources through, and a full `case TypeArray:` was added mirroring the pre-existing `case TypeObject:` — dense indices, sparse indices, named accessors, named plain data, and symbol properties (accessor + plain).
- Both new named-property loops filter out numeric-looking keys with `vm.ParseArrayIndex`/`tryParseArrayIndex` rather than `vm.LooksLikeArrayIndex` — the latter has no upper bound, so an out-of-range key like `"4294967295"` (past the 2³²-2 array-index ceiling) would be skipped by *both* the named-property loop (looks like an index) and the sparse-index loop (too big to be one), vanishing from the copy entirely. Both loops now use the same predicate `arraySparseIndices` itself uses, so they partition the key space with no gap.

## Out of scope (filed as follow-up)

Two narrower, pre-existing gaps found while investigating, left unfixed here: `Object.keys(arr)` doesn't enumerate a named enumerable **accessor** property at all, and neither `Object.assign`'s nor spread's dense-index copy loop invokes an accessor installed *at* a numeric index via `Object.defineProperty` (both read the stale data slot). Different mechanism, different call sites than what this ticket described.

## Tests

`tests/scripts/object_assign_spread_array_named_symbol_props.ts` — 10 checks covering, for both `Object.assign` and spread: a plain named string property, a non-enumerable named string property, a named enumerable accessor (getter invoked exactly once per operation), a named non-enumerable accessor (never invoked), a plain symbol property, a non-enumerable symbol data property, a symbol-keyed enumerable accessor (getter invoked exactly once per operation), a symbol-keyed non-enumerable accessor (never invoked), a sanity check that indices are still copied, and the out-of-range numeric-key case. Every check verified against real Node.js output.

`go build ./...`, `gofmt`, `go vet ./...`, and `go test ./...` all clean, no regressions.

Based on `fix-array-defineproperty-symbol` (#353): the symbol-accessor test cases depend on that PR's `Object.defineProperty(arr, sym, {...})` support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
