### PR TITLE
fix(vm): Proxy has/delete/symbol-set/unscopables fallbacks recurse through a nested Proxy target

### DIFF
--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -1116,8 +1116,18 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 			}
 			return true, InterpretOK, result
 		} else {
-			// No set trap, fallback to target - implement directly to avoid recursion
+			// No set trap: per spec, return target.[[Set]](P, V, Receiver) -
+			// mirrors opSetProp's own string-key TypeProxy recursion just
+			// above in this file (this symbol-key sibling never got the
+			// same fix): a target that is itself a Proxy used to fall
+			// straight to the `else { return true, InterpretOK,
+			// *valueToSet }` below and silently do nothing (not even
+			// write), instead of resolving through that inner proxy's own
+			// trap-or-fallback.
 			target := proxy.target
+			if target.Type() == TypeProxy {
+				return vm.opSetPropSymbol(ip, &target, symKey, valueToSet)
+			}
 			if target.Type() == TypeObject {
 				po := target.AsPlainObject()
 				key := NewSymbolKey(symKey)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -5015,8 +5015,17 @@ startExecution:
 							}
 							hasProperty = result.IsTruthy()
 						} else {
-							// No has trap, fallback to target
-							hasProperty = checkNonProxyWithObj(proxy.target)
+							// No has trap, fallback to target.[[HasProperty]] -
+							// proxyHasPropertyFallback (not
+							// checkNonProxyWithObj, which - true to its
+							// name - stops at a TypeObject/TypeDictObject/
+							// TypePromise target and answers false for
+							// anything else, including a further-nested
+							// Proxy) so that inner proxy's own trap or
+							// fallback gets consulted instead of the
+							// with-object being treated as "doesn't have
+							// this property" outright.
+							hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 						}
 					} else {
 						hasProperty = checkNonProxyWithObj(withObj)
@@ -5079,13 +5088,15 @@ startExecution:
 									stillExists = result.IsTruthy()
 								}
 							} else {
-								// No has trap, check target
-								switch proxy.target.Type() {
-								case TypeObject:
-									stillExists = proxy.target.AsPlainObject().Has(propName)
-								case TypeDictObject:
-									stillExists = proxy.target.AsDictObject().Has(propName)
-								}
+								// No has trap, check target.[[HasProperty]] -
+								// proxyHasPropertyFallback (not a hand-rolled
+								// TypeObject/TypeDictObject-only switch) so a target
+								// that is itself a Proxy resolves correctly instead of
+								// being treated as "not present" outright, and so does
+								// every other target kind proxyHasPropertyFallback
+								// already covers (TypeArray, TypeMap, TypeSet,
+								// TypeRegExp, ... - see its own definition).
+								stillExists = vm.proxyHasPropertyFallback(proxy.target, propName)
 							}
 						}
 					}
@@ -5265,13 +5276,15 @@ startExecution:
 											hasProperty = result.IsTruthy()
 										}
 									} else {
-										// No has trap, check target
-										switch proxy.target.Type() {
-										case TypeObject:
-											hasProperty = proxy.target.AsPlainObject().Has(propName)
-										case TypeDictObject:
-											hasProperty = proxy.target.AsDictObject().Has(propName)
-										}
+									// No has trap, check target.[[HasProperty]] -
+									// proxyHasPropertyFallback (not a hand-rolled
+									// TypeObject/TypeDictObject-only switch) so a target
+									// that is itself a Proxy resolves correctly instead of
+									// being treated as "not present" outright, and so does
+									// every other target kind proxyHasPropertyFallback
+									// already covers (TypeArray, TypeMap, TypeSet,
+									// TypeRegExp, ... - see its own definition).
+									hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 									}
 								}
 							}
@@ -5461,16 +5474,13 @@ startExecution:
 							}
 							hasProperty = result.IsTruthy()
 						} else {
-							// No has trap, fallback to target
-							target := proxy.target
-							switch target.Type() {
-							case TypeObject:
-								hasProperty = target.AsPlainObject().Has(propName)
-							case TypeDictObject:
-								hasProperty = target.AsDictObject().Has(propName)
-							default:
-								hasProperty = false
-							}
+							// No has trap, fallback to target.[[HasProperty]] -
+							// proxyHasPropertyFallback (not a
+							// TypeObject/TypeDictObject-only switch) so a
+							// target that is itself a Proxy resolves
+							// correctly instead of being treated as "not
+							// present" outright.
+							hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 						}
 
 					case TypeObject:
@@ -5655,11 +5665,16 @@ startExecution:
 							}
 							hasProperty = result.IsTruthy()
 						} else {
-							// No has trap, check target
-							target := proxy.target
-							if target.Type() == TypeObject {
-								hasProperty = target.AsPlainObject().Has(propName)
-							}
+							// No has trap, check target.[[HasProperty]] -
+							// proxyHasPropertyFallback (not a bare
+							// TypeObject-only check) so a target that is itself a
+							// Proxy resolves correctly instead of being treated as
+							// "not present" outright, and so does every other
+							// target kind proxyHasPropertyFallback already covers
+							// (TypeDictObject, TypeArray, TypeMap, TypeSet,
+							// TypeRegExp, ... - see its own definition), not just
+							// TypeObject.
+							hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 						}
 					} else if withObj.Type() == TypeObject {
 						obj := withObj.AsPlainObject()
@@ -5775,10 +5790,18 @@ startExecution:
 						}
 						return result.IsTruthy(), false
 					} else {
-						// No has trap, fallback to target
-						if proxy.target.Type() == TypeObject {
-							return proxy.target.AsPlainObject().Has(propName), false
-						}
+						// No has trap, fallback to target.[[HasProperty]] -
+						// proxyHasPropertyFallback (not a bare `if
+						// target.Type() == TypeObject { ...Has... }`) so a
+						// target that is itself a Proxy (checking that inner
+						// proxy own has trap first) resolves correctly
+						// instead of being treated as "not present" outright,
+						// and so does every other target kind
+						// proxyHasPropertyFallback already covers
+						// (TypeDictObject, TypeArray, TypeMap, TypeSet,
+						// TypeRegExp, ... - see its own definition), not just
+						// TypeObject.
+						return vm.proxyHasPropertyFallback(proxy.target, propName), false
 					}
 				}
 				return false, false
@@ -5958,12 +5981,22 @@ startExecution:
 							}
 							stillExists = result.IsTruthy()
 						} else {
-							// No has trap, check on target
+							// No has trap, check on target - a TypeProxy
+							// target gets proxyHasPropertyFallback (which
+							// itself recurses into that inner proxy's own
+							// trap or fallback) instead of falling into the
+							// same "default: true" this switch's other
+							// unhandled kinds deliberately keep, so this
+							// step 2 check isn't left assuming a
+							// nested-Proxy binding is unconditionally
+							// "still there" without ever actually asking it.
 							switch proxy.target.Type() {
 							case TypeObject:
 								stillExists = proxy.target.AsPlainObject().Has(propName)
 							case TypeDictObject:
 								stillExists = proxy.target.AsDictObject().Has(propName)
+							case TypeProxy:
+								stillExists = vm.proxyHasPropertyFallback(proxy.target, propName)
 							default:
 								stillExists = true
 							}
@@ -6081,12 +6114,19 @@ startExecution:
 							}
 							stillExists = result.IsTruthy()
 						} else {
-							// No has trap, check on target
+							// No has trap, check on target - a TypeProxy
+							// target gets proxyHasPropertyFallback (which
+							// itself recurses into that inner proxy's own
+							// trap or fallback) instead of falling into the
+							// same "default: true" this switch's other
+							// unhandled kinds deliberately keep.
 							switch proxy.target.Type() {
 							case TypeObject:
 								stillExists = proxy.target.AsPlainObject().Has(propName)
 							case TypeDictObject:
 								stillExists = proxy.target.AsDictObject().Has(propName)
+							case TypeProxy:
+								stillExists = vm.proxyHasPropertyFallback(proxy.target, propName)
 							default:
 								stillExists = true
 							}
@@ -16649,16 +16689,13 @@ startExecution:
 						}
 					}
 				} else {
-					// No delete trap, fallback to target
-					if proxy.target.IsObject() {
-						if proxy.target.Type() == TypeObject {
-							po := proxy.target.AsPlainObject()
-							success = po.DeleteOwn(propName)
-						} else if proxy.target.Type() == TypeDictObject {
-							d := proxy.target.AsDictObject()
-							success = d.DeleteOwn(propName)
-						}
-					}
+					// No delete trap, fallback to target.[[Delete]] -
+					// proxyDeleteFallback (not a bare TypeObject/
+					// TypeDictObject-only check) so a target that is
+					// itself a Proxy (checking that inner proxy's own
+					// deleteProperty trap first) resolves correctly
+					// instead of `delete` silently doing nothing.
+					success = vm.proxyDeleteFallback(proxy.target, propName)
 				}
 			} else if obj.IsObject() {
 				if obj.Type() == TypeObject {
@@ -18039,17 +18076,31 @@ func (vm *VM) isUnscopable(withObj Value, propName string) (bool, bool) {
 			unscopablesVal = result
 			hasUnscopables = result.Type() != TypeUndefined
 		} else {
-			// No get trap, fallback to target
-			if proxy.target.Type() == TypeObject {
-				var err error
-				unscopablesVal, hasUnscopables, err = vm.GetSymbolPropertyWithGetter(proxy.target, vm.SymbolUnscopables)
-				if err != nil {
-					return false, true
-				}
-				if vm.unwinding {
-					return false, true
-				}
+			// No get trap, fallback to target.[[Get]] - via
+			// getSymbolPropertyWithReceiver (pkg/vm/vm_init.go, the
+			// symbol-key twin of getPropertyWithReceiver), not
+			// GetSymbolPropertyWithGetter, which - despite its name
+			// suggesting general symbol-property support - only ever
+			// handles a TypeObject or TypeRegExp obj directly and falls
+			// to "For non-objects, just return undefined" for anything
+			// else, TypeProxy included; it was ALSO wrongly assumed
+			// (by an earlier version of this fix, based on misreading an
+			// unrelated function's switch case while grepping the whole
+			// file) to already have Proxy support, so simply dropping the
+			// old `if proxy.target.Type() == TypeObject` guard here
+			// wasn't enough on its own - it still needed a helper that
+			// actually recurses through a further-nested Proxy target,
+			// which getSymbolPropertyWithReceiver already does (mirrors
+			// getPropertyWithReceiver's own TypeProxy case).
+			result, err := vm.getSymbolPropertyWithReceiver(proxy.target, vm.SymbolUnscopables, withObj)
+			if err != nil {
+				return false, true
 			}
+			if vm.unwinding {
+				return false, true
+			}
+			unscopablesVal = result
+			hasUnscopables = result.Type() != TypeUndefined
 		}
 
 	default:
@@ -21821,6 +21872,49 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 			return vm.ObjectPrototype.AsPlainObject().Has(propKey)
 		}
 		return false
+	default:
+		return false
+	}
+}
+
+// proxyDeleteFallback implements [[Delete]]'s fallback for a proxy target
+// when the outer proxy's own handler has no deleteProperty trap: per
+// ECMA-262 10.5.10 step 10, this delegates to target.[[Delete]](P) -
+// recursing if the target is itself a Proxy (checking that inner proxy's
+// own deleteProperty trap first, not just falling through further, the
+// same way proxyHasPropertyFallback just above already recurses for its
+// own analogous "has" case). Used by OpDeleteProp's Proxy case, which
+// used to only handle a TypeObject/TypeDictObject target directly - a
+// nested trap-less Proxy target (or any other kind) silently did nothing
+// (`delete` reporting whatever `success` defaulted to) instead of
+// resolving through it. Mirrors proxyHasPropertyFallback's own choice of
+// silently treating a thrown trap error as "did nothing" rather than
+// propagating it - an existing, established convention in this file for
+// this class of best-effort fallback helper, not something introduced
+// here.
+func (vm *VM) proxyDeleteFallback(target Value, propKey string) bool {
+	switch target.Type() {
+	case TypeProxy:
+		proxy := target.AsProxy()
+		if proxy.Revoked {
+			return false
+		}
+		if deleteTrap, ok := proxyGetTrap(proxy.handler, "deleteProperty"); ok && deleteTrap.Type() != TypeUndefined && deleteTrap.Type() != TypeNull {
+			if deleteTrap.IsCallable() {
+				trapArgs := []Value{proxy.target, NewString(propKey)}
+				result, err := vm.Call(deleteTrap, proxy.handler, trapArgs)
+				if err != nil {
+					return false
+				}
+				return result.IsTruthy()
+			}
+			return false
+		}
+		return vm.proxyDeleteFallback(proxy.target, propKey)
+	case TypeObject:
+		return target.AsPlainObject().DeleteOwn(propKey)
+	case TypeDictObject:
+		return target.AsDictObject().DeleteOwn(propKey)
 	default:
 		return false
 	}

--- a/tests/scripts/proxy_nested_target_delete_symbolset_unscopables.ts
+++ b/tests/scripts/proxy_nested_target_delete_symbolset_unscopables.ts
@@ -1,0 +1,83 @@
+// expect: true
+// Three more sites from the same audit as
+// tests/scripts/proxy_with_statement_nested_target_has_fallback.ts (see
+// its header for the full background), each a different trap:
+//
+//   1. OpDeleteProp's Proxy case ("No delete trap, fallback to target"):
+//      only handled TypeObject/TypeDictObject directly - `delete
+//      proxy.prop` where the target is another trap-less Proxy silently
+//      did nothing (`success` stayed whatever it defaulted to) instead
+//      of resolving through it. Fixed via the new proxyDeleteFallback
+//      helper (pkg/vm/vm.go), mirroring proxyHasPropertyFallback's own
+//      TypeProxy recursion for the analogous "has" case.
+//
+//   2. opSetPropSymbol's Proxy case ("No set trap, fallback to target -
+//      implement directly to avoid recursion", pkg/vm/op_setprop.go):
+//      only handled TypeObject - a nested Proxy target silently did
+//      nothing, not even a write. Its STRING-key sibling (opSetProp)
+//      already correctly recursed via `if target.Type() == TypeProxy {
+//      return vm.opSetProp(ip, &target, propName, valueToSet) }`; this
+//      symbol-key twin never got the same fix. Fixed the same way:
+//      `if target.Type() == TypeProxy { return vm.opSetPropSymbol(ip,
+//      &target, symKey, valueToSet) }`.
+//
+//   3. isUnscopable's own Proxy branch ("No get trap, fallback to
+//      target", backing @@unscopables consultation during a
+//      `with`-statement): gated behind `if proxy.target.Type() ==
+//      TypeObject`, so a nested Proxy target's own @@unscopables was
+//      never even asked about - the `with` binding always won,
+//      regardless of what the target declared unscopable. Fixed via
+//      getSymbolPropertyWithReceiver (pkg/vm/vm_init.go, the symbol-key
+//      twin of getPropertyWithReceiver - NOT GetSymbolPropertyWithGetter,
+//      which despite its name only ever handles a TypeObject or
+//      TypeRegExp obj directly and does not recurse through a Proxy
+//      target at all, an earlier version of this fix wrongly assumed
+//      otherwise and had to be corrected after this exact check still
+//      failed).
+//
+// All verified against real Node output.
+
+const checks: boolean[] = [];
+
+// --- 1. delete through a nested trap-less Proxy target. ---
+{
+  const inner: any = { d: 1 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  const deleted = delete p2.d;
+  checks.push(deleted === true && "d" in inner === false);
+}
+
+// --- 2. symbol-keyed property set through a nested trap-less Proxy
+// target. ---
+{
+  const sym = Symbol("s");
+  const inner: any = {};
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  p2[sym] = 42;
+  checks.push(inner[sym] === 42);
+}
+
+// --- 3. Symbol.unscopables lookup through a nested trap-less Proxy
+// target during a `with`-statement: the with-object must honor the
+// REAL target's @@unscopables and skip the property, leaving the local
+// variable untouched. ---
+{
+  const inner: any = { z: 999 };
+  Object.defineProperty(inner, Symbol.unscopables, {
+    value: { z: true },
+    configurable: true,
+  });
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let z = "local";
+    with (p2) {
+      return z;
+    }
+  }
+  checks.push(f() === "local");
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_with_statement_nested_target_has_fallback.ts
+++ b/tests/scripts/proxy_with_statement_nested_target_has_fallback.ts
@@ -1,0 +1,143 @@
+// expect: true
+// Follow-up filed while regression-testing earlier PRs in this stack: an
+// audit of pkg/vm/vm.go for the same "no trap, fall back to target
+// directly, only handles TypeObject/TypeDictObject" shape that affected
+// the `get` trap (OpObjectSpread, opGetProp, OpGetIndex - all fixed by
+// prior commits on this branch) turned up SEVEN more sites, all backing
+// the `has` trap's no-trap fallback for every `with`-statement opcode:
+// OpGetWithProperty, OpSetWithProperty, OpGetWithOrLocal,
+// OpSetWithOrLocal, OpResolveWithBinding (the checkWithObjProperty
+// closure), OpSetWithByBinding, and OpGetWithByBinding. Each checked
+// `proxy.target.Type() == TypeObject` (a couple also TypeDictObject) and
+// silently answered "property not present" for any other kind, including
+// a further-nested trap-less Proxy target:
+//
+//   const inner = { x: 5 };
+//   const p1 = new Proxy(inner, {});
+//   const p2 = new Proxy(p1, {}); // no has trap; p1 has none either
+//   function f() {
+//     let x = 1;
+//     with (p2) { x = 99; } // p2 claims "x" only if it can see inner.x
+//     return [x, inner.x];
+//   }
+//   f(); // was [99, 1] (with-object never claimed the binding) -
+//        // now [1, 99], matching Node
+//
+// Fixed by routing every site through proxyHasPropertyFallback (the
+// helper an earlier PR in this stack introduced and already used for
+// OpIn's own `has` fallback) instead of each site's own hand-rolled
+// TypeObject/TypeDictObject-only check - it already recurses through a
+// nested Proxy target (checking that inner proxy's own has trap first)
+// and covers several other target kinds these sites didn't (TypeArray,
+// TypeMap, TypeSet, TypeRegExp, TypePromise, ...). Two of the seven
+// sites (OpSetWithByBinding, OpGetWithByBinding) keep their own
+// deliberate "unhandled kind -> assume still bound, don't throw"
+// default for SetMutableBinding's step-2 check (a design choice
+// predating this fix, not something this fix changes) - only their
+// TypeProxy case was added, delegating to proxyHasPropertyFallback for
+// that one kind specifically.
+//
+// Each check below exercises a different one of the seven opcodes,
+// verified against real Node output. All use the same shape: a nested,
+// fully trap-less Proxy chain wrapping a real object, so `with` can only
+// correctly claim the binding by resolving all the way through.
+
+const checks: boolean[] = [];
+declare var gRead: any;
+declare var gWrite: any;
+declare var gCompound: any;
+
+// --- 1. OpGetWithProperty: reading a global variable inside `with`. ---
+{
+  const inner: any = { gRead: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  (globalThis as any).gRead = 1;
+  function readGlobal() {
+    with (p2) {
+      return gRead;
+    }
+  }
+  checks.push(readGlobal() === 5);
+}
+
+// --- 2. OpSetWithProperty: writing a global variable inside `with`. ---
+{
+  const inner: any = { gWrite: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  (globalThis as any).gWrite = 1;
+  function writeGlobal() {
+    with (p2) {
+      gWrite = 42;
+    }
+  }
+  writeGlobal();
+  checks.push((globalThis as any).gWrite === 1 && inner.gWrite === 42);
+}
+
+// --- 3. OpGetWithOrLocal: reading a local variable inside `with` - the
+// with-object must take priority over the local. ---
+{
+  const inner: any = { x: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let x = 1;
+    with (p2) {
+      return x;
+    }
+  }
+  checks.push(f() === 5);
+}
+
+// --- 4. OpSetWithOrLocal: writing a local variable inside `with` - the
+// with-object must claim the binding, leaving the local untouched. ---
+{
+  const inner: any = { x: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let x = 1;
+    with (p2) {
+      x = 99;
+    }
+    return [x, inner.x];
+  }
+  const [x, ix] = f();
+  checks.push(x === 1 && ix === 99);
+}
+
+// --- 5-7. OpResolveWithBinding + OpSetWithByBinding + OpGetWithByBinding:
+// a compound assignment inside `with`, for both a local and a global
+// variable - exercises all three opcodes together (resolving which
+// binding to use, then the get-then-set halves of the compound op). ---
+{
+  const inner: any = { lx: 10 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let lx = 1;
+    with (p2) {
+      lx += 5;
+    }
+    return [lx, inner.lx];
+  }
+  const [lx, ilx] = f();
+  checks.push(lx === 1 && ilx === 15);
+}
+{
+  const inner: any = { gCompound: 10 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  (globalThis as any).gCompound = 1;
+  function f() {
+    with (p2) {
+      gCompound += 5;
+    }
+  }
+  f();
+  checks.push((globalThis as any).gCompound === 1 && inner.gCompound === 15);
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Follow-up filed as a consolidated audit while regression-testing the `get`-trap nested-Proxy-target fixes earlier in this stack (OpObjectSpread, opGetProp, OpGetIndex): the same "no trap, fall back to target directly, only TypeObject/TypeDictObject" shape turned up at eleven more sites, for `has`, `delete`, symbol-keyed `set`, and `@@unscopables` rather than `get`.

**`has` (seven sites — every `with`-statement opcode)**: `OpGetWithProperty`, `OpSetWithProperty`, `OpGetWithOrLocal`, `OpSetWithOrLocal`, `OpResolveWithBinding` (the `checkWithObjProperty` closure), `OpSetWithByBinding`, and `OpGetWithByBinding` each checked `proxy.target.Type() == TypeObject` and silently answered "not present" for anything else, including a further-nested trap-less Proxy target — so a `with` block could never correctly delegate through such a chain:

```js
const inner = { x: 5 };
const p1 = new Proxy(inner, {});
const p2 = new Proxy(p1, {}); // no has trap; p1 has none either
function f() {
  let x = 1;
  with (p2) { return x; }
}
f(); // was 1 (local) - now 5, matching Node
```

Fixed by routing every site through `proxyHasPropertyFallback` (already introduced for `OpIn`'s own `has` fallback) instead of each site's own hand-rolled check — it already recurses through a nested Proxy target and covers several other kinds (`TypeArray`, `TypeMap`, `TypeSet`, `TypeRegExp`, `TypePromise`, ...). Two sites (`OpSetWithByBinding`, `OpGetWithByBinding`) keep their own deliberate "unhandled kind → assume still bound, don't throw" default for `SetMutableBinding`'s step-2 check — only their `TypeProxy` case was added.

**`delete` (`OpDeleteProp`)**: only handled `TypeObject`/`TypeDictObject` directly. Fixed via a new `proxyDeleteFallback` helper mirroring `proxyHasPropertyFallback`'s own recursion (including its established convention of not propagating a thrown trap error).

**Symbol-keyed `set`** (`op_setprop.go`'s `opSetPropSymbol`): only handled `TypeObject` — its STRING-key sibling already recursed via `if target.Type() == TypeProxy { return vm.opSetProp(...) }`; this symbol-key twin never got the same fix. Fixed the same way.

**`@@unscopables` lookup**: gated behind `if proxy.target.Type() == TypeObject`. Worth flagging — an earlier version of this fix just dropped that guard and called `GetSymbolPropertyWithGetter` unconditionally, based on a misread of an unrelated function's switch case while grepping the whole file for `case TypeProxy:`. That function actually only handles `TypeObject`/`TypeRegExp` directly and falls to "return undefined" for anything else, so the fix built cleanly but the new regression test still failed. Caught by testing the repro directly rather than trusting the build — same lesson as the `OpGetIndex` PR earlier in this stack. Corrected to `getSymbolPropertyWithReceiver` (the symbol-key twin of `getPropertyWithReceiver`, which does have a proper `TypeProxy` case).

Every fix verified against real Node output.

`tests/scripts/proxy_with_statement_nested_target_has_fallback.ts` covers all seven `has`-fallback sites. `tests/scripts/proxy_nested_target_delete_symbolset_unscopables.ts` covers delete, symbol-keyed set, and `@@unscopables`.

`go test ./tests -run TestScripts -timeout 180s` and `go test ./pkg/...` both pass.

Based on `fix-opgetindex-proxy-target-fallback` (#362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
