### PR TITLE
fix(vm): native GetProperty/SetProperty entry points handle a Proxy correctly

### DIFF
--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1286,134 +1286,70 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			*dest = result
 			return true, InterpretOK, *dest
 		} else {
-			// No get trap, fallback to target - implement directly to avoid recursion
-			target := proxy.target
-			if target.Type() == TypeObject {
-				if result, handled := vm.handleSpecialProperties(target, propName); handled {
-					*dest = result
-					return true, InterpretOK, *dest
+			// No get trap: fall back to target.[[Get]] via
+			// getPropertyWithReceiver, not a hand-rolled reimplementation
+			// (what used to live here, added to "avoid recursion" - but
+			// it only ever handled a TypeObject/TypeDictObject/callable
+			// target; every other legal proxy.target kind (TypeArray,
+			// TypeMap, TypeSet, TypePromise, TypeRegExp, TypeGenerator,
+			// TypeBoundFunction, TypeNativeFunction,
+			// TypeNativeFunctionWithProps, TypeArguments, a further-nested
+			// Proxy, ...) fell through to a bare `*dest = Undefined`
+			// instead - e.g. `new Proxy(someArray, {})` (no get trap, a
+			// real Array target) silently read `undefined` for EVERY
+			// property, including "length": handleSpecialProperties and
+			// handlePrimitiveMethod, both called here, switch on the
+			// TARGET's kind (TypeArray/TypeMap/TypeSet/... for the
+			// former, TypeString/TypeArray/TypeMap/... for the latter)
+			// but were only ever reached when target.Type() == TypeObject
+			// was already true - so neither call could ever actually
+			// match anything; both were dead code at this specific call
+			// site. getPropertyWithReceiver already handles every kind
+			// (including recursing through a further-nested Proxy) and
+			// already threads a receiver through any accessor/trap found
+			// along the way, exactly like the get-trap-call branch above
+			// does with *objVal - so this isn't a behavior change for the
+			// TypeObject/TypeDictObject/callable kinds that WERE already
+			// handled here, only an extension to the kinds that weren't.
+			result, err := vm.getPropertyWithReceiver(proxy.target, propName, *objVal)
+			if err != nil {
+				if ee, ok := err.(ExceptionError); ok {
+					if frame != nil && !frameWasNil {
+						frame.ip = ip - 4
+					}
+					vm.throwException(ee.GetExceptionValue())
+					if !vm.unwinding {
+						return false, InterpretOK, Undefined
+					}
+					return false, InterpretRuntimeError, Undefined
 				}
-				if result, handled := vm.handlePrimitiveMethod(target, propName); handled {
-					*dest = result
-					return true, InterpretOK, *dest
-				}
-				// Use enhanced property resolution with prototype caching and metadata
-				if holder, offset, isAccessor, found := vm.resolvePropertyMeta(target, propName, nil, 0); found {
-					if isAccessor {
-						if g, _, _, _, ok := holder.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-							res, err := vm.Call(g, target, nil)
-							if err != nil {
-								if ee, ok := err.(ExceptionError); ok {
-									if frame != nil && !frameWasNil {
-										frame.ip = ip - 4
-									}
-									vm.throwException(ee.GetExceptionValue())
-									if !vm.unwinding {
-										return false, InterpretOK, Undefined
-									}
-									return false, InterpretRuntimeError, Undefined
-								}
-								var excVal Value
-								if errCtor, ok := vm.GetGlobal("Error"); ok {
-									if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
-										excVal = res
-									} else {
-										eo := NewObject(vm.ErrorPrototype).AsPlainObject()
-										eo.SetOwn("name", NewString("Error"))
-										eo.SetOwn("message", NewString(err.Error()))
-										excVal = NewValueFromPlainObject(eo)
-									}
-								} else {
-									eo := NewObject(vm.ErrorPrototype).AsPlainObject()
-									eo.SetOwn("name", NewString("Error"))
-									eo.SetOwn("message", NewString(err.Error()))
-									excVal = NewValueFromPlainObject(eo)
-								}
-								if frame != nil && !frameWasNil {
-									frame.ip = ip - 4
-								}
-								vm.throwException(excVal)
-								if !vm.unwinding {
-									return false, InterpretOK, Undefined
-								}
-								return false, InterpretRuntimeError, Undefined
-							}
-							*dest = res
-						} else {
-							*dest = Undefined
-						}
+				var excVal Value
+				if errCtor, ok := vm.GetGlobal("Error"); ok {
+					if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+						excVal = res
 					} else {
-						*dest = holder.properties[offset]
+						eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+						eo.SetOwn("name", NewString("Error"))
+						eo.SetOwn("message", NewString(err.Error()))
+						excVal = NewValueFromPlainObject(eo)
 					}
-					return true, InterpretOK, *dest
-				}
-			} else if target.Type() == TypeDictObject {
-				dict := target.AsDictObject()
-				if fv, ok := dict.Get(propName); ok {
-					*dest = fv
 				} else {
-					*dest = Undefined
+					eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+					eo.SetOwn("name", NewString("Error"))
+					eo.SetOwn("message", NewString(err.Error()))
+					excVal = NewValueFromPlainObject(eo)
 				}
-				return true, InterpretOK, *dest
-			} else if target.IsCallable() {
-				// Function target - look up properties from Function.prototype
-				// Function.prototype can be TypeNativeFunctionWithProps (common case)
-				// or TypeObject (less common)
-				if vm.FunctionPrototype.Type() == TypeNativeFunctionWithProps {
-					funcProto := vm.FunctionPrototype.AsNativeFunctionWithProps()
-					if v, ok := funcProto.Properties.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					// Walk prototype chain from Function.prototype.Properties
-					current := funcProto.Properties.GetPrototype()
-					for current.typ != TypeNull && current.typ != TypeUndefined {
-						if current.IsObject() {
-							if current.Type() == TypeObject {
-								proto := current.AsPlainObject()
-								if v, ok := proto.GetOwn(propName); ok {
-									*dest = v
-									return true, InterpretOK, *dest
-								}
-								current = proto.prototype
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					}
-				} else if vm.FunctionPrototype.IsObject() {
-					funcProto := vm.FunctionPrototype.AsPlainObject()
-					if v, ok := funcProto.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					// Walk prototype chain from Function.prototype
-					current := funcProto.prototype
-					for current.typ != TypeNull && current.typ != TypeUndefined {
-						if current.IsObject() {
-							if current.Type() == TypeObject {
-								proto := current.AsPlainObject()
-								if v, ok := proto.GetOwn(propName); ok {
-									*dest = v
-									return true, InterpretOK, *dest
-								}
-								current = proto.prototype
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					}
+				if frame != nil && !frameWasNil {
+					frame.ip = ip - 4
 				}
-				*dest = Undefined
-				return true, InterpretOK, *dest
-			} else {
-				*dest = Undefined
-				return true, InterpretOK, *dest
+				vm.throwException(excVal)
+				if !vm.unwinding {
+					return false, InterpretOK, Undefined
+				}
+				return false, InterpretRuntimeError, Undefined
 			}
+			*dest = result
+			return true, InterpretOK, *dest
 		}
 	}
 

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1707,6 +1707,51 @@ func (vm *VM) SetProperty(obj Value, propName string, value Value) error {
 		}
 		return nil
 
+	case TypeProxy:
+		// This case didn't exist at all before this fix - obj.Type() ==
+		// TypeProxy fell to the `default: return nil` no-op below, so
+		// every native Go caller of SetProperty (e.g.
+		// pkg/builtins/array_generic.go's arrayLikeSetLength, which
+		// Array.prototype.pop/shift/... use to shrink .length) silently
+		// did nothing when writing to a Proxy - `Array.prototype.pop.call(
+		// new Proxy(realArray, {}))` deleted the right element but never
+		// actually updated realArray.length, even though ordinary
+		// `proxy.length = n` assignment syntax (the bytecode OpSetProp
+		// path, op_setprop.go) already handled this correctly. Mirrors
+		// op_setprop.go's own TypeProxy case: GetMethod(handler, "set")
+		// via getInheritedGeneric (an inherited trap counts, and this
+		// covers the same wider range of legal handler kinds
+		// proxyGetTrap's TypeObject/TypeDictObject-only switch doesn't -
+		// Array, Closure, Function, ...), and a no-trap fallback that
+		// recurses into SetProperty on the target - covering the same
+		// TypeArray/TypeObject/TypeDictObject/TypeArguments/TypeRegExp
+		// cases above (including "length" on a real Array) plus a
+		// further-nested Proxy target automatically, since this same
+		// switch runs again for it.
+		proxy := obj.AsProxy()
+		if proxy.Revoked {
+			return vm.NewTypeError("Cannot set property on a revoked Proxy")
+		}
+		setTrap, hasSetTrap := vm.getInheritedGeneric(proxy.Handler(), "set")
+		if hasSetTrap && setTrap.Type() != TypeUndefined && setTrap.Type() != TypeNull {
+			if !setTrap.IsCallable() {
+				return vm.NewTypeError("'set' on proxy: trap is not a function")
+			}
+			// handler.set(target, propertyKey, value, receiver) - receiver
+			// is the proxy itself, per ECMA-262 10.5.9 step 8.
+			result, err := vm.Call(setTrap, proxy.Handler(), []Value{proxy.Target(), NewString(propName), value, obj})
+			if err != nil {
+				return err
+			}
+			if result.IsFalsey() {
+				return vm.NewTypeError("'set' on proxy: trap returned falsish for property '" + propName + "'")
+			}
+			return nil
+		}
+		// No set trap: delegate to target.[[Set]]() - recursing through
+		// this same switch handles a further-nested Proxy target too.
+		return vm.SetProperty(proxy.Target(), propName, value)
+
 	default:
 		// For non-objects, this is a no-op (or could throw in strict mode)
 		return nil

--- a/tests/scripts/proxy_native_length_get_set.ts
+++ b/tests/scripts/proxy_native_length_get_set.ts
@@ -1,0 +1,141 @@
+// expect: true
+// Two related bugs in the NATIVE/Go-level property access entry points
+// pkg/builtins uses (vm.GetProperty/getPropertyWithReceiver and
+// vm.SetProperty, pkg/vm/vm_init.go) - as opposed to the bytecode-compiled
+// OpGetProp/OpSetProp paths, which already handled these cases correctly -
+// found while regression-testing the pkg/vm Proxy trap-lookup fixes
+// earlier in this stack:
+//
+//   1. vm.SetProperty had NO `case TypeProxy` at all - a TypeProxy `obj`
+//      fell straight to `default: return nil` (a silent no-op). Every
+//      native Go caller that writes a property via SetProperty on a
+//      Proxy did nothing, most visibly
+//      pkg/builtins/array_generic.go's arrayLikeSetLength (used by
+//      Array.prototype.pop/shift/splice/copyWithin to shrink `.length`
+//      after removing an element): `Array.prototype.pop.call(new
+//      Proxy(realArray, {}))` deleted the right element but never
+//      updated realArray.length, even though ordinary `proxy.length = n`
+//      assignment syntax (bytecode OpSetProp, op_setprop.go) already
+//      worked correctly for the exact same proxy and key.
+//
+//   2. op_getprop.go's opGetProp (bytecode OpGetProp, `proxy.prop`) had a
+//      "no get trap, fallback to target" branch that only ever handled a
+//      TypeObject/TypeDictObject/callable target - every other legal
+//      proxy.target kind (TypeArray, TypeMap, TypeSet, TypePromise,
+//      TypeRegExp, TypeGenerator, TypeBoundFunction, TypeNativeFunction,
+//      TypeNativeFunctionWithProps, TypeArguments, a further-nested
+//      Proxy, ...) fell to a bare `*dest = Undefined`. Two helper calls
+//      in that branch (handleSpecialProperties, handlePrimitiveMethod)
+//      switch on the TARGET's own kind (TypeArray/TypeMap/TypeString/...)
+//      but were only ever reached once target.Type() == TypeObject was
+//      already established - so neither call could ever actually match
+//      anything at that call site; both were dead code there. Most
+//      visibly: `new Proxy(realArray, {})` (no get trap, a real Array
+//      target) silently read `undefined` for EVERY property, including
+//      "length" itself.
+//
+// Fixed via:
+//   - SetProperty gained a `case TypeProxy` mirroring op_setprop.go's own
+//     TypeProxy case: GetMethod(handler, "set") via getInheritedGeneric
+//     (an inherited trap counts), and a no-trap fallback that recurses
+//     into SetProperty on the target - reaching the existing
+//     TypeArray/TypeObject/TypeDictObject/TypeArguments/TypeRegExp cases
+//     (including "length" on a real Array) automatically, plus a
+//     further-nested Proxy target (recursing through this same switch
+//     again).
+//   - opGetProp's "no get trap" branch now delegates to
+//     getPropertyWithReceiver (pkg/vm/vm_init.go) instead of its own
+//     partial reimplementation - that function already handles every
+//     Value kind (including TypeArray's "length", and recursing through
+//     a further-nested Proxy) and already threads the receiver through
+//     any accessor/trap found along the way, matching how this same
+//     function's get-trap-call branch already does.
+//
+// Not fixed here (a separate, pre-existing, confirmed-independent bug
+// filed as a follow-up): OpGetIndex (bracket notation, `proxy[key]`) has
+// its OWN "no get trap, fallback to target" switch with the same
+// incompleteness, but for a different opcode - `new Proxy(arguments, {})`
+// reads its own `.length` correctly (dot notation, opGetProp, fixed
+// above) but `p[0]`/`p[1]` (bracket notation, OpGetIndex) still read
+// `undefined`. Not covered by this file.
+
+const checks: boolean[] = [];
+
+// --- 1. Array.prototype.pop via .call() on a plain, trap-less
+// array-wrapping Proxy: deletes the right element AND shrinks the real
+// array's length (arrayLikeSetLength -> SetProperty -> the new TypeProxy
+// case -> the target's own "length" case). Matches Node exactly. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  const popped = Array.prototype.pop.call(p);
+  checks.push(popped === 3 && arr.length === 2);
+}
+
+// --- 2. Array.prototype.shift via .call(): same shape, a different
+// arrayLikeDelete/arrayLikeSetLength call site. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  const shifted = Array.prototype.shift.call(p);
+  checks.push(shifted === 1 && arr.length === 2 && arr[0] === 2 && arr[1] === 3);
+}
+
+// --- 3. Reading `.length` directly off a trap-less array-wrapping Proxy
+// (dot notation, opGetProp's fixed fallback) - was `undefined` before
+// this fix, regardless of any prior mutation. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  checks.push(p.length === 3 && p[0] === 1 && p[1] === 2);
+}
+
+// --- 4. Same read, immediately after a native-path mutation (pop),
+// isolating the get-path fix from the set-path fix (check 1 already
+// covers arr.length directly; this covers reading it back through the
+// proxy too). ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  Array.prototype.pop.call(p);
+  checks.push(p.length === 2);
+}
+
+// --- 5. `.length` write via ordinary assignment syntax (bytecode
+// OpSetProp, already correct before this fix) still agrees with the
+// now-fixed native path - not a regression check for something new,
+// just confirming both paths land on the same real array state. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  p.length = 1;
+  checks.push(arr.length === 1 && p.length === 1);
+}
+
+// --- 6. opGetProp's fallback extension beyond TypeArray: RegExp
+// lastIndex through a trap-less Proxy (was already reachable via a
+// TypeObject-adjacent path before, but exercised here as a second
+// non-TypeObject/TypeDictObject/callable target kind, for coverage
+// alongside check 3's Array case). ---
+{
+  const re: any = /a/g;
+  const p: any = new Proxy(re, {});
+  re.lastIndex = 5;
+  checks.push(p.lastIndex === 5);
+}
+
+// --- 7. A TypeDictObject handler (a TS enum at runtime) must still not
+// panic for either the fixed get or set path. ---
+{
+  enum DictHandler7 {
+    A,
+    B,
+  }
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, DictHandler7 as any);
+  checks.push(p.length === 3);
+  const popped = Array.prototype.pop.call(p);
+  checks.push(popped === 3 && arr.length === 2);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Direct follow-up fix for the chip filed against #354/#356's regression testing: `pkg/builtins` (and any other native Go caller) reaches a Proxy through `vm.GetProperty`/`vm.SetProperty` (`pkg/vm/vm_init.go`) rather than the bytecode-compiled `OpGetProp`/`OpSetProp` paths — and those native entry points had two separate, real bugs the bytecode paths didn't:

1. **`vm.SetProperty` had NO `case TypeProxy` at all** — fell straight to `default: return nil`, a silent no-op. Most visibly, `pkg/builtins/array_generic.go`'s `arrayLikeSetLength` (used by `Array.prototype.pop`/`shift`/`splice`/`copyWithin` to shrink `.length`) calls `vm.SetProperty` for its `TypeProxy` case — so `Array.prototype.pop.call(new Proxy(realArray, {}))` deleted the right element but never updated `realArray.length`, even though ordinary `proxy.length = n` assignment (bytecode `OpSetProp`, already correct) worked fine for the same proxy/key.

2. **`op_getprop.go`'s `opGetProp`'s "no get trap, fallback to target" branch** (commented "implement directly to avoid recursion") only ever handled a `TypeObject`/`TypeDictObject`/callable target — every other legal `proxy.target` kind (`TypeArray`, `TypeMap`, `TypeSet`, `TypePromise`, `TypeRegExp`, `TypeGenerator`, `TypeBoundFunction`, `TypeNativeFunction`, `TypeNativeFunctionWithProps`, `TypeArguments`, a further-nested Proxy, ...) fell to a bare `*dest = Undefined`. Two of that branch's own helper calls (`handleSpecialProperties`, `handlePrimitiveMethod`) switch on the TARGET's kind but were only ever reached once `target.Type() == TypeObject` was already established — both were dead code at that call site. Most visibly: `new Proxy(realArray, {})` (no get trap) silently read `undefined` for EVERY property, including `.length` itself.

Fixed:
- `SetProperty` gained a `case TypeProxy`, mirroring `op_setprop.go`'s own TypeProxy case (`getInheritedGeneric` for the set trap, no-trap fallback recurses into `SetProperty` on the target — reaching the existing `TypeArray`/`TypeObject`/`TypeDictObject`/`TypeArguments`/`TypeRegExp` cases, including "length" on a real Array, plus a further-nested Proxy target automatically).
- `opGetProp`'s "no get trap" branch now delegates to `getPropertyWithReceiver` (the same helper `vm.GetProperty` itself is built on) instead of its own partial reimplementation — net simplification, ~130 lines replaced by one delegating call.

Verified against real Node output for both repros from the filed task.

**Not fixed here** (a separate, pre-existing, confirmed-independent bug found while regression-testing this and filed as its own follow-up): `OpGetIndex` (bracket notation, `proxy[key]`) has its OWN "no get trap, fallback to target" switch with the same shape of incompleteness — a Proxy wrapping `arguments` now reads `.length` correctly (dot notation, fixed here) but `p[0]`/`p[1]` (bracket notation) still read `undefined`.

`tests/scripts/proxy_native_length_get_set.ts` covers pop/shift via `.call()` on a plain array-wrapping Proxy, reading `.length` directly (with and without a prior native-path mutation), a RegExp `.lastIndex` read through a trap-less Proxy, and a `TypeDictObject` handler not panicking for either path.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./pkg/...` both pass.

Based on `fix-objectspread-proxy-no-ownkeys-trap` (#356).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
