### PR TITLE
fix(vm): OpGetIndex's no-get-trap Proxy fallback covers every target kind

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8573,8 +8573,38 @@ startExecution:
 								}
 							}
 						}
-					case TypeObject, TypeDictObject:
-						// Handle object indexing on target
+					default:
+						// Every other target kind (TypeObject, TypeDictObject,
+						// TypeMap, TypeSet, TypePromise, TypeRegExp,
+						// TypeGenerator, TypeArguments, TypeBoundFunction,
+						// TypeNativeFunction, TypeNativeFunctionWithProps, a
+						// further-nested TypeProxy, ...) - used to be a bare
+						// `registers[destReg] = Undefined` for anything besides
+						// TypeObject/TypeDictObject (which got a delegation to
+						// opGetProp), so e.g. `new Proxy(arguments, {})[0]`
+						// silently read undefined even though the identical
+						// key read via dot notation (opGetProp's own no-trap
+						// fallback, already fixed for this same shape of bug)
+						// worked fine. Delegating to opGetProp here too (an
+						// earlier version of this fix did) would have been
+						// wrong for exactly that TypeArguments case: opGetProp
+						// only ever handles "length"/"callee"/named overflow
+						// properties for a TypeArguments objVal, never a plain
+						// numeric index like "0" - that resolution lives
+						// separately, in OpGetIndex's own direct (non-Proxy)
+						// TypeArguments case a few thousand lines up in this
+						// same function, via vm.argumentsGet. Rather than a
+						// FOURTH copy of that per-kind logic, delegate to
+						// getPropertyWithReceiver (pkg/vm/vm_init.go) instead -
+						// the same helper vm.GetProperty and opGetProp's own
+						// fallback are already built on, and unlike opGetProp
+						// it already handles every one of these kinds
+						// completely (TypeArguments included: length, callee,
+						// and numeric index via argumentsGet - see its own
+						// TypeArguments case for the full rationale). receiver
+						// is baseVal (the proxy itself), matching the
+						// get-trap-call branch above, which passes the same
+						// baseVal as the trap's own receiver argument.
 						var key string
 						switch indexVal.Type() {
 						case TypeString:
@@ -8585,17 +8615,41 @@ startExecution:
 							registers[destReg] = Undefined
 						}
 						if key != "" {
-							if ok, status, value := vm.opGetProp(frame, ip, &targetBase, key, &registers[destReg]); !ok {
-								if status != InterpretOK {
-									return status, value
+							result, err := vm.getPropertyWithReceiver(targetBase, key, baseVal)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+									if !vm.unwinding {
+										// Exception was caught by a handler, reload frame and continue
+										frame = &vm.frames[vm.frameCount-1]
+										closure = frame.closure
+										function = closure.Fn
+										code = function.Chunk.Code
+										constants = function.Chunk.Constants
+										registers = frame.registers
+										ip = frame.ip
+										continue
+									}
+									return InterpretRuntimeError, Undefined
 								}
-								goto reloadFrame
+								vm.ThrowTypeError(err.Error())
+								if !vm.unwinding {
+									// Exception was caught by a handler, reload frame and continue
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									code = function.Chunk.Code
+									constants = function.Chunk.Constants
+									registers = frame.registers
+									ip = frame.ip
+									continue
+								}
+								return InterpretRuntimeError, Undefined
 							}
+							registers[destReg] = result
 						} else {
 							registers[destReg] = Undefined
 						}
-					default:
-						registers[destReg] = Undefined
 					}
 				}
 

--- a/tests/scripts/proxy_opgetindex_target_fallback.ts
+++ b/tests/scripts/proxy_opgetindex_target_fallback.ts
@@ -1,0 +1,111 @@
+// expect: true
+// OpGetIndex's Proxy handling (pkg/vm/vm.go, `case OpGetIndex:`, backing
+// bracket-notation `proxy[key]`) had its OWN "no get trap, fallback to
+// target" switch, separate from opGetProp's (dot notation, `proxy.prop`,
+// already fixed for the same shape of bug two commits back on this
+// branch):
+//
+//   targetBase := proxy.target
+//   switch targetBase.Type() {
+//   case TypeArray:
+//       ... (numeric fast path, string/symbol index delegates to opGetProp)
+//   case TypeObject, TypeDictObject:
+//       ... delegates to opGetProp for the key ...
+//   default:
+//       registers[destReg] = Undefined
+//   }
+//
+// Every proxy.target kind besides TypeArray/TypeObject/TypeDictObject -
+// TypeArguments, TypeMap, TypeSet, TypePromise, TypeRegExp, TypeGenerator,
+// TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps, a
+// further-nested TypeProxy, ... - fell to that bare `default:` and
+// silently read `undefined` for every bracket-accessed key, even though
+// the identical key read via dot notation (opGetProp's own fallback,
+// already correct) worked fine:
+//
+//   function f(a, b) {
+//     const p = new Proxy(arguments, {});
+//     return [p.length, p[0], p[1]]; // was [2, undefined, undefined]
+//   }
+//   f(10, 20); // now [2, 10, 20], matching Node
+//
+// Fixed by widening the `default:` case to delegate to
+// getPropertyWithReceiver (pkg/vm/vm_init.go) instead of doing nothing -
+// the same helper vm.GetProperty and opGetProp's own fallback are already
+// built on, and it already handles every one of these kinds completely,
+// INCLUDING TypeArguments's numeric-index case (which opGetProp itself
+// does NOT handle - opGetProp's TypeArguments branch only ever resolves
+// "length"/"callee"/named overflow properties, never a plain numeric
+// index like "0"; that resolution lives separately in OpGetIndex's own
+// direct, non-Proxy TypeArguments case via vm.argumentsGet - delegating
+// this fallback to opGetProp instead of getPropertyWithReceiver, as an
+// earlier version of this fix did, would have looked plausible and
+// fixed every OTHER kind while leaving TypeArguments's numeric index
+// broken). TypeArray keeps its own direct handling (a hand-rolled dense-
+// element fast path for the numeric case), unchanged - only the
+// `default:` arm changed.
+//
+// checks 1-2: the task's own repro (numeric index, "length" as a
+// bracket key) and a RegExp `.lastIndex` bracket read - two kinds that
+// used to fall to `default:`.
+// check 3: nested trap-less Proxy target via bracket notation (the
+// OpGetIndex counterpart to the earlier OpObjectSpread/opGetProp fix for
+// the same shape of bug via dot notation).
+// check 4: TypeArray target still works via bracket notation (the
+// numeric fast path this fix did NOT touch, confirming no regression).
+// check 5: a TypeDictObject handler (a TS enum at runtime) must not
+// panic for the extended default case.
+
+const checks: boolean[] = [];
+
+// --- 1. Arguments via bracket notation: numeric index and "length" as
+// an explicit bracket key. ---
+{
+  function f(a: number, b: number) {
+    const p: any = new Proxy(arguments, {});
+    return [p[0], p[1], p["length"]];
+  }
+  const [a0, a1, alen] = f(10, 20);
+  checks.push(a0 === 10 && a1 === 20 && alen === 2);
+}
+
+// --- 2. RegExp lastIndex via bracket notation through a no-trap
+// proxy. ---
+{
+  const re: any = /a/g;
+  re.lastIndex = 3;
+  const pr: any = new Proxy(re, {});
+  checks.push(pr["lastIndex"] === 3);
+}
+
+// --- 3. Nested trap-less Proxy target via bracket notation. ---
+{
+  const inner: any = { c: 3 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  const key = "c";
+  checks.push(p2[key] === 3);
+}
+
+// --- 4. TypeArray target still works via bracket notation (the
+// existing numeric fast path and string-key array delegation, both
+// left untouched by this fix). ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  checks.push(p[0] === 1 && p[1] === 2 && p["length"] === 3);
+}
+
+// --- 5. A TypeDictObject handler (a TS enum at runtime) must not panic
+// for the extended default case. ---
+{
+  enum DictHandler5 {
+    A,
+    B,
+  }
+  const re2: any = /b/;
+  const pr2: any = new Proxy(re2, DictHandler5 as any);
+  checks.push(pr2["lastIndex"] === 0);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Follow-up filed while regression-testing #360/#361: `OpGetIndex`'s Proxy handling (`pkg/vm/vm.go`, bracket-notation `proxy[key]`) has its OWN "no get trap, fallback to target" switch, separate from `opGetProp`'s (dot notation, already fixed for the same shape of bug):

```go
targetBase := proxy.target
switch targetBase.Type() {
case TypeArray:
    ... (numeric fast path, string/symbol index delegates to opGetProp)
case TypeObject, TypeDictObject:
    ... delegates to opGetProp for the key ...
default:
    registers[destReg] = Undefined
}
```

Every `proxy.target` kind besides `TypeArray`/`TypeObject`/`TypeDictObject` — `TypeArguments`, `TypeMap`, `TypeSet`, `TypePromise`, `TypeRegExp`, `TypeGenerator`, `TypeBoundFunction`, `TypeNativeFunction`, `TypeNativeFunctionWithProps`, a further-nested `TypeProxy`, ... — fell to that bare `default:` and silently read `undefined` for every bracket-accessed key, even though the identical key via dot notation worked fine:

```js
function f(a, b) {
  const p = new Proxy(arguments, {});
  return [p.length, p[0], p[1]]; // was [2, undefined, undefined]
}
f(10, 20); // now [2, 10, 20], matching Node
```

Fixed by widening `default:` to delegate to `getPropertyWithReceiver` (`pkg/vm/vm_init.go`) — the same helper `vm.GetProperty` and `opGetProp`'s own fallback are already built on.

**Worth flagging**: an earlier version of this fix delegated to `opGetProp` instead (the task's own first suggested approach, and mirroring the existing `TypeObject`/`TypeDictObject` case). That looked plausible and fixed every kind *except* `TypeArguments` — `opGetProp`'s own `TypeArguments` branch only ever resolves `"length"`/`"callee"`/named overflow properties, never a plain numeric index like `"0"` (that lives separately in `OpGetIndex`'s own direct, non-Proxy `TypeArguments` case via `vm.argumentsGet`). Caught by testing the repro directly rather than trusting the build. `getPropertyWithReceiver`'s own `TypeArguments` case already handles the numeric-index path correctly, so switching to it closed the gap without a fourth hand-rolled copy of that logic. `TypeArray` keeps its own dense-element fast path unchanged.

Verified against real Node output for every check.

`tests/scripts/proxy_opgetindex_target_fallback.ts` covers: the task's own repro, a RegExp `.lastIndex` bracket read, a nested trap-less Proxy target via bracket notation, the `TypeArray` fast path still working, and a `TypeDictObject` handler not panicking.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./pkg/...` both pass.

Based on `fix-nested-proxy-target-get-fallback` (#361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
