### PR TITLE
fix(builtins,vm): arrays' named accessor properties and index accessors reach enumeration/copy operations

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1816,6 +1816,103 @@ func arraySparseIndexValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Val
 	return vm.Undefined, nil
 }
 
+// arrayDenseIndexValue reads the value at a dense-range array index (i <
+// DenseLength()), calling its getter if Object.defineProperty installed
+// an accessor there instead of blindly trusting arrObj.Get(i), which reads
+// `elements` directly with no accessor check at all. An index accessor is
+// never written into elements in the first place - see
+// ArrayDefineOwnProperty's own doc comment ("Every read path that knows
+// about per-index accessors ... checks GetOwnAccessor before ever
+// consulting the elements slice, so nothing needs to be written there") -
+// this is exactly one of those read paths, previously missed:
+//
+//	const arr = [1, 2, 3];
+//	Object.defineProperty(arr, "1", { get() { return 99; }, enumerable: true });
+//	arr[1];                    // 99 - the index-access path already checks
+//	Object.assign({}, arr)[1]; // before: 2 (stale element) - Node: 99
+//
+// The sparse half of this same read (arraySparseIndexValue, above) already
+// gets it right; this is its dense-range counterpart.
+func arrayDenseIndexValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Value, i int) (vm.Value, error) {
+	key := strconv.Itoa(i)
+	if getter, _, _, _, isAccessor := a.GetOwnAccessor(key); isAccessor {
+		if getter.Type() == vm.TypeUndefined {
+			return vm.Undefined, nil
+		}
+		return vmInstance.Call(getter, receiver, nil)
+	}
+	return a.Get(i), nil
+}
+
+// arrayNamedKeys returns an array's own named (non-index) property keys:
+// AccessorKeys() (an accessor installed via Object.defineProperty lives in
+// getters/setters, never in `properties` - see ArrayObject.
+// DefineAccessorProperty's own doc comment, which explicitly deletes the
+// properties entry when converting a plain property to an accessor, so a
+// given name lives in at most one of the two stores at a time) followed by
+// NamedPropertyKeys() (plain data). Both are filtered with
+// vm.ParseArrayIndex - not vm.LooksLikeArrayIndex, which has no upper
+// bound and would let an out-of-range numeric key like "4294967295" slip
+// past both this filter and arraySparseIndices' own vm.ParseArrayIndex
+// filter, vanishing from enumeration entirely - to exclude a sparse index
+// sharing either map, which arraySparseIndices already covers.
+//
+// Before this, a named ACCESSOR property was invisible to every array
+// enumeration/collection operation that walked NamedPropertyKeys() alone:
+//
+//	const arr = [1, 2];
+//	Object.defineProperty(arr, "foo", { get() { return 5; }, enumerable: true });
+//	Object.keys(arr); // before: ["0","1"] - Node: ["0","1","foo"]
+//
+// enumerableOnly mirrors arraySparseIndices' own parameter: true for
+// for-in/Object.keys/values/entries/Object.assign (own-ENUMERABLE-
+// properties only, per CopyDataProperties/EnumerableOwnPropertyNames),
+// false for Object.getOwnPropertyNames/Reflect.ownKeys (every own key
+// regardless of enumerability).
+func arrayNamedKeys(a *vm.ArrayObject, enumerableOnly bool) []string {
+	var keys []string
+	for _, name := range a.AccessorKeys() {
+		if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+			continue
+		}
+		if enumerableOnly {
+			if _, _, enumerable, _, isAccessor := a.GetOwnAccessor(name); !isAccessor || !enumerable {
+				continue
+			}
+		}
+		keys = append(keys, name)
+	}
+	for _, name := range a.NamedPropertyKeys() {
+		if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+			continue
+		}
+		if enumerableOnly {
+			if _, enumerable, ok := a.GetNamedPropertyDescriptor(name); !ok || !enumerable {
+				continue
+			}
+		}
+		keys = append(keys, name)
+	}
+	return keys
+}
+
+// arrayNamedKeyValue reads the value of a named (non-index) own property
+// arrayNamedKeys already found, calling its getter if it's an accessor -
+// the named-key counterpart to arrayDenseIndexValue/arraySparseIndexValue,
+// for Object.values/entries.
+func arrayNamedKeyValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Value, name string) (vm.Value, error) {
+	if getter, _, _, _, isAccessor := a.GetOwnAccessor(name); isAccessor {
+		if getter.Type() == vm.TypeUndefined {
+			return vm.Undefined, nil
+		}
+		return vmInstance.Call(getter, receiver, nil)
+	}
+	if v, _, ok := a.GetNamedPropertyDescriptor(name); ok {
+		return v, nil
+	}
+	return vm.Undefined, nil
+}
+
 func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined to object")
@@ -2042,14 +2139,11 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			keysArray.Append(vm.NewString(strconv.Itoa(idx)))
 		}
 		// Named own properties (an exec result's index/input/groups/indices,
-		// or anything stored on the array) follow the indices.
-		for _, key := range arrObj.NamedPropertyKeys() {
-			if vm.LooksLikeArrayIndex(key) {
-				continue
-			}
-			if _, enumerable, ok := arrObj.GetNamedPropertyDescriptor(key); ok && enumerable {
-				keysArray.Append(vm.NewString(key))
-			}
+		// or anything stored on the array, accessor or plain) follow the
+		// indices - see arrayNamedKeys' own doc comment for why this can't
+		// be NamedPropertyKeys() alone.
+		for _, key := range arrayNamedKeys(arrObj, true) {
+			keysArray.Append(vm.NewString(key))
 		}
 	case vm.TypeArguments:
 		argsObj := obj.AsArguments()
@@ -2476,7 +2570,14 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
-			valuesArray.Append(arrObj.Get(i))
+			// arrayDenseIndexValue, not arrObj.Get(i) - see that function's
+			// own doc comment for why a plain element read misses an index
+			// accessor installed via Object.defineProperty.
+			value, err := arrayDenseIndexValue(vmInstance, arrObj, obj, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			valuesArray.Append(value)
 		}
 		// A sparse index beyond the dense range (paserati#176/#178 - see
 		// arraySparseIndices) lives in the properties map (or, for an
@@ -2486,6 +2587,17 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		// calling the getter for an accessor index.
 		for _, idx := range arraySparseIndices(arrObj, true) {
 			value, err := arraySparseIndexValue(vmInstance, arrObj, obj, idx)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			valuesArray.Append(value)
+		}
+		// Named (non-index) own properties, accessor or plain - see
+		// arrayNamedKeys' own doc comment. Before this, Object.values(arr)
+		// never returned a value for `arr.foo = ...` at all, regardless of
+		// whether foo was a plain property or an accessor.
+		for _, key := range arrayNamedKeys(arrObj, true) {
+			value, err := arrayNamedKeyValue(vmInstance, arrObj, obj, key)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -2611,9 +2723,16 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
+			// arrayDenseIndexValue, not arrObj.Get(i) - see that function's
+			// own doc comment for why a plain element read misses an index
+			// accessor installed via Object.defineProperty.
+			value, err := arrayDenseIndexValue(vmInstance, arrObj, obj, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
 			entry := vm.NewArray()
 			entry.AsArray().Append(vm.NewString(key))
-			entry.AsArray().Append(arrObj.Get(i))
+			entry.AsArray().Append(value)
 			entriesArray.Append(entry)
 		}
 		// A sparse index beyond the dense range (paserati#176/#178 - see
@@ -2629,6 +2748,20 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			}
 			entry := vm.NewArray()
 			entry.AsArray().Append(vm.NewString(strconv.Itoa(idx)))
+			entry.AsArray().Append(value)
+			entriesArray.Append(entry)
+		}
+		// Named (non-index) own properties, accessor or plain - see
+		// arrayNamedKeys' own doc comment. Before this, Object.entries(arr)
+		// never produced an entry for `arr.foo = ...` at all, regardless of
+		// whether foo was a plain property or an accessor.
+		for _, key := range arrayNamedKeys(arrObj, true) {
+			value, err := arrayNamedKeyValue(vmInstance, arrObj, obj, key)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			entry := vm.NewArray()
+			entry.AsArray().Append(vm.NewString(key))
 			entry.AsArray().Append(value)
 			entriesArray.Append(entry)
 		}
@@ -2761,10 +2894,13 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			arrObj.Append(vm.NewString(strconv.Itoa(idx)))
 		}
 		arrObj.Append(vm.NewString("length"))
-		for _, key := range a.NamedPropertyKeys() {
-			if !vm.LooksLikeArrayIndex(key) {
-				arrObj.Append(vm.NewString(key))
-			}
+		// Named own properties (accessor or plain) - see arrayNamedKeys'
+		// own doc comment for why NamedPropertyKeys() alone missed a named
+		// accessor property here. enumerableOnly=false: getOwnPropertyNames
+		// wants every own key regardless of enumerability, same as the
+		// sparse-index loop above.
+		for _, key := range arrayNamedKeys(a, false) {
+			arrObj.Append(vm.NewString(key))
 		}
 	case vm.TypeFunction:
 		fn := obj.AsFunction()
@@ -3550,13 +3686,22 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			}
 		} else if source.Type() == vm.TypeArray {
 			arrObj := source.AsArray()
-			// For arrays, copy indexed properties
+			// For arrays, copy indexed properties. arrayDenseIndexValue, not
+			// arrObj.Get(i): HasOwnIndexProperty above correctly treats an
+			// index accessor (installed via Object.defineProperty) as
+			// existing, but a bare arrObj.Get(i) reads `elements` directly
+			// with no accessor check, so it would copy the stale
+			// underlying element instead of calling the getter - see
+			// arrayDenseIndexValue's own doc comment.
 			for i := 0; i < arrObj.DenseLength(); i++ {
 				key := strconv.Itoa(i)
 				if !arrObj.HasOwnIndexProperty(key, i) {
 					continue // hole - not an own property at all, nothing to copy (paserati#300)
 				}
-				value := arrObj.Get(i)
+				value, err := arrayDenseIndexValue(vmInstance, arrObj, source, i)
+				if err != nil {
+					return vm.Undefined, err
+				}
 				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
 					return vm.Undefined, err
 				}
@@ -5706,10 +5851,35 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 		}
 	case vm.TypeArray:
 		arr := obj.AsArray()
-		for i := 0; i < arr.Length(); i++ {
-			stringKeys = append(stringKeys, strconv.Itoa(i))
+		// This used to loop `i := 0; i < arr.Length()` - arr.Length() is
+		// the array's .length property, which a huge sparse index (one
+		// defined past maxDenseArrayDefineIndex via Object.defineProperty,
+		// see ArrayDefineOwnProperty) extends without growing `elements`
+		// at all, making this a multi-billion-iteration hang for an array
+		// that otherwise holds a handful of elements - the exact
+		// paserati#176/#178 shape every other array-key-collecting
+		// operation in this file already guards against by bounding the
+		// per-index scan to DenseLength() and walking arraySparseIndices
+		// separately (O(number of sparse entries), not O(index value)).
+		// It also never collected any NAMED (non-index) key at all -
+		// plain or accessor - so `arr.foo = "bar"` and an
+		// Object.defineProperty(arr, "foo", {get, ...}) accessor were
+		// both silently dropped, on top of the loop's own hang risk.
+		for i := 0; i < arr.DenseLength(); i++ {
+			key := strconv.Itoa(i)
+			if !arr.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
+			stringKeys = append(stringKeys, key)
+		}
+		// getOwnPropertyDescriptors wants every own key regardless of
+		// enumerability, hence enumerableOnly=false for both helpers below
+		// - matching Object.getOwnPropertyNames' own TypeArray case.
+		for _, idx := range arraySparseIndices(arr, false) {
+			stringKeys = append(stringKeys, strconv.Itoa(idx))
 		}
 		stringKeys = append(stringKeys, "length")
+		stringKeys = append(stringKeys, arrayNamedKeys(arr, false)...)
 		// This case never collected symbol keys at all, so
 		// Object.getOwnPropertyDescriptors(arr) silently dropped a symbol
 		// property entirely (whether a plain `arr[sym] = v` or one defined

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14878,10 +14878,29 @@ startExecution:
 				}
 				// Then the named (non-index) own properties: an exec result's
 				// index/input/groups/indices, or anything a program stored on
-				// the array. Sparse indices living in the named/accessor
-				// stores were already handled above.
+				// the array - accessor properties (AccessorKeys(), e.g. an
+				// Object.defineProperty(arr, "foo", {get, enumerable}) -
+				// stored in getters/setters, never in `properties`, so
+				// NamedPropertyKeys() alone can't see it) first, then plain
+				// data properties. Sparse indices living in either store were
+				// already handled above via arraySparseIndices, so both loops
+				// filter them out with tryParseArrayIndex - not
+				// LooksLikeArrayIndex, which has no upper bound and would let
+				// an out-of-range numeric key like "4294967295" slip past
+				// both this filter and arraySparseIndices' own filter,
+				// vanishing from enumeration entirely (see the matching
+				// object-spread TypeArray case above for the full
+				// explanation of that predicate mismatch).
+				for _, key := range arr.AccessorKeys() {
+					if _, isIndex := tryParseArrayIndex(key); isIndex {
+						continue
+					}
+					if _, _, enumerable, _, isAccessor := arr.GetOwnAccessor(key); isAccessor && enumerable {
+						keys = append(keys, key)
+					}
+				}
 				for _, key := range arr.NamedPropertyKeys() {
-					if LooksLikeArrayIndex(key) {
+					if _, isIndex := tryParseArrayIndex(key); isIndex {
 						continue
 					}
 					if _, enumerable, ok := arr.GetNamedPropertyDescriptor(key); ok && enumerable {

--- a/tests/scripts/array_named_accessor_enum_and_index_accessor_read.ts
+++ b/tests/scripts/array_named_accessor_enum_and_index_accessor_read.ts
@@ -1,0 +1,395 @@
+// expect: true
+// Two related gaps in how arrays' own properties get enumerated/copied,
+// both stemming from the same root causes as this session's earlier
+// array-property fixes:
+//
+// Gap 1 - a named ENUMERABLE ACCESSOR property (installed via
+// Object.defineProperty(arr, "foo", {get, enumerable: true})) was
+// invisible to every operation that collects an array's named keys by
+// walking ArrayObject.NamedPropertyKeys() alone - a plain-data-only
+// store (see DefineAccessorProperty's own doc comment: converting a
+// name to an accessor deletes its NamedPropertyKeys()/`properties`
+// entry entirely, moving it to getters/setters instead, visible only
+// via AccessorKeys()). Confirmed missing from Object.keys,
+// Object.values, Object.entries, Object.getOwnPropertyNames,
+// Reflect.ownKeys, and for-in:
+//
+//   const arr = [1, 2];
+//   Object.defineProperty(arr, "foo", { get() { return 5; }, enumerable: true });
+//   Object.keys(arr);
+//   // before: ["0", "1"]           - missing "foo"
+//   // Node:   ["0", "1", "foo"]
+//
+// Object.values/Object.entries had a broader version of the same gap:
+// they never walked ANY named property at all, accessor or plain, so
+// even a plain `arr.foo = "bar"` (no accessor involved) was dropped.
+//
+// Fixed by adding a shared arrayNamedKeys(a, enumerableOnly) helper
+// (pkg/builtins/object_init.go, mirroring the existing arraySparseIndices
+// helper's shape/doc-comment) that walks AccessorKeys() then
+// NamedPropertyKeys(), and a matching helper in pkg/vm/vm.go's own
+// for-in case (package vm has its own, separate hand-rolled duplicate of
+// this same array-property-collection logic, same as arraySparseIndices
+// does - see that function's own comment in both files).
+//
+// Gap 2 - Object.assign didn't invoke a numeric-INDEX accessor (one
+// installed AT an existing element, e.g.
+// Object.defineProperty(arr, "1", {get, enumerable: true})) at all -
+// its dense-range copy loop checked HasOwnIndexProperty (which does
+// consult accessors) to decide whether the index exists, then read the
+// VALUE via arrObj.Get(i), which returns the stale `elements` slot
+// directly with no accessor check:
+//
+//   const arr = [1, 2, 3];
+//   Object.defineProperty(arr, "1", { get() { return 99; }, enumerable: true });
+//   arr[1];                    // 99 - ordinary index access already gets this right
+//   Object.assign({}, arr)[1]; // before: 2 (stale element) - Node: 99
+//
+// Object.values/Object.entries had the identical dense-range gap.
+// Object-literal spread's TypeArray case (this session's earlier fix)
+// already got this right from the start - locked in below as a sanity
+// check, not a fix.
+//
+// Fixed with a new arrayDenseIndexValue helper (the dense-range sibling
+// of the pre-existing arraySparseIndexValue), used by Object.assign's
+// dense-index copy loop and Object.values/entries' own dense-index
+// loops.
+//
+// Object.getOwnPropertyDescriptors' TypeArray case had an even bigger
+// version of gap 1 (it collected NO named key at all, plain or
+// accessor) plus its own separate bug: it looped `i := 0; i <
+// arr.Length()` instead of bounding the per-index scan to
+// DenseLength() and walking arraySparseIndices for anything beyond it -
+// the exact paserati#176/#178 multi-billion-iteration hang shape every
+// other array-key-collecting function in this file already guards
+// against, since a sparse index far past DenseLength() extends
+// arr.Length() without growing `elements`. Fixed the same way as the
+// others: DenseLength() bound + arraySparseIndices(enumerableOnly:
+// false) + arrayNamedKeys(enumerableOnly: false).
+//
+// Every check below was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Object.keys omits a named enumerable accessor property. ---
+{
+  const arr: any = [1, 2];
+  Object.defineProperty(arr, "foo", {
+    get() {
+      return 5;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(JSON.stringify(Object.keys(arr)) === '["0","1","foo"]');
+}
+
+// --- 2. Object.values omits a plain named property entirely (not an
+// accessor at all - the broader half of the gap: this loop didn't walk
+// ANY named property before the fix, not just accessor ones). Kept as
+// its own array (rather than combined with an accessor property) since
+// paserati doesn't track true creation order across the separate
+// plain-data/accessor stores a named property can live in - Node
+// orders "plain" before "acc" here because that's insertion order, a
+// property this fix deliberately doesn't take on; see check 3 below for
+// a same-array combination that only depends on membership, not order. ---
+{
+  const arr2: any = [1, 2];
+  arr2.plain = "p";
+  checks.push(JSON.stringify(Object.values(arr2)) === "[1,2,\"p\"]");
+}
+
+// --- 3. Object.entries omits a named accessor property entirely, and
+// the getter must actually be invoked (not a stale/absent slot). ---
+{
+  const arr3: any = [1, 2];
+  let calls3 = 0;
+  Object.defineProperty(arr3, "acc", {
+    get() {
+      calls3++;
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Object.entries(arr3)) ===
+      '[["0",1],["1",2],["acc","a"]]' && calls3 === 1
+  );
+}
+
+// --- 4. Object.getOwnPropertyNames omits a named enumerable accessor
+// property (getOwnPropertyNames wants every own key regardless of
+// enumerability, so this must include a NON-enumerable one too). ---
+{
+  // Two separate arrays, not one array carrying both accessor names:
+  // AccessorKeys() (pkg/vm/value.go) walks Go maps (getters/setters),
+  // whose iteration order is randomized per run - two accessor names on
+  // the same array would make an exact-order assertion here flaky
+  // (paserati doesn't track a named property's true creation order
+  // across separate stores at all - see check 2's comment - so this
+  // isn't a fixable ordering gap, just something a test must avoid
+  // depending on when a single array holds more than one same-store
+  // named key).
+  const arr4a: any = [1, 2];
+  Object.defineProperty(arr4a, "acc", {
+    get() {
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const arr4b: any = [1, 2];
+  Object.defineProperty(arr4b, "hiddenAcc", {
+    get() {
+      return "h";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Object.getOwnPropertyNames(arr4a)) ===
+      '["0","1","length","acc"]' &&
+      JSON.stringify(Object.getOwnPropertyNames(arr4b)) ===
+        '["0","1","length","hiddenAcc"]'
+  );
+}
+
+// --- 5. Reflect.ownKeys omits a named enumerable accessor property
+// (delegates to the same collection logic as getOwnPropertyNames, so
+// this locks in that the delegation actually picked up the fix). ---
+{
+  const arr5: any = [1, 2];
+  Object.defineProperty(arr5, "acc", {
+    get() {
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Reflect.ownKeys(arr5)) === '["0","1","length","acc"]'
+  );
+}
+
+// --- 6. for-in omits a named enumerable accessor property, and skips a
+// named NON-enumerable one (for-in only visits enumerable keys). ---
+{
+  const arr6: any = [1, 2];
+  Object.defineProperty(arr6, "acc", {
+    get() {
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(arr6, "hiddenAcc", {
+    get() {
+      return "h";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const seen: string[] = [];
+  for (const k in arr6) {
+    seen.push(k);
+  }
+  checks.push(JSON.stringify(seen) === '["0","1","acc"]');
+}
+
+// --- 7. Object.assign doesn't invoke a numeric-index accessor - copies
+// the stale underlying element instead of calling the getter. ---
+{
+  const arr7: any = [1, 2, 3];
+  let calls7 = 0;
+  Object.defineProperty(arr7, "1", {
+    get() {
+      calls7++;
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const copy7 = Object.assign({}, arr7);
+  checks.push(copy7[1] === 99 && calls7 === 1);
+}
+
+// --- 8. Object.values/Object.entries also miss an index accessor's
+// real value (same dense-range gap as Object.assign). ---
+{
+  const arr8: any = [1, 2, 3];
+  Object.defineProperty(arr8, "0", {
+    get() {
+      return "zero";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Object.values(arr8)) === '["zero",2,3]' &&
+      JSON.stringify(Object.entries(arr8)) ===
+        '[["0","zero"],["1",2],["2",3]]'
+  );
+}
+
+// --- 9. Sanity: object-literal spread already invoked a dense-index
+// accessor correctly before this fix (this session's earlier
+// Object.assign/spread PR) - must still work, unchanged. ---
+{
+  const arr9: any = [1, 2, 3];
+  let calls9 = 0;
+  Object.defineProperty(arr9, "1", {
+    get() {
+      calls9++;
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const spread9: any = { ...arr9 };
+  checks.push(spread9[1] === 99 && calls9 === 1);
+}
+
+// --- 10. Sanity: a NON-enumerable named accessor is still excluded from
+// Object.keys/values/entries/Object.assign/spread (only
+// getOwnPropertyNames/Reflect.ownKeys/getOwnPropertyDescriptors want
+// non-enumerable own keys) - the enumerableOnly gate on the new
+// arrayNamedKeys helper must still work in both directions. ---
+{
+  const arr10: any = [1, 2];
+  let calls10 = 0;
+  Object.defineProperty(arr10, "hidden", {
+    get() {
+      calls10++;
+      return "h";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const keys10 = Object.keys(arr10);
+  const values10 = Object.values(arr10);
+  const assign10 = Object.assign({}, arr10);
+  const spread10: any = { ...arr10 };
+  checks.push(
+    !keys10.includes("hidden") &&
+      values10.length === 2 &&
+      !("hidden" in assign10) &&
+      !("hidden" in spread10) &&
+      calls10 === 0
+  );
+}
+
+// --- 11. Combined: an array carrying all four property shapes at once
+// (dense-index accessor, sparse-index accessor, named accessor, named
+// plain) must agree with Node across every operation in one shot - a
+// single-shape probe can pass while a combination still double-counts
+// or drops a key two different loops both claim (or both skip). ---
+{
+  const arr11: any = [1, 2, 3];
+  Object.defineProperty(arr11, "1", {
+    get() {
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(arr11, "1000", {
+    get() {
+      return "sparse";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(arr11, "namedAcc", {
+    get() {
+      return "na";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  arr11.namedPlain = "np";
+
+  const expectedKeys = '["0","1","2","1000","namedAcc","namedPlain"]';
+  const expectedValues = '[1,99,3,"sparse","na","np"]';
+  const expectedEntries =
+    '[["0",1],["1",99],["2",3],["1000","sparse"],["namedAcc","na"],["namedPlain","np"]]';
+  const expectedGopn =
+    '["0","1","2","1000","length","namedAcc","namedPlain"]';
+  const expectedAssignSpread =
+    '{"0":1,"1":99,"2":3,"1000":"sparse","namedAcc":"na","namedPlain":"np"}';
+
+  const forin: string[] = [];
+  for (const k in arr11) {
+    forin.push(k);
+  }
+
+  checks.push(
+    JSON.stringify(Object.keys(arr11)) === expectedKeys &&
+      JSON.stringify(Object.values(arr11)) === expectedValues &&
+      JSON.stringify(Object.entries(arr11)) === expectedEntries &&
+      JSON.stringify(Object.getOwnPropertyNames(arr11)) === expectedGopn &&
+      JSON.stringify(Reflect.ownKeys(arr11)) === expectedGopn &&
+      JSON.stringify(forin) === expectedKeys &&
+      JSON.stringify(Object.assign({}, arr11)) === expectedAssignSpread &&
+      JSON.stringify({ ...arr11 }) === expectedAssignSpread
+  );
+}
+
+// --- 12. Object.getOwnPropertyDescriptors omitted every named key
+// entirely (plain or accessor) - checked individually (not via a
+// whole-object JSON.stringify) so this doesn't depend on the same
+// cross-store/map-iteration ordering check 4 had to avoid. ---
+{
+  const arr12: any = [1, 2];
+  arr12.plain = "p";
+  Object.defineProperty(arr12, "acc", {
+    get() {
+      return "a";
+    },
+    set(_v: any) {},
+    enumerable: true,
+    configurable: true,
+  });
+  const descs12 = Object.getOwnPropertyDescriptors(arr12);
+  const has0 = "0" in descs12;
+  const has1 = "1" in descs12;
+  const hasLength = "length" in descs12;
+  checks.push(
+    descs12.plain.value === "p" &&
+      descs12.plain.enumerable === true &&
+      descs12.plain.writable === true &&
+      typeof descs12.acc.get === "function" &&
+      typeof descs12.acc.set === "function" &&
+      descs12.acc.value === undefined &&
+      descs12.acc.enumerable === true &&
+      has0 &&
+      has1 &&
+      hasLength
+  );
+}
+
+// --- 13. Object.getOwnPropertyDescriptors must not hang on a huge
+// sparse index (the same paserati#176/#178 shape every other
+// array-key-collecting operation in this file already guards against -
+// this function's own array-key loop used to scan 0..arr.Length()
+// directly instead of bounding to DenseLength() + arraySparseIndices).
+// No wall-clock assertion here - a hardware-dependent timing check is
+// its own kind of flaky. If the scan were still unbounded, this would
+// hang and fail the whole suite at the timeout level, which is signal
+// enough; this just asserts the result is still correct. ---
+{
+  const arr13: any = [1, 2];
+  Object.defineProperty(arr13, "1000000000", {
+    value: "far",
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  const descs13 = Object.getOwnPropertyDescriptors(arr13);
+  checks.push(
+    descs13["1000000000"].value === "far" &&
+      descs13.length.value === 1000000001
+  );
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Bugs

**Gap 1 - a named enumerable accessor on an array is invisible to key/enumeration operations.** `ArrayObject` stores a named accessor property (`Object.defineProperty(arr, "foo", {get, enumerable: true})`) in `getters`/`setters`, never in `properties` (`NamedPropertyKeys()`'s backing store) - see `DefineAccessorProperty`'s own doc comment, which explicitly deletes the `properties` entry when converting a name to an accessor. Every operation that only walked `NamedPropertyKeys()` missed it:

```js
const arr = [1, 2];
Object.defineProperty(arr, "foo", { get() { return 5; }, enumerable: true });
Object.keys(arr);
// before: ["0", "1"]           - missing "foo"
// Node:   ["0", "1", "foo"]
```

Confirmed missing from `Object.keys`, `Object.values`, `Object.entries`, `Object.getOwnPropertyNames`, `Reflect.ownKeys` (delegates to `getOwnPropertyNames`, so it inherits the fix for free), `for-in`, and `Object.getOwnPropertyDescriptors`. `Object.values`/`Object.entries` had a broader version: they never walked *any* named property at all, so even a plain `arr.foo = "bar"` was dropped.

**Gap 2 - `Object.assign` doesn't invoke a numeric-index accessor, copying the stale element instead:**

```js
const arr = [1, 2, 3];
Object.defineProperty(arr, "1", { get() { return 99; }, enumerable: true });
arr[1];                    // 99 - ordinary index access already gets this right
Object.assign({}, arr)[1]; // before: 2 (stale element) - Node: 99
```

`HasOwnIndexProperty` (used to check existence) does consult accessors, but the value read (`arrObj.Get(i)`) reads `elements` directly with no accessor check. `Object.values`/`Object.entries` had the identical dense-range gap. Object-literal spread's `TypeArray` case (#358) already got this right from the start - locked in with a regression test, not touched.

**Gap 3 (found while fixing gap 1, folded into this PR rather than filed separately):** `Object.getOwnPropertyDescriptors`' `TypeArray` case collected no named key at all - not even a plain one - and separately looped `i := 0; i < arr.Length()` instead of bounding the scan to `DenseLength()` + `arraySparseIndices`, the exact `paserati#176`/`#178` hang shape every other array-key-collecting function here already guards against (a sparse index far past `DenseLength()` extends `.length` without growing `elements`).

## Fix

- `pkg/builtins/object_init.go`: new `arrayNamedKeys(a, enumerableOnly)` helper (mirrors `arraySparseIndices`' shape) walking `AccessorKeys()` then `NamedPropertyKeys()`, both filtered by `vm.ParseArrayIndex` (not `vm.LooksLikeArrayIndex`, which has no upper bound - see #358's fix for why that matters). New `arrayDenseIndexValue`/`arrayNamedKeyValue` helpers (dense-range/named-key siblings of the pre-existing `arraySparseIndexValue`) for the value-read side. Applied across `Object.keys/values/entries/getOwnPropertyNames/assign/getOwnPropertyDescriptors`.
- `pkg/vm/vm.go`: `for-in`'s `TypeArray` case gained the matching `AccessorKeys()` loop (package `vm` has its own separate duplicate of this array-key-collection logic, same split as `arraySparseIndices`).

**Known, deliberate limitation:** `arrayNamedKeys` emits accessor-store keys before plain-data-store keys, unconditionally - it doesn't track true cross-store creation order the way Node does. An array with both a plain named property and a named accessor property may enumerate them in a different order than Node. Out of scope here (the ticket describes membership gaps, not ordering, and this matches the divergence `Object.assign`/spread's own array-property loops already carry). The regression test deliberately avoids asserting cross-store order for this reason.

## Tests

`tests/scripts/array_named_accessor_enum_and_index_accessor_read.ts` - 13 checks: gap 1 for each of the six affected operations (including non-enumerable-accessor exclusion cases), gap 2 for `Object.assign`/`values`/`entries` plus a sanity check that spread already had it right, a combined check running one array with all four property shapes (dense-index accessor, sparse-index accessor, named accessor, named plain) through all nine operations at once and diffing against Node byte-for-byte, and two checks for the `getOwnPropertyDescriptors` fix (named-key inclusion, and a huge-sparse-index case that would have hung before this fix). Every check verified against real Node.js output; re-run 25x to confirm no Go-map-iteration-order flakiness (two checks originally hit this and were restructured to avoid depending on same-store key order).

`go build ./...`, `gofmt`, `go vet ./...`, and `go test ./...` all clean, no regressions.

Based on `fix-objectassign-spread-array-props` (#358): the spread sanity check depends on that PR's `TypeArray` spread case, and this reuses `arraySparseIndices`/`arraySparseIndexValue` from the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
