### PR TITLE
chore(merge): integrate chain-A Proxy/Reflect stack (through #363) into main

### DIFF
--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -329,7 +329,11 @@ func arrayLikeGetProxy(vmInstance *vm.VM, proxyVal vm.Value, i int) (vm.Value, b
 		return vm.Undefined, false, vmInstance.NewTypeError("Cannot perform 'has' on a proxy that has been revoked")
 	}
 	key := strconv.Itoa(i)
-	if hasTrap, ok := proxy.Handler().AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != vm.TypeUndefined && hasTrap.Type() != vm.TypeNull {
+	// GetMethod(handler, "has") per spec: an inherited trap counts, not
+	// just an own one - vmInstance.ProxyGetTrap (not a bare
+	// proxy.Handler().AsPlainObject().GetOwn("has")) for the same reason
+	// documented on its pkg/vm definition.
+	if hasTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "has"); ok && hasTrap.Type() != vm.TypeUndefined && hasTrap.Type() != vm.TypeNull {
 		if !hasTrap.IsCallable() {
 			return vm.Undefined, false, vmInstance.NewTypeError("'has' on proxy: trap is not a function")
 		}
@@ -559,7 +563,11 @@ func proxyDeleteProperty(vmInstance *vm.VM, proxyVal vm.Value, i int, key string
 	if proxy.Revoked {
 		return vmInstance.NewTypeError("Cannot delete property from a revoked Proxy")
 	}
-	deleteTrap, ok := proxy.Handler().AsPlainObject().GetOwn("deleteProperty")
+	// GetMethod(handler, "deleteProperty") per spec: an inherited trap
+	// counts, not just an own one - vmInstance.ProxyGetTrap (not a bare
+	// proxy.Handler().AsPlainObject().GetOwn("deleteProperty")) for the
+	// same reason documented on its pkg/vm definition.
+	deleteTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "deleteProperty")
 	if !ok || deleteTrap.Type() == vm.TypeUndefined || deleteTrap.Type() == vm.TypeNull {
 		return arrayLikeDelete(vmInstance, proxy.Target(), i)
 	}

--- a/pkg/builtins/function_init.go
+++ b/pkg/builtins/function_init.go
@@ -801,14 +801,11 @@ func getPrototypeOfValue(vmInstance *vm.VM, val vm.Value) (vm.Value, error) {
 			return vm.Undefined, vmInstance.NewTypeError("Cannot perform 'getPrototypeOf' on a proxy that has been revoked")
 		}
 		handler := proxy.Handler()
-		var trap vm.Value
-		var hasTrap bool
-		switch handler.Type() {
-		case vm.TypeObject:
-			trap, hasTrap = handler.AsPlainObject().GetOwn("getPrototypeOf")
-		case vm.TypeDictObject:
-			trap, hasTrap = handler.AsDictObject().GetOwn("getPrototypeOf")
-		}
+		// GetMethod(handler, "getPrototypeOf") per spec: an inherited trap
+		// counts, not just an own one - vmInstance.ProxyGetTrap (not a bare
+		// handler.AsPlainObject().GetOwn("getPrototypeOf")) for the same
+		// reason documented on its pkg/vm definition.
+		trap, hasTrap := vmInstance.ProxyGetTrap(handler, "getPrototypeOf")
 		if hasTrap && trap.IsCallable() {
 			result, err := vmInstance.Call(trap, handler, []vm.Value{proxy.Target()})
 			if err != nil {

--- a/pkg/builtins/json_init.go
+++ b/pkg/builtins/json_init.go
@@ -984,28 +984,32 @@ func getProxyOwnKeys(vmInstance *vm.VM, proxy *vm.ProxyObject) ([]string, error)
 	}
 
 	handler := proxy.Handler()
-	if handler.Type() == vm.TypeObject {
-		handlerObj := handler.AsPlainObject()
-		ownKeysTrap, hasOwnKeysTrap := handlerObj.GetOwn("ownKeys")
-		if hasOwnKeysTrap && ownKeysTrap.IsCallable() {
-			// Call ownKeys trap: handler.ownKeys(target)
-			keysResult, err := vmInstance.Call(ownKeysTrap, handler, []vm.Value{proxy.Target()})
-			if err != nil {
-				return nil, err
-			}
-			// Extract keys from result array
-			var keys []string
-			if keysResult.Type() == vm.TypeArray {
-				arr := keysResult.AsArray()
-				for i := 0; i < arr.Length(); i++ {
-					keyVal := arr.Get(i)
-					if keyVal.Type() == vm.TypeString {
-						keys = append(keys, keyVal.ToString())
-					}
+	// GetMethod(handler, "ownKeys") per spec: an inherited trap counts, not
+	// just an own one, and a TypeDictObject handler (a TS enum or module
+	// namespace value at runtime) must still be checked for the trap
+	// instead of being treated as trap-less outright -
+	// vmInstance.ProxyGetTrap, not the previous
+	// `if handler.Type() == vm.TypeObject { ...GetOwn... }` which silently
+	// answered "no trap" for any other handler kind.
+	ownKeysTrap, hasOwnKeysTrap := vmInstance.ProxyGetTrap(handler, "ownKeys")
+	if hasOwnKeysTrap && ownKeysTrap.IsCallable() {
+		// Call ownKeys trap: handler.ownKeys(target)
+		keysResult, err := vmInstance.Call(ownKeysTrap, handler, []vm.Value{proxy.Target()})
+		if err != nil {
+			return nil, err
+		}
+		// Extract keys from result array
+		var keys []string
+		if keysResult.Type() == vm.TypeArray {
+			arr := keysResult.AsArray()
+			for i := 0; i < arr.Length(); i++ {
+				keyVal := arr.Get(i)
+				if keyVal.Type() == vm.TypeString {
+					keys = append(keys, keyVal.ToString())
 				}
 			}
-			return keys, nil
 		}
+		return keys, nil
 	}
 
 	// No ownKeys trap - recurse into target

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -691,12 +691,14 @@ func (o *ObjectInitializer) InitRuntime(ctx *RuntimeContext) error {
 				return vm.Undefined, vmInstance.NewTypeError("Cannot set prototype of revoked Proxy")
 			}
 			handler := proxy.Handler()
-			var setProtoTrap vm.Value
-			var hasTrap bool
-			if handler.Type() == vm.TypeObject {
-				po := handler.AsPlainObject()
-				setProtoTrap, hasTrap = po.GetOwn("setPrototypeOf")
-			}
+			// GetMethod(handler, "setPrototypeOf") per spec: an inherited
+			// trap counts, not just an own one, and a TypeDictObject
+			// handler (a TS enum or module namespace value at runtime)
+			// must still be checked for the trap instead of being treated
+			// as trap-less outright - vmInstance.ProxyGetTrap, not the
+			// previous `if handler.Type() == vm.TypeObject { ...GetOwn... }`
+			// which silently answered "no trap" for any other handler kind.
+			setProtoTrap, hasTrap := vmInstance.ProxyGetTrap(handler, "setPrototypeOf")
 			if hasTrap && setProtoTrap.IsCallable() {
 				result, err := vmInstance.CallArgs2(setProtoTrap, handler, proxy.Target(), protoArg)
 				if err != nil {
@@ -1262,14 +1264,11 @@ func lookupSymbolProp(vmInstance *vm.VM, val vm.Value, symKey vm.PropertyKey, sy
 			return vm.Undefined, vmInstance.NewTypeError("Cannot perform 'get' on a proxy that has been revoked")
 		}
 		handler := proxy.Handler()
-		var getTrap vm.Value
-		var hasGetTrap bool
-		switch handler.Type() {
-		case vm.TypeObject:
-			getTrap, hasGetTrap = handler.AsPlainObject().GetOwn("get")
-		case vm.TypeDictObject:
-			getTrap, hasGetTrap = handler.AsDictObject().GetOwn("get")
-		}
+		// GetMethod(handler, "get") per spec: an inherited trap counts, not
+		// just an own one - vmInstance.ProxyGetTrap (not a bare
+		// handler.AsPlainObject().GetOwn("get")) for the same reason
+		// documented on its pkg/vm definition.
+		getTrap, hasGetTrap := vmInstance.ProxyGetTrap(handler, "get")
 		if hasGetTrap && getTrap.IsCallable() {
 			return vmInstance.CallArgs3(getTrap, handler, proxy.Target(), vmInstance.SymbolToStringTag, val)
 		}
@@ -2235,8 +2234,12 @@ func objectGetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			return vm.Undefined, vmInstance.NewTypeError("Cannot get prototype of revoked Proxy")
 		}
 
-		// Check if handler has a getPrototypeOf trap (per spec: GetMethod treats null/undefined as absent)
-		if trap, ok := proxy.Handler().AsPlainObject().GetOwn("getPrototypeOf"); ok && !trap.IsUndefined() && trap.Type() != vm.TypeNull {
+		// Check if handler has a getPrototypeOf trap. GetMethod(handler,
+		// "getPrototypeOf") per spec: an inherited trap counts, not just
+		// an own one - vmInstance.ProxyGetTrap (not a bare
+		// proxy.Handler().AsPlainObject().GetOwn("getPrototypeOf")) for
+		// the same reason documented on its pkg/vm definition.
+		if trap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "getPrototypeOf"); ok && !trap.IsUndefined() && trap.Type() != vm.TypeNull {
 			// Validate trap is callable
 			if !trap.IsFunction() {
 				return vm.Undefined, vmInstance.NewTypeError("'getPrototypeOf' on proxy: trap is not a function")
@@ -2336,8 +2339,12 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			return vm.Undefined, vmInstance.NewTypeError("Cannot set prototype of revoked Proxy")
 		}
 
-		// Check for setPrototypeOf trap (per spec: GetMethod treats null/undefined as absent)
-		if setProtoTrap, ok := proxy.Handler().AsPlainObject().GetOwn("setPrototypeOf"); ok && !setProtoTrap.IsUndefined() && setProtoTrap.Type() != vm.TypeNull {
+		// Check for setPrototypeOf trap. GetMethod(handler, "setPrototypeOf")
+		// per spec: an inherited trap counts, not just an own one -
+		// vmInstance.ProxyGetTrap (not a bare
+		// proxy.Handler().AsPlainObject().GetOwn("setPrototypeOf")) for
+		// the same reason documented on its pkg/vm definition.
+		if setProtoTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "setPrototypeOf"); ok && !setProtoTrap.IsUndefined() && setProtoTrap.Type() != vm.TypeNull {
 			// Validate trap is callable
 			if !setProtoTrap.IsFunction() {
 				return vm.Undefined, vmInstance.NewTypeError("'setPrototypeOf' on proxy: trap is not a function")
@@ -3664,8 +3671,12 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			return vm.Undefined, vmInstance.NewTypeError("Cannot define property on revoked Proxy")
 		}
 
-		// Check for defineProperty trap (per spec: GetMethod treats null/undefined as absent)
-		if defineTrap, ok := proxy.Handler().AsPlainObject().GetOwn("defineProperty"); ok && !defineTrap.IsUndefined() && defineTrap.Type() != vm.TypeNull {
+		// Check for defineProperty trap. GetMethod(handler, "defineProperty")
+		// per spec: an inherited trap counts, not just an own one -
+		// vmInstance.ProxyGetTrap (not a bare
+		// proxy.Handler().AsPlainObject().GetOwn("defineProperty")) for
+		// the same reason documented on its pkg/vm definition.
+		if defineTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "defineProperty"); ok && !defineTrap.IsUndefined() && defineTrap.Type() != vm.TypeNull {
 			// Validate trap is callable
 			if !defineTrap.IsFunction() {
 				return vm.Undefined, vmInstance.NewTypeError("'defineProperty' on proxy: trap is not a function")
@@ -4576,8 +4587,12 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			return vm.Undefined, vmInstance.NewTypeError("Cannot get property descriptor on revoked Proxy")
 		}
 
-		// Check for getOwnPropertyDescriptor trap (per spec: GetMethod treats null/undefined as absent)
-		if getTrap, ok := proxy.Handler().AsPlainObject().GetOwn("getOwnPropertyDescriptor"); ok && !getTrap.IsUndefined() && getTrap.Type() != vm.TypeNull {
+		// Check for getOwnPropertyDescriptor trap. GetMethod(handler,
+		// "getOwnPropertyDescriptor") per spec: an inherited trap counts,
+		// not just an own one - vmInstance.ProxyGetTrap (not a bare
+		// proxy.Handler().AsPlainObject().GetOwn("getOwnPropertyDescriptor"))
+		// for the same reason documented on its pkg/vm definition.
+		if getTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "getOwnPropertyDescriptor"); ok && !getTrap.IsUndefined() && getTrap.Type() != vm.TypeNull {
 			// Validate trap is callable
 			if !getTrap.IsFunction() {
 				return vm.Undefined, vmInstance.NewTypeError("'getOwnPropertyDescriptor' on proxy: trap is not a function")
@@ -5660,8 +5675,12 @@ func objectIsExtensibleWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, err
 			return vm.Undefined, vmInstance.NewTypeError("Cannot check extensibility of revoked Proxy")
 		}
 
-		// Check for isExtensible trap (per spec: GetMethod treats null/undefined as absent)
-		if extTrap, ok := proxy.Handler().AsPlainObject().GetOwn("isExtensible"); ok && !extTrap.IsUndefined() && extTrap.Type() != vm.TypeNull {
+		// Check for isExtensible trap. GetMethod(handler, "isExtensible")
+		// per spec: an inherited trap counts, not just an own one -
+		// vmInstance.ProxyGetTrap (not a bare
+		// proxy.Handler().AsPlainObject().GetOwn("isExtensible")) for the
+		// same reason documented on its pkg/vm definition.
+		if extTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "isExtensible"); ok && !extTrap.IsUndefined() && extTrap.Type() != vm.TypeNull {
 			// Validate trap is callable
 			if !extTrap.IsFunction() {
 				return vm.Undefined, vmInstance.NewTypeError("'isExtensible' on proxy: trap is not a function")
@@ -5749,8 +5768,12 @@ func objectPreventExtensionsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value
 			return vm.Undefined, vmInstance.NewTypeError("Cannot prevent extensions on revoked Proxy")
 		}
 
-		// Check for preventExtensions trap (per spec: GetMethod treats null/undefined as absent)
-		if prevTrap, ok := proxy.Handler().AsPlainObject().GetOwn("preventExtensions"); ok && !prevTrap.IsUndefined() && prevTrap.Type() != vm.TypeNull {
+		// Check for preventExtensions trap. GetMethod(handler,
+		// "preventExtensions") per spec: an inherited trap counts, not
+		// just an own one - vmInstance.ProxyGetTrap (not a bare
+		// proxy.Handler().AsPlainObject().GetOwn("preventExtensions")) for
+		// the same reason documented on its pkg/vm definition.
+		if prevTrap, ok := vmInstance.ProxyGetTrap(proxy.Handler(), "preventExtensions"); ok && !prevTrap.IsUndefined() && prevTrap.Type() != vm.TypeNull {
 			// Validate trap is callable
 			if !prevTrap.IsFunction() {
 				return vm.Undefined, vmInstance.NewTypeError("'preventExtensions' on proxy: trap is not a function")

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2718,18 +2718,28 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 		arrObj.Append(vm.NewString("length"))
 		return arr, nil
 	case vm.TypeObject:
-		if obj.Type() == vm.TypeObject {
-			po := obj.AsPlainObject()
-			// OwnPropertyNames returns ALL own string property names including non-enumerable
-			for _, k := range po.OwnPropertyNames() {
-				arrObj.Append(vm.NewString(k))
-			}
-		} else if obj.Type() == vm.TypeDictObject {
-			d := obj.AsDictObject()
-			// DictObject.OwnPropertyNames returns all property names
-			for _, k := range d.OwnPropertyNames() {
-				arrObj.Append(vm.NewString(k))
-			}
+		po := obj.AsPlainObject()
+		// OwnPropertyNames returns ALL own string property names including non-enumerable
+		for _, k := range po.OwnPropertyNames() {
+			arrObj.Append(vm.NewString(k))
+		}
+	case vm.TypeDictObject:
+		// This used to be an unreachable `else if` nested inside the
+		// `case vm.TypeObject:` body above (dead code - within that case,
+		// obj.Type() is always TypeObject, so the else-if branch could
+		// never run) - meaning Object.getOwnPropertyNames on a DictObject
+		// (a TypeScript `enum`, or a module namespace object - both
+		// reachable from user code, see pkg/compiler/compile_enum.go and
+		// module_bindings.go) fell all the way through to this function's
+		// `default: return arr, nil` and answered [] instead of listing
+		// the enum's real own properties. Found while adding this
+		// function's new TypeProxy case, since a Proxy wrapping a
+		// DictObject target would otherwise silently inherit the exact
+		// same bug through the new delegation.
+		d := obj.AsDictObject()
+		// DictObject.OwnPropertyNames returns all property names
+		for _, k := range d.OwnPropertyNames() {
+			arrObj.Append(vm.NewString(k))
 		}
 	case vm.TypeArray:
 		a := obj.AsArray()
@@ -2949,6 +2959,34 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 				arrObj.Append(vm.NewString(k))
 			}
 		}
+	case vm.TypeProxy:
+		// This switch never had a case for TypeProxy at all - it fell
+		// through to `default: return arr, nil` and answered [] for ANY
+		// Proxy, regardless of what its target actually has:
+		//
+		//   const target = { a: 1 };
+		//   Object.getOwnPropertyNames(new Proxy(target, {})); // before: [] - Node: ["a"]
+		//
+		// proxyOwnPropertyKeys implements the shared ECMA-262 10.5.11
+		// [[OwnPropertyKeys]] machinery (also used by
+		// objectGetOwnPropertySymbolsWithVM's own new TypeProxy case below
+		// and by Reflect.ownKeys, reflect_init.go) - one trap invocation
+		// (or delegation) producing the full mixed string+symbol key list,
+		// which each of those three callers then filters differently, per
+		// spec (they all call the same internal method and filter its
+		// result, rather than each doing its own separate trap
+		// invocation - calling a possibly-side-effecting trap twice for
+		// what should be one [[OwnPropertyKeys]] call would itself be a
+		// bug).
+		keys, err := proxyOwnPropertyKeys(vmInstance, obj)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for _, k := range keys {
+			if k.Type() != vm.TypeSymbol {
+				arrObj.Append(k)
+			}
+		}
 	default:
 		// Non-object types return empty array
 		return arr, nil
@@ -3017,9 +3055,178 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 				arrObj.Append(s)
 			}
 		}
+	} else if obj.Type() == vm.TypeProxy {
+		// Same gap, same fix, as objectGetOwnPropertyNamesWithVM's new
+		// TypeProxy case above (see its comment for the full rationale) -
+		// this function had no case for TypeProxy at all either, so
+		// Object.getOwnPropertySymbols(new Proxy(target, {})) always
+		// answered [] regardless of what symbol-keyed properties `target`
+		// actually had. Filters proxyOwnPropertyKeys's shared mixed-key
+		// result down to symbols, the mirror image of the string-only
+		// filter in objectGetOwnPropertyNamesWithVM.
+		keys, err := proxyOwnPropertyKeys(vmInstance, obj)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		for _, k := range keys {
+			if k.Type() == vm.TypeSymbol {
+				arrObj.Append(k)
+			}
+		}
 	}
 	// DictObject does not support symbols; returns empty array
 	return arr, nil
+}
+
+// proxyOwnPropertyKeys implements ECMA-262 10.5.11 [[OwnPropertyKeys]] for a
+// Proxy exotic object - the single shared entry point objectGetOwnPropertyNamesWithVM,
+// objectGetOwnPropertySymbolsWithVM, and Reflect.ownKeys (reflect_init.go)
+// all delegate to and then filter differently, per spec (all three call the
+// same internal method and filter its result - not each doing its own
+// separate trap invocation, which would invoke a possibly-side-effecting
+// trap more than once for what should be a single [[OwnPropertyKeys]] call).
+//
+// Implements spec steps 1-7 (revoked check, GetMethod(handler, "ownKeys"),
+// CreateListFromArrayLike with its String|Symbol element-type restriction,
+// and the unconditional "no duplicate entries" check) plus the "no trap"
+// delegation (step 4's `return ? target.[[OwnPropertyKeys]]()`).
+//
+// Deliberately DOES NOT implement steps 8-16 (the [[Extensible]]/
+// configurable-key invariant validation a well-behaved trap must satisfy) -
+// a trap's raw result is returned as-is once past the checks above. This is
+// right for a well-behaved trap (verified against Node: a trap that simply
+// returns a different key list gets that list back verbatim) and wrong only
+// for one that violates those invariants (Node throws a TypeError there;
+// this returns the trap's result instead) - a real, narrower, deliberately
+// deferred gap (see the follow-up chip this was flagged with) rather than
+// the wrong tradeoff of delegating to the target's own keys instead, which
+// would produce an equally wrong but LESS plausible-looking answer for the
+// overwhelmingly common "trap just returns its own list" case.
+func proxyOwnPropertyKeys(vmInstance *vm.VM, proxyVal vm.Value) ([]vm.Value, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return nil, vmInstance.NewTypeError("Cannot perform 'ownKeys' on a revoked Proxy")
+	}
+	handler := proxy.Handler()
+	target := proxy.Target()
+
+	// GetMethod(handler, "ownKeys"): an inherited trap counts, undefined/
+	// null mean "no trap" - mirrors reflect_has.go's proxyReflectHas and
+	// reflect_init.go's reflectProxySet/reflectProxyDefineDataProperty,
+	// since proxyGetTrap (pkg/vm) is unexported and unreachable from this
+	// package.
+	var trap vm.Value
+	var hasTrap bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		trap, hasTrap = handler.AsPlainObject().Get("ownKeys")
+	case vm.TypeDictObject:
+		trap, hasTrap = handler.AsDictObject().Get("ownKeys")
+	}
+	if !hasTrap || trap.Type() == vm.TypeUndefined || trap.Type() == vm.TypeNull {
+		// No trap: delegate to target.[[OwnPropertyKeys]]() - concatenate
+		// the string-key and symbol-key halves, which for a plain
+		// (non-Proxy) target is exactly ECMA-262 10.1.11
+		// OrdinaryOwnPropertyKeys's required order (integer indices, then
+		// string keys, then symbol keys, all in creation order) - and
+		// recurses correctly for a nested Proxy target via this same
+		// function, through objectGetOwnPropertyNamesWithVM's own
+		// TypeProxy case calling back into this one.
+		namesVal, err := objectGetOwnPropertyNamesWithVM(vmInstance, []vm.Value{target})
+		if err != nil {
+			return nil, err
+		}
+		symsVal, err := objectGetOwnPropertySymbolsWithVM(vmInstance, []vm.Value{target})
+		if err != nil {
+			return nil, err
+		}
+		var keys []vm.Value
+		if namesVal.Type() == vm.TypeArray {
+			namesArr := namesVal.AsArray()
+			for i := 0; i < namesArr.Length(); i++ {
+				keys = append(keys, namesArr.Get(i))
+			}
+		}
+		if symsVal.Type() == vm.TypeArray {
+			symsArr := symsVal.AsArray()
+			for i := 0; i < symsArr.Length(); i++ {
+				keys = append(keys, symsArr.Get(i))
+			}
+		}
+		return keys, nil
+	}
+	if !trap.IsCallable() {
+		return nil, vmInstance.NewTypeError("'ownKeys' on proxy: trap is not a function")
+	}
+
+	trapResultArray, err := vmInstance.Call(trap, handler, []vm.Value{target})
+	if err != nil {
+		return nil, err
+	}
+
+	// CreateListFromArrayLike(trapResultArray, « String, Symbol »): accept
+	// a real array (the overwhelmingly common case) via a fast path, or
+	// any array-like object via .length + indexed access (mirrors the
+	// CreateListFromArrayLike pattern already inlined at reflect_init.go's
+	// "apply"/"construct" closures for their own argumentsList parameter).
+	var rawElements []vm.Value
+	if trapResultArray.Type() == vm.TypeArray {
+		trapArr := trapResultArray.AsArray()
+		for i := 0; i < trapArr.Length(); i++ {
+			rawElements = append(rawElements, trapArr.Get(i))
+		}
+	} else if trapResultArray.IsObject() {
+		lengthVal, err := vmInstance.GetProperty(trapResultArray, "length")
+		if err != nil {
+			return nil, err
+		}
+		length := int(lengthVal.ToFloat())
+		if length < 0 {
+			length = 0
+		}
+		for i := 0; i < length; i++ {
+			val, err := vmInstance.GetProperty(trapResultArray, strconv.Itoa(i))
+			if err != nil {
+				return nil, err
+			}
+			rawElements = append(rawElements, val)
+		}
+	} else {
+		return nil, vmInstance.NewTypeError("'ownKeys' on proxy: trap result is not an object")
+	}
+
+	// Dedup by CONTENT for a string (its `.ToString()`) and by IDENTITY for
+	// a symbol (its underlying *SymbolObject pointer) - NOT by vm.Value
+	// equality directly: two runtime-built TypeString values holding the
+	// same text are not guaranteed to compare equal via Go's `==` on
+	// vm.Value (verified: a literal "a" and a runtime-concatenated
+	// "a" + "" trap result failed to dedup when keyed on the raw Value,
+	// silently letting Node's genuine duplicate-entries TypeError through
+	// as if the list were fine).
+	type ownKeyDedupKey struct {
+		str string
+		sym *vm.SymbolObject
+	}
+	seen := make(map[ownKeyDedupKey]bool, len(rawElements))
+	trapResult := make([]vm.Value, 0, len(rawElements))
+	for _, el := range rawElements {
+		if el.Type() != vm.TypeString && el.Type() != vm.TypeSymbol {
+			return nil, vmInstance.NewTypeError(el.ToString() + " is not a valid property name")
+		}
+		var dedupKey ownKeyDedupKey
+		if el.Type() == vm.TypeSymbol {
+			dedupKey = ownKeyDedupKey{sym: el.AsSymbolObject()}
+		} else {
+			dedupKey = ownKeyDedupKey{str: el.ToString()}
+		}
+		if seen[dedupKey] {
+			return nil, vmInstance.NewTypeError("'ownKeys' on proxy: trap returned duplicate entries")
+		}
+		seen[dedupKey] = true
+		trapResult = append(trapResult, el)
+	}
+
+	return trapResult, nil
 }
 
 // reflectOwnKeysImpl returns own property keys: string names first (any enumerability), then symbols

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2913,6 +2913,25 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 				arrObj.Append(s)
 			}
 		}
+	} else if obj.Type() == vm.TypeNativeFunction || obj.Type() == vm.TypeNativeFunctionWithProps || obj.Type() == vm.TypeBoundFunction {
+		// These three callable kinds keep their own properties in the same
+		// lazily-allocated *PlainObject side table shape as TypeFunction/
+		// TypeClosure above (OwnPropertiesTable, pkg/vm/properties_table.go),
+		// but this function never had a case for any of them at all - so
+		// Object.getOwnPropertySymbols always answered [] even after
+		// Object.defineProperty had just added a symbol-keyed own property,
+		// even though Object.getOwnPropertyDescriptor(obj, sym) already
+		// correctly reported that same property existing (and, for
+		// TypeNativeFunction/TypeNativeFunctionWithProps,
+		// Object.getOwnPropertyDescriptors already lists it correctly too -
+		// PR #339 fixed that plural function's own equivalent gap for these
+		// same three kinds without this singular-purpose function being
+		// touched, which is what let this one lag behind unnoticed).
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			for _, s := range props.OwnSymbolKeys() {
+				arrObj.Append(s)
+			}
+		}
 	}
 	// DictObject does not support symbols; returns empty array
 	return arr, nil
@@ -5193,6 +5212,28 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 				}
 				symbolKeys = append(symbolKeys, nf.Properties.OwnSymbolKeys()...)
 			}
+		}
+	case vm.TypeBoundFunction:
+		// This case didn't exist at all before this fix, so
+		// Object.getOwnPropertyDescriptors(boundFn) always returned {}
+		// entirely - missing even "name"/"length", unlike every other
+		// callable kind's branch in this same switch (which all
+		// synthesize those two explicitly, since for THEM name/length
+		// aren't real entries in the side table). A bound function is the
+		// one callable kind where "name" ("bound " + original name) and
+		// "length" (computed at bind time) genuinely ARE real own
+		// properties set directly into bf.Properties (see
+		// pkg/vm/property_helpers.go's "Bound functions: 'name'/'length'
+		// is a real own property set at bind time" comments), so unlike
+		// TypeFunction/TypeNativeFunction*/TypeClosure above, no special
+		// synthesis is needed here - a plain OwnPropertyNames()/
+		// OwnSymbolKeys() walk already includes them alongside any other
+		// custom own property (Object.defineProperty, bracket-notation
+		// assignment).
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			stringKeys = append(stringKeys, bf.Properties.OwnPropertyNames()...)
+			symbolKeys = append(symbolKeys, bf.Properties.OwnSymbolKeys()...)
 		}
 	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
 		// These exotic kinds keep their ordinary own properties in the same

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2089,6 +2089,23 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 			}
 		}
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+		// Same side table as the exotic kinds above (OwnPropertiesTable,
+		// pkg/vm/properties_table.go) - this case was missing entirely, so
+		// Object.keys always came back empty for these four kinds even
+		// after a custom own property was defined on one (e.g. r.custom =
+		// 42, or Object.defineProperty once that gap is fixed too).
+		// RegExp's "lastIndex" never appears here: it's a real Go field on
+		// RegExpObject, not a side-table entry, and it's non-enumerable in
+		// any case (Object.getOwnPropertyDescriptor's TypeRegExp case,
+		// same file).
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			for _, key := range props.OwnKeys() {
+				if _, _, en, _, ok := props.GetOwnDescriptor(key); ok && en {
+					keysArray.Append(vm.NewString(key))
+				}
+			}
+		}
 	}
 
 	return keys, nil
@@ -4050,6 +4067,67 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
 			}
 		}
+	} else if obj.Type() == vm.TypeRegExp || obj.Type() == vm.TypeMap || obj.Type() == vm.TypeSet || obj.Type() == vm.TypePromise {
+		// These exotic kinds keep their ordinary own properties in the same
+		// lazily-allocated side table Function/Closure use above
+		// (OwnPropertiesTable/EnsureOwnPropertiesTable, pkg/vm/
+		// properties_table.go, shared by ownPropertiesSlot's switch) - this
+		// branch was missing entirely, so a fresh RegExp/Map/Set/Promise
+		// (no table yet - the common case, since nothing else forces one
+		// into existence first) made Object.defineProperty/
+		// Reflect.defineProperty silently do nothing while still returning
+		// the object as if it had succeeded.
+		//
+		// RegExp's "lastIndex" is excluded: it is a real Go field on
+		// RegExpObject (see reflectDeleteProperty's TypeRegExp case -
+		// {writable: true, configurable: false}), not a side-table entry -
+		// a table write here would create a second, disconnected
+		// "lastIndex" that shadows nothing real. Redefining lastIndex
+		// through defineProperty remains a pre-existing, untouched gap
+		// (still the same no-op it already was, not a new regression).
+		if obj.Type() == vm.TypeRegExp && !keyIsSymbol && propName == "lastIndex" {
+			// no-op - see comment above.
+		} else if props := vm.EnsureOwnPropertiesTable(obj); props != nil {
+			isAccessor0 := false
+			if keyIsSymbol {
+				if _, _, _, _, ok := props.GetOwnAccessorByKey(vm.NewSymbolKey(propSym)); ok {
+					isAccessor0 = true
+				}
+			} else if _, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				isAccessor0 = true
+			}
+			// Preserve the existing value when the descriptor doesn't
+			// specify one and isn't converting to/from an accessor -
+			// DefineOwnProperty otherwise overwrites an existing data
+			// property's value with the zero Value{} passed here (mirrors
+			// the TypeObject branch above).
+			if !hasValue && !isAccessor0 && !(hasGetter || hasSetter) {
+				if keyIsSymbol {
+					if existingVal, ok := props.GetOwnByKey(vm.NewSymbolKey(propSym)); ok {
+						value = existingVal
+					}
+				} else if existingVal, ok := props.GetOwn(propName); ok {
+					value = existingVal
+				}
+			}
+			var defined bool
+			if hasGetter || hasSetter {
+				if keyIsSymbol {
+					defined = props.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				} else {
+					defined = props.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				}
+			} else {
+				if keyIsSymbol {
+					defined = props.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+				} else {
+					defined = props.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
+			}
+		}
 	}
 
 	return obj, nil
@@ -4799,6 +4877,53 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 		}
 	}
 
+	// Map/Set/Promise have no intrinsic own properties of their own (unlike
+	// RegExp's "lastIndex" above) - only whatever a program has defined on
+	// the same side table via Object/Reflect.defineProperty or a plain
+	// assignment (OwnPropertiesTable, pkg/vm/properties_table.go). This case
+	// was missing entirely, so Object.getOwnPropertyDescriptor always
+	// answered undefined for a custom property on one of these three kinds.
+	if obj.Type() == vm.TypeMap || obj.Type() == vm.TypeSet || obj.Type() == vm.TypePromise {
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			if keyIsSymbol {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := props.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := props.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			} else {
+				if g, s, e, c, ok := props.GetOwnAccessor(propName); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := props.GetOwnDescriptor(propName); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+		}
+	}
+
 	return vm.Undefined, nil
 }
 
@@ -4897,6 +5022,31 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 					}
 				}
 			}
+		}
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+		// These exotic kinds keep their ordinary own properties in the same
+		// lazily-allocated side table (OwnPropertiesTable, pkg/vm/
+		// properties_table.go) as Function/Closure/NativeFunctionWithProps
+		// above - this case was missing entirely, so
+		// Object.getOwnPropertyDescriptors always returned {} for one of
+		// these four kinds even after a real own property had been defined
+		// or assigned on it, despite the single-key
+		// Object.getOwnPropertyDescriptor already answering correctly for
+		// the exact same property.
+		//
+		// RegExp's "lastIndex" is its own case: like TypeFunction's
+		// synthesized "length"/"name"/"prototype" intrinsics above, it is a
+		// real own property that isn't stored in the side table at all (a
+		// Go field on RegExpObject instead - see
+		// objectGetOwnPropertyDescriptorWithVM's TypeRegExp handling, same
+		// file), so it has to be added explicitly rather than falling out
+		// of OwnPropertyNames().
+		if obj.Type() == vm.TypeRegExp {
+			stringKeys = append(stringKeys, "lastIndex")
+		}
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			stringKeys = append(stringKeys, props.OwnPropertyNames()...)
+			symbolKeys = append(symbolKeys, props.OwnSymbolKeys()...)
 		}
 	}
 

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -4822,9 +4822,37 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 		}
 	case vm.TypeBoundFunction:
 		bf := obj.AsBoundFunction()
-		// Bound function name/length are real own properties in bf.Properties
-		// They can be deleted (configurable:true) or redefined via Object.defineProperty
 		if bf.Properties != nil {
+			// A symbol key never names the synthesized "name"/"length"
+			// intrinsics above, so it skips straight to the side-table
+			// lookup - mirroring the TypeMap/TypeSet/TypePromise block
+			// below (accessor first, then data), which this case never
+			// had at all: it only ever looked up `propName`, a string, so
+			// `Object.getOwnPropertyDescriptor(boundFn, sym)` answered
+			// undefined even for a real own symbol property that
+			// Reflect.has/`in` already found correctly.
+			if keyIsSymbol {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := bf.Properties.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := bf.Properties.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				return vm.Undefined, nil
+			}
+			// Bound function name/length are real own properties in bf.Properties
+			// They can be deleted (configurable:true) or redefined via Object.defineProperty
 			if propName == "name" || propName == "length" {
 				if val, ok := bf.Properties.GetOwn(propName); ok {
 					_, w, e, c, _ := bf.Properties.GetOwnDescriptor(propName)
@@ -4854,6 +4882,38 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	// Handle RegExp intrinsic property: lastIndex
 	// Per ECMAScript spec: {value: 0, writable: true, enumerable: false, configurable: false}
 	if obj.Type() == vm.TypeRegExp {
+		// A symbol key is never "lastIndex" (a symbol never equals a
+		// string), so that intrinsic check stays string-only and this
+		// skips straight to the side-table lookup - mirroring the
+		// TypeMap/TypeSet/TypePromise block above (accessor first, then
+		// data), which the "custom properties on the regex" check just
+		// below never had at all: it only ever looked up `propName`, a
+		// string, so `Object.getOwnPropertyDescriptor(regex, sym)`
+		// answered undefined even for a real own symbol property that
+		// Reflect.has/`in` already found correctly.
+		if keyIsSymbol {
+			regexObj := obj.AsRegExpObject()
+			if regexObj != nil && regexObj.Properties != nil {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := regexObj.Properties.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := regexObj.Properties.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+			return vm.Undefined, nil
+		}
 		if propName == "lastIndex" {
 			regexObj := obj.AsRegExpObject()
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2089,16 +2089,19 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 			}
 		}
-	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps:
 		// Same side table as the exotic kinds above (OwnPropertiesTable,
 		// pkg/vm/properties_table.go) - this case was missing entirely, so
-		// Object.keys always came back empty for these four kinds even
+		// Object.keys always came back empty for these six kinds even
 		// after a custom own property was defined on one (e.g. r.custom =
 		// 42, or Object.defineProperty once that gap is fixed too).
 		// RegExp's "lastIndex" never appears here: it's a real Go field on
 		// RegExpObject, not a side-table entry, and it's non-enumerable in
 		// any case (Object.getOwnPropertyDescriptor's TypeRegExp case,
-		// same file).
+		// same file). TypeNativeFunction/TypeNativeFunctionWithProps'
+		// "name"/"length" intrinsics are non-enumerable synthesized
+		// properties, not side-table entries either, so they're correctly
+		// excluded here the same way.
 		if props := vm.OwnPropertiesTable(obj); props != nil {
 			for _, key := range props.OwnKeys() {
 				if _, _, en, _, ok := props.GetOwnDescriptor(key); ok && en {
@@ -5166,6 +5169,29 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 						stringKeys = append(stringKeys, k)
 					}
 				}
+				// Symbol keys were missing here too (e.g. a symbol property
+				// defined on a native constructor like Boolean/Number) -
+				// same gap as the TypeNativeFunction branch below, fixed
+				// alongside it since it's the identical one-line fix on the
+				// identical *PlainObject side table.
+				symbolKeys = append(symbolKeys, nfp.Properties.OwnSymbolKeys()...)
+			}
+		} else {
+			// TypeNativeFunction: a plain native method's own custom
+			// properties - this branch never existed at all, so
+			// Object.getOwnPropertyDescriptors(nf) only ever reported
+			// "length"/"name", silently dropping anything just defined via
+			// Object.defineProperty or bracket-notation assignment (the
+			// single-key Object.getOwnPropertyDescriptor already answered
+			// correctly for the exact same property).
+			nf := obj.AsNativeFunction()
+			if nf.Properties != nil {
+				for _, k := range nf.Properties.OwnPropertyNames() {
+					if k != "length" && k != "name" {
+						stringKeys = append(stringKeys, k)
+					}
+				}
+				symbolKeys = append(symbolKeys, nf.Properties.OwnSymbolKeys()...)
 			}
 		}
 	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -5023,6 +5023,31 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 				}
 			}
 		}
+	case vm.TypeRegExp, vm.TypeMap, vm.TypeSet, vm.TypePromise:
+		// These exotic kinds keep their ordinary own properties in the same
+		// lazily-allocated side table (OwnPropertiesTable, pkg/vm/
+		// properties_table.go) as Function/Closure/NativeFunctionWithProps
+		// above - this case was missing entirely, so
+		// Object.getOwnPropertyDescriptors always returned {} for one of
+		// these four kinds even after a real own property had been defined
+		// or assigned on it, despite the single-key
+		// Object.getOwnPropertyDescriptor already answering correctly for
+		// the exact same property.
+		//
+		// RegExp's "lastIndex" is its own case: like TypeFunction's
+		// synthesized "length"/"name"/"prototype" intrinsics above, it is a
+		// real own property that isn't stored in the side table at all (a
+		// Go field on RegExpObject instead - see
+		// objectGetOwnPropertyDescriptorWithVM's TypeRegExp handling, same
+		// file), so it has to be added explicitly rather than falling out
+		// of OwnPropertyNames().
+		if obj.Type() == vm.TypeRegExp {
+			stringKeys = append(stringKeys, "lastIndex")
+		}
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			stringKeys = append(stringKeys, props.OwnPropertyNames()...)
+			symbolKeys = append(symbolKeys, props.OwnSymbolKeys()...)
+		}
 	}
 
 	// Get descriptor for each string key

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2794,8 +2794,19 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			}
 		}
 
-		// If no prototype was found in Properties, add it at the end
-		if !hasPrototype {
+		// If no prototype was found in Properties, only synthesize one when
+		// this function is actually constructible - an arrow function or a
+		// plain (non-generator) async function has NO "prototype" own
+		// property at all per spec, unlike an ordinary function, a
+		// generator function, or an async generator function, which all
+		// have one. This used to append "prototype" here unconditionally,
+		// which was wrong for exactly those two kinds (verified against
+		// Node: Object.getOwnPropertyNames(() => {}) is ["length","name"],
+		// no "prototype"). vm.IsConstructor already implements this exact
+		// rule for TypeFunction/TypeClosure
+		// (!IsArrowFunction && !(IsAsync && !IsGenerator)) - reused here
+		// rather than duplicated.
+		if !hasPrototype && vmInstance.IsConstructor(obj) {
 			arrObj.Append(vm.NewString("prototype"))
 		}
 	case vm.TypeClosure:
@@ -2840,7 +2851,9 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			}
 		}
 
-		if !hasPrototype {
+		// Same guard as the TypeFunction case above - see its comment for
+		// the full rationale and Node verification.
+		if !hasPrototype && vmInstance.IsConstructor(obj) {
 			arrObj.Append(vm.NewString("prototype"))
 		}
 	case vm.TypeNativeFunctionWithProps:

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2864,6 +2864,78 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 				arrObj.Append(vm.NewString(k))
 			}
 		}
+	case vm.TypeNativeFunction:
+		// A plain (non-Props) native function - this switch never had a case
+		// for it at all, so Object.getOwnPropertyNames fell to the
+		// default/"non-object types" branch and answered [] even for a
+		// function with real own properties (Object.defineProperty already
+		// let you add one - Object.getOwnPropertyDescriptor(s) already
+		// listed it correctly, PR #339). Mirrors the
+		// TypeNativeFunctionWithProps case above - "length"/"name" are
+		// synthesized (not real own properties for this kind either), and
+		// "prototype" is included only when this native function is
+		// actually a constructor (checked here since, unlike
+		// TypeFunction/TypeClosure below, every TypeNativeFunction defined
+		// in this codebase today is IsConstructor==false in practice, so
+		// this guard is what correctly keeps "prototype" OFF a plain
+		// native function like Array.prototype.slice - verified against
+		// Node, which agrees: no "prototype" there).
+		nf := obj.AsNativeFunction()
+		var propNames []string
+		if props := vm.OwnPropertiesTable(obj); props != nil {
+			propNames = props.OwnPropertyNames()
+		}
+
+		for _, k := range propNames {
+			if isIntegerIndex(k) {
+				arrObj.Append(vm.NewString(k))
+			}
+		}
+
+		arrObj.Append(vm.NewString("length"))
+		arrObj.Append(vm.NewString("name"))
+
+		hasPrototype := false
+		for _, k := range propNames {
+			if k == "prototype" {
+				hasPrototype = true
+				break
+			}
+		}
+		if hasPrototype {
+			arrObj.Append(vm.NewString("prototype"))
+		}
+
+		for _, k := range propNames {
+			if k != "length" && k != "name" && k != "prototype" && !isIntegerIndex(k) {
+				arrObj.Append(vm.NewString(k))
+			}
+		}
+
+		if !hasPrototype && nf.IsConstructor {
+			arrObj.Append(vm.NewString("prototype"))
+		}
+	case vm.TypeBoundFunction:
+		// Another kind this switch never had a case for at all - fell to
+		// the default/empty branch. Unlike every other callable kind
+		// above, a bound function needs NO synthesis whatsoever: "name"
+		// (bound " + original) and "length" are REAL own properties
+		// written directly into bf.Properties at bind time (PR #343's
+		// "Bound functions: 'name'/'length' is a real own property set at
+		// bind time" precedent - re-synthesizing them here would just
+		// duplicate them), and a bound function exotic object never has
+		// its own "prototype" property at all, regardless of whether its
+		// target is a constructor (verified against Node:
+		// `Reflect.ownKeys(SomeClass.bind(null))` is `["length","name"]`,
+		// no "prototype", even though SomeClass itself has one). So the
+		// stored table's own names, already integer-indices-first per
+		// OwnPropertyNames(), are the complete, correctly-ordered answer.
+		bf := obj.AsBoundFunction()
+		if bf.Properties != nil {
+			for _, k := range bf.Properties.OwnPropertyNames() {
+				arrObj.Append(vm.NewString(k))
+			}
+		}
 	default:
 		// Non-object types return empty array
 		return arr, nil

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3454,7 +3454,8 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		obj.Type() == vm.TypeFunction ||
 		obj.Type() == vm.TypeClosure ||
 		obj.Type() == vm.TypeNativeFunctionWithProps ||
-		obj.Type() == vm.TypeBoundFunction
+		obj.Type() == vm.TypeBoundFunction ||
+		obj.Type() == vm.TypeNativeFunction
 	if !isObjectLike {
 		return vm.Undefined, vmInstance.NewTypeError("Object.defineProperty called on non-object")
 	}
@@ -4009,6 +4010,39 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 					defined = nfp.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
 				} else {
 					defined = nfp.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
+				}
+			}
+			if !defined {
+				return vm.Undefined, definePropertyRejected(vmInstance, propName, propSym, keyIsSymbol)
+			}
+		}
+	} else if obj.Type() == vm.TypeNativeFunction {
+		// Plain native functions (e.g. Array.prototype.push) store additional
+		// properties in Properties exactly like TypeNativeFunctionWithProps
+		// above - the isObjectLike gate near the top of this function used to
+		// exclude TypeNativeFunction entirely, so Object.defineProperty on
+		// one of these threw "called on non-object" even though a
+		// bracket-notation assignment on the exact same value already wrote
+		// into this same table fine (pkg/vm/properties_table.go's
+		// ownPropertiesSlot has always listed TypeNativeFunction alongside
+		// the other four callable kinds).
+		nf := obj.AsNativeFunction()
+		if nf != nil {
+			if nf.Properties == nil {
+				nf.Properties = vm.EnsureOwnPropertiesTable(obj)
+			}
+			var defined bool
+			if hasGetter || hasSetter {
+				if keyIsSymbol {
+					defined = nf.Properties.DefineAccessorPropertyByKey(vm.NewSymbolKey(propSym), getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				} else {
+					defined = nf.Properties.DefineAccessorProperty(propName, getter, hasGetter, setter, hasSetter, enumerablePtr, configurablePtr)
+				}
+			} else {
+				if keyIsSymbol {
+					defined = nf.Properties.DefineOwnPropertyByKey(vm.NewSymbolKey(propSym), value, writablePtr, enumerablePtr, configurablePtr)
+				} else {
+					defined = nf.Properties.DefineOwnProperty(propName, value, writablePtr, enumerablePtr, configurablePtr)
 				}
 			}
 			if !defined {
@@ -4786,6 +4820,36 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 		}
 	case vm.TypeNativeFunction:
 		nf := obj.AsNativeFunction()
+		// A symbol key is never "name"/"length" (a symbol never equals a
+		// string), so it skips straight to the side-table lookup - mirroring
+		// the TypeBoundFunction block below (accessor first, then data).
+		// Before this, TypeNativeFunction never checked nf.Properties at
+		// all here, symbol or string key: Object.defineProperty on a plain
+		// native function (e.g. Array.prototype.push) now writes into that
+		// table (a separate, sibling fix), but this getter still answered
+		// undefined for what it had just written.
+		if keyIsSymbol {
+			if nf.Properties != nil {
+				symKey := vm.NewSymbolKey(propSym)
+				if g, s, e, c, ok := nf.Properties.GetOwnAccessorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, w, e, c, ok := nf.Properties.GetOwnDescriptorByKey(symKey); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(w))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+			return vm.Undefined, nil
+		}
 		if propName == "name" && !nf.DeletedName {
 			descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 			descriptor.SetOwn("value", vm.NewString(nf.Name))
@@ -4801,6 +4865,27 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 			descriptor.SetOwn("enumerable", vm.BooleanValue(false))
 			descriptor.SetOwn("configurable", vm.BooleanValue(true))
 			return vm.NewValueFromPlainObject(descriptor), nil
+		}
+		// Any other own property (set via bracket-notation assignment or
+		// Object.defineProperty on this same table) - accessor first, then
+		// data, mirroring the symbol-key check above.
+		if nf.Properties != nil {
+			if g, s, e, c, ok := nf.Properties.GetOwnAccessor(propName); ok {
+				descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+				descriptor.SetOwn("get", g)
+				descriptor.SetOwn("set", s)
+				descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+				descriptor.SetOwn("configurable", vm.BooleanValue(c))
+				return vm.NewValueFromPlainObject(descriptor), nil
+			}
+			if v, w, e, c, ok := nf.Properties.GetOwnDescriptor(propName); ok {
+				descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+				descriptor.SetOwn("value", v)
+				descriptor.SetOwn("writable", vm.BooleanValue(w))
+				descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+				descriptor.SetOwn("configurable", vm.BooleanValue(c))
+				return vm.NewValueFromPlainObject(descriptor), nil
+			}
 		}
 	case vm.TypeNativeFunctionWithProps:
 		nfp := obj.AsNativeFunctionWithProps()

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -3016,6 +3016,26 @@ func objectGetOwnPropertySymbolsWithVM(vmInstance *vm.VM, args []vm.Value) (vm.V
 		for _, s := range po.OwnSymbolKeys() {
 			arrObj.Append(s)
 		}
+	} else if obj.Type() == vm.TypeArray {
+		// ArrayObject already stores symbol-keyed properties
+		// (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp - that's how
+		// `arr[sym] = v` works at all), but this function never had a
+		// case for TypeArray at all, so Object.getOwnPropertySymbols on
+		// an array with a real symbol property silently answered []
+		// (verified against Node, which lists it):
+		//
+		//   const arr = [1, 2, 3];
+		//   arr[Symbol("s")] = 42;
+		//   Object.getOwnPropertySymbols(arr).length; // before: 0 - Node: 1
+		//
+		// ArrayObject.OwnSymbolKeys() (pkg/vm/value.go) is the new
+		// enumerator this case needed - it didn't exist at all before
+		// this fix, unlike PlainObject's own OwnSymbolKeys the TypeObject
+		// case above already used.
+		a := obj.AsArray()
+		for _, s := range a.OwnSymbolKeys() {
+			arrObj.Append(s)
+		}
 	} else if obj.Type() == vm.TypeFunction {
 		// Functions store properties in their Properties field
 		fn := obj.AsFunction()
@@ -4830,6 +4850,51 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	// Check arrays first before plainObj (arrays can also be AsPlainObject but their indices are stored separately)
 	if obj.Type() == vm.TypeArray {
 		arrObj := obj.AsArray()
+		// Symbol-keyed own properties (arr[sym] = v) live in ArrayObject's
+		// own symbolProps map (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp,
+		// pkg/vm/value.go) - completely separate from the propName-based
+		// index/"length"/named-property checks below, all of which are
+		// meaningless for a symbol key (propName is "" here). This function
+		// never had a symbol-key branch for TypeArray at all, so it fell
+		// through the propName checks (none matched an empty propName) and
+		// then the switch below (which also has no TypeArray case), landing
+		// on the final default and reporting undefined even for a symbol
+		// property that demonstrably exists - Object.getOwnPropertySymbols
+		// lists it (task_778749f8) and `arr[sym]`/Reflect.get both read it
+		// back correctly, but Object.getOwnPropertyDescriptor claimed no
+		// such property existed:
+		//
+		//   const arr = [1, 2, 3]; const s = Symbol("x"); arr[s] = 42;
+		//   Object.getOwnPropertyDescriptor(arr, s);
+		//   // before: undefined
+		//   // Node:   {value: 42, writable: true, enumerable: true, configurable: true}
+		//
+		// Symbol properties on arrays have no separate attribute-override
+		// tracking (unlike named string properties' propertyDesc map), so -
+		// verified against Node - the descriptor is always the plain
+		// ordinary-property default: writable/enumerable/configurable all
+		// true. This is only safe because Object.defineProperty(arr, sym,
+		// {...}) is ITSELF currently a no-op for arrays (verified: it
+		// neither stores into symbolProps nor throws, so no non-default
+		// attribute combination or accessor can exist to misreport here) -
+		// a separate, pre-existing gap, not fixed by this branch. If a
+		// future fix adds symbol-keyed defineProperty support for arrays,
+		// this hardcoded true/true/true (and the early `return
+		// vm.Undefined, nil` for an absent key just below) will need to
+		// consult whatever attribute storage that fix introduces instead.
+		if keyIsSymbol {
+			if sym := propSym.AsSymbolObject(); sym != nil {
+				if v, ok := arrObj.GetSymbolProp(sym); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("value", v)
+					descriptor.SetOwn("writable", vm.BooleanValue(true))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(true))
+					descriptor.SetOwn("configurable", vm.BooleanValue(true))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+			}
+			return vm.Undefined, nil
+		}
 		isFrozen := arrObj.IsFrozen()
 		// An index (or named key) explicitly turned into an accessor via
 		// Object.defineProperty takes priority over the plain-element read

--- a/pkg/builtins/reflect_has.go
+++ b/pkg/builtins/reflect_has.go
@@ -215,11 +215,19 @@ func reflectHas(vmInstance *vm.VM, target vm.Value, key vm.Value) (bool, error) 
 			}
 		}
 		if isSym {
-			// See HasFunctionPrototypeProperty's doc comment: a symbol
-			// key on a callable isn't handled by the string-only
-			// FunctionPrototype fallback, so it stays unconditionally
-			// false here - same as it already was before this fix.
-			return false, nil
+			// HasFunctionPrototypeSymbolProperty mirrors OpIn's own
+			// TypeFunction/TypeClosure/TypeBoundFunction/TypeNativeFunction/
+			// TypeNativeFunctionWithProps symbol-key cases (vm.go), which
+			// walk FunctionPrototype's chain for an inherited symbol
+			// property like Symbol.hasInstance. Before this, `in` and
+			// Reflect.has already disagreed here in principle (in's walk
+			// used to look for FunctionPrototype as a bare PlainObject and
+			// silently find nothing, since it's actually a
+			// TypeNativeFunctionWithProps at runtime - see that function's
+			// doc comment), but with in's walk now fixed, leaving this
+			// unconditionally false would make the disagreement real
+			// instead of masked.
+			return vmInstance.HasFunctionPrototypeSymbolProperty(propKey), nil
 		}
 		return vmInstance.HasFunctionPrototypeProperty(name), nil
 	}

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -391,7 +391,15 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 		target := args[0]
 
-		if !target.IsObject() {
+		// Every sibling Reflect method in this file (get/set/has/apply/
+		// construct/...) gates on "!IsObject() && !IsCallable()" - this one
+		// used to gate on "!IsObject()" alone, so it threw a TypeError
+		// outright for a plain function, a class, a native function, a
+		// native constructor, or a bound function - values every other
+		// Reflect method here already accepts. Confirmed against Node:
+		// Reflect.ownKeys(Array.prototype.slice) is ["length","name"]
+		// there, not a throw.
+		if !target.IsObject() && !target.IsCallable() {
 			return vm.Undefined, vmInstance.NewTypeError("Reflect.ownKeys called on non-object")
 		}
 
@@ -400,6 +408,55 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 		arr := keysArray.AsArray()
 
 		switch target.Type() {
+		case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+			// Fixing the gate above just made these five kinds reach this
+			// switch instead of throwing - but the switch itself had no
+			// case for any of them, so they'd have fallen through to
+			// "return keysArray, nil" and answered [] instead of actually
+			// throwing OR actually working (silently wrong either way).
+			//
+			// Rather than hand-rolling a THIRD independent per-kind
+			// name/length/prototype synthesis switch alongside
+			// objectGetOwnPropertyNamesWithVM's (Object.getOwnPropertyNames)
+			// and objectGetOwnPropertySymbolsWithVM's (Object.
+			// getOwnPropertySymbols) own already-correct ones - the exact
+			// "N independent copies of the same per-kind dispatch slowly
+			// drift apart" pattern behind most of this session's bug
+			// fixes - delegate straight to those two for these five kinds
+			// only (TypeObject/TypeDictObject/TypeArray/TypeProxy below
+			// keep their own existing, already-correct logic exactly as
+			// it was; TypeNativeFunction/TypeBoundFunction were just added
+			// to objectGetOwnPropertyNamesWithVM as part of this same fix,
+			// since it had no case for either of them either - the same
+			// gap, just one level down).
+			//
+			// Per ECMAScript 10.1.11 OrdinaryOwnPropertyKeys, Reflect.
+			// ownKeys's required order - integer indices ascending, then
+			// string keys in creation order, then symbol keys in creation
+			// order - is exactly what concatenating these two functions'
+			// own outputs already produces, so no reordering is needed
+			// here.
+			namesVal, err := objectGetOwnPropertyNamesWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if namesVal.Type() == vm.TypeArray {
+				namesArr := namesVal.AsArray()
+				for i := 0; i < namesArr.Length(); i++ {
+					arr.Append(namesArr.Get(i))
+				}
+			}
+			symsVal, err := objectGetOwnPropertySymbolsWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if symsVal.Type() == vm.TypeArray {
+				symsArr := symsVal.AsArray()
+				for i := 0; i < symsArr.Length(); i++ {
+					arr.Append(symsArr.Get(i))
+				}
+			}
+			return keysArray, nil
 		case vm.TypeObject:
 			obj := target.AsPlainObject()
 			// 1. String keys (all, including non-enumerable)

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -53,7 +53,16 @@ func (r *ReflectInitializer) InitTypes(ctx *TypeContext) error {
 	// Create Reflect object type with all 13 methods
 	reflectType := types.NewObjectType().
 		// Property operations
-		WithProperty("get", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Any)).
+		//
+		// "get" takes an optional third `receiver` argument (used as the
+		// `this` an accessor's getter is called with - the runtime
+		// implementation now actually reads it, see reflectObj's "get"
+		// closure below). Reflect.set/Reflect.construct have the exact
+		// same "optional trailing argument the runtime accepts but the
+		// declared signature doesn't" gap for their own optional
+		// receiver/newTarget parameters - left alone here (out of this
+		// fix's scope) and flagged as a separate follow-up.
+		WithProperty("get", types.NewOptionalFunction([]types.Type{types.Any, keyType, types.Any}, types.Any, []bool{false, false, true})).
 		WithProperty("set", types.NewSimpleFunction([]types.Type{types.Any, keyType, types.Any}, types.Boolean)).
 		WithProperty("has", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
 		WithProperty("deleteProperty", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
@@ -94,39 +103,40 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	// Reflect.get(target, propertyKey [, receiver])
+	// Per ECMAScript spec, this invokes [[Get]] and returns the result -
+	// receiver defaults to target, and is what any accessor's getter along
+	// the way is called with as `this` (10.1.8 [[Get]] step 5/6). The
+	// actual per-kind dispatch (own-accessor-then-data, prototype-chain
+	// walk, Proxy trap invocation and invariant checks, both string and
+	// Symbol keys) lives in pkg/vm/vm_init.go's
+	// GetPropertyWithReceiver/ReflectGetSymbolPropertyWithReceiver, which
+	// this used to duplicate a much narrower, TypeObject/TypeDictObject/
+	// TypeArray-only, string-key-only version of inline - silently
+	// returning undefined for every other kind (Function, Map, Set,
+	// RegExp, BoundFunction, NativeFunction, NativeFunctionWithProps,
+	// Promise, TypedArray, Proxy, ...) and unconditionally stringifying
+	// even a Symbol key.
 	reflectObj.SetOwnNonEnumerable("get", vm.NewNativeFunction(2, false, "get", func(args []vm.Value) (vm.Value, error) {
 		if len(args) < 2 {
 			return vm.Undefined, vmInstance.NewTypeError("Reflect.get requires at least 2 arguments")
 		}
 		target := args[0]
-		propKey := args[1].ToString()
+		key := args[1]
 
 		if !target.IsObject() && !target.IsCallable() {
 			return vm.Undefined, vmInstance.NewTypeError("Reflect.get called on non-object")
 		}
 
-		// Perform simple property get
-		switch target.Type() {
-		case vm.TypeObject:
-			if val, ok := target.AsPlainObject().Get(propKey); ok {
-				return val, nil
-			}
-		case vm.TypeDictObject:
-			if val, ok := target.AsDictObject().Get(propKey); ok {
-				return val, nil
-			}
-		case vm.TypeArray:
-			arr := target.AsArray()
-			if propKey == "length" {
-				return vm.Number(float64(arr.Length())), nil
-			}
-			// Try numeric index using strconv
-			if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 && idx < arr.Length() {
-				return arr.Get(idx), nil
-			}
+		// Receiver defaults to target if not provided (ECMA-262 28.1.7).
+		receiver := target
+		if len(args) >= 3 {
+			receiver = args[2]
 		}
 
-		return vm.Undefined, nil
+		if key.Type() == vm.TypeSymbol {
+			return vmInstance.ReflectGetSymbolPropertyWithReceiver(target, key, receiver)
+		}
+		return vmInstance.GetPropertyWithReceiver(target, key.ToString(), receiver)
 	}))
 
 	// Reflect.set(target, propertyKey [, value [, receiver]])

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -842,30 +842,51 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 				arr.Append(vm.NewString(key))
 			}
 		case vm.TypeArray:
-			arrayObj := target.AsArray()
-			// Add numeric indices - skipping holes (paserati#300): a hole
-			// from `delete arr[i]`, a literal elision, or `new Array(n)` is
-			// not an own property at all.
-			for i := 0; i < arrayObj.DenseLength(); i++ {
-				key := strconv.Itoa(i)
-				if !arrayObj.HasOwnIndexProperty(key, i) {
-					continue
+			// This used to hand-roll its own index/sparse-index/"length"
+			// logic - byte-for-byte identical to
+			// objectGetOwnPropertyNamesWithVM's own TypeArray case except
+			// for one thing: it never appended NAMED (non-index) string
+			// properties at all, so an array with an ad-hoc property like
+			// `arr.foo = "bar"` was missing "foo" from Reflect.ownKeys even
+			// though Object.getOwnPropertyNames(arr) correctly included it
+			// (verified against Node, which lists it in both). It also had
+			// no symbol-key coverage whatsoever - ArrayObject.OwnSymbolKeys
+			// (pkg/vm/value.go) is a brand-new method this exact fix added,
+			// since Object.getOwnPropertySymbols had no TypeArray case
+			// either before this.
+			//
+			// Rather than hand-rolling BOTH gaps' worth of duplicate logic
+			// a second time in a second independent switch - the "N
+			// independent copies of the same per-kind dispatch slowly
+			// drift apart" pattern behind most of this session's bug
+			// fixes, and exactly how this array case ended up missing
+			// named properties while its sibling function didn't - this
+			// now delegates to objectGetOwnPropertyNamesWithVM +
+			// objectGetOwnPropertySymbolsWithVM, mirroring the five
+			// callable kinds' own delegation above (task_06547fb2). Their
+			// index/sparse-index/"length" handling is already identical to
+			// what this case had, so this is a pure superset: same output
+			// for everything that already worked, plus the two gaps closed.
+			namesVal, err := objectGetOwnPropertyNamesWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
+			}
+			if namesVal.Type() == vm.TypeArray {
+				namesArr := namesVal.AsArray()
+				for i := 0; i < namesArr.Length(); i++ {
+					arr.Append(namesArr.Get(i))
 				}
-				arr.Append(vm.NewString(key))
 			}
-			// A sparse index beyond the dense range (paserati#176/#178 -
-			// see arraySparseIndices in object_init.go) is an integer-
-			// indexed own key too, so per OrdinaryOwnPropertyKeys it
-			// belongs here, in ascending numeric order, before "length" -
-			// not visited by iterating up to it, which is exactly the
-			// multi-billion-iteration hang this fixes. Reflect.ownKeys
-			// wants every own key regardless of enumerability, hence
-			// enumerableOnly=false.
-			for _, idx := range arraySparseIndices(arrayObj, false) {
-				arr.Append(vm.NewString(strconv.Itoa(idx)))
+			symsVal, err := objectGetOwnPropertySymbolsWithVM(vmInstance, []vm.Value{target})
+			if err != nil {
+				return vm.Undefined, err
 			}
-			// Add "length"
-			arr.Append(vm.NewString("length"))
+			if symsVal.Type() == vm.TypeArray {
+				symsArr := symsVal.AsArray()
+				for i := 0; i < symsArr.Length(); i++ {
+					arr.Append(symsArr.Get(i))
+				}
+			}
 		case vm.TypeProxy:
 			// This used to claim (inaccurately) to "delegate to
 			// Object.getOwnPropertyNames + getOwnPropertySymbols as a

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -156,14 +156,14 @@ func reflectOrdinarySet(vmInstance *vm.VM, target vm.Value, propKey string, valu
 			// chain - per 10.1.9.2 step 4, the actual write still targets
 			// Receiver, not wherever this descriptor was found (which may
 			// be `target` itself, or an ancestor `target` inherits from).
-			return reflectCreateOrUpdateDataProperty(receiver, propKey, value)
+			return reflectCreateOrUpdateDataProperty(vmInstance, receiver, propKey, value)
 		}
 		current = vmInstance.PrototypeOf(current)
 	}
 	// Not found anywhere in target's chain - 10.1.9 step 4's implicit
 	// {value: undefined, writable: true, enumerable: true, configurable:
 	// true} default takes the same data-write path.
-	return reflectCreateOrUpdateDataProperty(receiver, propKey, value)
+	return reflectCreateOrUpdateDataProperty(vmInstance, receiver, propKey, value)
 }
 
 // reflectCreateOrUpdateDataProperty implements the receiver-side half of
@@ -172,7 +172,23 @@ func reflectOrdinarySet(vmInstance *vm.VM, target vm.Value, propKey string, valu
 // same key (an accessor or non-writable data property there refuses the
 // write - verified against Node for both), and otherwise create or
 // overwrite receiver's own data property with the new value.
-func reflectCreateOrUpdateDataProperty(receiver vm.Value, propKey string, value vm.Value) (bool, error) {
+//
+// A TypeProxy receiver is real, common code here, not a rare edge case:
+// Reflect.set defaults `receiver` to `target`, so
+// Reflect.set(someProxy, key, value) - the single most natural way to call
+// Reflect.set on a Proxy at all - reaches this function with a Proxy
+// receiver on its very first, simplest invocation. reflectGetOwnAccessorGeneric
+// and reflectGetOwnDataDescriptorGeneric don't special-case TypeProxy (their
+// `default` branch reports "not found", since OwnPropertiesTable doesn't
+// cover Proxy), so those two pre-checks above the switch are a no-op for a
+// Proxy receiver rather than a real 10.1.9.2 step 4.c
+// Receiver.[[GetOwnProperty]](P) check - verified against Node that this
+// doesn't change the outcome for the common "receiver has no existing
+// descriptor" case, which is what reflectProxyDefineDataProperty's own
+// getOwnPropertyDescriptor trap invocation (for side-effect parity, not
+// result-branching - matching this file's pre-existing level of rigor for
+// that trap) also confirms.
+func reflectCreateOrUpdateDataProperty(vmInstance *vm.VM, receiver vm.Value, propKey string, value vm.Value) (bool, error) {
 	// Per 10.1.9.2 step 4.a: if Receiver is not an object, return false -
 	// verified against Node: Reflect.set({}, "y", 5, 42) is false, not a
 	// throw.
@@ -217,6 +233,8 @@ func reflectCreateOrUpdateDataProperty(receiver vm.Value, propKey string, value 
 		}
 		arr.SetOwn(propKey, value)
 		return true, nil
+	case vm.TypeProxy:
+		return reflectProxyDefineDataProperty(vmInstance, receiver, propKey, value)
 	default:
 		// A callable or other exotic receiver kind (Function/Closure/
 		// NativeFunction/.../Promise) - use its shared side-table, the
@@ -228,6 +246,215 @@ func reflectCreateOrUpdateDataProperty(receiver vm.Value, propKey string, value 
 		}
 		return false, nil
 	}
+}
+
+// reflectProxyDefineDataProperty implements the receiver-side write
+// (10.1.9.2's CreateDataProperty(Receiver, ...) step, generalized to an
+// "update or create" per reflectCreateOrUpdateDataProperty's own contract)
+// when `receiver` turns out to be a Proxy - i.e. Receiver.[[DefineOwnProperty]]
+// (10.5.6): the handler's `defineProperty` trap if present, else delegate
+// straight to CreateDataProperty on the proxy's own target (which may
+// itself be another Proxy, handled by the recursive call into
+// reflectCreateOrUpdateDataProperty below).
+//
+// Also invokes the handler's `getOwnPropertyDescriptor` trap first, if
+// present, purely for spec/side-effect parity with what this function
+// supersedes (the old inline "receiver is a distinct Proxy" block this
+// commit removes from the "set" closure) - verified against Node that its
+// result doesn't change the outcome for the common case of a receiver with
+// no pre-existing descriptor for this key, which is the only case this
+// function (and its predecessor) actually handles; a receiver-Proxy with a
+// genuinely conflicting existing descriptor is not modeled here, matching
+// the prior code's own scope.
+func reflectProxyDefineDataProperty(vmInstance *vm.VM, proxyVal vm.Value, propKey string, value vm.Value) (bool, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return false, vmInstance.NewTypeError("Cannot perform 'defineProperty' on a revoked Proxy")
+	}
+	handler := proxy.Handler()
+	target := proxy.Target()
+
+	// GetMethod(handler, "getOwnPropertyDescriptor"): side-effect-only call,
+	// matching the block this supersedes - its result isn't consulted.
+	var getOwnPropDescTrap vm.Value
+	var hasGetOwnPropDesc bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		getOwnPropDescTrap, hasGetOwnPropDesc = handler.AsPlainObject().Get("getOwnPropertyDescriptor")
+	case vm.TypeDictObject:
+		getOwnPropDescTrap, hasGetOwnPropDesc = handler.AsDictObject().Get("getOwnPropertyDescriptor")
+	}
+	if hasGetOwnPropDesc && getOwnPropDescTrap.Type() != vm.TypeUndefined && getOwnPropDescTrap.Type() != vm.TypeNull {
+		if !getOwnPropDescTrap.IsCallable() {
+			return false, vmInstance.NewTypeError("'getOwnPropertyDescriptor' on proxy: trap is not a function")
+		}
+		if _, err := vmInstance.Call(getOwnPropDescTrap, handler, []vm.Value{target, vm.NewString(propKey)}); err != nil {
+			return false, err
+		}
+	}
+
+	// GetMethod(handler, "defineProperty"): an inherited trap counts,
+	// undefined/null mean "no trap" - mirrors reflectHas's proxyReflectHas
+	// (reflect_has.go), since proxyGetTrap (pkg/vm) is unexported and
+	// unreachable from this package.
+	var defineTrap vm.Value
+	var hasDefineTrap bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		defineTrap, hasDefineTrap = handler.AsPlainObject().Get("defineProperty")
+	case vm.TypeDictObject:
+		defineTrap, hasDefineTrap = handler.AsDictObject().Get("defineProperty")
+	}
+	if !hasDefineTrap || defineTrap.Type() == vm.TypeUndefined || defineTrap.Type() == vm.TypeNull {
+		// No trap: delegate straight to CreateDataProperty on the
+		// underlying target - recurses through this same generic function
+		// for whatever kind `target` turns out to be, including yet
+		// another Proxy.
+		return reflectCreateOrUpdateDataProperty(vmInstance, target, propKey, value)
+	}
+	if !defineTrap.IsCallable() {
+		return false, vmInstance.NewTypeError("'defineProperty' on proxy: trap is not a function")
+	}
+
+	// CreateDataProperty's descriptor is always {value: V, writable: true,
+	// enumerable: true, configurable: true} (7.3.5) - not whatever
+	// descriptor `target`'s own property (if any) already had, since this
+	// function models the "property doesn't exist on receiver yet" case.
+	descObj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	descObj.SetOwn("value", value)
+	descObj.SetOwn("writable", vm.BooleanValue(true))
+	descObj.SetOwn("enumerable", vm.BooleanValue(true))
+	descObj.SetOwn("configurable", vm.BooleanValue(true))
+	result, err := vmInstance.Call(defineTrap, handler, []vm.Value{target, vm.NewString(propKey), vm.NewValueFromPlainObject(descObj)})
+	if err != nil {
+		return false, err
+	}
+	return result.IsTruthy(), nil
+}
+
+// reflectProxySet implements Reflect.set's Proxy-TARGET path - ECMA-262
+// 10.5.9 [[Set]] - which this function previously had no case for at all:
+// `target.Type() == TypeProxy` passed the "set" closure's object gate
+// (Value.IsObject() is a contiguous [TypeObject, TypeProxy] range check, so
+// it's true for a Proxy), but neither the removed isDataProp computation
+// nor the final target-kind switch had a case for TypeProxy, so it fell
+// through to an unconditional `return false` for ANY Proxy target, with or
+// without a `set` trap:
+//
+//	const target = {};
+//	const p = new Proxy(target, {});
+//	Reflect.set(p, "x", 5); // before: false, target.x stayed undefined - Node: true, target.x === 5
+//
+// Mirrors op_setprop.go's opSetProp TypeProxy handling (the bytecode
+// `obj.x = v` path, which already gets this right for that narrower case),
+// but forwards Reflect.set's own `receiver` argument to the trap - NOT
+// necessarily the proxy itself, unlike ordinary assignment where the
+// receiver is always the object the property access happened on. Also
+// deliberately does NOT copy opSetProp's own no-trap fallback shape (it
+// writes directly to `target` instead of `Receiver` in the "property
+// absent everywhere" case - the same class of bug task_cd1507d7 fixed for
+// Reflect.set's non-Proxy path) - the no-trap branch here instead recurses
+// into reflectSetDispatch, reusing the already-correct
+// reflectOrdinarySet/reflectCreateOrUpdateDataProperty pair.
+func reflectProxySet(vmInstance *vm.VM, proxyVal vm.Value, propKey string, value vm.Value, receiver vm.Value) (bool, error) {
+	proxy := proxyVal.AsProxy()
+	if proxy.Revoked {
+		return false, vmInstance.NewTypeError("Cannot perform 'set' on a revoked Proxy")
+	}
+	handler := proxy.Handler()
+	target := proxy.Target()
+
+	// GetMethod(handler, "set"): an inherited trap counts, undefined/null
+	// mean "no trap" - mirrors reflectHas's proxyReflectHas (reflect_has.go).
+	var trap vm.Value
+	var hasTrap bool
+	switch handler.Type() {
+	case vm.TypeObject:
+		trap, hasTrap = handler.AsPlainObject().Get("set")
+	case vm.TypeDictObject:
+		trap, hasTrap = handler.AsDictObject().Get("set")
+	}
+	if !hasTrap || trap.Type() == vm.TypeUndefined || trap.Type() == vm.TypeNull {
+		// No trap: per spec, return target.[[Set]](P, V, Receiver) -
+		// recurse into Reflect.set's own general dispatch for whatever
+		// kind `target` (the proxy's own target, which may itself be
+		// another Proxy) turns out to be, with the SAME receiver
+		// Reflect.set was originally called with (not necessarily this
+		// proxy).
+		return reflectSetDispatch(vmInstance, target, propKey, value, receiver)
+	}
+	if !trap.IsCallable() {
+		return false, vmInstance.NewTypeError("'set' on proxy: trap is not a function")
+	}
+
+	// Trap args per 10.5.9 step 8: (target, propertyKey, V, Receiver) -
+	// propKey is passed as a plain string here (pre-existing, unrelated to
+	// this fix: Reflect.set's own args[1].ToString() up in the "set"
+	// closure already stringifies a Symbol key before it ever reaches this
+	// function - so Reflect.set(proxy, Symbol.iterator, v) hands the trap
+	// "Symbol(Symbol.iterator)" as a string rather than the real Symbol.
+	// Not fixed here - see the PR body for why - but flagged, since this
+	// is the first place that mangled key becomes externally observable to
+	// user code (a trap function), not just internally wrong).
+	result, err := vmInstance.Call(trap, handler, []vm.Value{target, vm.NewString(propKey), value, receiver})
+	if err != nil {
+		return false, err
+	}
+	if result.IsFalsey() {
+		return false, nil
+	}
+
+	// ECMAScript 10.5.9 invariant validation (steps 13-15): a truish trap
+	// result is rejected if target has a non-configurable property whose
+	// invariant the trap tried to silently violate. Mirrors opSetProp's own
+	// TypeObject-only version of this check (pkg/vm/op_setprop.go) - not
+	// generalized to every VM kind here, matching that existing precedent
+	// and this file's own established scope (a Proxy's real-world target is
+	// overwhelmingly a plain object in practice).
+	if target.Type() == vm.TypeObject {
+		targetObj := target.AsPlainObject()
+		if _, s, _, c, isAccessor := targetObj.GetOwnAccessor(propKey); isAccessor {
+			if !c && s.Type() == vm.TypeUndefined {
+				return false, vmInstance.NewTypeError("'set' on proxy: trap returned truish for property '" + propKey + "' which exists in the proxy target as a non-configurable accessor without a setter")
+			}
+		} else if v, w, _, c, found := targetObj.GetOwnDescriptor(propKey); found {
+			if !c && !w {
+				if !v.StrictlyEquals(value) {
+					return false, vmInstance.NewTypeError("'set' on proxy: trap returned truish for property '" + propKey + "' which exists in the proxy target as a non-configurable and non-writable data property with a different value")
+				}
+			}
+		}
+	}
+
+	return true, nil
+}
+
+// reflectSetDispatch is Reflect.set's core dispatch, shared by the "set"
+// NativeFunction closure itself and every recursive delegation site above
+// (a Proxy target with no trap, a Proxy receiver with no trap) that needs
+// to re-enter the same logic for a different target/receiver pair.
+func reflectSetDispatch(vmInstance *vm.VM, target vm.Value, propKey string, value vm.Value, receiver vm.Value) (bool, error) {
+	if target.Type() == vm.TypeProxy {
+		return reflectProxySet(vmInstance, target, propKey, value, receiver)
+	}
+
+	// Module Namespace Exotic Object [[Set]] behavior (ECMAScript 10.4.6.9)
+	// [[Set]] on a namespace always returns false
+	if target.Type() == vm.TypeObject {
+		if po := target.AsPlainObject(); po.IsModuleNamespace() {
+			return false, nil
+		}
+	}
+
+	switch target.Type() {
+	case vm.TypeObject, vm.TypeDictObject, vm.TypeArray:
+		return reflectOrdinarySet(vmInstance, target, propKey, value, receiver)
+	}
+
+	// target is some other kind this function doesn't model a set for.
+	// Matches this function's prior behavior for every kind it didn't have
+	// a case for.
+	return false, nil
 }
 
 // reflectToArrayLength mirrors pkg/vm/vm_init.go's unexported
@@ -381,95 +608,29 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.BooleanValue(false), vmInstance.NewTypeError("Reflect.set called on non-object")
 		}
 
-		// Module Namespace Exotic Object [[Set]] behavior (ECMAScript 10.4.6.9)
-		// [[Set]] on a namespace always returns false
-		if target.Type() == vm.TypeObject {
-			if po := target.AsPlainObject(); po.IsModuleNamespace() {
-				return vm.BooleanValue(false), nil
-			}
-		}
-
-		// For Proxy targets, we need to use the set trap differently
-		// The set trap was already called by the caller (opSetProp), so here we
-		// are implementing the actual Set algorithm that Reflect.set uses internally
-		// when called from a Proxy set trap
-
-		// Check if the property is a data property on the target
-		isDataProp := false
-		switch target.Type() {
-		case vm.TypeObject:
-			obj := target.AsPlainObject()
-			if _, _, _, _, isAccessor := obj.GetOwnAccessor(propKey); !isAccessor {
-				isDataProp = true
-			}
-		case vm.TypeDictObject:
-			isDataProp = true // DictObject doesn't support accessors
-		case vm.TypeArray:
-			isDataProp = true
-		}
-
-		// If receiver is different from target (e.g., receiver is a Proxy),
-		// we need to call receiver's [[GetOwnProperty]] and [[DefineOwnProperty]]
-		// per ECMAScript 10.1.9.2 OrdinarySetWithOwnDescriptor
-		if isDataProp && receiver.Type() == vm.TypeProxy && receiver != target {
-			proxy := receiver.AsProxy()
-			if proxy.Revoked {
-				return vm.BooleanValue(false), vmInstance.NewTypeError("Cannot perform 'set' on a revoked Proxy")
-			}
-
-			handler := proxy.Handler()
-			proxyTarget := proxy.Target()
-
-			// Step 2.c: Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
-			// This triggers the getOwnPropertyDescriptor trap on the receiver Proxy
-			getOwnPropDescTrap, hasGetOwnPropDesc := handler.AsPlainObject().GetOwn("getOwnPropertyDescriptor")
-			if hasGetOwnPropDesc && getOwnPropDescTrap.IsCallable() {
-				trapArgs := []vm.Value{proxyTarget, vm.NewString(propKey)}
-				_, err := vmInstance.Call(getOwnPropDescTrap, handler, trapArgs)
-				if err != nil {
-					return vm.BooleanValue(false), err
-				}
-			}
-
-			// Step 2.d.iv: Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
-			// This triggers the defineProperty trap on the receiver Proxy
-			definePropertyTrap, hasDefineProperty := handler.AsPlainObject().GetOwn("defineProperty")
-			if hasDefineProperty && definePropertyTrap.IsCallable() {
-				// Create a property descriptor with just the value
-				valueDesc := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
-				valueDesc.SetOwn("value", value)
-				trapArgs := []vm.Value{proxyTarget, vm.NewString(propKey), vm.NewValueFromPlainObject(valueDesc)}
-				result, err := vmInstance.Call(definePropertyTrap, handler, trapArgs)
-				if err != nil {
-					return vm.BooleanValue(false), err
-				}
-				return vm.BooleanValue(result.IsTruthy()), nil
-			}
-		}
-
-		// Property set on target, implementing the real ECMA-262 10.1.9
-		// OrdinarySet / 10.1.9.2 OrdinarySetWithOwnDescriptor algorithm -
-		// see reflectOrdinarySet's own comment for the full rationale.
-		// This used to be a "just SetOwn/Set directly on target" fallback
-		// that ignored `receiver` entirely (writing to target even when a
-		// distinct receiver was given - the exact bug this fix closes)
-		// and never checked for an own or inherited accessor at all (so
-		// even the receiver === target case silently clobbered an
-		// existing setter instead of calling it - found while fixing the
-		// receiver bug, since walking descriptors is required for either
-		// fix).
-		switch target.Type() {
-		case vm.TypeObject, vm.TypeDictObject, vm.TypeArray:
-			ok, err := reflectOrdinarySet(vmInstance, target, propKey, value, receiver)
-			return vm.BooleanValue(ok), err
-		}
-
-		// target is some other kind this function doesn't model a set for
-		// (e.g. a Proxy - Reflect.set(someProxy, ...) has its own,
-		// separate, larger pre-existing gap: unrelated to the receiver
-		// bug this fix closes, not touched here). Matches this function's
-		// prior behavior for every kind it didn't have a case for.
-		return vm.BooleanValue(false), nil
+		// The actual algorithm - ECMA-262 10.1.9/10.1.9.2 OrdinarySet(WithOwnDescriptor)
+		// for a plain target, or 10.5.9 [[Set]] when target is a Proxy -
+		// lives in reflectSetDispatch, shared with the recursive delegation
+		// sites a Proxy target or a Proxy receiver without the relevant
+		// trap need to re-enter.
+		//
+		// This used to inline a "receiver is a distinct Proxy" special case
+		// right here (checking isDataProp on `target` first) that only
+		// handled a receiver-Proxy WITH a defineProperty trap present, and
+		// otherwise silently fell through to a "Simple property set on
+		// target" fallback that ignored `receiver` entirely - the bug
+		// task_cd1507d7 fixed for every OTHER receiver kind, but this
+		// Proxy-receiver special case sat upstream of that fix and kept
+		// intercepting before it could run. It's superseded now, not
+		// patched: reflectCreateOrUpdateDataProperty's own TypeProxy case
+		// (reflectProxyDefineDataProperty) handles a Proxy receiver
+		// completely - trap present or not - so this closure no longer
+		// needs a separate inline special case for it, and `target` never
+		// had a Proxy case here at all (task_18cd4923 - `target` itself
+		// being a Proxy fell through to an unconditional `false` for ANY
+		// Proxy target, trap or no trap).
+		ok, err := reflectSetDispatch(vmInstance, target, propKey, value, receiver)
+		return vm.BooleanValue(ok), err
 	}))
 
 	// Reflect.has(target, propertyKey)

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -57,13 +57,24 @@ func (r *ReflectInitializer) InitTypes(ctx *TypeContext) error {
 		// "get" takes an optional third `receiver` argument (used as the
 		// `this` an accessor's getter is called with - the runtime
 		// implementation now actually reads it, see reflectObj's "get"
-		// closure below). Reflect.set/Reflect.construct have the exact
-		// same "optional trailing argument the runtime accepts but the
-		// declared signature doesn't" gap for their own optional
-		// receiver/newTarget parameters - left alone here (out of this
-		// fix's scope) and flagged as a separate follow-up.
+		// closure below). "set"/"construct" have the same shape of gap for
+		// their own optional trailing arguments - fixed alongside "get"
+		// here rather than left as a separate follow-up, since the runtime
+		// already accepted a 4th/3rd argument for both before this fix
+		// (Reflect.set(t, k, v, receiver) already worked under
+		// --no-typecheck; Reflect.construct(t, args, newTarget) did NOT -
+		// see the "construct" closure below for the real, causally-coupled
+		// runtime bug this surfaced and fixed in the same commit).
+		//
+		// "set"'s spec signature (ECMA-262, and lib.es2015.reflect.d.ts in
+		// the pinned TypeScript v6.0.3 tree) is
+		// `set(target, propertyKey, value, receiver?)` - only the trailing
+		// `receiver` is optional, `value` is required (it legitimately
+		// defaults to `undefined` at the VALUE level when omitted, same as
+		// any other required `any`-typed parameter given `undefined` -
+		// that's not the same as the parameter itself being optional).
 		WithProperty("get", types.NewOptionalFunction([]types.Type{types.Any, keyType, types.Any}, types.Any, []bool{false, false, true})).
-		WithProperty("set", types.NewSimpleFunction([]types.Type{types.Any, keyType, types.Any}, types.Boolean)).
+		WithProperty("set", types.NewOptionalFunction([]types.Type{types.Any, keyType, types.Any, types.Any}, types.Boolean, []bool{false, false, false, true})).
 		WithProperty("has", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
 		WithProperty("deleteProperty", types.NewSimpleFunction([]types.Type{types.Any, keyType}, types.Boolean)).
 		// Prototype operations
@@ -79,7 +90,7 @@ func (r *ReflectInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("preventExtensions", types.NewSimpleFunction([]types.Type{types.Any}, types.Boolean)).
 		// Function operations
 		WithProperty("apply", types.NewSimpleFunction([]types.Type{types.Any, types.Any, types.Any}, types.Any)).
-		WithProperty("construct", types.NewSimpleFunction([]types.Type{types.Any, types.Any}, types.Any))
+		WithProperty("construct", types.NewOptionalFunction([]types.Type{types.Any, types.Any, types.Any}, types.Any, []bool{false, false, true}))
 
 	return ctx.DefineGlobal("Reflect", reflectType)
 }

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -867,23 +867,25 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			// Add "length"
 			arr.Append(vm.NewString("length"))
 		case vm.TypeProxy:
-			// For proxies, this should invoke the ownKeys trap
-			// For now, delegate to Object.getOwnPropertyNames + getOwnPropertySymbols
-			// This is a simplification
-			if objCtor, ok := vmInstance.GetGlobal("Object"); ok {
-				if objCtor.Type() == vm.TypeNativeFunctionWithProps {
-					nfp := objCtor.AsNativeFunctionWithProps()
-					if f, ok := nfp.Properties.GetOwn("getOwnPropertyNames"); ok {
-						if names, err := vmInstance.Call(f, vm.Undefined, []vm.Value{target}); err == nil {
-							if names.Type() == vm.TypeArray {
-								namesArr := names.AsArray()
-								for i := 0; i < namesArr.Length(); i++ {
-									arr.Append(namesArr.Get(i))
-								}
-							}
-						}
-					}
-				}
+			// This used to claim (inaccurately) to "delegate to
+			// Object.getOwnPropertyNames + getOwnPropertySymbols as a
+			// simplification" - but the delegation target itself had no
+			// TypeProxy case at all (objectGetOwnPropertyNamesWithVM,
+			// object_init.go), so the "simplification" was a complete
+			// no-op: Reflect.ownKeys on ANY Proxy, trap or no trap,
+			// always answered [] before this fix. proxyOwnPropertyKeys
+			// (object_init.go) is the real, shared ECMA-262 10.5.11
+			// [[OwnPropertyKeys]] implementation - see its own comment for
+			// what it does and doesn't validate - used here directly
+			// rather than through Object.getOwnPropertyNames, since this
+			// caller wants the FULL mixed string+symbol result, not one
+			// filtered half of it.
+			keys, err := proxyOwnPropertyKeys(vmInstance, target)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			for _, k := range keys {
+				arr.Append(k)
 			}
 		}
 

--- a/pkg/builtins/reflect_init.go
+++ b/pkg/builtins/reflect_init.go
@@ -41,6 +41,212 @@ func isConstructor(v vm.Value) bool {
 	}
 }
 
+// reflectGetOwnAccessorGeneric returns the getter/setter pair for v's own
+// accessor property named propKey, covering PlainObject's and
+// ArrayObject's own accessor support plus the shared side-table
+// (*PlainObject) the nine ownPropertiesSlot kinds (Function/Closure/
+// NativeFunction/NativeFunctionWithProps/BoundFunction/RegExp/Map/Set/
+// Promise) keep under OwnPropertiesTable, via the `default` branch.
+// DictObject doesn't support accessors at all (pre-existing, matches
+// every other DictObject case in this file). Any OTHER kind (e.g.
+// TypeArguments, TypeTypedArray) that OwnPropertiesTable doesn't cover
+// falls through the same `default` branch to isAccessor=false, not found
+// - reflectOrdinarySet's walk treats that as "no own property here" and
+// continues up the chain, so an exotic kind sitting as a link in a
+// prototype chain (rare, and not exercised by this fix's own tests) is
+// silently skipped rather than mishandled. Callers still need to
+// separately check for a data property when isAccessor is false.
+func reflectGetOwnAccessorGeneric(v vm.Value, propKey string) (getter vm.Value, setter vm.Value, isAccessor bool) {
+	switch v.Type() {
+	case vm.TypeObject:
+		g, s, _, _, ok := v.AsPlainObject().GetOwnAccessor(propKey)
+		return g, s, ok
+	case vm.TypeArray:
+		g, s, _, _, ok := v.AsArray().GetOwnAccessor(propKey)
+		return g, s, ok
+	case vm.TypeDictObject:
+		return vm.Undefined, vm.Undefined, false
+	default:
+		if props := vm.OwnPropertiesTable(v); props != nil {
+			g, s, _, _, ok := props.GetOwnAccessor(propKey)
+			return g, s, ok
+		}
+		return vm.Undefined, vm.Undefined, false
+	}
+}
+
+// reflectGetOwnDataDescriptorGeneric returns the value and writability of
+// v's own DATA property named propKey (call reflectGetOwnAccessorGeneric
+// first to rule out an accessor - this function doesn't check for one).
+// Mirrors reflectGetOwnAccessorGeneric's kind coverage, plus TypeArray's
+// own index/"length"/named-property shapes (an array has no side-table
+// analog for these - they're modeled directly on ArrayObject).
+func reflectGetOwnDataDescriptorGeneric(v vm.Value, propKey string) (value vm.Value, writable bool, found bool) {
+	switch v.Type() {
+	case vm.TypeObject:
+		val, w, _, _, ok := v.AsPlainObject().GetOwnDescriptor(propKey)
+		return val, w, ok
+	case vm.TypeDictObject:
+		val, w, _, _, ok := v.AsDictObject().GetOwnDescriptor(propKey)
+		return val, w, ok
+	case vm.TypeArray:
+		arr := v.AsArray()
+		if propKey == "length" {
+			return vm.Number(float64(arr.Length())), true, true
+		}
+		if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 {
+			if arr.HasOwnIndexProperty(propKey, idx) {
+				return arr.Get(idx), true, true
+			}
+			return vm.Undefined, false, false
+		}
+		if val, ok := arr.GetOwn(propKey); ok {
+			return val, true, true
+		}
+		return vm.Undefined, false, false
+	default:
+		if props := vm.OwnPropertiesTable(v); props != nil {
+			val, w, _, _, ok := props.GetOwnDescriptor(propKey)
+			return val, w, ok
+		}
+		return vm.Undefined, false, false
+	}
+}
+
+// reflectOrdinarySet implements ECMA-262 10.1.9 OrdinarySet /
+// 10.1.9.2 OrdinarySetWithOwnDescriptor for Reflect.set's non-Proxy-target
+// path: walk `target`'s own property, then its whole [[Prototype]] chain,
+// for the first applicable descriptor. An accessor's setter is invoked
+// with `receiver` as `this` regardless of where in the chain it was found
+// (accessors don't write data anywhere, so `target` vs `receiver` doesn't
+// matter for this branch). A data descriptor - found on target itself, an
+// ancestor, or nowhere at all (the implicit "value: undefined, writable:
+// true" default per 10.1.9 step 4) - always has its actual write land on
+// `receiver`, never on whichever object in the chain the descriptor was
+// found on: this is the exact distinction the pre-existing "Simple
+// property set on target" fallback got wrong, unconditionally writing to
+// `target` regardless of `receiver`.
+//
+// Before this fix, `target`'s OWN accessor wasn't invoked at all either -
+// the old fallback went straight to a raw SetOwn/Set call with no
+// descriptor awareness whatsoever, for every case including
+// receiver === target (verified against Node: Reflect.set on an object
+// with its own setter silently no-opped the setter instead of calling
+// it). Fixing the general-receiver case required walking descriptors
+// anyway, so both bugs share one fix.
+func reflectOrdinarySet(vmInstance *vm.VM, target vm.Value, propKey string, value vm.Value, receiver vm.Value) (bool, error) {
+	current := target
+	for i := 0; i < 200 && current.Type() != vm.TypeNull && current.Type() != vm.TypeUndefined; i++ {
+		if _, setter, isAccessor := reflectGetOwnAccessorGeneric(current, propKey); isAccessor {
+			// Per 10.1.9.2 step 3: an accessor descriptor with no setter
+			// means the property is effectively read-only - Set fails
+			// (verified against Node: returns false, doesn't throw here
+			// since Reflect.set never throws for an ordinary failure).
+			if setter.Type() == vm.TypeUndefined {
+				return false, nil
+			}
+			_, err := vmInstance.Call(setter, receiver, []vm.Value{value})
+			return err == nil, err
+		}
+		if _, writable, found := reflectGetOwnDataDescriptorGeneric(current, propKey); found {
+			if !writable {
+				return false, nil
+			}
+			// A writable data descriptor exists somewhere in target's own
+			// chain - per 10.1.9.2 step 4, the actual write still targets
+			// Receiver, not wherever this descriptor was found (which may
+			// be `target` itself, or an ancestor `target` inherits from).
+			return reflectCreateOrUpdateDataProperty(receiver, propKey, value)
+		}
+		current = vmInstance.PrototypeOf(current)
+	}
+	// Not found anywhere in target's chain - 10.1.9 step 4's implicit
+	// {value: undefined, writable: true, enumerable: true, configurable:
+	// true} default takes the same data-write path.
+	return reflectCreateOrUpdateDataProperty(receiver, propKey, value)
+}
+
+// reflectCreateOrUpdateDataProperty implements the receiver-side half of
+// 10.1.9.2 OrdinarySetWithOwnDescriptor once target's chain has determined
+// a data write is called for: consult receiver's OWN descriptor for the
+// same key (an accessor or non-writable data property there refuses the
+// write - verified against Node for both), and otherwise create or
+// overwrite receiver's own data property with the new value.
+func reflectCreateOrUpdateDataProperty(receiver vm.Value, propKey string, value vm.Value) (bool, error) {
+	// Per 10.1.9.2 step 4.a: if Receiver is not an object, return false -
+	// verified against Node: Reflect.set({}, "y", 5, 42) is false, not a
+	// throw.
+	if !receiver.IsObject() && !receiver.IsCallable() {
+		return false, nil
+	}
+
+	if _, _, isAccessor := reflectGetOwnAccessorGeneric(receiver, propKey); isAccessor {
+		return false, nil
+	}
+	if _, writable, found := reflectGetOwnDataDescriptorGeneric(receiver, propKey); found && !writable {
+		return false, nil
+	}
+
+	switch receiver.Type() {
+	case vm.TypeObject:
+		receiver.AsPlainObject().SetOwn(propKey, value)
+		return true, nil
+	case vm.TypeDictObject:
+		receiver.AsDictObject().SetOwn(propKey, value)
+		return true, nil
+	case vm.TypeArray:
+		arr := receiver.AsArray()
+		if propKey == "length" {
+			// The old "Simple property set on target" fallback this
+			// function replaces had an explicit "Setting length is
+			// complex, skip for now" no-op stub here - meaning
+			// Reflect.set(arr, "length", n) already silently failed to
+			// resize before this fix (verified against Node, which does
+			// resize). Since this generic data-write path would otherwise
+			// treat "length" as an ordinary named property and stash a
+			// bogus one via arr.SetOwn - worse than the prior no-op,
+			// since it'd shadow/corrupt the array's real length concept -
+			// it needs its own case, not silence, now that this path
+			// handles it at all.
+			arr.SetLength(reflectToArrayLength(value))
+			return true, nil
+		}
+		if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 {
+			arr.Set(idx, value)
+			return true, nil
+		}
+		arr.SetOwn(propKey, value)
+		return true, nil
+	default:
+		// A callable or other exotic receiver kind (Function/Closure/
+		// NativeFunction/.../Promise) - use its shared side-table, the
+		// same mechanism Object.defineProperty and friends already use
+		// for these kinds elsewhere in this codebase.
+		if props := vm.EnsureOwnPropertiesTable(receiver); props != nil {
+			props.SetOwn(propKey, value)
+			return true, nil
+		}
+		return false, nil
+	}
+}
+
+// reflectToArrayLength mirrors pkg/vm/vm_init.go's unexported
+// toLengthIntForSetProperty (ToLength clamping for an array's "length"
+// property) - duplicated rather than imported since that helper is
+// unexported and this is the one place in package builtins that needs the
+// exact same clamp.
+func reflectToArrayLength(v vm.Value) int {
+	n := v.ToFloat()
+	if n != n || n <= 0 {
+		return 0
+	}
+	const maxSafeInteger = 9007199254740991
+	if n > maxSafeInteger {
+		n = maxSafeInteger
+	}
+	return int(n)
+}
+
 type ReflectInitializer struct{}
 
 func (r *ReflectInitializer) Name() string  { return "Reflect" }
@@ -241,26 +447,28 @@ func (r *ReflectInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
-		// Simple property set on target
+		// Property set on target, implementing the real ECMA-262 10.1.9
+		// OrdinarySet / 10.1.9.2 OrdinarySetWithOwnDescriptor algorithm -
+		// see reflectOrdinarySet's own comment for the full rationale.
+		// This used to be a "just SetOwn/Set directly on target" fallback
+		// that ignored `receiver` entirely (writing to target even when a
+		// distinct receiver was given - the exact bug this fix closes)
+		// and never checked for an own or inherited accessor at all (so
+		// even the receiver === target case silently clobbered an
+		// existing setter instead of calling it - found while fixing the
+		// receiver bug, since walking descriptors is required for either
+		// fix).
 		switch target.Type() {
-		case vm.TypeObject:
-			target.AsPlainObject().SetOwn(propKey, value)
-			return vm.BooleanValue(true), nil
-		case vm.TypeDictObject:
-			target.AsDictObject().SetOwn(propKey, value)
-			return vm.BooleanValue(true), nil
-		case vm.TypeArray:
-			arr := target.AsArray()
-			if propKey == "length" {
-				// Setting length is complex, skip for now
-				return vm.BooleanValue(true), nil
-			}
-			if idx, err := strconv.Atoi(propKey); err == nil && idx >= 0 {
-				arr.Set(idx, value)
-				return vm.BooleanValue(true), nil
-			}
+		case vm.TypeObject, vm.TypeDictObject, vm.TypeArray:
+			ok, err := reflectOrdinarySet(vmInstance, target, propKey, value, receiver)
+			return vm.BooleanValue(ok), err
 		}
 
+		// target is some other kind this function doesn't model a set for
+		// (e.g. a Proxy - Reflect.set(someProxy, ...) has its own,
+		// separate, larger pre-existing gap: unrelated to the receiver
+		// bug this fix closes, not touched here). Matches this function's
+		// prior behavior for every kind it didn't have a case for.
 		return vm.BooleanValue(false), nil
 	}))
 

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -96,21 +96,21 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			return false, nil
 		}
 
-		// Get the apply trap from handler (handler can be PlainObject or DictObject)
+		// Get the apply trap from handler. GetMethod(handler, "apply") per
+		// spec: an inherited trap counts, not just an own one - proxyGetTrap
+		// (not a bare handler.AsPlainObject().GetOwn("apply")) for the same
+		// reason documented on its own definition. This also drops the
+		// `default: throw "Proxy handler is not an object"` the inline
+		// switch used to have for any handler.Type() besides TypeObject/
+		// TypeDictObject (a Map, Array, RegExp, ... - anything IsObject()
+		// besides those two, all legal per the Proxy constructor's own
+		// validation): that path disagreed with vm.Call's TypeProxy case
+		// (pkg/vm/vm_init.go, backing e.g. Reflect.apply on the same kind
+		// of proxy), which has never thrown here and instead silently
+		// falls through to "no apply trap" below - matching that instead
+		// of inventing a third answer.
 		handler := proxy.Handler()
-		var applyTrap Value
-		var hasApplyTrap bool
-
-		switch handler.Type() {
-		case TypeObject:
-			applyTrap, hasApplyTrap = handler.AsPlainObject().GetOwn("apply")
-		case TypeDictObject:
-			applyTrap, hasApplyTrap = handler.AsDictObject().GetOwn("apply")
-		default:
-			// Handler is not an object - should not happen if proxy was constructed correctly
-			vm.ThrowTypeError("Proxy handler is not an object")
-			return false, nil
-		}
+		applyTrap, hasApplyTrap := proxyGetTrap(handler, "apply")
 
 		// Check for apply trap
 		if hasApplyTrap && applyTrap.Type() != TypeUndefined && applyTrap.Type() != TypeNull {

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1482,9 +1482,33 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		*dest = Undefined
 		return true, InterpretOK, *dest
 	case TypeArray:
+		// Arrays: consult the array's OWN symbol-keyed properties first -
+		// opSetPropSymbol's TypeArray case (pkg/vm/op_setprop.go) already
+		// writes `arr[sym] = v` into ArrayObject.symbolProps via
+		// SetSymbolProp, but this case used to skip straight to the
+		// prototype chain without ever checking it, so the read half of
+		// the exact same feature silently returned undefined - or, worse,
+		// a same-named symbol property inherited from Array.prototype -
+		// instead of the array's own value:
+		//
+		//   const arr = [1, 2, 3];
+		//   const sym = Symbol("s");
+		//   arr[sym] = 42;
+		//   arr[sym]; // before: undefined - Node: 42
+		//
+		// GetSymbolProp already existed and worked (that's how
+		// HasOwnSymbolProp/Object.getOwnPropertySymbols's new TypeArray
+		// case can see it) - this case just never called it.
+		arrObj := base.AsArray()
+		if sym := symKey.AsSymbolObject(); sym != nil {
+			if v, ok := arrObj.GetSymbolProp(sym); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+		}
 		// Arrays: consult the per-instance prototype override (subclassing)
 		// before falling back to the realm's intrinsic Array.prototype.
-		proto := base.AsArray().prototype
+		proto := arrObj.prototype
 		if !proto.IsObject() {
 			proto = vm.ArrayPrototype
 		}

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -102,6 +102,62 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 	if objVal.Type() == TypeNativeFunction {
 		nf := objVal.AsNativeFunction()
 		if nf != nil && nf.Properties != nil {
+			// Check for an accessor property first (getters/setters) -
+			// mirrors TypeBoundFunction's equivalent check in
+			// handleCallableProperty (property_helpers.go). Without this,
+			// an accessor defined via Object.defineProperty(nf, "custom",
+			// {get(){...}}) fell straight to GetOwn below, which - for an
+			// accessor field - returns (Undefined, true) (DefineAccessorProperty
+			// appends a placeholder Undefined properties slot for it), so
+			// `nf.custom` silently answered undefined instead of calling
+			// the getter, even though the same accessor's *setter* already
+			// ran correctly via `nf.custom = v` (pkg/vm/op_setprop.go).
+			if g, _, _, _, ok := nf.Properties.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					res, err := vm.Call(g, *objVal, nil)
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							if frame != nil && !frameWasNil {
+								frame.ip = ip - 4
+							}
+							vm.throwException(ee.GetExceptionValue())
+							if !vm.unwinding {
+								return false, InterpretOK, Undefined
+							}
+							return false, InterpretRuntimeError, Undefined
+						}
+						var excVal Value
+						if errCtor, ok := vm.GetGlobal("Error"); ok {
+							if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+								excVal = res
+							} else {
+								eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+								eo.SetOwn("name", NewString("Error"))
+								eo.SetOwn("message", NewString(err.Error()))
+								excVal = NewValueFromPlainObject(eo)
+							}
+						} else {
+							eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+							eo.SetOwn("name", NewString("Error"))
+							eo.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(eo)
+						}
+						if frame != nil && !frameWasNil {
+							frame.ip = ip - 4
+						}
+						vm.throwException(excVal)
+						if !vm.unwinding {
+							return false, InterpretOK, Undefined
+						}
+						return false, InterpretRuntimeError, Undefined
+					}
+					*dest = res
+					return true, InterpretOK, *dest
+				}
+				// Setter-only accessor (no getter): reads as undefined per spec.
+				*dest = Undefined
+				return true, InterpretOK, *dest
+			}
 			if prop, exists := nf.Properties.GetOwn(propName); exists {
 				*dest = prop
 				return true, InterpretOK, *dest
@@ -2182,6 +2238,91 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 				*dest = v
 				return true, InterpretOK, *dest
 			}
+		}
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+
+	// NativeFunction: check own symbol properties (accessor first, mirroring
+	// TypeObject's GetOwnAccessorByKey-then-GetOwnByKey pattern above and
+	// this same TypeNativeFunction kind's string-key equivalent in
+	// opGetProp's block 3b), then Function.prototype chain.
+	//
+	// This case didn't exist at all before this fix, so a symbol-keyed own
+	// property - even a plain data one - set via bracket-notation
+	// assignment or Object.defineProperty always fell through to the
+	// DictObject default below and read back as undefined, even though
+	// Object.getOwnPropertyDescriptor already showed it existed correctly.
+	//
+	// The accessor check specifically was added after review flagged an
+	// asymmetry a first pass introduced: opGetProp's block 3b (string keys,
+	// same TypeNativeFunction kind) invokes an own accessor's getter, so
+	// leaving this symbol-key sibling without one would have made
+	// `nf.custom` call the getter while `nf[sym]` did not, on the very
+	// same value in the same commit - worse than the pre-fix state of
+	// "symbol keys don't work at all". TypeFunction/TypeClosure/
+	// TypeBoundFunction/TypeNativeFunctionWithProps above still lack this
+	// (none of those four invoke a symbol-key accessor's getter; TypeObject,
+	// separately, already does - see its own case earlier in this
+	// function), so that remains a real, separate, still-open gap.
+	if base.Type() == TypeNativeFunction {
+		nf := base.AsNativeFunction()
+		key := NewSymbolKey(symKey)
+		if nf.Properties != nil {
+			if g, _, _, _, ok := nf.Properties.GetOwnAccessorByKey(key); ok {
+				if g.Type() != TypeUndefined {
+					res, err := vm.Call(g, base, nil)
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							if frame != nil && !frameWasNil {
+								frame.ip = ip - 4
+							}
+							vm.throwException(ee.GetExceptionValue())
+							if !vm.unwinding {
+								return false, InterpretOK, Undefined
+							}
+							return false, InterpretRuntimeError, Undefined
+						}
+						var excVal Value
+						if errCtor, ok := vm.GetGlobal("Error"); ok {
+							if res2, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+								excVal = res2
+							} else {
+								eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+								eo.SetOwn("name", NewString("Error"))
+								eo.SetOwn("message", NewString(err.Error()))
+								excVal = NewValueFromPlainObject(eo)
+							}
+						} else {
+							eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+							eo.SetOwn("name", NewString("Error"))
+							eo.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(eo)
+						}
+						if frame != nil && !frameWasNil {
+							frame.ip = ip - 4
+						}
+						vm.throwException(excVal)
+						if !vm.unwinding {
+							return false, InterpretOK, Undefined
+						}
+						return false, InterpretRuntimeError, Undefined
+					}
+					*dest = res
+					return true, InterpretOK, *dest
+				}
+				// Setter-only accessor (no getter): reads as undefined per spec.
+				*dest = Undefined
+				return true, InterpretOK, *dest
+			}
+			if v, ok := nf.Properties.GetOwnByKey(key); ok {
+				*dest = v
+				return true, InterpretOK, *dest
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			*dest = v
+			return true, InterpretOK, *dest
 		}
 		*dest = Undefined
 		return true, InterpretOK, *dest

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1186,15 +1186,11 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			return false, InterpretRuntimeError, Undefined
 		}
 
-		// Check if handler has a get trap (handler can be PlainObject or DictObject)
-		var getTrap Value
-		var hasGetTrap bool
-		switch proxy.handler.Type() {
-		case TypeObject:
-			getTrap, hasGetTrap = proxy.handler.AsPlainObject().GetOwn("get")
-		case TypeDictObject:
-			getTrap, hasGetTrap = proxy.handler.AsDictObject().GetOwn("get")
-		}
+		// Check if handler has a get trap. GetMethod(handler, "get") per
+		// spec: an inherited trap counts, not just an own one - proxyGetTrap
+		// (not a bare proxy.handler.AsPlainObject().GetOwn("get")) for the
+		// same reason documented on its own definition.
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
 		if hasGetTrap && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !getTrap.IsCallable() {

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1286,134 +1286,70 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			*dest = result
 			return true, InterpretOK, *dest
 		} else {
-			// No get trap, fallback to target - implement directly to avoid recursion
-			target := proxy.target
-			if target.Type() == TypeObject {
-				if result, handled := vm.handleSpecialProperties(target, propName); handled {
-					*dest = result
-					return true, InterpretOK, *dest
+			// No get trap: fall back to target.[[Get]] via
+			// getPropertyWithReceiver, not a hand-rolled reimplementation
+			// (what used to live here, added to "avoid recursion" - but
+			// it only ever handled a TypeObject/TypeDictObject/callable
+			// target; every other legal proxy.target kind (TypeArray,
+			// TypeMap, TypeSet, TypePromise, TypeRegExp, TypeGenerator,
+			// TypeBoundFunction, TypeNativeFunction,
+			// TypeNativeFunctionWithProps, TypeArguments, a further-nested
+			// Proxy, ...) fell through to a bare `*dest = Undefined`
+			// instead - e.g. `new Proxy(someArray, {})` (no get trap, a
+			// real Array target) silently read `undefined` for EVERY
+			// property, including "length": handleSpecialProperties and
+			// handlePrimitiveMethod, both called here, switch on the
+			// TARGET's kind (TypeArray/TypeMap/TypeSet/... for the
+			// former, TypeString/TypeArray/TypeMap/... for the latter)
+			// but were only ever reached when target.Type() == TypeObject
+			// was already true - so neither call could ever actually
+			// match anything; both were dead code at this specific call
+			// site. getPropertyWithReceiver already handles every kind
+			// (including recursing through a further-nested Proxy) and
+			// already threads a receiver through any accessor/trap found
+			// along the way, exactly like the get-trap-call branch above
+			// does with *objVal - so this isn't a behavior change for the
+			// TypeObject/TypeDictObject/callable kinds that WERE already
+			// handled here, only an extension to the kinds that weren't.
+			result, err := vm.getPropertyWithReceiver(proxy.target, propName, *objVal)
+			if err != nil {
+				if ee, ok := err.(ExceptionError); ok {
+					if frame != nil && !frameWasNil {
+						frame.ip = ip - 4
+					}
+					vm.throwException(ee.GetExceptionValue())
+					if !vm.unwinding {
+						return false, InterpretOK, Undefined
+					}
+					return false, InterpretRuntimeError, Undefined
 				}
-				if result, handled := vm.handlePrimitiveMethod(target, propName); handled {
-					*dest = result
-					return true, InterpretOK, *dest
-				}
-				// Use enhanced property resolution with prototype caching and metadata
-				if holder, offset, isAccessor, found := vm.resolvePropertyMeta(target, propName, nil, 0); found {
-					if isAccessor {
-						if g, _, _, _, ok := holder.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-							res, err := vm.Call(g, target, nil)
-							if err != nil {
-								if ee, ok := err.(ExceptionError); ok {
-									if frame != nil && !frameWasNil {
-										frame.ip = ip - 4
-									}
-									vm.throwException(ee.GetExceptionValue())
-									if !vm.unwinding {
-										return false, InterpretOK, Undefined
-									}
-									return false, InterpretRuntimeError, Undefined
-								}
-								var excVal Value
-								if errCtor, ok := vm.GetGlobal("Error"); ok {
-									if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
-										excVal = res
-									} else {
-										eo := NewObject(vm.ErrorPrototype).AsPlainObject()
-										eo.SetOwn("name", NewString("Error"))
-										eo.SetOwn("message", NewString(err.Error()))
-										excVal = NewValueFromPlainObject(eo)
-									}
-								} else {
-									eo := NewObject(vm.ErrorPrototype).AsPlainObject()
-									eo.SetOwn("name", NewString("Error"))
-									eo.SetOwn("message", NewString(err.Error()))
-									excVal = NewValueFromPlainObject(eo)
-								}
-								if frame != nil && !frameWasNil {
-									frame.ip = ip - 4
-								}
-								vm.throwException(excVal)
-								if !vm.unwinding {
-									return false, InterpretOK, Undefined
-								}
-								return false, InterpretRuntimeError, Undefined
-							}
-							*dest = res
-						} else {
-							*dest = Undefined
-						}
+				var excVal Value
+				if errCtor, ok := vm.GetGlobal("Error"); ok {
+					if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+						excVal = res
 					} else {
-						*dest = holder.properties[offset]
+						eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+						eo.SetOwn("name", NewString("Error"))
+						eo.SetOwn("message", NewString(err.Error()))
+						excVal = NewValueFromPlainObject(eo)
 					}
-					return true, InterpretOK, *dest
-				}
-			} else if target.Type() == TypeDictObject {
-				dict := target.AsDictObject()
-				if fv, ok := dict.Get(propName); ok {
-					*dest = fv
 				} else {
-					*dest = Undefined
+					eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+					eo.SetOwn("name", NewString("Error"))
+					eo.SetOwn("message", NewString(err.Error()))
+					excVal = NewValueFromPlainObject(eo)
 				}
-				return true, InterpretOK, *dest
-			} else if target.IsCallable() {
-				// Function target - look up properties from Function.prototype
-				// Function.prototype can be TypeNativeFunctionWithProps (common case)
-				// or TypeObject (less common)
-				if vm.FunctionPrototype.Type() == TypeNativeFunctionWithProps {
-					funcProto := vm.FunctionPrototype.AsNativeFunctionWithProps()
-					if v, ok := funcProto.Properties.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					// Walk prototype chain from Function.prototype.Properties
-					current := funcProto.Properties.GetPrototype()
-					for current.typ != TypeNull && current.typ != TypeUndefined {
-						if current.IsObject() {
-							if current.Type() == TypeObject {
-								proto := current.AsPlainObject()
-								if v, ok := proto.GetOwn(propName); ok {
-									*dest = v
-									return true, InterpretOK, *dest
-								}
-								current = proto.prototype
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					}
-				} else if vm.FunctionPrototype.IsObject() {
-					funcProto := vm.FunctionPrototype.AsPlainObject()
-					if v, ok := funcProto.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					// Walk prototype chain from Function.prototype
-					current := funcProto.prototype
-					for current.typ != TypeNull && current.typ != TypeUndefined {
-						if current.IsObject() {
-							if current.Type() == TypeObject {
-								proto := current.AsPlainObject()
-								if v, ok := proto.GetOwn(propName); ok {
-									*dest = v
-									return true, InterpretOK, *dest
-								}
-								current = proto.prototype
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					}
+				if frame != nil && !frameWasNil {
+					frame.ip = ip - 4
 				}
-				*dest = Undefined
-				return true, InterpretOK, *dest
-			} else {
-				*dest = Undefined
-				return true, InterpretOK, *dest
+				vm.throwException(excVal)
+				if !vm.unwinding {
+					return false, InterpretOK, Undefined
+				}
+				return false, InterpretRuntimeError, Undefined
 			}
+			*dest = result
+			return true, InterpretOK, *dest
 		}
 	}
 

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -63,8 +63,15 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			return false, InterpretRuntimeError, Undefined
 		}
 
-		// Check if handler has a set trap (per spec: GetMethod returns undefined for null/undefined)
-		setTrap, ok := vm.getOwnGeneric(proxy.handler, "set")
+		// Check if handler has a set trap. GetMethod(handler, "set") per
+		// spec: an inherited trap counts, not just an own one -
+		// getInheritedGeneric (not getOwnGeneric) for the same reason
+		// proxyGetTrap replaced a bare handler.AsPlainObject().GetOwn(...)
+		// at the other trap call sites in this package; unlike proxyGetTrap,
+		// getInheritedGeneric also covers the full range of handler kinds
+		// getOwnGeneric already did (Array, Closure, Function, ...), not
+		// just TypeObject/TypeDictObject.
+		setTrap, ok := vm.getInheritedGeneric(proxy.handler, "set")
 		if ok && setTrap.Type() != TypeUndefined && setTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !setTrap.IsCallable() {
@@ -511,7 +518,11 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 				// Found a proxy in the chain - invoke its set trap
 				proxy := current.AsProxy()
 				if !proxy.Revoked {
-					if setTrap, ok := vm.getOwnGeneric(proxy.handler, "set"); ok && setTrap.IsCallable() {
+					// getInheritedGeneric (not getOwnGeneric): GetMethod(handler,
+					// "set") per spec counts an inherited trap too - see the
+					// other "set" trap sites in this file for the full
+					// rationale.
+					if setTrap, ok := vm.getInheritedGeneric(proxy.handler, "set"); ok && setTrap.IsCallable() {
 						// Call the set trap: trap(target, property, value, receiver)
 						// receiver is the original primitive coerced to object
 						trapArgs := []Value{proxy.Target(), NewString(propName), *valueToSet, *objVal}
@@ -1070,8 +1081,10 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 			return false, InterpretRuntimeError, Undefined
 		}
 
-		// Check if handler has a set trap
-		setTrap, ok := vm.getOwnGeneric(proxy.handler, "set")
+		// Check if handler has a set trap. getInheritedGeneric (not
+		// getOwnGeneric): GetMethod(handler, "set") per spec counts an
+		// inherited trap too.
+		setTrap, ok := vm.getInheritedGeneric(proxy.handler, "set")
 		if ok && setTrap.IsCallable() {
 			// Call the set trap: handler.set(target, propertyKey, value, receiver)
 			trapArgs := []Value{proxy.target, symKey, *valueToSet, *objVal}

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -1116,8 +1116,18 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 			}
 			return true, InterpretOK, result
 		} else {
-			// No set trap, fallback to target - implement directly to avoid recursion
+			// No set trap: per spec, return target.[[Set]](P, V, Receiver) -
+			// mirrors opSetProp's own string-key TypeProxy recursion just
+			// above in this file (this symbol-key sibling never got the
+			// same fix): a target that is itself a Proxy used to fall
+			// straight to the `else { return true, InterpretOK,
+			// *valueToSet }` below and silently do nothing (not even
+			// write), instead of resolving through that inner proxy's own
+			// trap-or-fallback.
 			target := proxy.target
+			if target.Type() == TypeProxy {
+				return vm.opSetPropSymbol(ip, &target, symKey, valueToSet)
+			}
 			if target.Type() == TypeObject {
 				po := target.AsPlainObject()
 				key := NewSymbolKey(symKey)

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -1203,6 +1203,25 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		return true, InterpretOK, *valueToSet
 	}
 
+	// Every remaining exotic kind that keeps its ordinary own properties in
+	// a lazily-allocated side table (OwnPropertiesTable/
+	// EnsureOwnPropertiesTable, pkg/vm/properties_table.go, via
+	// ownPropertiesSlot) shares this one branch - Map/Set/Promise here
+	// alongside BoundFunction/NativeFunctionWithProps/NativeFunction, which
+	// (unlike TypeFunction/TypeClosure/TypeRegExp just above) had no
+	// explicit case at all. A symbol-keyed bracket assignment
+	// (obj[sym] = v) on any of these silently did nothing - falling all
+	// the way through to the "ignore symbol set" branch below - even
+	// though the equivalent string-keyed assignment (opSetProp, called by
+	// OpSetIndex's outer switch) already writes into the exact same table.
+	switch objVal.Type() {
+	case TypeMap, TypeSet, TypePromise, TypeBoundFunction, TypeNativeFunctionWithProps, TypeNativeFunction:
+		if props := EnsureOwnPropertiesTable(*objVal); props != nil {
+			return vm.setOwnCheckedByKey(props, NewSymbolKey(symKey), *valueToSet)
+		}
+		return true, InterpretOK, *valueToSet
+	}
+
 	// Only PlainObject supports symbol keys for now
 	if objVal.Type() != TypeObject {
 		// DictObject or others: ignore symbol set (non-strict semantics)

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -337,7 +337,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			fn.Properties.DefineOwnProperty("prototype", *valueToSet, &w, &e, &c)
 			return true, InterpretOK, *valueToSet
 		}
-		return vm.setOwnChecked(fn.Properties, propName, *valueToSet)
+		return vm.setOwnChecked(fn.Properties, propName, *objVal, *valueToSet)
 	case TypeClosure:
 		closure := AsClosure(*objVal)
 		// Use closure's own Properties to avoid sharing with other closures using same FunctionObject
@@ -429,7 +429,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			closure.Properties.DefineOwnProperty("prototype", *valueToSet, &w, &e, &c)
 			return true, InterpretOK, *valueToSet
 		}
-		return vm.setOwnChecked(closure.Properties, propName, *valueToSet)
+		return vm.setOwnChecked(closure.Properties, propName, *objVal, *valueToSet)
 	case TypeNativeFunctionWithProps:
 		nfp := objVal.AsNativeFunctionWithProps()
 		if nfp != nil {
@@ -444,7 +444,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if nfp.Properties == nil {
 				nfp.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(nfp.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(nfp.Properties, propName, *objVal, *valueToSet)
 		}
 	case TypeNativeFunction:
 		nf := objVal.AsNativeFunction()
@@ -459,7 +459,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if nf.Properties == nil {
 				nf.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(nf.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(nf.Properties, propName, *objVal, *valueToSet)
 		}
 	}
 
@@ -470,7 +470,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		}
 		bf := objVal.AsBoundFunction()
 		if bf.Properties != nil {
-			return vm.setOwnChecked(bf.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(bf.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	}
@@ -951,7 +951,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if regex.Properties == nil {
 				regex.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(regex.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(regex.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypeMap:
@@ -961,7 +961,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if mapObj.Properties == nil {
 				mapObj.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(mapObj.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(mapObj.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypeSet:
@@ -971,7 +971,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if setObj.Properties == nil {
 				setObj.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(setObj.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(setObj.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypePromise:
@@ -982,7 +982,7 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 			if promiseObj.Properties == nil {
 				promiseObj.Properties = newPropertiesTable()
 			}
-			return vm.setOwnChecked(promiseObj.Properties, propName, *valueToSet)
+			return vm.setOwnChecked(promiseObj.Properties, propName, *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	case TypeArrayBuffer:
@@ -1168,7 +1168,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 			if regex.Properties == nil {
 				regex.Properties = newPropertiesTable()
 			}
-			return vm.setOwnCheckedByKey(regex.Properties, NewSymbolKey(symKey), *valueToSet)
+			return vm.setOwnCheckedByKey(regex.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	}
@@ -1179,7 +1179,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		if funcObj.Properties == nil {
 			funcObj.Properties = newPropertiesTable()
 		}
-		return vm.setOwnCheckedByKey(funcObj.Properties, NewSymbolKey(symKey), *valueToSet)
+		return vm.setOwnCheckedByKey(funcObj.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 	}
 
 	// Closure objects: store symbol properties on their Properties object
@@ -1188,7 +1188,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		if closure.Properties == nil {
 			closure.Properties = newPropertiesTable()
 		}
-		return vm.setOwnCheckedByKey(closure.Properties, NewSymbolKey(symKey), *valueToSet)
+		return vm.setOwnCheckedByKey(closure.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 	}
 
 	// Array objects: store symbol properties directly on the array
@@ -1217,7 +1217,7 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 	switch objVal.Type() {
 	case TypeMap, TypeSet, TypePromise, TypeBoundFunction, TypeNativeFunctionWithProps, TypeNativeFunction:
 		if props := EnsureOwnPropertiesTable(*objVal); props != nil {
-			return vm.setOwnCheckedByKey(props, NewSymbolKey(symKey), *valueToSet)
+			return vm.setOwnCheckedByKey(props, NewSymbolKey(symKey), *objVal, *valueToSet)
 		}
 		return true, InterpretOK, *valueToSet
 	}

--- a/pkg/vm/properties_table.go
+++ b/pkg/vm/properties_table.go
@@ -110,11 +110,19 @@ func ownPropertiesSlot(v Value) **PlainObject {
 //
 // A rejection is silent in sloppy mode and a TypeError in strict mode, which is
 // what makes Object.freeze / Object.seal / Object.preventExtensions on a
-// function, RegExp, Map or Set actually bite. Accessor properties are left to
-// the callers that dispatch to setters before they get here.
+// function, RegExp, Map or Set actually bite. An existing accessor is handled
+// first, by setOwnAccessorSetter - see that function's comment for why this
+// can no longer be left to "the callers that dispatch to setters before they
+// get here", which most callers never actually did.
+//
+// receiver is the `this` an existing accessor's setter is invoked with - the
+// exotic value itself (the function, RegExp, Map, ...), not props.
 //
 // Returns the opcode-shaped triple, so call sites can `return` it directly.
-func (vm *VM) setOwnChecked(props *PlainObject, name string, v Value) (bool, InterpretResult, Value) {
+func (vm *VM) setOwnChecked(props *PlainObject, name string, receiver Value, v Value) (bool, InterpretResult, Value) {
+	if handled, ok, status, result := vm.setOwnAccessorSetter(props, keyFromString(name), name, receiver, v); handled {
+		return ok, status, result
+	}
 	if allowed, threw := vm.tableSetAllowed(props, keyFromString(name), name); !allowed {
 		if threw {
 			return false, InterpretRuntimeError, Undefined
@@ -138,7 +146,23 @@ func (vm *VM) setOwnChecked(props *PlainObject, name string, v Value) (bool, Int
 // non-configurable. Redefining an *existing* property still passes nil
 // throughout, so DefineOwnPropertyByKey's own already-correct
 // attribute-preserving behavior for that case is untouched.
-func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (bool, InterpretResult, Value) {
+//
+// receiver is the `this` an existing accessor's setter is invoked with - see
+// setOwnChecked.
+func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, receiver Value, v Value) (bool, InterpretResult, Value) {
+	// An existing accessor must go through setOwnAccessorSetter, which calls
+	// its setter (or no-ops / throws for a getter-only one) - never through
+	// the "existing property" branch below. That branch used to be reached
+	// for an accessor too (tableSetAllowed's isAccessor check reports
+	// allowed=true for one), landing on
+	// `props.DefineOwnPropertyByKey(key, v, nil, nil, nil)`, whose
+	// accessor-to-data conversion silently clobbered the accessor into a
+	// plain data property instead of calling its setter. Reproduced
+	// identically for a plain function's symbol accessor - see
+	// https://github.com/nooga/paserati/pull/333 "Found, not fixed".
+	if handled, ok, status, result := vm.setOwnAccessorSetter(props, key, key.debugName(), receiver, v); handled {
+		return ok, status, result
+	}
 	if allowed, threw := vm.tableSetAllowed(props, key, key.debugName()); !allowed {
 		if threw {
 			return false, InterpretRuntimeError, Undefined
@@ -146,20 +170,11 @@ func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (
 		return true, InterpretOK, v
 	}
 	// HasOwnByKey re-derives existence tableSetAllowed already checked
-	// (GetOwnAccessorByKey/GetOwnDescriptorByKey) - a third linear scan
-	// over the same shape, not a different question. Left as its own call
-	// rather than threading a result out of tableSetAllowed, since that
-	// function's signature is shared with the string-key path.
-	//
-	// Note: if key already names an accessor, tableSetAllowed's
-	// isAccessor check reports allowed=true, and this falls into the
-	// "existing" branch below with nil attribute pointers -
-	// DefineOwnPropertyByKey's accessor-to-data conversion then silently
-	// clobbers the accessor into a plain data property instead of calling
-	// its setter (or, getter-only, leaving it untouched). That is a
-	// distinct, pre-existing bug in its own right (reproduces identically
-	// for a plain function's symbol accessor, unaffected by this specific
-	// existence check) - not introduced or fixed here.
+	// (GetOwnDescriptorByKey, now that the accessor case above already
+	// consumed GetOwnAccessorByKey's answer) - a second linear scan over the
+	// same shape, not a different question. Left as its own call rather than
+	// threading a result out of tableSetAllowed, since that function's
+	// signature is shared with the string-key path.
 	if !props.HasOwnByKey(key) {
 		w, e, c := true, true, true
 		props.DefineOwnPropertyByKey(key, v, &w, &e, &c)
@@ -167,6 +182,75 @@ func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (
 	}
 	props.DefineOwnPropertyByKey(key, v, nil, nil, nil)
 	return true, InterpretOK, v
+}
+
+// setOwnAccessorSetter is the accessor half of ordinary [[Set]] (ECMAScript
+// OrdinarySetWithOwnDescriptor), shared by setOwnChecked and
+// setOwnCheckedByKey so every side-table kind (Function, Closure, RegExp,
+// Map, Set, Promise, BoundFunction, NativeFunction(WithProps)) gets it once
+// instead of each opSetProp/opSetPropSymbol call site reimplementing it (or,
+// for most of them, not implementing it at all - see below).
+//
+// When key names an existing accessor, this fully handles the assignment:
+// calls the setter with receiver as `this` if one exists, or - for a
+// getter-only accessor - silently no-ops in sloppy mode and throws a
+// TypeError in strict mode, per spec. It must never fall through to writing
+// a data property over an accessor. handled is false when key does not name
+// an accessor at all, in which case the caller proceeds with its own
+// data-property logic.
+//
+// Before this existed, an existing accessor's setter was only ever invoked
+// by two of the nine call sites (TypeFunction/TypeClosure in opSetProp,
+// which each pre-checked GetOwnAccessor before reaching setOwnChecked) - the
+// other seven (RegExp/Map/Set/Promise/BoundFunction/NativeFunction(WithProps),
+// for both string and symbol keys) called straight into setOwnChecked /
+// setOwnCheckedByKey, whose only accessor awareness was tableSetAllowed's
+// isAccessor check reporting the write as merely "allowed": for the
+// string-key path that reached PlainObject.SetOwn, which silently no-ops on
+// an accessor field (writable defaults to false for one) without ever
+// calling its setter; for the symbol-key path that reached
+// DefineOwnPropertyByKey with nil attributes, which clobbered the accessor
+// into a data property instead (the bug this function was written to fix).
+func (vm *VM) setOwnAccessorSetter(props *PlainObject, key PropertyKey, display string, receiver Value, v Value) (handled, ok bool, status InterpretResult, result Value) {
+	_, setter, _, _, isAccessor := props.GetOwnAccessorByKey(key)
+	if !isAccessor {
+		return false, true, InterpretOK, Undefined
+	}
+	if setter.Type() != TypeUndefined {
+		_, err := vm.Call(setter, receiver, []Value{v})
+		if err != nil {
+			if ee, eok := err.(ExceptionError); eok {
+				vm.throwException(ee.GetExceptionValue())
+				return true, false, InterpretRuntimeError, Undefined
+			}
+			var excVal Value
+			if errCtor, gok := vm.GetGlobal("Error"); gok {
+				if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+					excVal = res
+				} else {
+					eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+					eo.SetOwn("name", NewString("Error"))
+					eo.SetOwn("message", NewString(err.Error()))
+					excVal = NewValueFromPlainObject(eo)
+				}
+			} else {
+				eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+				eo.SetOwn("name", NewString("Error"))
+				eo.SetOwn("message", NewString(err.Error()))
+				excVal = NewValueFromPlainObject(eo)
+			}
+			vm.throwException(excVal)
+			return true, false, InterpretRuntimeError, Undefined
+		}
+		return true, true, InterpretOK, v
+	}
+	// Getter-only: silent no-op in sloppy mode, TypeError in strict mode -
+	// mirrors opSetProp's TypeObject prototype-chain accessor-setter check.
+	if vm.IsInStrictMode() {
+		vm.ThrowTypeError("Cannot set property '" + display + "' which has only a getter")
+		return true, false, InterpretRuntimeError, Undefined
+	}
+	return true, true, InterpretOK, v
 }
 
 // tableSetAllowed applies setOwnChecked's rejections. threw is true when a

--- a/pkg/vm/properties_table.go
+++ b/pkg/vm/properties_table.go
@@ -127,12 +127,42 @@ func (vm *VM) setOwnChecked(props *PlainObject, name string, v Value) (bool, Int
 
 // setOwnCheckedByKey is setOwnChecked for a symbol (or otherwise non-string)
 // key. It stores through DefineOwnPropertyByKey because that is what the
-// symbol-set paths already did.
+// symbol-set paths already did - but a plain assignment (obj[sym] = v) is
+// ordinary [[Set]], not Object.defineProperty: a brand-new property must
+// come out {writable: true, enumerable: true, configurable: true} ("regular
+// assignment semantics", per SetOwn's comment for the string-key path,
+// pkg/vm/object.go), not DefineOwnPropertyByKey's own default of false for
+// every attribute a nil pointer leaves unspecified. Passing nil for all
+// three - as this used to unconditionally do - silently created every
+// symbol property from a plain assignment as non-writable, non-enumerable,
+// non-configurable. Redefining an *existing* property still passes nil
+// throughout, so DefineOwnPropertyByKey's own already-correct
+// attribute-preserving behavior for that case is untouched.
 func (vm *VM) setOwnCheckedByKey(props *PlainObject, key PropertyKey, v Value) (bool, InterpretResult, Value) {
 	if allowed, threw := vm.tableSetAllowed(props, key, key.debugName()); !allowed {
 		if threw {
 			return false, InterpretRuntimeError, Undefined
 		}
+		return true, InterpretOK, v
+	}
+	// HasOwnByKey re-derives existence tableSetAllowed already checked
+	// (GetOwnAccessorByKey/GetOwnDescriptorByKey) - a third linear scan
+	// over the same shape, not a different question. Left as its own call
+	// rather than threading a result out of tableSetAllowed, since that
+	// function's signature is shared with the string-key path.
+	//
+	// Note: if key already names an accessor, tableSetAllowed's
+	// isAccessor check reports allowed=true, and this falls into the
+	// "existing" branch below with nil attribute pointers -
+	// DefineOwnPropertyByKey's accessor-to-data conversion then silently
+	// clobbers the accessor into a plain data property instead of calling
+	// its setter (or, getter-only, leaving it untouched). That is a
+	// distinct, pre-existing bug in its own right (reproduces identically
+	// for a plain function's symbol accessor, unaffected by this specific
+	// existence check) - not introduced or fixed here.
+	if !props.HasOwnByKey(key) {
+		w, e, c := true, true, true
+		props.DefineOwnPropertyByKey(key, v, &w, &e, &c)
 		return true, InterpretOK, v
 	}
 	props.DefineOwnPropertyByKey(key, v, nil, nil, nil)

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -1048,13 +1048,22 @@ func HasOwnFunctionIntrinsic(target Value, name string) bool {
 // for pkg/builtins: Reflect.has's callable cases (Function, Closure,
 // NativeFunction, NativeFunctionWithProps, BoundFunction) need the exact
 // same "own side table, then FunctionPrototype" fallback OpIn's own
-// callable cases already use internally, for a string key (this does not
-// handle a symbol key - FunctionPrototype's own representation, a
-// PlainObject in the common case but possibly a NativeFunctionWithProps,
-// needs a manual walk to support that correctly; see OpIn's
-// TypeFunction/TypeClosure symbol branches in vm.go for the pattern).
+// callable cases already use internally, for a string key.
 func (vm *VM) HasFunctionPrototypeProperty(propKey string) bool {
 	return vm.hasFunctionPrototypeProperty(propKey)
+}
+
+// HasFunctionPrototypeSymbolProperty is HasFunctionPrototypeProperty for a
+// symbol key (e.g. Symbol.hasInstance), exported for pkg/builtins so
+// Reflect.has's callable case can use the exact same walk OpIn's own
+// callable cases use internally (vm.go's hasFunctionPrototypeSymbolProperty)
+// instead of unconditionally answering false for any symbol key beyond a
+// callable's own side table - which would otherwise have `in` (which does
+// walk this chain) disagree with Reflect.has for an inherited symbol
+// property, the same "in disagrees with Reflect.has" bug class fixed
+// elsewhere in this function for string keys.
+func (vm *VM) HasFunctionPrototypeSymbolProperty(key PropertyKey) bool {
+	return vm.hasFunctionPrototypeSymbolProperty(key)
 }
 
 // handleSpecialProperties handles special properties like .length

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -219,10 +219,18 @@ type ArrayObject struct {
 	properties   map[string]Value        // Named properties (e.g., "index", "input" for match results)
 	propertyDesc map[string]PropertyDesc // Property descriptors for named properties
 	symbolProps  map[*SymbolObject]Value // Symbol-keyed properties (e.g., Symbol.iterator override)
-	getters      map[string]Value        // Accessor getters for named properties
-	setters      map[string]Value        // Accessor setters for named properties
-	extensible   bool                    // When false, no new properties can be added (for Object.freeze/seal)
-	frozen       bool                    // When true, elements are also non-writable and non-configurable
+	// symbolPropOrder tracks symbolProps' keys in creation order - a Go map
+	// has none, but ECMA-262 10.1.11 OrdinaryOwnPropertyKeys requires
+	// symbol-keyed own properties to enumerate in the order they were
+	// created (verified against Node: two symbols added to an array
+	// enumerate in insertion order via Object.getOwnPropertySymbols and
+	// Reflect.ownKeys, and stay after every string key regardless of when
+	// each was added relative to the symbols). See OwnSymbolKeys.
+	symbolPropOrder []*SymbolObject
+	getters         map[string]Value // Accessor getters for named properties
+	setters         map[string]Value // Accessor setters for named properties
+	extensible      bool             // When false, no new properties can be added (for Object.freeze/seal)
+	frozen          bool             // When true, elements are also non-writable and non-configurable
 	// lengthNonWritable tracks Object.defineProperty(arr, "length",
 	// {writable: false}) - stored inverted (zero value = writable, the ES
 	// default) so every existing ArrayObject construction site, which
@@ -2844,6 +2852,12 @@ func (a *ArrayObject) SetSymbolProp(sym *SymbolObject, val Value) {
 	if a.symbolProps == nil {
 		a.symbolProps = make(map[*SymbolObject]Value)
 	}
+	if _, existed := a.symbolProps[sym]; !existed {
+		// New key - record its creation-order position. An overwrite of an
+		// already-present key keeps its original position, matching
+		// ordinary property semantics (redefining a value doesn't move it).
+		a.symbolPropOrder = append(a.symbolPropOrder, sym)
+	}
 	a.symbolProps[sym] = val
 }
 
@@ -2854,6 +2868,21 @@ func (a *ArrayObject) HasOwnSymbolProp(sym *SymbolObject) bool {
 	}
 	_, ok := a.symbolProps[sym]
 	return ok
+}
+
+// OwnSymbolKeys returns every symbol this array has an own property for, in
+// creation order - mirrors PlainObject.OwnSymbolKeys's shape/contract
+// (pkg/vm/object.go), used by Object.getOwnPropertySymbols and
+// Reflect.ownKeys (pkg/builtins). Array symbol-keyed properties previously
+// had no enumerator at all despite genuinely being stored (GetSymbolProp/
+// SetSymbolProp/HasOwnSymbolProp already worked) - Object.getOwnPropertySymbols
+// on an array with a real symbol property silently answered [] before this.
+func (a *ArrayObject) OwnSymbolKeys() []Value {
+	symbols := make([]Value, 0, len(a.symbolPropOrder))
+	for _, sym := range a.symbolPropOrder {
+		symbols = append(symbols, Value{typ: TypeSymbol, obj: unsafe.Pointer(sym)})
+	}
+	return symbols
 }
 
 // DefineAccessorProperty defines an accessor property on the array object
@@ -3663,5 +3692,17 @@ func (a *ArrayObject) DeleteSymbolProp(sym *SymbolObject) bool {
 	}
 	_, existed := a.symbolProps[sym]
 	delete(a.symbolProps, sym)
+	if existed {
+		// Keep symbolPropOrder in sync - a re-added key after deletion
+		// gets a fresh, later creation-order position via SetSymbolProp's
+		// own "not already present" check, matching how deleting then
+		// redefining an ordinary property moves it to the end too.
+		for i, s := range a.symbolPropOrder {
+			if s == sym {
+				a.symbolPropOrder = append(a.symbolPropOrder[:i], a.symbolPropOrder[i+1:]...)
+				break
+			}
+		}
+	}
 	return existed
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3553,8 +3553,19 @@ startExecution:
 						return InterpretRuntimeError, Undefined
 					}
 
-					// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-					if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+					// Check if handler has a 'has' trap. proxyGetTrap (not a
+					// bare proxy.handler.AsPlainObject().GetOwn("has")) for
+					// two reasons found while adding the symbol-key sibling
+					// of this exact case (see task_125640b9's PR body):
+					// GetMethod semantics (10.5.7 step 4) mean an INHERITED
+					// "has" trap counts too, not just an own one; and a
+					// handler that happens to be a TypeDictObject (a TS
+					// enum/module namespace value) must not panic
+					// AsPlainObject(). Both bugs were real here before this
+					// fix - confirmed via `"x" in new Proxy({}, Object.create({has(){return true}}))`
+					// (false instead of true) and `"x" in new Proxy({}, someEnum)`
+					// (a process-crashing panic, not a catchable exception).
+					if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 						// Validate trap is callable
 						if !hasTrap.IsCallable() {
 							vm.ThrowTypeError("'has' on proxy: trap is not a function")
@@ -21498,8 +21509,11 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 		if proxy.Revoked {
 			return false
 		}
-		// Check if the proxy's handler has a 'has' trap
-		if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+		// Check if the proxy's handler has a 'has' trap - proxyGetTrap, not
+		// a bare GetOwn, for the same two reasons as OpIn's own TypeProxy
+		// case above (GetMethod's inherited-trap semantics, and a
+		// TypeDictObject handler panicking AsPlainObject()).
+		if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 			if hasTrap.IsCallable() {
 				trapArgs := []Value{proxy.target, NewString(propKey)}
 				result, err := vm.Call(hasTrap, proxy.handler, trapArgs)
@@ -21517,6 +21531,18 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 	case TypeDictObject:
 		return target.AsDictObject().Has(propKey)
 	case TypeArray:
+		// NOT fixed here (pre-existing, out of this task's scope): unlike
+		// OpIn's own direct-target TypeArray case, which checks
+		// ArrayHasOwnIndex (paserati#176/#178 - a numerically-in-range
+		// index is NOT necessarily an own property, e.g. after a distant
+		// defineProperty inflates .length) before falling to the
+		// prototype chain, this still uses the simpler, wrong
+		// `index < arrayObj.Length()` test. Left alone since this task's
+		// three fixes are the trap-lookup bugs and the seven-kind
+		// fallback-coverage gap, not this unrelated pre-existing
+		// correctness issue - flagged as a third bullet on the same
+		// follow-up as the other unfixed trap-lookup sites this task's
+		// review turned up (see task's PR body).
 		arrayObj := target.AsArray()
 		if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
 			return index < arrayObj.Length()
@@ -21595,6 +21621,84 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 			}
 		}
 		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeNativeFunctionWithProps:
+		// Same own-table-then-FunctionPrototype shape as TypeFunction/
+		// TypeClosure above - mirrors OpIn's own direct-target
+		// TypeNativeFunctionWithProps case (pkg/vm/vm.go) exactly.
+		nf := target.AsNativeFunctionWithProps()
+		if HasOwnFunctionIntrinsic(target, propKey) {
+			return true
+		}
+		if nf.Properties != nil && nf.Properties.Has(propKey) {
+			return true
+		}
+		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeNativeFunction:
+		// Mirrors OpIn's own direct-target TypeNativeFunction case.
+		nf := target.AsNativeFunction()
+		if HasOwnFunctionIntrinsic(target, propKey) {
+			return true
+		}
+		if nf.Properties != nil && nf.Properties.Has(propKey) {
+			return true
+		}
+		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeBoundFunction:
+		// Mirrors OpIn's own direct-target TypeBoundFunction case.
+		bf := target.AsBoundFunction()
+		if bf.Properties != nil && bf.Properties.Has(propKey) {
+			return true
+		}
+		return vm.hasFunctionPrototypeProperty(propKey)
+	case TypeSet:
+		// Mirrors OpIn's own direct-target TypeSet case: own "size", then
+		// the side table, then Set.prototype and beyond.
+		if propKey == "size" {
+			return true
+		}
+		setObj := target.AsSet()
+		if setObj.Properties != nil && setObj.Properties.HasOwn(propKey) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), keyFromString(propKey))
+	case TypeMap:
+		// Mirrors OpIn's own direct-target TypeMap case.
+		if propKey == "size" {
+			return true
+		}
+		mapObj := target.AsMap()
+		if mapObj.Properties != nil && mapObj.Properties.HasOwn(propKey) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), keyFromString(propKey))
+	case TypePromise:
+		// Mirrors OpIn's own direct-target TypePromise case: the side
+		// table (a Promise exposes no intrinsic own state, but a plain
+		// assignment can still add one), then Promise.prototype.
+		promiseObj := target.AsPromise()
+		if promiseObj.Properties != nil && promiseObj.Properties.HasOwn(propKey) {
+			return true
+		}
+		if vm.PromisePrototype.IsObject() {
+			return vm.PromisePrototype.AsPlainObject().Has(propKey)
+		}
+		return false
+	case TypeArguments:
+		// Mirrors OpIn's own direct-target TypeArguments case.
+		argObj := target.AsArguments()
+		if propKey == "length" {
+			return true
+		}
+		if propKey == "callee" && !argObj.IsStrict() {
+			return true
+		}
+		if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
+			return index < argObj.Length()
+		}
+		if vm.ObjectPrototype.IsObject() {
+			return vm.ObjectPrototype.AsPlainObject().Has(propKey)
+		}
+		return false
 	default:
 		return false
 	}
@@ -21733,6 +21837,60 @@ func (vm *VM) proxyHasSymbolPropertyFallback(target Value, propVal Value) bool {
 			}
 		}
 		return vm.hasFunctionPrototypeSymbolProperty(key)
+	case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:
+		// Same shape as TypeFunction/TypeClosure above - mirrors OpIn's own
+		// symbol-key direct-target case for these three kinds (pkg/vm/vm.go).
+		if props := OwnPropertiesTable(target); props != nil {
+			if _, ok := props.GetOwnByKey(key); ok {
+				return true
+			}
+		}
+		return vm.hasFunctionPrototypeSymbolProperty(key)
+	case TypeSet:
+		// Mirrors OpIn's own symbol-key direct-target TypeSet case: own
+		// table, then Set.prototype and beyond.
+		setObj := target.AsSet()
+		if setObj.Properties != nil && setObj.Properties.HasOwnByKey(key) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), key)
+	case TypeMap:
+		// Mirrors OpIn's own symbol-key direct-target TypeMap case.
+		mapObj := target.AsMap()
+		if mapObj.Properties != nil && mapObj.Properties.HasOwnByKey(key) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), key)
+	case TypePromise:
+		// Mirrors OpIn's own symbol-key direct-target TypePromise case:
+		// own table first, then Promise.prototype's chain.
+		promiseObj := target.AsPromise()
+		if promiseObj.Properties != nil && promiseObj.Properties.HasOwnByKey(key) {
+			return true
+		}
+		if vm.PromisePrototype.IsObject() {
+			return vm.hasPropertyByKeyFromPrototypeChain(vm.PromisePrototype, key)
+		}
+		return false
+	case TypeArguments:
+		// Mirrors OpIn's own symbol-key direct-target TypeArguments case:
+		// Array.prototype first (for Symbol.iterator), then Object.prototype.
+		// Deliberately does NOT check argObj.HasOwnSymbolProp(...) first
+		// (every other kind's case here does check its own table before
+		// falling to a prototype) - this matches OpIn's own symbol-key
+		// TypeArguments case and reflectHas's explicit comment that "a
+		// symbol key on an Arguments object isn't handled by either" - a
+		// pre-existing, consistent gap across all three, not a new
+		// asymmetry introduced here.
+		if vm.ArrayPrototype.IsObject() {
+			if vm.hasPropertyByKeyFromPrototypeChain(vm.ArrayPrototype, key) {
+				return true
+			}
+		}
+		if vm.ObjectPrototype.IsObject() {
+			return vm.hasPropertyByKeyFromPrototypeChain(vm.ObjectPrototype, key)
+		}
+		return false
 	default:
 		return false
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -9410,8 +9410,14 @@ startExecution:
 					return InterpretRuntimeError, Undefined
 				}
 
-				// Check if handler has ownKeys trap
-				ownKeysTrap, hasOwnKeysTrap := proxy.Handler().AsPlainObject().GetOwn("ownKeys")
+				// Check if handler has ownKeys trap. GetMethod(handler,
+				// "ownKeys") per spec: an inherited trap counts, not just
+				// an own one - proxyGetTrap (not a bare
+				// proxy.Handler().AsPlainObject().GetOwn("ownKeys")) for
+				// the same reason documented on its own definition; also
+				// avoids AsPlainObject() panicking for a TypeDictObject
+				// handler (a TS enum or module namespace value at runtime).
+				ownKeysTrap, hasOwnKeysTrap := proxyGetTrap(proxy.Handler(), "ownKeys")
 				if hasOwnKeysTrap && ownKeysTrap.IsCallable() {
 					// Call ownKeys trap: handler.ownKeys(target)
 					trapArgs := []Value{proxy.Target()}
@@ -9438,9 +9444,10 @@ startExecution:
 
 					arr := keysResult.AsArray()
 
-					// Get traps from handler
-					getOwnPropDescTrap, hasGetOwnPropDescTrap := proxy.Handler().AsPlainObject().GetOwn("getOwnPropertyDescriptor")
-					getTrap, hasGetTrap := proxy.Handler().AsPlainObject().GetOwn("get")
+					// Get traps from handler - proxyGetTrap for both, same
+					// reasons as the ownKeys trap lookup just above.
+					getOwnPropDescTrap, hasGetOwnPropDescTrap := proxyGetTrap(proxy.Handler(), "getOwnPropertyDescriptor")
+					getTrap, hasGetTrap := proxyGetTrap(proxy.Handler(), "get")
 
 					// Process each key in order returned by ownKeys
 					for i := 0; i < arr.Length(); i++ {
@@ -11289,15 +11296,12 @@ startExecution:
 					return InterpretRuntimeError, Undefined
 				}
 
-				// Check for construct trap (handler can be PlainObject or DictObject)
-				var constructTrap Value
-				var hasConstructTrap bool
-				switch proxy.Handler().Type() {
-				case TypeObject:
-					constructTrap, hasConstructTrap = proxy.Handler().AsPlainObject().GetOwn("construct")
-				case TypeDictObject:
-					constructTrap, hasConstructTrap = proxy.Handler().AsDictObject().GetOwn("construct")
-				}
+				// Check for construct trap. GetMethod(handler, "construct")
+				// per spec: an inherited trap counts, not just an own one -
+				// proxyGetTrap (not a bare
+				// proxy.Handler().AsPlainObject().GetOwn("construct")) for
+				// the same reason documented on its own definition.
+				constructTrap, hasConstructTrap := proxyGetTrap(proxy.Handler(), "construct")
 
 				if hasConstructTrap && constructTrap.Type() != TypeUndefined && constructTrap.Type() != TypeNull {
 					// Validate trap is callable

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14666,21 +14666,23 @@ startExecution:
 						cur = pv.AsPlainObject()
 					}
 				}
-			case TypeMap, TypeSet, TypePromise:
+			case TypeMap, TypeSet, TypePromise, TypeNativeFunction, TypeNativeFunctionWithProps:
 				// Same side table as TypeRegExp just above (OwnPropertiesTable,
 				// pkg/vm/properties_table.go) - this case was missing
 				// entirely, so `for (k in map)`/`for (k in set)`/
-				// `for (k in promise)` came back with nothing even after a
-				// plain assignment onto the value. Map/Set's own "size" is
-				// never an own property (it's a getter on Map.prototype/
-				// Set.prototype - Object.getOwnPropertyDescriptor(new Map(),
-				// "size") is undefined in Node), and Promise exposes no
-				// user-accessible own state, so only the side table matters
+				// `for (k in promise)`/`for (k in nativeFn)` came back with
+				// nothing even after a plain assignment onto the value.
+				// Map/Set's own "size" is never an own property (it's a
+				// getter on Map.prototype/Set.prototype -
+				// Object.getOwnPropertyDescriptor(new Map(), "size") is
+				// undefined in Node), Promise exposes no user-accessible own
+				// state, and TypeNativeFunction/TypeNativeFunctionWithProps'
+				// "name"/"length" are non-enumerable synthesized intrinsics,
+				// not side-table entries - so only the side table matters
 				// here, same as RegExp's "lastIndex" staying excluded above.
-				// OwnPropertiesTable abstracts over the three kinds' actual
-				// field names (MapObject/SetObject/PromiseObject.Properties)
-				// via ownPropertiesSlot, so one case covers all three
-				// instead of duplicating the TypeRegExp case's body three
+				// OwnPropertiesTable abstracts over all five kinds' actual
+				// field names via ownPropertiesSlot, so one case covers them
+				// instead of duplicating the TypeRegExp case's body five
 				// times.
 				if props := OwnPropertiesTable(objValue); props != nil {
 					seen := make(map[string]bool)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3445,7 +3445,7 @@ startExecution:
 						return InterpretRuntimeError, Undefined
 					}
 
-					if hasTrap, ok := proxyGetHasTrap(proxy.handler); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+					if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 						if !hasTrap.IsCallable() {
 							vm.ThrowTypeError("'has' on proxy: trap is not a function")
 							if !vm.unwinding {
@@ -21600,29 +21600,34 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 	}
 }
 
-// proxyGetHasTrap looks up a Proxy handler's "has" trap the way
-// GetMethod(handler, "has") does per spec (10.5.7 step 4): an inherited
-// trap counts, not just an own one, and the handler can be a TypeDictObject
-// (a module namespace or enum value, pkg/vm/object.go's NewDictObject) as
-// well as an ordinary TypeObject - AsPlainObject() on the former panics.
+// proxyGetTrap looks up a Proxy handler's trap (e.g. "has", "get") the way
+// GetMethod(handler, trapName) does per spec: an inherited trap counts,
+// not just an own one, and the handler can be a TypeDictObject (a module
+// namespace or enum value, pkg/vm/object.go's NewDictObject) as well as an
+// ordinary TypeObject - AsPlainObject() on the former panics.
 //
-// This exists because both of this function's callers (OpIn's symbol-key
-// TypeProxy case above and proxyHasSymbolPropertyFallback below) used to
-// inline `proxy.handler.AsPlainObject().GetOwn("has")` directly, copied
+// Originally added (as the "has"-only proxyGetHasTrap) because OpIn's
+// symbol-key TypeProxy case and proxyHasSymbolPropertyFallback below used
+// to inline `proxy.handler.AsPlainObject().GetOwn("has")` directly, copied
 // from the pre-existing string-key TypeProxy case's identical shape a few
 // lines below - itself not spec-correct on either count (own-only, and an
 // unguarded AsPlainObject that panics for a TypeDictObject handler; try
-// `new Proxy({}, someEnum)` on either the string- or symbol-key path
-// before this fix). That pre-existing gap was left alone here rather than
-// silently fixed as a drive-by - it's flagged as a shared follow-up
-// instead (see this branch's PR body) since fixing it changes the
-// string-key path's behavior too and deserves its own verification.
-func proxyGetHasTrap(handler Value) (Value, bool) {
+// `new Proxy({}, someEnum)` on either the string- or symbol-key `in` path).
+// That pre-existing `in`-path gap was left alone rather than silently
+// fixed as a drive-by (see task_125640b9's PR body) since fixing it
+// changes established `in`/Reflect.has behavior on a path that fix wasn't
+// scoped to touch.
+//
+// Generalized to take a trap name so getPropertyWithReceiver's Proxy case
+// (pkg/vm/vm_init.go, backing Reflect.get) can reuse it for the "get"
+// trap instead of carrying its own copy of the same two bugs forward a
+// third time.
+func proxyGetTrap(handler Value, trapName string) (Value, bool) {
 	switch handler.Type() {
 	case TypeObject:
-		return handler.AsPlainObject().Get("has")
+		return handler.AsPlainObject().Get(trapName)
 	case TypeDictObject:
-		return handler.AsDictObject().Get("has")
+		return handler.AsDictObject().Get(trapName)
 	default:
 		return Undefined, false
 	}
@@ -21653,7 +21658,7 @@ func (vm *VM) proxyHasSymbolPropertyFallback(target Value, propVal Value) bool {
 		if proxy.Revoked {
 			return false
 		}
-		if hasTrap, ok := proxyGetHasTrap(proxy.handler); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+		if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 			if hasTrap.IsCallable() {
 				trapArgs := []Value{proxy.target, propVal}
 				result, err := vm.Call(hasTrap, proxy.handler, trapArgs)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3408,6 +3408,44 @@ startExecution:
 							cur = pv.AsPlainObject()
 						}
 					}
+				case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:
+					// Same shape as TypeFunction/TypeClosure above: all three
+					// carry their own lazily-allocated Properties side table
+					// (pkg/vm/function.go - BoundFunctionObject,
+					// NativeFunctionObject, NativeFunctionObjectWithProps all
+					// have a Properties *PlainObject field), so a symbol-keyed
+					// bracket assignment (bound[sym] = v, Array[sym] = v) is
+					// findable the same way a Function's is - own table
+					// first, then walk Function.prototype for an inherited
+					// symbol property (e.g. Symbol.hasInstance).
+					//
+					// Before this case existed, these three fell to the
+					// default below and always answered false here even
+					// though Reflect.has (pkg/builtins/reflect_has.go) and
+					// the own table itself already agreed the property was
+					// there - the same "in disagrees with Reflect.has"
+					// pattern fixed for Promise (see the TypePromise case's
+					// history) and for RegExp/Map/Set's own cases above.
+					symKey := NewSymbolKey(propVal)
+					if props := OwnPropertiesTable(objVal); props != nil {
+						if _, ok := props.GetOwnByKey(symKey); ok {
+							hasProperty = true
+							break
+						}
+					}
+					if vm.FunctionPrototype.IsObject() {
+						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
+							if _, ok := cur.GetOwnByKey(symKey); ok {
+								hasProperty = true
+								break
+							}
+							pv := cur.GetPrototype()
+							if !pv.IsObject() {
+								break
+							}
+							cur = pv.AsPlainObject()
+						}
+					}
 				default:
 					hasProperty = false
 				}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8573,8 +8573,38 @@ startExecution:
 								}
 							}
 						}
-					case TypeObject, TypeDictObject:
-						// Handle object indexing on target
+					default:
+						// Every other target kind (TypeObject, TypeDictObject,
+						// TypeMap, TypeSet, TypePromise, TypeRegExp,
+						// TypeGenerator, TypeArguments, TypeBoundFunction,
+						// TypeNativeFunction, TypeNativeFunctionWithProps, a
+						// further-nested TypeProxy, ...) - used to be a bare
+						// `registers[destReg] = Undefined` for anything besides
+						// TypeObject/TypeDictObject (which got a delegation to
+						// opGetProp), so e.g. `new Proxy(arguments, {})[0]`
+						// silently read undefined even though the identical
+						// key read via dot notation (opGetProp's own no-trap
+						// fallback, already fixed for this same shape of bug)
+						// worked fine. Delegating to opGetProp here too (an
+						// earlier version of this fix did) would have been
+						// wrong for exactly that TypeArguments case: opGetProp
+						// only ever handles "length"/"callee"/named overflow
+						// properties for a TypeArguments objVal, never a plain
+						// numeric index like "0" - that resolution lives
+						// separately, in OpGetIndex's own direct (non-Proxy)
+						// TypeArguments case a few thousand lines up in this
+						// same function, via vm.argumentsGet. Rather than a
+						// FOURTH copy of that per-kind logic, delegate to
+						// getPropertyWithReceiver (pkg/vm/vm_init.go) instead -
+						// the same helper vm.GetProperty and opGetProp's own
+						// fallback are already built on, and unlike opGetProp
+						// it already handles every one of these kinds
+						// completely (TypeArguments included: length, callee,
+						// and numeric index via argumentsGet - see its own
+						// TypeArguments case for the full rationale). receiver
+						// is baseVal (the proxy itself), matching the
+						// get-trap-call branch above, which passes the same
+						// baseVal as the trap's own receiver argument.
 						var key string
 						switch indexVal.Type() {
 						case TypeString:
@@ -8585,17 +8615,41 @@ startExecution:
 							registers[destReg] = Undefined
 						}
 						if key != "" {
-							if ok, status, value := vm.opGetProp(frame, ip, &targetBase, key, &registers[destReg]); !ok {
-								if status != InterpretOK {
-									return status, value
+							result, err := vm.getPropertyWithReceiver(targetBase, key, baseVal)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+									if !vm.unwinding {
+										// Exception was caught by a handler, reload frame and continue
+										frame = &vm.frames[vm.frameCount-1]
+										closure = frame.closure
+										function = closure.Fn
+										code = function.Chunk.Code
+										constants = function.Chunk.Constants
+										registers = frame.registers
+										ip = frame.ip
+										continue
+									}
+									return InterpretRuntimeError, Undefined
 								}
-								goto reloadFrame
+								vm.ThrowTypeError(err.Error())
+								if !vm.unwinding {
+									// Exception was caught by a handler, reload frame and continue
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									code = function.Chunk.Code
+									constants = function.Chunk.Constants
+									registers = frame.registers
+									ip = frame.ip
+									continue
+								}
+								return InterpretRuntimeError, Undefined
 							}
+							registers[destReg] = result
 						} else {
 							registers[destReg] = Undefined
 						}
-					default:
-						registers[destReg] = Undefined
 					}
 				}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -9418,6 +9418,8 @@ startExecution:
 				// avoids AsPlainObject() panicking for a TypeDictObject
 				// handler (a TS enum or module namespace value at runtime).
 				ownKeysTrap, hasOwnKeysTrap := proxyGetTrap(proxy.Handler(), "ownKeys")
+
+				var keys []Value
 				if hasOwnKeysTrap && ownKeysTrap.IsCallable() {
 					// Call ownKeys trap: handler.ownKeys(target)
 					trapArgs := []Value{proxy.Target()}
@@ -9443,15 +9445,52 @@ startExecution:
 					}
 
 					arr := keysResult.AsArray()
+					keys = make([]Value, arr.Length())
+					for i := 0; i < arr.Length(); i++ {
+						keys[i] = arr.Get(i)
+					}
+				} else {
+					// No ownKeys trap: per ECMA-262 10.5.11 step 5,
+					// [[OwnPropertyKeys]] delegates to
+					// target.[[OwnPropertyKeys]]() instead of contributing
+					// no properties at all - proxyOwnKeysFallback recurses
+					// through a further-nested Proxy target the same way
+					// pkg/builtins' getProxyOwnKeys/proxyOwnPropertyKeys
+					// already do (checking each inner proxy's own ownKeys
+					// trap first). This proxy's OWN
+					// getOwnPropertyDescriptor/get traps below still apply
+					// to each resulting key regardless of where the key
+					// list came from - GetMethod([[OwnPropertyKeys]]) and
+					// GetMethod([[Get]]) are independent per spec
+					// (confirmed against Node).
+					keyStrs, err := vm.proxyOwnKeysFallback(proxy.Target())
+					if err != nil {
+						frame.ip = ip
+						if ee, ok := err.(ExceptionError); ok {
+							vm.throwException(ee.GetExceptionValue())
+						} else {
+							vm.runtimeError("ownKeys trap error: %v", err)
+						}
+						if !vm.unwinding {
+							continue
+						}
+						return InterpretRuntimeError, Undefined
+					}
+					keys = make([]Value, len(keyStrs))
+					for i, k := range keyStrs {
+						keys[i] = NewString(k)
+					}
+				}
 
+				{
 					// Get traps from handler - proxyGetTrap for both, same
 					// reasons as the ownKeys trap lookup just above.
 					getOwnPropDescTrap, hasGetOwnPropDescTrap := proxyGetTrap(proxy.Handler(), "getOwnPropertyDescriptor")
 					getTrap, hasGetTrap := proxyGetTrap(proxy.Handler(), "get")
 
 					// Process each key in order returned by ownKeys
-					for i := 0; i < arr.Length(); i++ {
-						keyVal := arr.Get(i)
+					for i := 0; i < len(keys); i++ {
+						keyVal := keys[i]
 						var keyStr string
 						isSymbolKey := keyVal.Type() == TypeSymbol
 
@@ -21749,6 +21788,72 @@ func proxyGetTrap(handler Value, trapName string) (Value, bool) {
 // reach it as vmInstance.ProxyGetTrap(...).
 func (vm *VM) ProxyGetTrap(handler Value, trapName string) (Value, bool) {
 	return proxyGetTrap(handler, trapName)
+}
+
+// proxyOwnKeysFallback implements [[OwnPropertyKeys]] for a Proxy whose
+// handler has no ownKeys trap: per ECMA-262 10.5.11 step 5, this delegates
+// to target.[[OwnPropertyKeys]](), which recurses if the target is itself
+// a Proxy (checking that inner proxy's own ownKeys trap first, not just
+// falling through further) - mirrors pkg/builtins/json_init.go's
+// getProxyOwnKeys and object_init.go's proxyOwnPropertyKeys, which already
+// do the same recursion for their own no-ownKeys-trap case; this is the
+// pkg/vm-local twin OpObjectSpread needs (pkg/vm can't import
+// pkg/builtins). String keys only, matching OpObjectSpread's existing
+// per-key loop, which already only spreads string keys even when a
+// ownKeys trap enumerates symbols too (a real, pre-existing,
+// out-of-scope-here gap the CopyDataProperties comment on that loop package
+// documents separately).
+//
+// Only called when the caller has already confirmed proxy's own handler
+// has no ownKeys trap; a trap found on a NESTED proxy target, however, is
+// used (matching getProxyOwnKeys/proxyOwnPropertyKeys) - the caller's own
+// getOwnPropertyDescriptor/get trap consultation for each returned key
+// still runs against the ORIGINAL top-level proxy's handler regardless of
+// where the key list came from, since GetMethod([[OwnPropertyKeys]]) and
+// GetMethod([[Get]]) are independent per spec (confirmed against Node: a
+// no-ownKeys-trap Proxy's get trap still runs during a spread).
+func (vm *VM) proxyOwnKeysFallback(target Value) ([]string, error) {
+	for target.Type() == TypeProxy {
+		proxy := target.AsProxy()
+		if proxy.Revoked {
+			return nil, vm.NewTypeError("Cannot perform 'ownKeys' on a revoked Proxy")
+		}
+		handler := proxy.Handler()
+		trap, hasTrap := proxyGetTrap(handler, "ownKeys")
+		if hasTrap && trap.IsCallable() {
+			result, err := vm.Call(trap, handler, []Value{proxy.Target()})
+			if err != nil {
+				return nil, err
+			}
+			if result.Type() != TypeArray {
+				return nil, vm.NewTypeError("ownKeys trap must return an array-like object")
+			}
+			arr := result.AsArray()
+			keys := make([]string, 0, arr.Length())
+			for i := 0; i < arr.Length(); i++ {
+				if keyVal := arr.Get(i); keyVal.Type() == TypeString {
+					keys = append(keys, keyVal.ToString())
+				}
+			}
+			return keys, nil
+		}
+		target = proxy.Target()
+	}
+	switch target.Type() {
+	case TypeObject:
+		return target.AsPlainObject().OwnKeys(), nil
+	case TypeDictObject:
+		return target.AsDictObject().OwnKeys(), nil
+	case TypeArray:
+		arr := target.AsArray()
+		keys := make([]string, arr.Length())
+		for i := range keys {
+			keys[i] = strconv.Itoa(i)
+		}
+		return keys, nil
+	default:
+		return nil, nil
+	}
 }
 
 // proxyHasSymbolPropertyFallback is proxyHasPropertyFallback's symbol-key

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3416,6 +3416,119 @@ startExecution:
 					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
 						hasProperty = true
 					}
+				case TypeProxy:
+					// Mirrors the non-symbol TypeProxy case just below
+					// exactly (revoked check, 'has' trap invocation with
+					// the invariant-validation steps, no-trap fallback to
+					// target.[[HasProperty]]) - only the propertyKey passed
+					// to the trap and used for the own-property lookups
+					// differs (the raw Symbol Value instead of a string).
+					// Before this case existed, ANY symbol-keyed `in` check
+					// on a Proxy fell to the default below and answered
+					// false unconditionally - regardless of a `has` trap or
+					// what the target actually has - even though
+					// Reflect.has (proxyReflectHas, pkg/builtins/
+					// reflect_has.go) already handled this correctly.
+					proxy := objVal.AsProxy()
+					if proxy.Revoked {
+						vm.ThrowTypeError("Cannot perform 'in' on a revoked Proxy")
+						if !vm.unwinding {
+							frame = &vm.frames[vm.frameCount-1]
+							closure = frame.closure
+							function = closure.Fn
+							code = function.Chunk.Code
+							constants = function.Chunk.Constants
+							registers = frame.registers
+							ip = frame.ip
+							continue
+						}
+						return InterpretRuntimeError, Undefined
+					}
+
+					if hasTrap, ok := proxyGetHasTrap(proxy.handler); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if !hasTrap.IsCallable() {
+							vm.ThrowTypeError("'has' on proxy: trap is not a function")
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							return InterpretRuntimeError, Undefined
+						}
+
+						// Call handler.has(target, propertyKey) - propertyKey
+						// is the raw Symbol value itself, matching
+						// proxyReflectHas's own trap args for a symbol key.
+						trapArgs := []Value{proxy.target, propVal}
+						result, err := vm.Call(hasTrap, proxy.handler, trapArgs)
+						if err != nil {
+							if ee, ok := err.(ExceptionError); ok {
+								vm.throwException(ee.GetExceptionValue())
+							} else {
+								vm.runtimeError("%s", err.Error())
+							}
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							return InterpretRuntimeError, Undefined
+						}
+						hasProperty = !result.IsFalsey()
+
+						// ECMAScript 10.5.7 step 11: invariant validation
+						// when the trap returns false.
+						if !hasProperty {
+							target := proxy.target
+							if target.Type() == TypeObject {
+								targetObj := target.AsPlainObject()
+								symKey := NewSymbolKey(propVal)
+								if _, _, _, c, found := targetObj.GetOwnDescriptorByKey(symKey); found && !c {
+									vm.ThrowTypeError("'has' on proxy: trap returned false for a property which exists in the proxy target as non-configurable")
+									if !vm.unwinding {
+										frame = &vm.frames[vm.frameCount-1]
+										closure = frame.closure
+										function = closure.Fn
+										code = function.Chunk.Code
+										constants = function.Chunk.Constants
+										registers = frame.registers
+										ip = frame.ip
+										continue
+									}
+									return InterpretRuntimeError, Undefined
+								}
+								if !targetObj.IsExtensible() {
+									if _, found := targetObj.GetOwnByKey(symKey); found {
+										vm.ThrowTypeError("'has' on proxy: trap returned false for a property but the proxy target is not extensible")
+										if !vm.unwinding {
+											frame = &vm.frames[vm.frameCount-1]
+											closure = frame.closure
+											function = closure.Fn
+											code = function.Chunk.Code
+											constants = function.Chunk.Constants
+											registers = frame.registers
+											ip = frame.ip
+											continue
+										}
+										return InterpretRuntimeError, Undefined
+									}
+								}
+							}
+						}
+					} else {
+						// No has trap, fallback to target.[[HasProperty]]
+						hasProperty = vm.proxyHasSymbolPropertyFallback(proxy.target, propVal)
+					}
 				default:
 					hasProperty = false
 				}
@@ -21482,6 +21595,139 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 			}
 		}
 		return vm.hasFunctionPrototypeProperty(propKey)
+	default:
+		return false
+	}
+}
+
+// proxyGetHasTrap looks up a Proxy handler's "has" trap the way
+// GetMethod(handler, "has") does per spec (10.5.7 step 4): an inherited
+// trap counts, not just an own one, and the handler can be a TypeDictObject
+// (a module namespace or enum value, pkg/vm/object.go's NewDictObject) as
+// well as an ordinary TypeObject - AsPlainObject() on the former panics.
+//
+// This exists because both of this function's callers (OpIn's symbol-key
+// TypeProxy case above and proxyHasSymbolPropertyFallback below) used to
+// inline `proxy.handler.AsPlainObject().GetOwn("has")` directly, copied
+// from the pre-existing string-key TypeProxy case's identical shape a few
+// lines below - itself not spec-correct on either count (own-only, and an
+// unguarded AsPlainObject that panics for a TypeDictObject handler; try
+// `new Proxy({}, someEnum)` on either the string- or symbol-key path
+// before this fix). That pre-existing gap was left alone here rather than
+// silently fixed as a drive-by - it's flagged as a shared follow-up
+// instead (see this branch's PR body) since fixing it changes the
+// string-key path's behavior too and deserves its own verification.
+func proxyGetHasTrap(handler Value) (Value, bool) {
+	switch handler.Type() {
+	case TypeObject:
+		return handler.AsPlainObject().Get("has")
+	case TypeDictObject:
+		return handler.AsDictObject().Get("has")
+	default:
+		return Undefined, false
+	}
+}
+
+// proxyHasSymbolPropertyFallback is proxyHasPropertyFallback's symbol-key
+// counterpart: [[HasProperty]] fallback for a proxy target when no 'has'
+// trap is defined, for a Symbol propKey rather than a string one. Used by
+// OpIn's symbol-key TypeProxy case (pkg/vm/vm.go) - mirrors
+// proxyReflectHas's own no-trap recursion (pkg/builtins/reflect_has.go),
+// which already handled this correctly for Reflect.has; `in` did not,
+// since its symbol-key switch had no TypeProxy case at all before this.
+//
+// Deliberately covers the same target-type scope as
+// proxyHasPropertyFallback (TypeProxy/TypeObject/TypeDictObject/TypeArray/
+// TypeRegExp/TypeFunction/TypeClosure, default false) rather than the
+// fuller Map/Set/Promise/BoundFunction/NativeFunction/
+// NativeFunctionWithProps/Arguments coverage OpIn's own symbol-key switch
+// has for a *direct* (non-Proxy) target - that asymmetry already exists in
+// the string-key fallback this mirrors, so a Proxy-wrapping-Map with no
+// trap has the same pre-existing gap for both key kinds, not a new one
+// introduced here.
+func (vm *VM) proxyHasSymbolPropertyFallback(target Value, propVal Value) bool {
+	key := NewSymbolKey(propVal)
+	switch target.Type() {
+	case TypeProxy:
+		proxy := target.AsProxy()
+		if proxy.Revoked {
+			return false
+		}
+		if hasTrap, ok := proxyGetHasTrap(proxy.handler); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+			if hasTrap.IsCallable() {
+				trapArgs := []Value{proxy.target, propVal}
+				result, err := vm.Call(hasTrap, proxy.handler, trapArgs)
+				if err != nil {
+					return false
+				}
+				return !result.IsFalsey()
+			}
+			return false
+		}
+		// Recursively check the nested proxy's target
+		return vm.proxyHasSymbolPropertyFallback(proxy.target, propVal)
+	case TypeObject:
+		po := target.AsPlainObject()
+		for cur := po; cur != nil; {
+			if _, ok := cur.GetOwnByKey(key); ok {
+				return true
+			}
+			pv := cur.GetPrototype()
+			if !pv.IsObject() {
+				break
+			}
+			cur = pv.AsPlainObject()
+		}
+		return false
+	case TypeDictObject:
+		// DictObject ignores symbols, same as OpIn's own symbol-key
+		// TypeDictObject case above.
+		return false
+	case TypeArray:
+		arrayObj := target.AsArray()
+		if arrayObj.HasOwnSymbolProp(propVal.AsSymbolObject()) {
+			return true
+		}
+		return vm.hasPropertyByKeyFromPrototypeChain(vm.effectiveBuiltinPrototype(target), key)
+	case TypeRegExp:
+		regexObj := target.AsRegExpObject()
+		if regexObj != nil && regexObj.Properties != nil {
+			if _, ok := regexObj.Properties.GetOwnByKey(key); ok {
+				return true
+			}
+		}
+		proto := Undefined
+		if regexObj != nil {
+			proto = regexObj.GetPrototype()
+		}
+		if !proto.IsObject() {
+			proto = vm.RegExpPrototype
+		}
+		if proto.IsObject() {
+			return vm.hasPropertyByKeyFromPrototypeChain(proto, key)
+		}
+		return false
+	case TypeFunction:
+		fn := target.AsFunction()
+		if fn.Properties != nil {
+			if _, ok := fn.Properties.GetOwnByKey(key); ok {
+				return true
+			}
+		}
+		return vm.hasFunctionPrototypeSymbolProperty(key)
+	case TypeClosure:
+		cl := target.AsClosure()
+		if cl.Properties != nil {
+			if _, ok := cl.Properties.GetOwnByKey(key); ok {
+				return true
+			}
+		}
+		if cl.Fn != nil && cl.Fn.Properties != nil {
+			if _, ok := cl.Fn.Properties.GetOwnByKey(key); ok {
+				return true
+			}
+		}
+		return vm.hasFunctionPrototypeSymbolProperty(key)
 	default:
 		return false
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3660,13 +3660,26 @@ startExecution:
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)
 					}
 				case TypeNativeFunction:
-					// Native functions don't have custom properties, but do
-					// carry the same "name"/"length" own intrinsics as any
-					// other callable (see TypeFunction's comment above,
-					// and TypeNativeFunctionWithProps's for why "prototype"
-					// is correctly excluded - a native method is never a
-					// constructor) before falling back to FunctionPrototype.
+					// A plain native function CAN have custom own properties -
+					// set via bracket-notation assignment, or (as of a recent
+					// fix to Object.defineProperty's target-type gate) via
+					// Object.defineProperty - stored in nf.Properties exactly
+					// like TypeBoundFunction below. This case used to claim
+					// "native functions don't have custom properties" and
+					// skip straight to FunctionPrototype, so `"x" in nf` was
+					// false right after `nf.x = 1`/`Object.defineProperty(nf,
+					// "x", ...)` even though Reflect.has(nf, "x") (and the
+					// table itself) already agreed it existed - the same
+					// "in disagrees with Reflect.has" gap already fixed here
+					// for TypeFunction/TypeNativeFunctionWithProps/TypeClosure/
+					// TypeBoundFunction above. Also carries the same
+					// "name"/"length" own intrinsics as any other callable
+					// (see TypeFunction's comment above) before falling back
+					// to FunctionPrototype.
+					nf := objVal.AsNativeFunction()
 					if HasOwnFunctionIntrinsic(objVal, propKey) {
+						hasProperty = true
+					} else if nf.Properties != nil && nf.Properties.Has(propKey) {
 						hasProperty = true
 					} else {
 						hasProperty = vm.hasFunctionPrototypeProperty(propKey)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3292,7 +3292,15 @@ startExecution:
 						}
 					}
 				case TypePromise:
-					// Walk Promise prototype chain for symbol properties
+					// Own side-table symbol property first (same table a
+					// plain assignment/Object.defineProperty writes into -
+					// see the non-symbol TypePromise case below), then walk
+					// the Promise.prototype chain for symbol properties.
+					promiseObj := objVal.AsPromise()
+					if promiseObj.Properties != nil && promiseObj.Properties.HasOwnByKey(NewSymbolKey(propVal)) {
+						hasProperty = true
+						break
+					}
 					proto := vm.PromisePrototype
 					if proto.IsObject() {
 						for cur := proto.AsPlainObject(); cur != nil; {
@@ -3671,9 +3679,23 @@ startExecution:
 						hasProperty = vm.ObjectPrototype.AsPlainObject().Has(propKey)
 					}
 				case TypePromise:
-					// Promise objects: check Promise.prototype chain
-					// Promises don't have user-accessible own properties, only internal state
-					if vm.PromisePrototype.IsObject() {
+					// Promise: a plain property CAN be assigned directly onto
+					// one (e.g. a subclass constructor doing `this.foo = 1`
+					// after super() - see op_setprop.go's TypePromise case,
+					// which writes into the same side table as Map/Set) even
+					// though a Promise exposes no *intrinsic* own state of its
+					// own - check that side table before falling back to
+					// Promise.prototype. This own-properties check was
+					// missing entirely (the stale comment here claimed
+					// Promises "don't have user-accessible own properties" -
+					// they do, once anything is assigned), so `in` answered
+					// false for an own property Reflect.has already found,
+					// and for-in's per-key re-verification (see
+					// TypeBoundFunction's comment above) silently dropped
+					// every such key that OpGetOwnKeys had just found.
+					if promiseObj := objVal.AsPromise(); promiseObj.Properties != nil && promiseObj.Properties.HasOwn(propKey) {
+						hasProperty = true
+					} else if vm.PromisePrototype.IsObject() {
 						hasProperty = vm.PromisePrototype.AsPlainObject().Has(propKey)
 					}
 				case TypeRegExp:
@@ -14548,6 +14570,41 @@ startExecution:
 				if regexObj != nil && regexObj.Properties != nil {
 					seen := make(map[string]bool)
 					cur := regexObj.Properties
+					for cur != nil {
+						for _, k := range cur.OwnKeys() {
+							if !seen[k] {
+								keys = append(keys, k)
+							}
+						}
+						for _, k := range cur.OwnPropertyNames() {
+							seen[k] = true
+						}
+						pv := cur.GetPrototype()
+						if !pv.IsObject() {
+							break
+						}
+						cur = pv.AsPlainObject()
+					}
+				}
+			case TypeMap, TypeSet, TypePromise:
+				// Same side table as TypeRegExp just above (OwnPropertiesTable,
+				// pkg/vm/properties_table.go) - this case was missing
+				// entirely, so `for (k in map)`/`for (k in set)`/
+				// `for (k in promise)` came back with nothing even after a
+				// plain assignment onto the value. Map/Set's own "size" is
+				// never an own property (it's a getter on Map.prototype/
+				// Set.prototype - Object.getOwnPropertyDescriptor(new Map(),
+				// "size") is undefined in Node), and Promise exposes no
+				// user-accessible own state, so only the side table matters
+				// here, same as RegExp's "lastIndex" staying excluded above.
+				// OwnPropertiesTable abstracts over the three kinds' actual
+				// field names (MapObject/SetObject/PromiseObject.Properties)
+				// via ownPropertiesSlot, so one case covers all three
+				// instead of duplicating the TypeRegExp case's body three
+				// times.
+				if props := OwnPropertiesTable(objValue); props != nil {
+					seen := make(map[string]bool)
+					cur := props
 					for cur != nil {
 						for _, k := range cur.OwnKeys() {
 							if !seen[k] {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3364,18 +3364,8 @@ startExecution:
 						}
 					}
 					// Walk Function.prototype chain
-					if vm.FunctionPrototype.IsObject() {
-						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
-							if _, ok := cur.GetOwnByKey(symKey); ok {
-								hasProperty = true
-								break
-							}
-							pv := cur.GetPrototype()
-							if !pv.IsObject() {
-								break
-							}
-							cur = pv.AsPlainObject()
-						}
+					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
+						hasProperty = true
 					}
 				case TypeClosure:
 					// Check closure's own properties first (shadows Fn.Properties)
@@ -3395,18 +3385,8 @@ startExecution:
 						}
 					}
 					// Walk Function.prototype chain
-					if vm.FunctionPrototype.IsObject() {
-						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
-							if _, ok := cur.GetOwnByKey(symKey); ok {
-								hasProperty = true
-								break
-							}
-							pv := cur.GetPrototype()
-							if !pv.IsObject() {
-								break
-							}
-							cur = pv.AsPlainObject()
-						}
+					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
+						hasProperty = true
 					}
 				case TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps:
 					// Same shape as TypeFunction/TypeClosure above: all three
@@ -3433,18 +3413,8 @@ startExecution:
 							break
 						}
 					}
-					if vm.FunctionPrototype.IsObject() {
-						for cur := vm.FunctionPrototype.AsPlainObject(); cur != nil; {
-							if _, ok := cur.GetOwnByKey(symKey); ok {
-								hasProperty = true
-								break
-							}
-							pv := cur.GetPrototype()
-							if !pv.IsObject() {
-								break
-							}
-							cur = pv.AsPlainObject()
-						}
+					if vm.hasFunctionPrototypeSymbolProperty(symKey) {
+						hasProperty = true
 					}
 				default:
 					hasProperty = false
@@ -17724,6 +17694,55 @@ func (vm *VM) hasFunctionPrototypeProperty(propKey string) bool {
 	return false
 }
 
+// functionPrototypeOwnTable returns the PlainObject actually holding
+// FunctionPrototype's own properties - see hasFunctionPrototypeProperty's
+// doc comment for why this isn't just vm.FunctionPrototype.AsPlainObject().
+// At runtime Function.prototype is created as a callable
+// TypeNativeFunctionWithProps (pkg/builtins/function_init.go, so that
+// Function.prototype() itself is a valid no-op call per spec), and its own
+// properties - including call/apply/bind/toString and
+// Symbol.hasInstance - live in that value's Properties side table, not in
+// vm.FunctionPrototype itself. Returns nil if FunctionPrototype is neither
+// shape (shouldn't happen once initialized) or its table isn't allocated.
+func (vm *VM) functionPrototypeOwnTable() *PlainObject {
+	switch vm.FunctionPrototype.Type() {
+	case TypeObject:
+		return vm.FunctionPrototype.AsPlainObject()
+	case TypeNativeFunctionWithProps:
+		if fp := vm.FunctionPrototype.AsNativeFunctionWithProps(); fp != nil {
+			return fp.Properties
+		}
+	}
+	return nil
+}
+
+// hasFunctionPrototypeSymbolProperty is hasFunctionPrototypeProperty for a
+// symbol key, used by OpIn's TypeFunction/TypeClosure/TypeBoundFunction/
+// TypeNativeFunction/TypeNativeFunctionWithProps cases to find an inherited
+// symbol property (e.g. Function.prototype[Symbol.hasInstance]) once a
+// callable's own Properties table doesn't have it. Before this existed,
+// each of those cases open-coded `vm.FunctionPrototype.AsPlainObject()`
+// directly - which is nil whenever FunctionPrototype is (as it always is
+// at runtime) a TypeNativeFunctionWithProps rather than a TypeObject, so
+// `vm.FunctionPrototype.IsObject()` was false and the walk never even
+// started. `Symbol.hasInstance in someFunction` answered false even though
+// `Symbol.hasInstance in Function.prototype` (addressed directly, going
+// through OpIn's own TypeNativeFunctionWithProps-aware handling) correctly
+// answered true, and even though the property demonstrably exists.
+func (vm *VM) hasFunctionPrototypeSymbolProperty(key PropertyKey) bool {
+	for cur := vm.functionPrototypeOwnTable(); cur != nil; {
+		if _, ok := cur.GetOwnByKey(key); ok {
+			return true
+		}
+		pv := cur.GetPrototype()
+		if !pv.IsObject() {
+			return false
+		}
+		cur = pv.AsPlainObject()
+	}
+	return false
+}
+
 // isUnscopable checks if a property is excluded by Symbol.unscopables on the with-object.
 // This properly triggers the getter for @@unscopables per ECMAScript spec.
 // Returns (unscopable, hadError) - if hadError is true, check vm.unwinding
@@ -21437,10 +21456,11 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 				return true
 			}
 		}
-		if vm.FunctionPrototype.Type() == TypeObject {
-			return vm.FunctionPrototype.AsPlainObject().Has(propKey)
-		}
-		return false
+		// Was `if vm.FunctionPrototype.Type() == TypeObject { ... }; return
+		// false` - silently false whenever FunctionPrototype is (as it
+		// always is at runtime) TypeNativeFunctionWithProps rather than
+		// TypeObject. See hasFunctionPrototypeProperty's doc comment.
+		return vm.hasFunctionPrototypeProperty(propKey)
 	case TypeClosure:
 		cl := target.AsClosure()
 		if propKey == "name" || propKey == "length" {
@@ -21459,10 +21479,7 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 				return true
 			}
 		}
-		if vm.FunctionPrototype.Type() == TypeObject {
-			return vm.FunctionPrototype.AsPlainObject().Has(propKey)
-		}
-		return false
+		return vm.hasFunctionPrototypeProperty(propKey)
 	default:
 		return false
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -9565,14 +9565,40 @@ startExecution:
 								return InterpretRuntimeError, Undefined
 							}
 						} else {
-							// No get trap - fallback to target
-							target := proxy.Target()
-							if target.Type() == TypeObject {
-								value, _ = target.AsPlainObject().GetOwn(keyStr)
-							} else if target.Type() == TypeDictObject {
-								value, _ = target.AsDictObject().GetOwn(keyStr)
-							} else {
-								value = Undefined
+							// No get trap - fallback to target.[[Get]] via
+							// GetPropertyWithReceiver (pkg/vm/vm_init.go,
+							// the same helper vm.GetProperty and
+							// opGetProp's own no-get-trap fallback are
+							// built on - see PR #360), not a bare
+							// GetOwn(keyStr) that only handled a
+							// TypeObject/TypeDictObject target directly.
+							// A target that is itself a Proxy (neither
+							// level with a get trap) silently answered
+							// Undefined for every key instead of
+							// recursing into that inner proxy's own
+							// [[Get]] - GetPropertyWithReceiver already
+							// does that recursion (and covers every other
+							// Value kind besides Object/DictObject a
+							// target can legally be, same rationale as
+							// #360's opGetProp fix). receiver stays
+							// sourceVal (the ORIGINAL top-level proxy this
+							// spread started from, not the intermediate
+							// `target`), matching the get-trap branch
+							// just above, which passes the same sourceVal
+							// as the trap's own receiver argument.
+							var err error
+							value, err = vm.GetPropertyWithReceiver(proxy.Target(), keyStr, sourceVal)
+							if err != nil {
+								frame.ip = ip
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("get error: %v", err)
+								}
+								if !vm.unwinding {
+									continue
+								}
+								return InterpretRuntimeError, Undefined
 							}
 						}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8783,8 +8783,21 @@ startExecution:
 				if !isValidArrayIndex {
 					// Handle Symbol keys directly
 					if indexVal.Type() == TypeSymbol {
+						frame.ip = ip
 						if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-							return status, res
+							// A thrown exception a handler caught leaves
+							// vm.unwinding false - reload the frame and keep
+							// going rather than aborting the whole run (see
+							// OpSetProp's dot-notation dispatch, and the
+							// TypeObject/callable branch below, for the same
+							// pattern). Without this check, e.g. assigning
+							// through a getter-only accessor on a Function's
+							// symbol-keyed property in strict mode threw
+							// uncatchably even from inside a try/catch.
+							if status != InterpretOK && vm.unwinding {
+								return status, res
+							}
+							goto reloadFrame
 						}
 						continue
 					}
@@ -8804,8 +8817,12 @@ startExecution:
 						}
 						// Per ECMAScript ToPropertyKey: if ToPrimitive returns a Symbol, use it directly
 						if primitiveVal.Type() == TypeSymbol {
+							frame.ip = ip
 							if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], primitiveVal, &valueVal); !ok {
-								return status, res
+								if status != InterpretOK && vm.unwinding {
+									return status, res
+								}
+								goto reloadFrame
 							}
 							continue
 						}
@@ -8813,8 +8830,9 @@ startExecution:
 					} else {
 						key = indexVal.ToString()
 					}
+					frame.ip = ip
 					if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						if status != InterpretOK {
+						if status != InterpretOK && vm.unwinding {
 							return status, res
 						}
 						goto reloadFrame
@@ -8912,8 +8930,9 @@ startExecution:
 						// Convert index to string for property key
 						key := fmt.Sprintf("%d", idx)
 						// Use opSetProp to handle property setting with accessor awareness
+						frame.ip = ip
 						if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-							if status != InterpretOK {
+							if status != InterpretOK && vm.unwinding {
 								return status, res
 							}
 							goto reloadFrame
@@ -8950,8 +8969,17 @@ startExecution:
 						// Skip setting silently (spec-incomplete structure)
 						continue
 					}
+					frame.ip = ip
 					if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-						return status, res
+						// Same unwinding check as the callable branch below -
+						// without it, a thrown exception (e.g. strict-mode
+						// assignment through a getter-only symbol-keyed
+						// accessor) aborted the whole run even from inside a
+						// try/catch that should have caught it.
+						if status != InterpretOK && vm.unwinding {
+							return status, res
+						}
+						goto reloadFrame
 					}
 					continue
 				default:
@@ -8973,8 +9001,12 @@ startExecution:
 						}
 						// Per ECMAScript ToPropertyKey: if ToPrimitive returns a Symbol, use it directly
 						if primitiveVal.Type() == TypeSymbol {
+							frame.ip = ip
 							if ok, status, res := vm.opSetPropSymbol(ip, &registers[baseReg], primitiveVal, &valueVal); !ok {
-								return status, res
+								if status != InterpretOK && vm.unwinding {
+									return status, res
+								}
+								goto reloadFrame
 							}
 							continue
 						}
@@ -9007,8 +9039,9 @@ startExecution:
 				} else {
 					// Route through opSetProp which handles extensibility, writable,
 					// prototype chain accessors, and global object sync
+					frame.ip = ip
 					if ok, status, res := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						if status != InterpretOK {
+						if status != InterpretOK && vm.unwinding {
 							return status, res
 						}
 						goto reloadFrame
@@ -9025,19 +9058,33 @@ startExecution:
 					// Non-numeric index (Symbol, string, etc.) - set property via prototype chain
 					switch indexVal.Type() {
 					case TypeSymbol:
+						frame.ip = ip
 						if ok, status, value := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-							return status, value
+							// Same unwinding check as the TypeObject/callable
+							// case above - see its comment.
+							if status != InterpretOK && vm.unwinding {
+								return status, value
+							}
+							goto reloadFrame
 						}
 					case TypeString:
 						key := AsString(indexVal)
+						frame.ip = ip
 						if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-							return status, value
+							if status != InterpretOK && vm.unwinding {
+								return status, value
+							}
+							goto reloadFrame
 						}
 					default:
 						// Convert to string for property access
 						key := indexVal.ToString()
+						frame.ip = ip
 						if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-							return status, value
+							if status != InterpretOK && vm.unwinding {
+								return status, value
+							}
+							goto reloadFrame
 						}
 					}
 				}
@@ -9046,18 +9093,30 @@ startExecution:
 				// Proxy objects: route all property setting through the proxy protocol via opSetProp
 				switch indexVal.Type() {
 				case TypeSymbol:
+					frame.ip = ip
 					if ok, status, value := vm.opSetPropSymbol(ip, &registers[baseReg], indexVal, &valueVal); !ok {
-						return status, value
+						if status != InterpretOK && vm.unwinding {
+							return status, value
+						}
+						goto reloadFrame
 					}
 				case TypeString:
 					key := AsString(indexVal)
+					frame.ip = ip
 					if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						return status, value
+						if status != InterpretOK && vm.unwinding {
+							return status, value
+						}
+						goto reloadFrame
 					}
 				default:
 					key := indexVal.ToString()
+					frame.ip = ip
 					if ok, status, value := vm.opSetProp(ip, &registers[baseReg], key, &valueVal); !ok {
-						return status, value
+						if status != InterpretOK && vm.unwinding {
+							return status, value
+						}
+						goto reloadFrame
 					}
 				}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -5015,8 +5015,17 @@ startExecution:
 							}
 							hasProperty = result.IsTruthy()
 						} else {
-							// No has trap, fallback to target
-							hasProperty = checkNonProxyWithObj(proxy.target)
+							// No has trap, fallback to target.[[HasProperty]] -
+							// proxyHasPropertyFallback (not
+							// checkNonProxyWithObj, which - true to its
+							// name - stops at a TypeObject/TypeDictObject/
+							// TypePromise target and answers false for
+							// anything else, including a further-nested
+							// Proxy) so that inner proxy's own trap or
+							// fallback gets consulted instead of the
+							// with-object being treated as "doesn't have
+							// this property" outright.
+							hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 						}
 					} else {
 						hasProperty = checkNonProxyWithObj(withObj)
@@ -5079,13 +5088,15 @@ startExecution:
 									stillExists = result.IsTruthy()
 								}
 							} else {
-								// No has trap, check target
-								switch proxy.target.Type() {
-								case TypeObject:
-									stillExists = proxy.target.AsPlainObject().Has(propName)
-								case TypeDictObject:
-									stillExists = proxy.target.AsDictObject().Has(propName)
-								}
+								// No has trap, check target.[[HasProperty]] -
+								// proxyHasPropertyFallback (not a hand-rolled
+								// TypeObject/TypeDictObject-only switch) so a target
+								// that is itself a Proxy resolves correctly instead of
+								// being treated as "not present" outright, and so does
+								// every other target kind proxyHasPropertyFallback
+								// already covers (TypeArray, TypeMap, TypeSet,
+								// TypeRegExp, ... - see its own definition).
+								stillExists = vm.proxyHasPropertyFallback(proxy.target, propName)
 							}
 						}
 					}
@@ -5265,13 +5276,15 @@ startExecution:
 											hasProperty = result.IsTruthy()
 										}
 									} else {
-										// No has trap, check target
-										switch proxy.target.Type() {
-										case TypeObject:
-											hasProperty = proxy.target.AsPlainObject().Has(propName)
-										case TypeDictObject:
-											hasProperty = proxy.target.AsDictObject().Has(propName)
-										}
+									// No has trap, check target.[[HasProperty]] -
+									// proxyHasPropertyFallback (not a hand-rolled
+									// TypeObject/TypeDictObject-only switch) so a target
+									// that is itself a Proxy resolves correctly instead of
+									// being treated as "not present" outright, and so does
+									// every other target kind proxyHasPropertyFallback
+									// already covers (TypeArray, TypeMap, TypeSet,
+									// TypeRegExp, ... - see its own definition).
+									hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 									}
 								}
 							}
@@ -5461,16 +5474,13 @@ startExecution:
 							}
 							hasProperty = result.IsTruthy()
 						} else {
-							// No has trap, fallback to target
-							target := proxy.target
-							switch target.Type() {
-							case TypeObject:
-								hasProperty = target.AsPlainObject().Has(propName)
-							case TypeDictObject:
-								hasProperty = target.AsDictObject().Has(propName)
-							default:
-								hasProperty = false
-							}
+							// No has trap, fallback to target.[[HasProperty]] -
+							// proxyHasPropertyFallback (not a
+							// TypeObject/TypeDictObject-only switch) so a
+							// target that is itself a Proxy resolves
+							// correctly instead of being treated as "not
+							// present" outright.
+							hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 						}
 
 					case TypeObject:
@@ -5655,11 +5665,16 @@ startExecution:
 							}
 							hasProperty = result.IsTruthy()
 						} else {
-							// No has trap, check target
-							target := proxy.target
-							if target.Type() == TypeObject {
-								hasProperty = target.AsPlainObject().Has(propName)
-							}
+							// No has trap, check target.[[HasProperty]] -
+							// proxyHasPropertyFallback (not a bare
+							// TypeObject-only check) so a target that is itself a
+							// Proxy resolves correctly instead of being treated as
+							// "not present" outright, and so does every other
+							// target kind proxyHasPropertyFallback already covers
+							// (TypeDictObject, TypeArray, TypeMap, TypeSet,
+							// TypeRegExp, ... - see its own definition), not just
+							// TypeObject.
+							hasProperty = vm.proxyHasPropertyFallback(proxy.target, propName)
 						}
 					} else if withObj.Type() == TypeObject {
 						obj := withObj.AsPlainObject()
@@ -5775,10 +5790,18 @@ startExecution:
 						}
 						return result.IsTruthy(), false
 					} else {
-						// No has trap, fallback to target
-						if proxy.target.Type() == TypeObject {
-							return proxy.target.AsPlainObject().Has(propName), false
-						}
+						// No has trap, fallback to target.[[HasProperty]] -
+						// proxyHasPropertyFallback (not a bare `if
+						// target.Type() == TypeObject { ...Has... }`) so a
+						// target that is itself a Proxy (checking that inner
+						// proxy own has trap first) resolves correctly
+						// instead of being treated as "not present" outright,
+						// and so does every other target kind
+						// proxyHasPropertyFallback already covers
+						// (TypeDictObject, TypeArray, TypeMap, TypeSet,
+						// TypeRegExp, ... - see its own definition), not just
+						// TypeObject.
+						return vm.proxyHasPropertyFallback(proxy.target, propName), false
 					}
 				}
 				return false, false
@@ -5958,12 +5981,22 @@ startExecution:
 							}
 							stillExists = result.IsTruthy()
 						} else {
-							// No has trap, check on target
+							// No has trap, check on target - a TypeProxy
+							// target gets proxyHasPropertyFallback (which
+							// itself recurses into that inner proxy's own
+							// trap or fallback) instead of falling into the
+							// same "default: true" this switch's other
+							// unhandled kinds deliberately keep, so this
+							// step 2 check isn't left assuming a
+							// nested-Proxy binding is unconditionally
+							// "still there" without ever actually asking it.
 							switch proxy.target.Type() {
 							case TypeObject:
 								stillExists = proxy.target.AsPlainObject().Has(propName)
 							case TypeDictObject:
 								stillExists = proxy.target.AsDictObject().Has(propName)
+							case TypeProxy:
+								stillExists = vm.proxyHasPropertyFallback(proxy.target, propName)
 							default:
 								stillExists = true
 							}
@@ -6081,12 +6114,19 @@ startExecution:
 							}
 							stillExists = result.IsTruthy()
 						} else {
-							// No has trap, check on target
+							// No has trap, check on target - a TypeProxy
+							// target gets proxyHasPropertyFallback (which
+							// itself recurses into that inner proxy's own
+							// trap or fallback) instead of falling into the
+							// same "default: true" this switch's other
+							// unhandled kinds deliberately keep.
 							switch proxy.target.Type() {
 							case TypeObject:
 								stillExists = proxy.target.AsPlainObject().Has(propName)
 							case TypeDictObject:
 								stillExists = proxy.target.AsDictObject().Has(propName)
+							case TypeProxy:
+								stillExists = vm.proxyHasPropertyFallback(proxy.target, propName)
 							default:
 								stillExists = true
 							}
@@ -16649,16 +16689,13 @@ startExecution:
 						}
 					}
 				} else {
-					// No delete trap, fallback to target
-					if proxy.target.IsObject() {
-						if proxy.target.Type() == TypeObject {
-							po := proxy.target.AsPlainObject()
-							success = po.DeleteOwn(propName)
-						} else if proxy.target.Type() == TypeDictObject {
-							d := proxy.target.AsDictObject()
-							success = d.DeleteOwn(propName)
-						}
-					}
+					// No delete trap, fallback to target.[[Delete]] -
+					// proxyDeleteFallback (not a bare TypeObject/
+					// TypeDictObject-only check) so a target that is
+					// itself a Proxy (checking that inner proxy's own
+					// deleteProperty trap first) resolves correctly
+					// instead of `delete` silently doing nothing.
+					success = vm.proxyDeleteFallback(proxy.target, propName)
 				}
 			} else if obj.IsObject() {
 				if obj.Type() == TypeObject {
@@ -18039,17 +18076,31 @@ func (vm *VM) isUnscopable(withObj Value, propName string) (bool, bool) {
 			unscopablesVal = result
 			hasUnscopables = result.Type() != TypeUndefined
 		} else {
-			// No get trap, fallback to target
-			if proxy.target.Type() == TypeObject {
-				var err error
-				unscopablesVal, hasUnscopables, err = vm.GetSymbolPropertyWithGetter(proxy.target, vm.SymbolUnscopables)
-				if err != nil {
-					return false, true
-				}
-				if vm.unwinding {
-					return false, true
-				}
+			// No get trap, fallback to target.[[Get]] - via
+			// getSymbolPropertyWithReceiver (pkg/vm/vm_init.go, the
+			// symbol-key twin of getPropertyWithReceiver), not
+			// GetSymbolPropertyWithGetter, which - despite its name
+			// suggesting general symbol-property support - only ever
+			// handles a TypeObject or TypeRegExp obj directly and falls
+			// to "For non-objects, just return undefined" for anything
+			// else, TypeProxy included; it was ALSO wrongly assumed
+			// (by an earlier version of this fix, based on misreading an
+			// unrelated function's switch case while grepping the whole
+			// file) to already have Proxy support, so simply dropping the
+			// old `if proxy.target.Type() == TypeObject` guard here
+			// wasn't enough on its own - it still needed a helper that
+			// actually recurses through a further-nested Proxy target,
+			// which getSymbolPropertyWithReceiver already does (mirrors
+			// getPropertyWithReceiver's own TypeProxy case).
+			result, err := vm.getSymbolPropertyWithReceiver(proxy.target, vm.SymbolUnscopables, withObj)
+			if err != nil {
+				return false, true
 			}
+			if vm.unwinding {
+				return false, true
+			}
+			unscopablesVal = result
+			hasUnscopables = result.Type() != TypeUndefined
 		}
 
 	default:
@@ -21821,6 +21872,49 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 			return vm.ObjectPrototype.AsPlainObject().Has(propKey)
 		}
 		return false
+	default:
+		return false
+	}
+}
+
+// proxyDeleteFallback implements [[Delete]]'s fallback for a proxy target
+// when the outer proxy's own handler has no deleteProperty trap: per
+// ECMA-262 10.5.10 step 10, this delegates to target.[[Delete]](P) -
+// recursing if the target is itself a Proxy (checking that inner proxy's
+// own deleteProperty trap first, not just falling through further, the
+// same way proxyHasPropertyFallback just above already recurses for its
+// own analogous "has" case). Used by OpDeleteProp's Proxy case, which
+// used to only handle a TypeObject/TypeDictObject target directly - a
+// nested trap-less Proxy target (or any other kind) silently did nothing
+// (`delete` reporting whatever `success` defaulted to) instead of
+// resolving through it. Mirrors proxyHasPropertyFallback's own choice of
+// silently treating a thrown trap error as "did nothing" rather than
+// propagating it - an existing, established convention in this file for
+// this class of best-effort fallback helper, not something introduced
+// here.
+func (vm *VM) proxyDeleteFallback(target Value, propKey string) bool {
+	switch target.Type() {
+	case TypeProxy:
+		proxy := target.AsProxy()
+		if proxy.Revoked {
+			return false
+		}
+		if deleteTrap, ok := proxyGetTrap(proxy.handler, "deleteProperty"); ok && deleteTrap.Type() != TypeUndefined && deleteTrap.Type() != TypeNull {
+			if deleteTrap.IsCallable() {
+				trapArgs := []Value{proxy.target, NewString(propKey)}
+				result, err := vm.Call(deleteTrap, proxy.handler, trapArgs)
+				if err != nil {
+					return false
+				}
+				return result.IsTruthy()
+			}
+			return false
+		}
+		return vm.proxyDeleteFallback(proxy.target, propKey)
+	case TypeObject:
+		return target.AsPlainObject().DeleteOwn(propKey)
+	case TypeDictObject:
+		return target.AsDictObject().DeleteOwn(propKey)
 	default:
 		return false
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -8936,7 +8936,7 @@ startExecution:
 					}
 				}
 
-			case TypeObject, TypeDictObject, TypeFunction, TypeClosure, TypeRegExp, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction, TypeAsyncNativeFunction: // Functions, closures, RegExps, and native functions can have properties
+			case TypeObject, TypeDictObject, TypeFunction, TypeClosure, TypeRegExp, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction, TypeAsyncNativeFunction, TypeMap, TypeSet, TypePromise: // Functions, closures, RegExps, native functions, and Map/Set/Promise can have properties
 				var key string
 				switch indexVal.Type() {
 				case TypeString:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4976,7 +4976,7 @@ startExecution:
 						}
 
 						// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-						if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 							if !hasTrap.IsCallable() {
 								frame.ip = ip
 								status := vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5062,7 +5062,7 @@ startExecution:
 						// For Proxy, use has trap
 						proxy := withObj.AsProxy()
 						if !proxy.Revoked {
-							if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.IsCallable() {
+							if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.IsCallable() {
 								trapArgs := []Value{proxy.target, NewString(propName)}
 								frame.ip = ip
 								vm.helperCallDepth++
@@ -5121,7 +5121,7 @@ startExecution:
 						// For Proxy, use get trap
 						proxy := withObj.AsProxy()
 						if !proxy.Revoked {
-							if getTrap, ok := proxy.handler.AsPlainObject().GetOwn("get"); ok && getTrap.IsCallable() {
+							if getTrap, ok := proxyGetTrap(proxy.handler, "get"); ok && getTrap.IsCallable() {
 								trapArgs := []Value{proxy.target, NewString(propName), withObj}
 								frame.ip = ip
 								vm.helperCallDepth++
@@ -5248,7 +5248,7 @@ startExecution:
 								// Use has trap for Proxy
 								proxy := withObj.AsProxy()
 								if !proxy.Revoked {
-									if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.IsCallable() {
+									if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.IsCallable() {
 										trapArgs := []Value{proxy.target, NewString(propName)}
 										frame.ip = ip
 										vm.helperCallDepth++
@@ -5304,7 +5304,7 @@ startExecution:
 									case TypeProxy:
 										proxy := withObj.AsProxy()
 										if !proxy.Revoked {
-											if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.IsCallable() {
+											if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.IsCallable() {
 												trapArgs := []Value{proxy.target, NewString(propName)}
 												frame.ip = ip
 												vm.helperCallDepth++
@@ -5421,7 +5421,7 @@ startExecution:
 						}
 
 						// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-						if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 							if !hasTrap.IsCallable() {
 								frame.ip = ip
 								status := vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5617,7 +5617,7 @@ startExecution:
 							return status, Undefined
 						}
 
-						if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+						if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 							if !hasTrap.IsCallable() {
 								frame.ip = ip
 								status := vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5749,7 +5749,7 @@ startExecution:
 					}
 
 					// Check if handler has a 'has' trap (per spec: GetMethod treats null/undefined as absent)
-					if hasTrap, ok := proxy.handler.AsPlainObject().GetOwn("has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
+					if hasTrap, ok := proxyGetTrap(proxy.handler, "has"); ok && hasTrap.Type() != TypeUndefined && hasTrap.Type() != TypeNull {
 						if !hasTrap.IsCallable() {
 							frame.ip = ip
 							vm.runtimeError("'has' on proxy: trap is not a function")
@@ -5943,7 +5943,7 @@ startExecution:
 					// For Proxy, call the 'has' trap per SetMutableBinding step 2
 					proxy := withObj.AsProxy()
 					if !proxy.Revoked {
-						hasTrap, hasHasTrap := proxy.handler.AsPlainObject().GetOwn("has")
+						hasTrap, hasHasTrap := proxyGetTrap(proxy.handler, "has")
 						if hasHasTrap && hasTrap.IsCallable() {
 							trapArgs := []Value{proxy.target, NewString(propName)}
 							vm.helperCallDepth++
@@ -6066,7 +6066,7 @@ startExecution:
 					// For Proxy, call the 'has' trap per GetBindingValue step 2
 					proxy := withObj.AsProxy()
 					if !proxy.Revoked {
-						hasTrap, hasHasTrap := proxy.handler.AsPlainObject().GetOwn("has")
+						hasTrap, hasHasTrap := proxyGetTrap(proxy.handler, "has")
 						if hasHasTrap && hasTrap.IsCallable() {
 							trapArgs := []Value{proxy.target, NewString(propName)}
 							vm.helperCallDepth++
@@ -8441,7 +8441,7 @@ startExecution:
 				}
 
 				// Check if handler has a get trap (per spec: GetMethod treats null/undefined as absent)
-				getTrap, ok := proxy.handler.AsPlainObject().GetOwn("get")
+				getTrap, ok := proxyGetTrap(proxy.handler, "get")
 				if ok && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
 					// Validate trap is callable
 					if !getTrap.IsCallable() {
@@ -16450,7 +16450,7 @@ startExecution:
 				}
 
 				// Check if handler has a delete trap (per spec: GetMethod treats null/undefined as absent)
-				deleteTrap, ok := proxy.handler.AsPlainObject().GetOwn("deleteProperty")
+				deleteTrap, ok := proxyGetTrap(proxy.handler, "deleteProperty")
 				if ok && deleteTrap.Type() != TypeUndefined && deleteTrap.Type() != TypeNull {
 					// Validate trap is callable
 					if !deleteTrap.IsCallable() {
@@ -17897,7 +17897,7 @@ func (vm *VM) isUnscopable(withObj Value, propName string) (bool, bool) {
 		}
 
 		// Check if handler has a 'get' trap
-		getTrap, hasGetTrap := proxy.handler.AsPlainObject().GetOwn("get")
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
 		if hasGetTrap && getTrap.IsCallable() {
 			// Call handler.get(target, Symbol.unscopables, receiver)
 			trapArgs := []Value{proxy.target, vm.SymbolUnscopables, withObj}
@@ -21531,26 +21531,25 @@ func (vm *VM) proxyHasPropertyFallback(target Value, propKey string) bool {
 	case TypeDictObject:
 		return target.AsDictObject().Has(propKey)
 	case TypeArray:
-		// NOT fixed here (pre-existing, out of this task's scope): unlike
-		// OpIn's own direct-target TypeArray case, which checks
-		// ArrayHasOwnIndex (paserati#176/#178 - a numerically-in-range
-		// index is NOT necessarily an own property, e.g. after a distant
-		// defineProperty inflates .length) before falling to the
-		// prototype chain, this still uses the simpler, wrong
-		// `index < arrayObj.Length()` test. Left alone since this task's
-		// three fixes are the trap-lookup bugs and the seven-kind
-		// fallback-coverage gap, not this unrelated pre-existing
-		// correctness issue - flagged as a third bullet on the same
-		// follow-up as the other unfixed trap-lookup sites this task's
-		// review turned up (see task's PR body).
+		// Now fixed to match OpIn's own direct-target TypeArray case:
+		// a numerically-in-range index is NOT necessarily an own property
+		// (paserati#176/#178 - e.g. after a distant defineProperty inflates
+		// .length without that index itself ever being set), so check real
+		// presence via ArrayHasOwnIndex instead of the simpler, wrong
+		// `index < arrayObj.Length()` test - falling through to the
+		// prototype-chain check below (ArrayPrototype.Has) on a miss,
+		// same as the non-index path already did, rather than answering
+		// false outright. tryParseArrayIndex (not strconv.Atoi) also
+		// rejects non-canonical numeric strings like "007", matching
+		// OpIn's own parsing.
 		arrayObj := target.AsArray()
-		if index, err := strconv.Atoi(propKey); err == nil && index >= 0 {
-			return index < arrayObj.Length()
-		}
-		if propKey == "length" {
+		if index, ok := tryParseArrayIndex(propKey); ok {
+			if ArrayHasOwnIndex(arrayObj, index) {
+				return true
+			}
+		} else if propKey == "length" {
 			return true
-		}
-		if _, ok := arrayObj.GetOwn(propKey); ok {
+		} else if _, ok := arrayObj.GetOwn(propKey); ok {
 			return true
 		}
 		if vm.ArrayPrototype.Type() == TypeObject {
@@ -21735,6 +21734,17 @@ func proxyGetTrap(handler Value, trapName string) (Value, bool) {
 	default:
 		return Undefined, false
 	}
+}
+
+// ProxyGetTrap is proxyGetTrap exported for pkg/builtins, which imports
+// pkg/vm but not vice versa, so cannot call the unexported package-level
+// function directly - mirrors the (*VM) HasPropertyOnPrototypeChain /
+// HasFunctionPrototypeSymbolProperty pattern used elsewhere for the same
+// cross-package need. Takes no *VM state (proxyGetTrap doesn't either);
+// the method receiver exists only so callers outside this package can
+// reach it as vmInstance.ProxyGetTrap(...).
+func (vm *VM) ProxyGetTrap(handler Value, trapName string) (Value, bool) {
+	return proxyGetTrap(handler, trapName)
 }
 
 // proxyHasSymbolPropertyFallback is proxyHasPropertyFallback's symbol-key

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -331,6 +331,32 @@ func (vm *VM) GetFrameCount() int {
 // GetProperty gets a property from an object value, properly handling getters and prototype chain
 // This is safe to call from native functions and will trigger property getters/throw exceptions
 func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
+	return vm.getPropertyWithReceiver(obj, propName, obj)
+}
+
+// GetPropertyWithReceiver is GetProperty with an explicit receiver for any
+// own or inherited accessor's getter to be called with as `this`, instead
+// of always the object the property was actually found on/started from.
+// Added for Reflect.get(target, key[, receiver]) (pkg/builtins/
+// reflect_init.go), whose optional third argument is exactly this - per
+// ECMA-262 10.1.8 [[Get]], an accessor's getter is invoked with Receiver
+// as its this value, which can legitimately differ from the object
+// [[Get]] started walking from (e.g. Reflect.get(proto, "x", instance)
+// calls proto's getter for "x" with `this = instance`).
+func (vm *VM) GetPropertyWithReceiver(obj Value, propName string, receiver Value) (Value, error) {
+	return vm.getPropertyWithReceiver(obj, propName, receiver)
+}
+
+// getPropertyWithReceiver is GetProperty/GetPropertyWithReceiver's shared
+// implementation. receiver is threaded through every accessor-getter
+// vm.Call and every recursive self-call (walking a [[Prototype]] set via
+// Object.setPrototypeOf, a Proxy's target when no trap is present, ...) so
+// a getter anywhere on the chain is always invoked with the ORIGINAL
+// receiver, not whichever intermediate object it was actually found on -
+// GetProperty's plain callers (which don't have a distinct receiver
+// concept) get receiver == obj, matching this function's behavior before
+// receiver support existed.
+func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value) (Value, error) {
 	// Simple implementation that doesn't use opGetProp to avoid unwinding issues
 	// Check for getter (including prototype chain) and call it, or return the property value
 
@@ -340,7 +366,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		// Check own accessor first
 		if g, _, _, _, ok := po.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 			// Call the getter with this=obj
-			result, err := vm.Call(g, obj, nil)
+			result, err := vm.Call(g, receiver, nil)
 			if err != nil {
 				return Undefined, err
 			}
@@ -353,29 +379,60 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		// Walk prototype chain for accessor or data properties
 		current := po.GetPrototype()
 		for current.typ != TypeNull && current.typ != TypeUndefined {
-			if current.IsObject() {
-				if current.Type() == TypeObject {
-					proto := current.AsPlainObject()
-					// Check for accessor in prototype
-					if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-						// Call the getter with this=original obj (not proto)
-						result, err := vm.Call(g, obj, nil)
-						if err != nil {
-							return Undefined, err
-						}
-						return result, nil
+			if current.Type() == TypeObject {
+				proto := current.AsPlainObject()
+				// Check for accessor in prototype
+				if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
+					// Call the getter with this=original obj (not proto)
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
 					}
-					// Check for data property in prototype
-					if value, exists := proto.GetOwn(propName); exists {
-						return value, nil
-					}
-					current = proto.GetPrototype()
-				} else {
-					break
+					return result, nil
 				}
-			} else {
-				break
+				// Check for data property in prototype
+				if value, exists := proto.GetOwn(propName); exists {
+					return value, nil
+				}
+				current = proto.GetPrototype()
+				continue
 			}
+			// The chain leaves plain-TypeObject territory (a callable or
+			// other exotic kind used as a [[Prototype]] via
+			// Object.create(fn)/Object.setPrototypeOf, or a class
+			// extending a native constructor) - recurse into the full
+			// per-kind dispatch instead of silently stopping, so an own
+			// property on THAT value's own table (a Function's
+			// Properties, say) is still found. NOT gated on
+			// current.IsObject(): every callable kind (TypeFunction,
+			// TypeClosure, TypeNativeFunction, TypeNativeFunctionWithProps,
+			// TypeBoundFunction) sorts BEFORE TypeObject in the ValueType
+			// enum (pkg/vm/value.go), so IsObject() - a contiguous
+			// [TypeObject, TypeProxy] range check - is FALSE for exactly
+			// the values this branch exists to handle; gating on it here
+			// (an earlier version of this fix did) silently reintroduced
+			// the very "stops early" bug this comment describes fixing.
+			// Found via the symbol-key sibling of this exact case
+			// (getSymbolPropertyWithReceiver) needing the identical fix
+			// for Reflect.get(Object.create(fn), sym) to work - this is
+			// the same gap for a string key, fixed alongside it in the
+			// same commit rather than left silently asymmetric between
+			// key kinds.
+			return vm.getPropertyWithReceiver(current, propName, receiver)
+		}
+		return Undefined, nil
+
+	case TypeDictObject:
+		// DictObject (a module namespace or TS enum value at runtime,
+		// pkg/vm/object.go's NewDictObject) - own properties only.
+		// DictObject doesn't support accessors (its own .Get comment says
+		// so) and has no user-facing prototype chain of its own, so this
+		// is just a direct own-table lookup. This case didn't exist at all
+		// before this fix, so Reflect.get on a module namespace or enum
+		// always answered undefined - found while implementing Reflect.get's
+		// general property support, not previously reported.
+		if v, ok := obj.AsDictObject().Get(propName); ok {
+			return v, nil
 		}
 		return Undefined, nil
 
@@ -449,14 +506,25 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		if proxy.Revoked {
 			return Undefined, vm.NewTypeError("Cannot perform 'get' on a revoked Proxy")
 		}
-		getTrap, hasGetTrap := proxy.handler.AsPlainObject().GetOwn("get")
+		// proxyGetTrap (not a bare proxy.handler.AsPlainObject().GetOwn("get"))
+		// for the same two reasons documented on its own definition: GetMethod
+		// semantics mean an INHERITED "get" trap counts too, and a handler
+		// that happens to be a TypeDictObject (a TS enum/module namespace
+		// value) must not panic AsPlainObject().
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
 		if hasGetTrap && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
 			// Validate trap is callable
 			if !getTrap.IsCallable() {
 				return Undefined, vm.NewTypeError("'get' on proxy: trap is not a function")
 			}
-			// Call the get trap: handler.get(target, propertyKey, receiver)
-			trapArgs := []Value{proxy.target, NewString(propName), obj}
+			// Call the get trap: handler.get(target, propertyKey, receiver) -
+			// receiver, not obj: obj is whichever value this switch is
+			// currently examining (which can be a Proxy reached partway
+			// through a longer chain), while receiver is the ORIGINAL
+			// object/value the caller's property access started from -
+			// exactly what ECMA-262 10.5.8 step 8 passes as the trap's
+			// third argument.
+			trapArgs := []Value{proxy.target, NewString(propName), receiver}
 			result, err := vm.Call(getTrap, proxy.handler, trapArgs)
 			if err != nil {
 				return Undefined, err
@@ -481,11 +549,31 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			}
 			return result, nil
 		}
-		// No get trap, fall through to target
-		return vm.GetProperty(proxy.target, propName)
+		// No get trap, fall through to target - still threading the
+		// original receiver through, not proxy.target, so a getter found
+		// further down the chain still sees the right `this`.
+		return vm.getPropertyWithReceiver(proxy.target, propName, receiver)
 
 	case TypePromise:
-		// Promise objects: check Promise.prototype chain
+		// Promise objects: own side-table property first (same table/gap
+		// as TypeSet/TypeMap above - Promises don't expose own state as
+		// ordinary properties, but a plain assignment or
+		// Object.defineProperty can still add one), then Promise.prototype.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if g, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := props.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
 		if vm.PromisePrototype.IsObject() {
 			proto := vm.PromisePrototype.AsPlainObject()
 			if v, ok := proto.Get(propName); ok {
@@ -515,7 +603,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					// Check for accessor property (getter) on prototype
 					if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
 						// Call the getter with this=original RegExp object
-						result, err := vm.Call(g, obj, nil)
+						result, err := vm.Call(g, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -532,7 +620,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 							if current.Type() == TypeObject {
 								grandProto := current.AsPlainObject()
 								if g, _, _, _, ok := grandProto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-									result, err := vm.Call(g, obj, nil)
+									result, err := vm.Call(g, receiver, nil)
 									if err != nil {
 										return Undefined, err
 									}
@@ -620,7 +708,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					if getter, _, _, _, ok := cur.GetOwnAccessor(propName); ok {
 						if getter.Type() != TypeUndefined {
 							// Call the getter with this=obj (the TypedArray)
-							result, err := vm.Call(getter, obj, nil)
+							result, err := vm.Call(getter, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -645,14 +733,37 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		return Undefined, nil
 
 	case TypeSet:
-		// Set objects: check prototype chain (especially for accessor properties like size)
+		// Set objects: own side-table property first (the same lazily-
+		// allocated table a plain `set.foo = 1`/Object.defineProperty
+		// assignment writes into - OwnPropertiesTable,
+		// pkg/vm/properties_table.go), THEN the prototype chain (for
+		// accessor properties like size). Before this, a Set's own custom
+		// property was invisible here even though Object.getOwnPropertyDescriptor/
+		// `in`/Reflect.has already agreed it existed - same "kind missing a
+		// side-table check" gap already fixed elsewhere in this switch
+		// (RegExp) and across OpIn/Object.keys/etc. in prior PRs.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if g, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := props.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
 		if vm.SetPrototype.IsObject() {
 			proto := vm.SetPrototype.AsPlainObject()
 			// Check for accessor (getter) first
 			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					// Call the getter with this=obj (the Set)
-					result, err := vm.Call(getter, obj, nil)
+					// Call the getter with this=receiver (the Set)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -668,14 +779,30 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 		return Undefined, nil
 
 	case TypeMap:
-		// Map objects: check prototype chain (especially for accessor properties like size)
+		// Map objects: same own-side-table-then-prototype-chain shape as
+		// TypeSet just above - see its comment.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if g, _, _, _, ok := props.GetOwnAccessor(propName); ok {
+				if g.Type() != TypeUndefined {
+					result, err := vm.Call(g, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := props.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
 		if vm.MapPrototype.IsObject() {
 			proto := vm.MapPrototype.AsPlainObject()
 			// Check for accessor (getter) first
 			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					// Call the getter with this=obj (the Map)
-					result, err := vm.Call(getter, obj, nil)
+					// Call the getter with this=receiver (the Map)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -699,7 +826,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor (getter) on own properties
 				if getter, _, _, _, ok := fn.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -720,7 +847,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			}
 			// Walk [[Prototype]] chain (set by Object.setPrototypeOf)
 			if fn.Prototype.Type() != TypeUndefined && fn.Prototype.Type() != TypeNull {
-				return vm.GetProperty(fn.Prototype, propName)
+				return vm.getPropertyWithReceiver(fn.Prototype, propName, receiver)
 			}
 			// Fall back to Function.prototype - use function's own realm if available (cross-realm)
 			funcProto := vm.FunctionPrototype
@@ -733,7 +860,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					// Check for accessor first
 					if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 						if getter.Type() != TypeUndefined {
-							result, err := vm.Call(getter, obj, nil)
+							result, err := vm.Call(getter, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -758,7 +885,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor (getter) on own properties
 				if getter, _, _, _, ok := cl.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -780,7 +907,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				}
 				// Walk [[Prototype]] chain (set by Object.setPrototypeOf)
 				if cl.Fn.Prototype.Type() != TypeUndefined && cl.Fn.Prototype.Type() != TypeNull {
-					return vm.GetProperty(cl.Fn.Prototype, propName)
+					return vm.getPropertyWithReceiver(cl.Fn.Prototype, propName, receiver)
 				}
 			}
 			// Fall back to Function.prototype (which is a NativeFunctionWithProps)
@@ -790,7 +917,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					// Check for accessor first
 					if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 						if getter.Type() != TypeUndefined {
-							result, err := vm.Call(getter, obj, nil)
+							result, err := vm.Call(getter, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -813,7 +940,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			// Check for accessor (getter) on own properties
 			if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					result, err := vm.Call(getter, obj, nil)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -845,7 +972,70 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor first
 				if getter, _, _, _, ok := fpNfp.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
+						if err != nil {
+							return Undefined, err
+						}
+						return result, nil
+					}
+					return Undefined, nil
+				}
+				if v, ok := fpNfp.Properties.Get(propName); ok {
+					return v, nil
+				}
+			}
+		}
+		return Undefined, nil
+
+	case TypeNativeFunction:
+		// A plain native function (e.g. Array.prototype.push) - same shape
+		// as TypeNativeFunctionWithProps just above, except its own
+		// intrinsics live directly on the value's own fields rather than
+		// under a *PlainObject with a IsConstructor flag. This case didn't
+		// exist at all before this fix (found while implementing
+		// Reflect.get's general property support, but this function -
+		// GetProperty/GetPropertyWithReceiver - is also used elsewhere,
+		// e.g. Reflect.apply/construct's generic array-like .length
+		// access), so Reflect.get(Array.prototype.push, "name") and
+		// friends always answered undefined, and any custom own property
+		// (Object.defineProperty, bracket-notation assignment) was
+		// invisible too - even though `in`/Reflect.has/
+		// Object.getOwnPropertyDescriptor already agreed those exist
+		// (fixed for THEM in earlier PRs in this stack).
+		nf := obj.AsNativeFunction()
+		if nf != nil && nf.Properties != nil {
+			if getter, _, _, _, ok := nf.Properties.GetOwnAccessor(propName); ok {
+				if getter.Type() != TypeUndefined {
+					result, err := vm.Call(getter, receiver, nil)
+					if err != nil {
+						return Undefined, err
+					}
+					return result, nil
+				}
+				return Undefined, nil
+			}
+			if v, ok := nf.Properties.GetOwn(propName); ok {
+				return v, nil
+			}
+		}
+		if nf != nil {
+			switch propName {
+			case "name":
+				if !nf.DeletedName {
+					return NewString(nf.Name), nil
+				}
+			case "length":
+				if !nf.DeletedLength {
+					return NumberValue(float64(nf.Arity)), nil
+				}
+			}
+		}
+		if vm.FunctionPrototype.Type() == TypeNativeFunctionWithProps {
+			fpNfp := vm.FunctionPrototype.AsNativeFunctionWithProps()
+			if fpNfp != nil && fpNfp.Properties != nil {
+				if getter, _, _, _, ok := fpNfp.Properties.GetOwnAccessor(propName); ok {
+					if getter.Type() != TypeUndefined {
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -867,7 +1057,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			// Check for accessor (getter) on own properties
 			if getter, _, _, _, ok := bf.Properties.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
-					result, err := vm.Call(getter, obj, nil)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -886,7 +1076,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 				// Check for accessor first
 				if getter, _, _, _, ok := nfp.Properties.GetOwnAccessor(propName); ok {
 					if getter.Type() != TypeUndefined {
-						result, err := vm.Call(getter, obj, nil)
+						result, err := vm.Call(getter, receiver, nil)
 						if err != nil {
 							return Undefined, err
 						}
@@ -954,7 +1144,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
 				if getter.Type() != TypeUndefined {
 					// Call the getter with this=obj (the BigInt)
-					result, err := vm.Call(getter, obj, nil)
+					result, err := vm.Call(getter, receiver, nil)
 					if err != nil {
 						return Undefined, err
 					}
@@ -988,7 +1178,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 			po := proto.AsPlainObject()
 			// Check for accessor (getter) first
 			if g, _, _, _, ok := po.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-				result, err := vm.Call(g, obj, nil)
+				result, err := vm.Call(g, receiver, nil)
 				if err != nil {
 					return Undefined, err
 				}
@@ -1004,7 +1194,7 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					if current.Type() == TypeObject {
 						cur := current.AsPlainObject()
 						if g, _, _, _, ok := cur.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-							result, err := vm.Call(g, obj, nil)
+							result, err := vm.Call(g, receiver, nil)
 							if err != nil {
 								return Undefined, err
 							}
@@ -1021,6 +1211,429 @@ func (vm *VM) GetProperty(obj Value, propName string) (Value, error) {
 					break
 				}
 			}
+		}
+		return Undefined, nil
+	}
+}
+
+// getOwnFromTableByKey checks one *PlainObject-backed own-property table
+// (a plain object's own fields, or an exotic kind's lazily-allocated
+// Properties side table - Function/Closure/NativeFunction/
+// NativeFunctionWithProps/BoundFunction/RegExp/Map/Set/Promise all keep
+// one, see pkg/vm/properties_table.go) for key, invoking an accessor's
+// getter with `this = receiver` if key names one. Returns (value, found,
+// error) - found is false and error is nil when key simply isn't there,
+// so callers can fall through to whatever comes next (a prototype chain,
+// a different table) without misreading "not found" as "found undefined".
+func (vm *VM) getOwnFromTableByKey(table *PlainObject, key PropertyKey, receiver Value) (Value, bool, error) {
+	if table == nil {
+		return Undefined, false, nil
+	}
+	if g, _, _, _, ok := table.GetOwnAccessorByKey(key); ok {
+		if g.Type() != TypeUndefined {
+			res, err := vm.Call(g, receiver, nil)
+			if err != nil {
+				return Undefined, true, err
+			}
+			return res, true, nil
+		}
+		// Setter-only accessor (no getter): reads as undefined per spec,
+		// but IS present, so still reported as found - a caller falling
+		// through to a lower-priority table/prototype for this key would
+		// otherwise incorrectly resurrect a shadowed property from there.
+		return Undefined, true, nil
+	}
+	if v, ok := table.GetOwnByKey(key); ok {
+		return v, true, nil
+	}
+	return Undefined, false, nil
+}
+
+// walkPlainObjectChainForKey walks a chain of ordinary (TypeObject)
+// prototypes starting at start, checking each level's own table via
+// getOwnFromTableByKey - the same accessor-then-data, getter-invoking
+// shape opGetPropSymbol's own TypeObject case (pkg/vm/op_getprop.go)
+// already uses for a direct property access, reused here so
+// GetPropertyWithReceiver (backing Reflect.get) gets the same fidelity
+// instead of a second, weaker, hand-rolled walk. Stops (found=false) as
+// soon as the chain reaches a non-TypeObject value (Null, a Proxy, or any
+// other exotic kind) - every concrete built-in prototype this is called
+// with (Array.prototype, Map.prototype, RegExp.prototype, the primitive
+// wrapper prototypes, ...) terminates in Object.prototype, itself a plain
+// TypeObject, so this is not a real limitation for those callers.
+func (vm *VM) walkPlainObjectChainForKey(start Value, key PropertyKey, receiver Value) (Value, bool, error) {
+	current := start
+	for current.IsObject() {
+		if current.Type() != TypeObject {
+			break
+		}
+		po := current.AsPlainObject()
+		if v, found, err := vm.getOwnFromTableByKey(po, key, receiver); found || err != nil {
+			return v, found, err
+		}
+		current = po.GetPrototype()
+	}
+	return Undefined, false, nil
+}
+
+// ReflectGetSymbolProperty is GetProperty for a Symbol-keyed property
+// (rather than a string-keyed one) - see GetPropertyWithReceiver's doc
+// comment for the receiver parameter's meaning. sym must be a Value of
+// TypeSymbol. Named distinctly from the pre-existing, narrower
+// GetSymbolProperty (obj, symbol) (Value, bool) below (RegExp/TypeObject
+// only, no getter invocation on non-RegExp/TypeObject kinds, no error
+// return) rather than overloading that name for a wider, error-returning
+// implementation an existing caller of the old one isn't expecting.
+func (vm *VM) ReflectGetSymbolProperty(obj Value, sym Value) (Value, error) {
+	return vm.getSymbolPropertyWithReceiver(obj, sym, obj)
+}
+
+// ReflectGetSymbolPropertyWithReceiver is ReflectGetSymbolProperty with an
+// explicit receiver - the symbol-key counterpart of
+// GetPropertyWithReceiver, added for the same reason
+// (Reflect.get(target, someSymbol[, receiver]), pkg/builtins/reflect_init.go).
+func (vm *VM) ReflectGetSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value) (Value, error) {
+	return vm.getSymbolPropertyWithReceiver(obj, sym, receiver)
+}
+
+// getSymbolPropertyWithReceiver mirrors getPropertyWithReceiver's per-kind
+// switch (same case list, same comments' reasoning) with the string-keyed
+// PlainObject methods (GetOwn/GetOwnAccessor/Get) replaced by their
+// *ByKey counterparts, i.e. using key := NewSymbolKey(sym) throughout
+// instead of propName. Where getPropertyWithReceiver open-codes its own
+// per-kind accessor/data check and hand-rolled prototype walk inline,
+// this uses the two shared helpers above instead - written once, for the
+// new symbol path, rather than reproducing that duplication a second
+// time; getPropertyWithReceiver's already-tested string-key logic is left
+// exactly as it was, not retrofitted onto the same helpers, to avoid
+// risking a regression there for this task's sake.
+//
+// The FunctionPrototype fallback used by every callable kind
+// (TypeFunction/TypeClosure/TypeNativeFunction/TypeNativeFunctionWithProps/
+// TypeBoundFunction) reuses the existing lookupSymbolOnProtoChain
+// (pkg/vm/op_getprop.go) rather than walkPlainObjectChainForKey, since
+// Function.prototype itself can be a TypeNativeFunctionWithProps at
+// runtime (see that function's own doc comment) - walkPlainObjectChainForKey
+// only handles a TypeObject chain. Matching lookupSymbolOnProtoChain's
+// existing behavior, this does NOT invoke an accessor's getter found on
+// the FunctionPrototype chain - a real, separate, still-open gap already
+// documented where it was first found (pkg/vm/op_getprop.go's
+// opGetPropSymbol, TypeNativeFunction case), not introduced or widened
+// here.
+func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value) (Value, error) {
+	key := NewSymbolKey(sym)
+
+	switch obj.Type() {
+	case TypeObject:
+		// Not walkPlainObjectChainForKey directly: that helper stops the
+		// instant the chain reaches a non-TypeObject value, which is fine
+		// for the built-in-prototype walks below (Array.prototype and
+		// siblings always terminate in Object.prototype, itself a plain
+		// TypeObject) but wrong here - obj's own [[Prototype]] chain can
+		// legitimately pass through a callable (`Object.create(someFn)`,
+		// or a class extending a native constructor), and a symbol
+		// property can live in THAT value's own Properties side table,
+		// not a PlainObject's fields. Recursing into the full per-kind
+		// dispatch (this same function) once the chain leaves TypeObject
+		// picks that up, instead of silently answering "not found":
+		//
+		//   const sym = Symbol("s");
+		//   function base() {}
+		//   base[sym] = "found";
+		//   Reflect.get(Object.create(base), sym); // Node: "found"
+		current := obj
+		for current.Type() == TypeObject {
+			po := current.AsPlainObject()
+			if v, found, err := vm.getOwnFromTableByKey(po, key, receiver); found || err != nil {
+				return v, err
+			}
+			current = po.GetPrototype()
+		}
+		if current.typ == TypeNull || current.typ == TypeUndefined {
+			return Undefined, nil
+		}
+		// NOT gated on current.IsObject(): every callable kind sorts
+		// BEFORE TypeObject in the ValueType enum (pkg/vm/value.go), so
+		// IsObject() - a contiguous [TypeObject, TypeProxy] range check -
+		// is FALSE for exactly the values (TypeFunction, TypeClosure,
+		// TypeNativeFunction, TypeNativeFunctionWithProps,
+		// TypeBoundFunction) this branch exists to reach. Gating on it
+		// (an earlier version of this fix did) silently reintroduced the
+		// "stops early, answers not-found" bug the comment above
+		// describes fixing - see getPropertyWithReceiver's TypeObject
+		// case (the string-key sibling of this one) for the same mistake
+		// caught and fixed the same way.
+		return vm.getSymbolPropertyWithReceiver(current, sym, receiver)
+
+	case TypeDictObject:
+		// DictObject ignores symbols entirely - matches OpIn's own
+		// symbol-key TypeDictObject case (pkg/vm/vm.go).
+		return Undefined, nil
+
+	case TypeArray:
+		arr := obj.AsArray()
+		if arr != nil {
+			if v, ok := arr.GetSymbolProp(sym.AsSymbolObject()); ok {
+				return v, nil
+			}
+			if vm.ArrayPrototype.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(vm.ArrayPrototype, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeGenerator:
+		if vm.GeneratorPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.GeneratorPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeProxy:
+		proxy := obj.AsProxy()
+		if proxy.Revoked {
+			return Undefined, vm.NewTypeError("Cannot perform 'get' on a revoked Proxy")
+		}
+		getTrap, hasGetTrap := proxyGetTrap(proxy.handler, "get")
+		if hasGetTrap && getTrap.Type() != TypeUndefined && getTrap.Type() != TypeNull {
+			if !getTrap.IsCallable() {
+				return Undefined, vm.NewTypeError("'get' on proxy: trap is not a function")
+			}
+			trapArgs := []Value{proxy.target, sym, receiver}
+			result, err := vm.Call(getTrap, proxy.handler, trapArgs)
+			if err != nil {
+				return Undefined, err
+			}
+			// ECMAScript 10.5.8 invariant validation, symbol-key version
+			// of getPropertyWithReceiver's TypeProxy case above.
+			if proxy.target.Type() == TypeObject {
+				targetObj := proxy.target.AsPlainObject()
+				if g, _, _, c, isAccessor := targetObj.GetOwnAccessorByKey(key); isAccessor && !c {
+					if g.Type() == TypeUndefined && !result.IsUndefined() {
+						return Undefined, vm.NewTypeError("'get' on proxy: property is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap returned a non-undefined value")
+					}
+				} else if v, w, _, c, found := targetObj.GetOwnDescriptorByKey(key); found && !c && !w {
+					if !v.StrictlyEquals(result) {
+						return Undefined, vm.NewTypeError("'get' on proxy: property is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value")
+					}
+				}
+			}
+			return result, nil
+		}
+		return vm.getSymbolPropertyWithReceiver(proxy.target, sym, receiver)
+
+	case TypePromise:
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if vm.PromisePrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.PromisePrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeRegExp:
+		regexObj := obj.AsRegExpObject()
+		if regexObj != nil {
+			if regexObj.Properties != nil {
+				if v, found, err := vm.getOwnFromTableByKey(regexObj.Properties, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+			proto := Undefined
+			proto = regexObj.GetPrototype()
+			if !proto.IsObject() {
+				proto = vm.RegExpPrototype
+			}
+			if proto.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeTypedArray:
+		// TypedArrays don't expose own symbol-keyed properties (only
+		// indices and the fixed set of string built-ins) - straight to
+		// the element-type-specific prototype, same selection as
+		// getPropertyWithReceiver's TypeTypedArray case.
+		ta := obj.AsTypedArray()
+		if ta != nil {
+			var proto Value
+			switch ta.GetElementType() {
+			case TypedArrayInt8:
+				proto = vm.Int8ArrayPrototype
+			case TypedArrayUint8:
+				proto = vm.Uint8ArrayPrototype
+			case TypedArrayUint8Clamped:
+				proto = vm.Uint8ClampedArrayPrototype
+			case TypedArrayInt16:
+				proto = vm.Int16ArrayPrototype
+			case TypedArrayUint16:
+				proto = vm.Uint16ArrayPrototype
+			case TypedArrayInt32:
+				proto = vm.Int32ArrayPrototype
+			case TypedArrayUint32:
+				proto = vm.Uint32ArrayPrototype
+			case TypedArrayFloat16:
+				proto = vm.Float16ArrayPrototype
+			case TypedArrayFloat32:
+				proto = vm.Float32ArrayPrototype
+			case TypedArrayFloat64:
+				proto = vm.Float64ArrayPrototype
+			case TypedArrayBigInt64:
+				proto = vm.BigInt64ArrayPrototype
+			case TypedArrayBigUint64:
+				proto = vm.BigUint64ArrayPrototype
+			default:
+				proto = vm.TypedArrayPrototype
+			}
+			if proto.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeSet:
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if vm.SetPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.SetPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeMap:
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if vm.MapPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.MapPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	case TypeFunction:
+		fn := obj.AsFunction()
+		if fn != nil && fn.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(fn.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeClosure:
+		cl := obj.AsClosure()
+		if cl != nil {
+			if cl.Properties != nil {
+				if v, found, err := vm.getOwnFromTableByKey(cl.Properties, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+			if cl.Fn != nil && cl.Fn.Properties != nil {
+				if v, found, err := vm.getOwnFromTableByKey(cl.Fn.Properties, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeNativeFunction:
+		nf := obj.AsNativeFunction()
+		if nf != nil && nf.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(nf.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeNativeFunctionWithProps:
+		nfp := obj.AsNativeFunctionWithProps()
+		if nfp != nil && nfp.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(nfp.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeBoundFunction:
+		bf := obj.AsBoundFunction()
+		if bf != nil && bf.Properties != nil {
+			if v, found, err := vm.getOwnFromTableByKey(bf.Properties, key, receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
+			return v, nil
+		}
+		return Undefined, nil
+
+	case TypeArguments:
+		args := obj.AsArguments()
+		if args != nil {
+			if v, ok := args.GetSymbolProp(sym.AsSymbolObject()); ok {
+				return v, nil
+			}
+			// Symbol.iterator is inherited from Array.prototype - check
+			// that first, then Object.prototype, matching OpIn's own
+			// symbol-key TypeArguments case (pkg/vm/vm.go).
+			if vm.ArrayPrototype.IsObject() {
+				if v, found, err := vm.walkPlainObjectChainForKey(vm.ArrayPrototype, key, receiver); found || err != nil {
+					return v, err
+				}
+			}
+			if vm.ObjectPrototype.IsObject() {
+				v, _, err := vm.walkPlainObjectChainForKey(vm.ObjectPrototype, key, receiver)
+				return v, err
+			}
+		}
+		return Undefined, nil
+
+	case TypeBigInt:
+		if vm.BigIntPrototype.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(vm.BigIntPrototype, key, receiver)
+			return v, err
+		}
+		return Undefined, nil
+
+	default:
+		var proto Value
+		switch obj.Type() {
+		case TypeBoolean:
+			proto = vm.BooleanPrototype
+		case TypeFloatNumber, TypeIntegerNumber:
+			proto = vm.NumberPrototype
+		case TypeString:
+			proto = vm.StringPrototype
+		case TypeSymbol:
+			proto = vm.SymbolPrototype
+		case TypeBigInt:
+			proto = vm.BigIntPrototype
+		}
+		if proto.IsObject() {
+			v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
+			return v, err
 		}
 		return Undefined, nil
 	}

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -2141,17 +2141,12 @@ func (vm *VM) Call(fn Value, thisValue Value, args []Value) (Value, error) {
 			return Undefined, vm.NewTypeError("Cannot perform 'apply' on a proxy that has been revoked")
 		}
 
-		// Get the apply trap from handler (handler can be PlainObject or DictObject)
+		// Get the apply trap from handler. GetMethod(handler, "apply") per
+		// spec: an inherited trap counts, not just an own one - proxyGetTrap
+		// (not a bare handler.AsPlainObject().GetOwn("apply")) for the same
+		// reason documented on its own definition.
 		handler := proxy.Handler()
-		var applyTrap Value
-		var hasApplyTrap bool
-
-		switch handler.Type() {
-		case TypeObject:
-			applyTrap, hasApplyTrap = handler.AsPlainObject().GetOwn("apply")
-		case TypeDictObject:
-			applyTrap, hasApplyTrap = handler.AsDictObject().GetOwn("apply")
-		}
+		applyTrap, hasApplyTrap := proxyGetTrap(handler, "apply")
 
 		// Check for apply trap
 		if hasApplyTrap && applyTrap.Type() != TypeUndefined && applyTrap.Type() != TypeNull {

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -2271,19 +2271,51 @@ func (vm *VM) ConstructWithNewTarget(constructor Value, args []Value, newTarget 
 
 		// Get prototype from newTarget (not constructor)
 		// Per ECMAScript, the prototype is determined by newTarget
-		var newTargetFn *FunctionObject
-		if newTarget.Type() == TypeClosure {
-			newTargetFn = newTarget.AsClosure().Fn
-		} else if newTarget.Type() == TypeFunction {
-			newTargetFn = newTarget.AsFunction()
-		}
-
+		//
+		// This used to unconditionally unwrap TypeClosure to its
+		// underlying, SHARED *FunctionObject (newTarget.AsClosure().Fn)
+		// and call GetOrCreatePrototypeWithVM on that directly - which
+		// creates/reads "prototype" on the function's own table, not the
+		// closure INSTANCE's table. But `someClosure.prototype = x`
+		// (op_setprop.go's TypeClosure case) writes into
+		// closure.Properties, a per-closure-instance side table that
+		// shadows the shared Fn's - exactly the same shadowing
+		// TypeFunction/TypeClosure's ordinary property-read path
+		// (getPropertyWithReceiver above) already respects. So
+		// Reflect.construct(Ctor, args, newTarget) with an explicit
+		// newTarget whose .prototype had been reassigned (or a class,
+		// which compiles to TypeClosure) silently used newTarget's
+		// stale, unshadowed default prototype instead of the real one:
+		//
+		//   function C(a) { this.a = a; }
+		//   function D() {}
+		//   D.prototype = { fromD: true };
+		//   Object.getPrototypeOf(Reflect.construct(C, [1], D)) === D.prototype; // before: false - Node: true
+		//
+		// Fixed by using ClosureObject.GetPrototypeWithVM (pkg/vm/function.go),
+		// which already gets this shadowing right - it's the same method
+		// OpValidateSuperclass (`class X extends Y`, pkg/vm/vm.go) already
+		// uses for the identical purpose. TypeNativeFunction/
+		// TypeNativeFunctionWithProps/TypeBoundFunction newTargets (a
+		// native or bound constructor) had the same bug via the same
+		// "fall back to constructor's own prototype, not newTarget's"
+		// path - handled by GetPrototypeFromConstructor below directly
+		// (their own "prototype" is a real, non-lazily-created property,
+		// so vm.GetProperty - which GetPrototypeFromConstructor calls -
+		// already reads it correctly for all three, unlike
+		// TypeFunction/TypeClosure's synthesized-on-first-access one).
 		var prototype Value
-		if newTargetFn != nil {
-			prototype = newTargetFn.GetOrCreatePrototypeWithVM(vm)
-		} else {
-			// Fallback to constructor's prototype
-			prototype = fn.GetOrCreatePrototypeWithVM(vm)
+		switch newTarget.Type() {
+		case TypeClosure:
+			prototype = newTarget.AsClosure().GetPrototypeWithVM(vm)
+		case TypeFunction:
+			prototype = newTarget.AsFunction().GetOrCreatePrototypeWithVM(vm)
+		default:
+			var gpfcErr error
+			prototype, gpfcErr = vm.GetPrototypeFromConstructor(newTarget, "%ObjectPrototype%")
+			if gpfcErr != nil {
+				return Undefined, gpfcErr
+			}
 		}
 
 		// ECMAScript spec 9.1.14 GetPrototypeFromConstructor:

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1707,6 +1707,51 @@ func (vm *VM) SetProperty(obj Value, propName string, value Value) error {
 		}
 		return nil
 
+	case TypeProxy:
+		// This case didn't exist at all before this fix - obj.Type() ==
+		// TypeProxy fell to the `default: return nil` no-op below, so
+		// every native Go caller of SetProperty (e.g.
+		// pkg/builtins/array_generic.go's arrayLikeSetLength, which
+		// Array.prototype.pop/shift/... use to shrink .length) silently
+		// did nothing when writing to a Proxy - `Array.prototype.pop.call(
+		// new Proxy(realArray, {}))` deleted the right element but never
+		// actually updated realArray.length, even though ordinary
+		// `proxy.length = n` assignment syntax (the bytecode OpSetProp
+		// path, op_setprop.go) already handled this correctly. Mirrors
+		// op_setprop.go's own TypeProxy case: GetMethod(handler, "set")
+		// via getInheritedGeneric (an inherited trap counts, and this
+		// covers the same wider range of legal handler kinds
+		// proxyGetTrap's TypeObject/TypeDictObject-only switch doesn't -
+		// Array, Closure, Function, ...), and a no-trap fallback that
+		// recurses into SetProperty on the target - covering the same
+		// TypeArray/TypeObject/TypeDictObject/TypeArguments/TypeRegExp
+		// cases above (including "length" on a real Array) plus a
+		// further-nested Proxy target automatically, since this same
+		// switch runs again for it.
+		proxy := obj.AsProxy()
+		if proxy.Revoked {
+			return vm.NewTypeError("Cannot set property on a revoked Proxy")
+		}
+		setTrap, hasSetTrap := vm.getInheritedGeneric(proxy.Handler(), "set")
+		if hasSetTrap && setTrap.Type() != TypeUndefined && setTrap.Type() != TypeNull {
+			if !setTrap.IsCallable() {
+				return vm.NewTypeError("'set' on proxy: trap is not a function")
+			}
+			// handler.set(target, propertyKey, value, receiver) - receiver
+			// is the proxy itself, per ECMA-262 10.5.9 step 8.
+			result, err := vm.Call(setTrap, proxy.Handler(), []Value{proxy.Target(), NewString(propName), value, obj})
+			if err != nil {
+				return err
+			}
+			if result.IsFalsey() {
+				return vm.NewTypeError("'set' on proxy: trap returned falsish for property '" + propName + "'")
+			}
+			return nil
+		}
+		// No set trap: delegate to target.[[Set]]() - recursing through
+		// this same switch handles a further-nested Proxy target too.
+		return vm.SetProperty(proxy.Target(), propName, value)
+
 	default:
 		// For non-objects, this is a no-op (or could throw in strict mode)
 		return nil

--- a/tests/scripts/array_getownpropertysymbols.ts
+++ b/tests/scripts/array_getownpropertysymbols.ts
@@ -1,0 +1,221 @@
+// expect: true
+// THE BIGGEST-BLAST-RADIUS FIX HERE: opGetPropSymbol's TypeArray case
+// (pkg/vm/op_getprop.go) - the VM READ PATH for `arr[sym]` - used to skip
+// straight to the Array.prototype chain without ever consulting the
+// array's OWN symbolProps at all, even though opSetPropSymbol's sibling
+// TypeArray case (pkg/vm/op_setprop.go) already wrote `arr[sym] = v`
+// there correctly:
+//
+//   const arr = [1, 2, 3]; const sym = Symbol("s"); arr[sym] = 42;
+//   arr[sym]; // before: undefined (or a same-named Array.prototype
+//             //         value, if one existed) - Node: 42
+//
+// This was found while verifying that `Reflect.get(arr, sym)` (which
+// already worked, via a different Go-side code path) agreed with
+// `arr[sym]` (the bytecode path, which didn't) - the exact "N call sites
+// for the same operation slowly drift apart" bug class this whole
+// session keeps finding. Left unfixed, this would have made
+// Object.getOwnPropertySymbols's own new TypeArray case (below) report a
+// symbol key that user code could never actually read back through
+// ordinary `arr[sym]` syntax - a dishonest half of a fix.
+//
+// A third, sibling gap found the same way:
+// Object.getOwnPropertyDescriptor(arr, sym) (objectGetOwnPropertyDescriptorWithVM,
+// pkg/builtins/object_init.go) had no symbol-key branch for TypeArray
+// either - it fell through the (propName-based, meaningless for a
+// symbol) index/length checks and then a switch with no TypeArray case,
+// landing on undefined even though the property demonstrably exists:
+//
+//   Object.getOwnPropertyDescriptor(arr, sym);
+//   // before: undefined
+//   // Node:   {value: 42, writable: true, enumerable: true, configurable: true}
+//
+// Object.getOwnPropertySymbols had no case at all for TypeArray - its
+// if/else-if chain covered TypeObject/TypeFunction/TypeClosure/
+// TypeNativeFunction/TypeNativeFunctionWithProps/TypeBoundFunction/
+// TypeProxy and fell through for everything else, silently returning []:
+//
+//   const arr = [1, 2, 3];
+//   arr[Symbol("s")] = 42;
+//   Object.getOwnPropertySymbols(arr).length; // before: 0 - Node: 1
+//
+// ArrayObject (pkg/vm/value.go) already stored symbol-keyed properties -
+// GetSymbolProp/SetSymbolProp/HasOwnSymbolProp already worked, that's how
+// `arr[sym] = v` and `sym in arr` worked at all - but had no enumerator
+// for them at all. Fixed by adding ArrayObject.OwnSymbolKeys(), backed by
+// a new symbolPropOrder []*SymbolObject field that SetSymbolProp appends
+// to (only on first insertion) and DeleteSymbolProp splices out of, so
+// symbols enumerate in creation order per ECMA-262 10.1.11
+// OrdinaryOwnPropertyKeys (verified against Node: insertion order, and
+// symbols always sort after every string key regardless of when each was
+// added relative to the other).
+//
+// Reflect.ownKeys's own TypeArray case had a SEPARATE, independent bug:
+// it hand-rolled its own index/sparse-index/"length" logic and never
+// included named (non-index) string properties at all, on top of having
+// no symbol coverage either. Rather than bolting a third independent
+// symbol-enumeration call site onto that hand-rolled logic, it was
+// rewritten to delegate to Object.getOwnPropertyNamesWithVM +
+// Object.getOwnPropertySymbolsWithVM instead - mirroring the delegation
+// already used for the five callable kinds (task_06547fb2) - which is a
+// verified pure superset of the old logic (identical index/sparse-index/
+// length handling) plus both gaps closed at once.
+//
+// NOTE on named (non-symbol) property ordering: this task deliberately
+// does NOT assert an order between multiple named string properties like
+// `arr.foo` and `arr.baz` on an array. ArrayObject.NamedPropertyKeys()
+// (pkg/vm/value.go) enumerates its `properties` map with a plain,
+// untracked `for k := range a.properties`, which is Go-map-iteration-
+// order (i.e. genuinely randomized per run) rather than creation order -
+// a separate, pre-existing bug already present in
+// Object.getOwnPropertyNames before this task touched anything, merely
+// newly SURFACED in Reflect.ownKeys by this task's delegation choice
+// (Reflect.ownKeys's old TypeArray case never included named properties
+// at all, so it couldn't previously expose this). Filed as a follow-up
+// chip rather than fixed here, since it's unrelated to symbol handling.
+// Checks below only assert symbol-keyed ordering/positioning and named-
+// property MEMBERSHIP, never named-property ORDER.
+
+const checks: boolean[] = [];
+
+// --- 1. Single symbol property on a plain array. ---
+{
+  const arr: any = [1, 2, 3];
+  const sym = Symbol("s");
+  arr[sym] = 42;
+  const syms = Object.getOwnPropertySymbols(arr);
+  checks.push(syms.length === 1 && syms[0] === sym && arr[sym] === 42);
+}
+
+// --- 2. Multiple symbol properties enumerate in creation order (the
+// symbolPropOrder mechanism this fix added - the one check that actually
+// discriminates "has an enumerator" from "has an ORDERED enumerator"). ---
+{
+  const arr2: any = [1, 2, 3];
+  const s1 = Symbol("s1");
+  const s2 = Symbol("s2");
+  arr2[s1] = "a";
+  arr2[s2] = "b";
+  const syms2 = Object.getOwnPropertySymbols(arr2);
+  checks.push(syms2.length === 2 && syms2[0] === s1 && syms2[1] === s2);
+}
+
+// --- 3. Reflect.ownKeys on an array with a symbol property: the symbol
+// comes after every string key (indices + "length"), per ECMA-262
+// 10.1.11 OrdinaryOwnPropertyKeys. ---
+{
+  const arr3: any = [1, 2, 3];
+  const sym3 = Symbol("s3");
+  arr3[sym3] = 99;
+  const keys3 = Reflect.ownKeys(arr3);
+  checks.push(
+    keys3.length === 5 &&
+      keys3[0] === "0" &&
+      keys3[1] === "1" &&
+      keys3[2] === "2" &&
+      keys3[3] === "length" &&
+      keys3[4] === sym3
+  );
+}
+
+// --- 4. Named string property + symbol together: membership only for
+// the named key (order between multiple named keys is a separate,
+// pre-existing, deliberately-not-fixed-here bug - see header comment),
+// but the symbol's POSITION (always last, after every string key) is
+// asserted since that ordering guarantee doesn't depend on the broken
+// map iteration at all. ---
+{
+  const arr4: any = [1, 2];
+  arr4.foo = "bar";
+  const sym4 = Symbol("s4");
+  arr4[sym4] = "c";
+  const keys4 = Reflect.ownKeys(arr4);
+  const stringKeys = keys4.slice(0, keys4.length - 1);
+  checks.push(
+    keys4.length === 5 &&
+      keys4[keys4.length - 1] === sym4 &&
+      stringKeys.indexOf("0") !== -1 &&
+      stringKeys.indexOf("1") !== -1 &&
+      stringKeys.indexOf("length") !== -1 &&
+      stringKeys.indexOf("foo") !== -1
+  );
+}
+
+// --- 5. Proxy wrapping an array with a symbol property, no trap: the
+// no-trap delegation (proxyOwnPropertyKeys, task_3c1fe018) picks up the
+// array's symbol via the newly-fixed Object.getOwnPropertySymbols path
+// transitively. ---
+{
+  const target5: any = [1, 2, 3];
+  const sym5 = Symbol("s5");
+  target5[sym5] = 5;
+  const p5 = new Proxy(target5, {});
+  const keys5 = Reflect.ownKeys(p5);
+  const syms5 = Object.getOwnPropertySymbols(p5);
+  checks.push(
+    keys5.length === 5 &&
+      keys5[keys5.length - 1] === sym5 &&
+      syms5.length === 1 &&
+      syms5[0] === sym5
+  );
+}
+
+// --- 6. A symbol property does not leak into Object.getOwnPropertyNames
+// or show up as an enumerable string key (sanity: the two enumerators
+// stay properly partitioned by key type). ---
+{
+  const arr6: any = [1, 2];
+  const sym6 = Symbol("s6");
+  arr6[sym6] = "hidden";
+  const names6 = Object.getOwnPropertyNames(arr6);
+  checks.push(names6.indexOf(sym6 as any) === -1 && names6.length === 3);
+}
+
+// --- 7. Object.getOwnPropertyDescriptor agrees with `arr[sym]` and
+// Reflect.get for the same array symbol property - all three read paths
+// (bytecode opGetPropSymbol, Reflect.get's Go-side property lookup, and
+// this function's own TypeArray branch) had independently drifted before
+// this fix; this pins all three at once so they can't silently
+// re-diverge. ---
+{
+  const arr7a: any = [1, 2, 3];
+  const sym7a = Symbol("x");
+  arr7a[sym7a] = 42;
+  const desc = Object.getOwnPropertyDescriptor(arr7a, sym7a) as any;
+  checks.push(
+    arr7a[sym7a] === 42 &&
+      Reflect.get(arr7a, sym7a) === 42 &&
+      sym7a in arr7a &&
+      desc !== undefined &&
+      desc.value === 42 &&
+      desc.writable === true &&
+      desc.enumerable === true &&
+      desc.configurable === true
+  );
+}
+
+// --- 8. Reading an array's own symbol property takes precedence over an
+// identically-keyed property on Array.prototype (opGetPropSymbol's
+// TypeArray case used to skip straight to the prototype chain without
+// ever consulting the array's own symbolProps at all, so this would have
+// found the prototype's value, or undefined, instead of the array's
+// own). ---
+{
+  const sym7 = Symbol("s7");
+  (Array.prototype as any)[sym7] = "from-prototype";
+  const arr7: any = [1, 2];
+  arr7[sym7] = "own-value";
+  const readBack = arr7[sym7];
+  // Array.prototype is a PlainObject, not an ArrayObject - its
+  // DeleteSymbolProp actually removes the entry (verified against Node;
+  // this is unrelated to ArrayObject.DeleteSymbolProp's own bug, which
+  // is never reached from the `delete` opcode at all - see the deferred
+  // follow-up chip), so cleaning up this way doesn't leak the symbol
+  // onto the shared intrinsic for later scripts. Assert the cleanup
+  // itself worked, not just trust it.
+  delete (Array.prototype as any)[sym7];
+  const cleanedUp = !(sym7 in (Array.prototype as any));
+  checks.push(readBack === "own-value" && cleanedUp);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/boundfn_descriptors_and_native_symbols.ts
+++ b/tests/scripts/boundfn_descriptors_and_native_symbols.ts
@@ -1,0 +1,155 @@
+// expect: true
+// Two independent gaps found while verifying PR #339 (native functions'
+// custom own properties), both in pkg/builtins/object_init.go, both
+// instances of the same "exotic VM kind missing from a per-type switch"
+// bug class that's recurred throughout this stack (PRs #329-#339):
+//
+//   1. objectGetOwnPropertyDescriptorsWithVM had no `case
+//      vm.TypeBoundFunction` at all - Object.getOwnPropertyDescriptors(
+//      boundFn) returned {} entirely, missing even "name"/"length", which
+//      every other callable kind's branch in this same switch synthesizes
+//      explicitly:
+//        function fn(a, b) {}
+//        const bound = fn.bind(null);
+//        Object.getOwnPropertyDescriptors(bound); // before: {} - Node: {length: {...}, name: {...}}
+//      Fixed with a new case - but unlike TypeFunction/TypeNativeFunction/
+//      TypeNativeFunctionWithProps/TypeClosure above it (which all
+//      synthesize "name"/"length" specially, since those aren't real
+//      table entries for them), a bound function's "name" ("bound " +
+//      original) and "length" ARE real own properties written directly
+//      into bf.Properties at bind time (pkg/vm/property_helpers.go) - so
+//      a plain OwnPropertyNames()/OwnSymbolKeys() walk already includes
+//      them, no special synthesis needed.
+//
+//   2. Object.getOwnPropertySymbols had no case for TypeNativeFunction,
+//      TypeNativeFunctionWithProps, or TypeBoundFunction at all (only
+//      TypeObject/TypeFunction/TypeClosure) - checked all three against
+//      Node per the task's own instruction, all three were broken:
+//        const nf = Array.prototype.pop;
+//        const sym = Symbol("k");
+//        Object.defineProperty(nf, sym, { value: 2, configurable: true });
+//        Object.getOwnPropertySymbols(nf).length; // before: 0 - Node: 1
+//      even though Object.getOwnPropertyDescriptor(nf, sym) already
+//      correctly reported the property existing. Fixed with one shared
+//      branch for all three kinds, using the generic OwnPropertiesTable
+//      helper (pkg/vm/properties_table.go) - the same one
+//      objectGetOwnPropertyDescriptorsWithVM and objectKeysWithVM already
+//      use for the identical purpose (PR #339).
+//
+// Found while verifying, NOT fixed here (a real but larger, separate
+// bug, flagged as a follow-up): Reflect.ownKeys throws a TypeError
+// outright on ANY callable target (its object-gate never checks
+// IsCallable(), unlike Reflect.get/has/etc. in the same file), and even
+// past that gate has no case for any callable kind at all - so
+// Reflect.ownKeys(nf) disagrees with the now-fixed
+// Object.getOwnPropertySymbols(nf) above. Confirmed via:
+//   Reflect.ownKeys(Array.prototype.slice); // before: throws TypeError - Node: ["length", "name", ...]
+// Not a one-line fix like the two above - it needs real per-kind string-
+// key synthesis (name/length/prototype per callable kind), mirroring
+// objectGetOwnPropertyDescriptorsWithVM's own stringKeys collection
+// logic, which is a distinctly larger scope than this task's two gaps.
+//
+// Each assertion below uses its own function/instance (bind()/defineProperty
+// on a fresh function per check), plus distinct global constructors
+// (Number/Boolean) for the two NativeFunctionWithProps checks - these are
+// real shared intrinsics with no reset between assertions in the same
+// test file, matching the established convention (see
+// nativefunction_get_and_enumerate.ts).
+
+const checks: boolean[] = [];
+
+// --- 1. BoundFunction: name/length now present with the correct
+// attributes (writable: false, enumerable: false, configurable: true -
+// real own properties, not synthesized). ---
+{
+  function fn1(a: number, b: number) {}
+  const bound1: any = fn1.bind(null);
+  const descs: any = Object.getOwnPropertyDescriptors(bound1);
+  checks.push(
+    !!descs.length &&
+      descs.length.value === 2 &&
+      descs.length.writable === false &&
+      descs.length.enumerable === false &&
+      descs.length.configurable === true
+  );
+  checks.push(
+    !!descs.name &&
+      descs.name.value === "bound fn1" &&
+      descs.name.writable === false &&
+      descs.name.enumerable === false &&
+      descs.name.configurable === true
+  );
+}
+
+// --- 2. BoundFunction: a custom string property and a custom symbol
+// property both show up in getOwnPropertyDescriptors alongside name/length. ---
+{
+  function fn2() {}
+  const bound2: any = fn2.bind(null);
+  Object.defineProperty(bound2, "vis2", { value: 1, enumerable: true, configurable: true });
+  const sym2 = Symbol("k2");
+  Object.defineProperty(bound2, sym2, { value: 2, configurable: true });
+  const descs: any = Object.getOwnPropertyDescriptors(bound2);
+  checks.push(!!descs.vis2 && descs.vis2.value === 1);
+  checks.push(!!descs[sym2] && descs[sym2].value === 2);
+}
+
+// --- 3. BoundFunction with no custom properties: getOwnPropertyDescriptors
+// reports exactly name and length, nothing extra or missing. ---
+{
+  function fn3() {}
+  const bound3: any = fn3.bind(null);
+  checks.push(Object.keys(Object.getOwnPropertyDescriptors(bound3)).length === 2);
+}
+
+// --- 4. Object.getOwnPropertySymbols on a plain native function
+// (Array.prototype.*-style, TypeNativeFunction). ---
+{
+  const nf4: any = Array.prototype.shift;
+  const sym4 = Symbol("k4");
+  Object.defineProperty(nf4, sym4, { value: "v4", configurable: true });
+  const syms = Object.getOwnPropertySymbols(nf4);
+  checks.push(syms.length === 1 && syms[0] === sym4);
+}
+
+// --- 5. Object.getOwnPropertySymbols on a native function with props
+// (a global constructor, TypeNativeFunctionWithProps). ---
+{
+  const sym5 = Symbol("k5");
+  Object.defineProperty(Number, sym5, { value: "v5", configurable: true });
+  const syms = Object.getOwnPropertySymbols(Number);
+  checks.push(syms.includes(sym5));
+}
+
+// --- 6. Object.getOwnPropertySymbols on a BoundFunction, set via
+// bracket-notation assignment rather than defineProperty. ---
+{
+  function fn6() {}
+  const bound6: any = fn6.bind(null);
+  const sym6 = Symbol("k6");
+  bound6[sym6] = "v6";
+  const syms = Object.getOwnPropertySymbols(bound6);
+  checks.push(syms.length === 1 && syms[0] === sym6);
+}
+
+// --- 7. Regression guard: a native function with no custom symbol
+// properties still reports an empty array, not a stale leftover. ---
+{
+  const nf7: any = Array.prototype.pop;
+  checks.push(Object.getOwnPropertySymbols(nf7).length === 0);
+}
+
+// --- 8. Object.getOwnPropertySymbols on a second, distinct
+// NativeFunctionWithProps constructor (Array, not Number/Boolean used
+// above) - comparing a before/after count rather than an absolute one,
+// since this is a real shared intrinsic no other check here touches
+// directly. ---
+{
+  const before = Object.getOwnPropertySymbols(Array).length;
+  const sym8 = Symbol("k8");
+  Object.defineProperty(Array, sym8, { value: 1, configurable: true });
+  const after = Object.getOwnPropertySymbols(Array);
+  checks.push(after.length === before + 1 && after.includes(sym8));
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/bracket_index_set_exotic.ts
+++ b/tests/scripts/bracket_index_set_exotic.ts
@@ -1,0 +1,87 @@
+// expect: true
+// OpSetIndex's exotic-kinds case (search "can have properties" in
+// pkg/vm/vm.go) had no TypeMap/TypeSet/TypePromise at all - unlike
+// TypeFunction/TypeClosure/TypeRegExp/TypeNativeFunction(WithProps)/
+// TypeBoundFunction, which were already there - so bracket-notation
+// assignment (obj[key] = v) on a Map/Set/Promise unconditionally threw
+// "Cannot set index on non-array/object/typedarray type", even for a
+// plain string key, while dot-notation (obj.key = v) worked fine.
+//
+// Fixing that alone surfaced a second, adjacent bug: a symbol-keyed
+// bracket assignment on ANY of these exotic kinds (Map/Set/Promise, but
+// also the already-listed BoundFunction/NativeFunctionWithProps/
+// NativeFunction) routes to opSetPropSymbol, which had no case for them
+// either and silently discarded the write. And once that was added, a
+// THIRD bug turned up: opSetPropSymbol's existing helper
+// (setOwnCheckedByKey, shared by RegExp/Function/Closure's already-working
+// symbol-set paths) created every new symbol property as
+// {writable: false, enumerable: false, configurable: false} instead of
+// the true/true/true a plain assignment should produce - a pre-existing
+// bug that predates this fix, now fixed for every kind that goes through
+// it.
+const checks: boolean[] = [];
+
+function checkStringKey(obj: any): boolean {
+  obj["strkey"] = 42;
+  if (obj.strkey !== 42) return false;
+  if (!("strkey" in obj) || !Reflect.has(obj, "strkey")) return false;
+  const desc: any = Object.getOwnPropertyDescriptor(obj, "strkey");
+  return (
+    desc !== undefined &&
+    desc.value === 42 &&
+    desc.writable === true &&
+    desc.enumerable === true &&
+    desc.configurable === true
+  );
+}
+
+// checkSymbolKey verifies the write actually happened via Reflect.has
+// (always) and, when checkDesc is true, via Object.getOwnPropertyDescriptor
+// too. It deliberately does NOT check the `in` operator or the descriptor
+// for every kind: two adjacent, pre-existing gaps in OTHER functions -
+// unrelated to this bracket-assignment fix, and tracked separately - would
+// make those assertions fail even though the write this fix is responsible
+// for succeeded correctly (confirmed via Reflect.has in every case below):
+//   - `in` (OpIn)'s symbol-key dispatch has no case at all for
+//     BoundFunction/NativeFunction/NativeFunctionWithProps.
+//   - Object.getOwnPropertyDescriptor's TypeRegExp/TypeBoundFunction blocks
+//     never check a symbol key, only a string name.
+function checkSymbolKey(obj: any, checkIn: boolean, checkDesc: boolean): boolean {
+  const sym = Symbol("k");
+  obj[sym] = 99;
+  if (!Reflect.has(obj, sym)) return false;
+  if (checkIn && !(sym in obj)) return false;
+  if (!checkDesc) return true;
+  const desc: any = Object.getOwnPropertyDescriptor(obj, sym);
+  return (
+    desc !== undefined &&
+    desc.value === 99 &&
+    desc.writable === true &&
+    desc.enumerable === true &&
+    desc.configurable === true
+  );
+}
+
+// --- string key, all four kinds ---
+checks.push(checkStringKey(new Map()));
+checks.push(checkStringKey(new Set()));
+checks.push(checkStringKey(Promise.resolve(1)));
+checks.push(checkStringKey(/x/g));
+
+// --- symbol key, all four kinds ---
+checks.push(checkSymbolKey(new Map(), true, true));
+checks.push(checkSymbolKey(new Set(), true, true));
+checks.push(checkSymbolKey(Promise.resolve(1), true, true));
+checks.push(checkSymbolKey(/y/g, true, false)); // descriptor-by-symbol gap tracked separately
+
+// --- symbol key, the callable kinds the task asked to double-check ---
+function plainFn() {}
+checks.push(checkSymbolKey(plainFn.bind(null), false, false)); // both gaps above apply
+const nfp: any = Array; // NativeFunctionWithProps
+checks.push(checkSymbolKey(nfp, false, true)); // `in` gap applies, descriptor already worked
+
+// --- a genuinely absent key is still absent after all this ---
+const untouched: any = new Map();
+checks.push(!("nope" in untouched) && !Reflect.has(untouched, "nope"));
+
+checks.every((c) => c === true);

--- a/tests/scripts/define_property_exotic_side_table.ts
+++ b/tests/scripts/define_property_exotic_side_table.ts
@@ -94,16 +94,17 @@ Object.preventExtensions(m3);
 Object.defineProperty(m3, "already", { value: 2 });
 checks.push(m3.already === 2);
 
-// --- pin the known, separately-tracked `in`-on-Promise gap explicitly
-// (rather than the roundTrips helper above silently skipping it): `in`
-// never checks a Promise's own side table at all, only Reflect.has does -
-// reproduces with plain assignment too, so it's unrelated to this fix. If
-// that gap gets fixed later, this assertion should fail and point
-// whoever's fixing it at updating checkIn above instead of it going
-// unnoticed. ---
+// --- Reflect.has finds a plain own property assigned onto a Promise
+// (unrelated to defineProperty itself, but worth pinning here since the
+// roundTrips helper above skips `in` for Promise entirely). `in` used to
+// disagree with Reflect.has here - it never checked a Promise's own side
+// table at all - but that was a separate bug in the `in` operator itself
+// (OpIn, pkg/vm/vm.go), not this defineProperty fix, so it's fixed in a
+// sibling PR (#332) instead of asserted on in this file: an assertion
+// here would flip depending on merge order between the two PRs. ---
 const pIn: any = Promise.resolve(3);
 pIn.viaAssign = 1;
-checks.push(Reflect.has(pIn, "viaAssign") && !("viaAssign" in pIn));
+checks.push(Reflect.has(pIn, "viaAssign"));
 
 // --- RegExp's "lastIndex" is excluded from the generic side-table write
 // (it's a real Go field, not a table entry) - defineProperty on it stays

--- a/tests/scripts/define_property_exotic_side_table.ts
+++ b/tests/scripts/define_property_exotic_side_table.ts
@@ -1,0 +1,117 @@
+// expect: true
+// Object.defineProperty/Reflect.defineProperty on a RegExp/Map/Set/Promise
+// that has never had a property defined on it (its side table -
+// OwnPropertiesTable, pkg/vm/properties_table.go - is still nil) used to
+// silently do nothing while still returning the object as if it had
+// succeeded: definePropertyWithVM's write-path had no branch at all for
+// these four kinds (a NativeFunctionWithProps/Function/Closure-only chain),
+// so it just fell through to `return obj, nil`. Object.keys and
+// Object.getOwnPropertyDescriptor had the matching gap for Map/Set/Promise
+// (RegExp's read side already worked via a dedicated lastIndex+side-table
+// block). Plain assignment (`r.custom = 42`) was never affected - it goes
+// through EnsureOwnPropertiesTable elsewhere in the property-set path.
+const checks: boolean[] = [];
+
+function roundTrips(obj: any, useReflect: boolean, checkIn: boolean): boolean {
+  const definer = useReflect
+    ? (o: any, k: string, d: any) => Reflect.defineProperty(o, k, d)
+    : (o: any, k: string, d: any) =>
+        Object.defineProperty(o, k, d) !== undefined;
+  const ok = definer(obj, "custom", {
+    value: 42,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  if (!ok) return false;
+  const desc: any = Object.getOwnPropertyDescriptor(obj, "custom");
+  if (!desc || desc.value !== 42 || !desc.writable || !desc.enumerable || !desc.configurable) {
+    return false;
+  }
+  if (!Reflect.has(obj, "custom")) return false;
+  // `in` on a Promise has its own, separate pre-existing gap (never
+  // checks the Promise's own side table at all, reproduces with plain
+  // assignment too - unrelated to this fix, tracked separately) - skip it
+  // for that one kind so this test stays about defineProperty, not that.
+  if (checkIn && !("custom" in obj)) return false;
+  if (Object.keys(obj).indexOf("custom") === -1) return false;
+  return true;
+}
+
+// --- Object.defineProperty, virgin side table, all four kinds ---
+checks.push(roundTrips(/x/g, false, true));
+checks.push(roundTrips(new Map(), false, true));
+checks.push(roundTrips(new Set(), false, true));
+checks.push(roundTrips(Promise.resolve(1), false, false));
+
+// --- Reflect.defineProperty, virgin side table, all four kinds ---
+checks.push(roundTrips(/y/, true, true));
+checks.push(roundTrips(new Map(), true, true));
+checks.push(roundTrips(new Set(), true, true));
+checks.push(roundTrips(Promise.resolve(2), true, false));
+
+// --- redefining with a partial descriptor preserves the omitted value,
+// not the zero Value{} DefineOwnProperty would otherwise write ---
+const m: any = new Map();
+Object.defineProperty(m, "foo", {
+  value: 10,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(m, "foo", { enumerable: false });
+const fooDesc: any = Object.getOwnPropertyDescriptor(m, "foo");
+checks.push(fooDesc.value === 10 && fooDesc.enumerable === false);
+
+// --- a symbol key round-trips the same way ---
+const s: any = new Set();
+const sym = Symbol("k");
+Object.defineProperty(s, sym, { value: 7, enumerable: true, configurable: true, writable: true });
+checks.push(
+  Object.getOwnPropertyDescriptor(s, sym).value === 7 &&
+    sym in s &&
+    Reflect.has(s, sym)
+);
+
+// --- extensibility is still enforced for a brand-new property (the side
+// table gets allocated by the write path now, but Object.preventExtensions
+// already allocates its own via EnsureOwnPropertiesTable, so the check at
+// definePropertyWithVM's extensibility guard still sees it) ---
+const m2: any = new Map();
+Object.preventExtensions(m2);
+let threw = false;
+try {
+  Object.defineProperty(m2, "nope", { value: 1, configurable: true });
+} catch (e: any) {
+  threw = e instanceof TypeError;
+}
+checks.push(threw);
+
+// --- redefining an EXISTING property still works after preventExtensions ---
+const m3: any = new Map();
+m3.already = 1;
+Object.preventExtensions(m3);
+Object.defineProperty(m3, "already", { value: 2 });
+checks.push(m3.already === 2);
+
+// --- pin the known, separately-tracked `in`-on-Promise gap explicitly
+// (rather than the roundTrips helper above silently skipping it): `in`
+// never checks a Promise's own side table at all, only Reflect.has does -
+// reproduces with plain assignment too, so it's unrelated to this fix. If
+// that gap gets fixed later, this assertion should fail and point
+// whoever's fixing it at updating checkIn above instead of it going
+// unnoticed. ---
+const pIn: any = Promise.resolve(3);
+pIn.viaAssign = 1;
+checks.push(Reflect.has(pIn, "viaAssign") && !("viaAssign" in pIn));
+
+// --- RegExp's "lastIndex" is excluded from the generic side-table write
+// (it's a real Go field, not a table entry) - defineProperty on it stays
+// the same pre-existing no-op it already was, not a new divergent shadow
+// copy that would make r.lastIndex and the descriptor disagree. ---
+const r: any = /z/g;
+Object.defineProperty(r, "lastIndex", { value: 5 });
+const liDesc: any = Object.getOwnPropertyDescriptor(r, "lastIndex");
+checks.push(r.lastIndex === liDesc.value);
+
+checks.every((c) => c === true);

--- a/tests/scripts/defineproperty_native_function.ts
+++ b/tests/scripts/defineproperty_native_function.ts
@@ -1,0 +1,145 @@
+// expect: true
+// Object.defineProperty threw "Object.defineProperty called on non-object"
+// on a plain TypeNativeFunction value (e.g. Array.prototype.push), even
+// though the exact same value already accepted a bracket-notation
+// assignment fine, and every other callable kind (TypeFunction,
+// TypeClosure, TypeBoundFunction, TypeNativeFunctionWithProps) was already
+// accepted - pkg/builtins/object_init.go's isObjectLike gate near the top
+// of objectDefinePropertyWithVM simply never listed TypeNativeFunction,
+// even though its Properties *PlainObject side table (pkg/vm/function.go)
+// is identical in shape to the other four callable kinds.
+//
+// Fixing the write side surfaced two read-side siblings that also never
+// checked a plain native function's Properties table at all:
+//   - objectGetOwnPropertyDescriptorWithVM's TypeNativeFunction case only
+//     ever answered "name"/"length" - defining anything else was invisible
+//     to Object.getOwnPropertyDescriptor.
+//   - OpIn's non-symbol TypeNativeFunction case (pkg/vm/vm.go) carried a
+//     comment claiming "native functions don't have custom properties" and
+//     skipped straight to the FunctionPrototype fallback, so `"x" in nf`
+//     disagreed with Reflect.has(nf, "x") right after defining "x".
+// All three are fixed here, in the same commit as the write-side fix -
+// same "don't ship half a causally-coupled fix" reasoning as PR #332.
+//
+// Each assertion below uses its own function (Array.prototype methods are
+// real shared intrinsics - a distinct one per check keeps one assertion's
+// mutation from being observable by another).
+
+const checks: boolean[] = [];
+
+function hasDataDesc(desc: any, value: unknown, writable: boolean, enumerable: boolean, configurable: boolean): boolean {
+  return (
+    desc !== undefined &&
+    desc.value === value &&
+    desc.writable === writable &&
+    desc.enumerable === enumerable &&
+    desc.configurable === configurable
+  );
+}
+
+// --- A data property via Object.defineProperty on a plain native function,
+// read back via Object.getOwnPropertyDescriptor (singular) and direct
+// property access. ---
+{
+  const nf: any = Array.prototype.push;
+  Object.defineProperty(nf, "tag", { value: 1, writable: true, enumerable: true, configurable: true });
+  checks.push(nf.tag === 1);
+  checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(nf, "tag"), 1, true, true, true));
+}
+
+// --- A symbol-keyed data property, same as above. Verified only via
+// Object.getOwnPropertyDescriptor, not `nf[sym]`: reading a symbol-keyed
+// property back via bracket notation on a plain native function has its
+// own separate, pre-existing GET-side gap (opGetPropSymbol has no
+// TypeNativeFunction case at all) - flagged independently, not fixed
+// here. ---
+{
+  const nf: any = Array.prototype.pop;
+  const sym = Symbol("k");
+  Object.defineProperty(nf, sym, { value: 2, writable: true, enumerable: true, configurable: true });
+  checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(nf, sym), 2, true, true, true));
+}
+
+// --- An accessor property: the setter actually runs (verified via a
+// captured side-effect variable, not a read-back). The getter is
+// confirmed callable via the descriptor's own `get` function, not via
+// `nf.custom` direct read - invoking an own accessor's getter through
+// ordinary property access on a plain native function is a second,
+// separate pre-existing GET-side gap (opGetProp's TypeNativeFunction
+// case only ever calls Properties.GetOwn, which doesn't return an
+// accessor's value) - also flagged independently, not fixed here. ---
+{
+  const nf: any = Array.prototype.shift;
+  let backing = 0;
+  Object.defineProperty(nf, "custom", {
+    get() {
+      return backing;
+    },
+    set(v: number) {
+      backing = v;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  nf.custom = 100;
+  checks.push(backing === 100);
+  const desc: any = Object.getOwnPropertyDescriptor(nf, "custom");
+  checks.push(typeof desc.get === "function" && desc.get() === 100 && typeof desc.set === "function");
+}
+
+// --- name/length intrinsics are preserved: still their synthesized
+// {writable: false, enumerable: false, configurable: true} shape, and
+// redefining name's *value* (permitted since it's configurable) works. ---
+{
+  const nf: any = Array.prototype.unshift;
+  checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(nf, "name"), "unshift", false, false, true));
+  checks.push(
+    hasDataDesc(Object.getOwnPropertyDescriptor(nf, "length"), Array.prototype.unshift.length, false, false, true)
+  );
+  Object.defineProperty(nf, "name", { value: "renamed" });
+  checks.push(nf.name === "renamed");
+}
+
+// --- `in`/Reflect.has agree for a property just defined via
+// Object.defineProperty, both string- and symbol-keyed. ---
+{
+  const nf: any = Array.prototype.slice;
+  Object.defineProperty(nf, "strkey", { value: 1, configurable: true });
+  checks.push("strkey" in nf && Reflect.has(nf, "strkey"));
+  const sym2 = Symbol("k2");
+  Object.defineProperty(nf, sym2, { value: 1, configurable: true });
+  checks.push(sym2 in nf && Reflect.has(nf, sym2));
+}
+
+// --- Reflect.defineProperty (delegates to the same fixed gate). ---
+{
+  const nf: any = Array.prototype.concat;
+  const ok = Reflect.defineProperty(nf, "viaReflect", { value: "v", writable: true, enumerable: true, configurable: true });
+  checks.push(ok === true);
+  checks.push(nf.viaReflect === "v");
+}
+
+// --- A genuinely absent property still answers undefined/false
+// everywhere. ---
+{
+  const nf: any = Array.prototype.indexOf;
+  checks.push(Object.getOwnPropertyDescriptor(nf, "absent") === undefined);
+  checks.push(!("absent" in nf) && !Reflect.has(nf, "absent"));
+}
+
+// --- Non-extensible rejects a new property (must be the LAST assertion
+// touching this particular function, since preventExtensions is permanent
+// for the life of this VM instance). ---
+{
+  const nf: any = Array.prototype.lastIndexOf;
+  Object.preventExtensions(nf);
+  let threw = false;
+  try {
+    Object.defineProperty(nf, "z", { value: 1, configurable: true });
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/for_in_map_set_promise.ts
+++ b/tests/scripts/for_in_map_set_promise.ts
@@ -1,0 +1,62 @@
+// expect: true
+// OpGetOwnKeys (pkg/vm/vm.go) drives for-in enumeration by switching on the
+// object's type - it had cases for TypeObject, TypeDictObject, TypeArray,
+// TypeArguments, TypeFunction, TypeClosure, TypeBoundFunction, and (as of a
+// prior fix) TypeRegExp, but none at all for TypeMap/TypeSet/TypePromise.
+// `for (k in map/set/promise)` always came back with nothing, even after a
+// plain assignment onto the value.
+//
+// Fixing the enumeration alone was not enough to make for-in over a
+// Promise agree with Node: for-in's compiled bytecode re-verifies each
+// enumerated key via OpIn's HasProperty-style check before yielding it in
+// the loop body (see TypeBoundFunction's comment in OpIn, same file, for
+// the identical mechanism) - and OpIn's TypePromise case never checked its
+// own side table at all, only Promise.prototype, so every key
+// OpGetOwnKeys had just found for a Promise was silently dropped again.
+// Fixed both together: OpGetOwnKeys gained a TypeMap/TypeSet/TypePromise
+// case, and OpIn's TypePromise case (both the string-key and symbol-key
+// switches) now checks the same side table Reflect.has already did.
+const checks: boolean[] = [];
+
+function forInKeys(obj: any): string[] {
+  const keys: string[] = [];
+  for (const k in obj) {
+    keys.push(k);
+  }
+  return keys;
+}
+
+// --- Map: a custom enumerable own property is enumerated; an empty one
+// enumerates nothing; "size" (an accessor on Map.prototype, not an own
+// property) and an inherited method (get) never appear ---
+const m: any = new Map();
+m.custom = 42;
+checks.push(forInKeys(m).join(",") === "custom");
+checks.push(forInKeys(new Map()).length === 0);
+checks.push(forInKeys(m).indexOf("size") === -1);
+checks.push(forInKeys(m).indexOf("get") === -1);
+
+// --- Set: same shape ---
+const s: any = new Set();
+s.custom = 1;
+checks.push(forInKeys(s).join(",") === "custom");
+checks.push(forInKeys(new Set()).length === 0);
+checks.push(forInKeys(s).indexOf("size") === -1);
+checks.push(forInKeys(s).indexOf("add") === -1);
+
+// --- Promise: same shape, plus this is the one that also needed the
+// OpIn fix (see file comment above) - without it this enumerated empty
+// despite OpGetOwnKeys finding "custom" ---
+const p: any = Promise.resolve(1);
+p.custom = 2;
+checks.push(forInKeys(p).join(",") === "custom");
+checks.push(forInKeys(Promise.resolve(1)).length === 0);
+checks.push(forInKeys(p).indexOf("then") === -1);
+
+// --- `in` and Reflect.has on a Promise's own property now agree, the
+// concrete symptom of the OpIn gap this fix closed alongside for-in ---
+const p2: any = Promise.resolve(3);
+p2.viaAssign = 1;
+checks.push(("viaAssign" in p2) && Reflect.has(p2, "viaAssign"));
+
+checks.every((c) => c === true);

--- a/tests/scripts/get_own_property_descriptor_symbol_regexp_boundfn.ts
+++ b/tests/scripts/get_own_property_descriptor_symbol_regexp_boundfn.ts
@@ -1,0 +1,109 @@
+// expect: true
+// objectGetOwnPropertyDescriptorWithVM's TypeBoundFunction case and its
+// TypeRegExp block (pkg/builtins/object_init.go) both looked up an own
+// property by string name only (propName), never checking keyIsSymbol or
+// using propSym - unlike the sibling TypeMap/TypeSet/TypePromise block in
+// the same function, which correctly branches on keyIsSymbol and uses
+// GetOwnAccessorByKey/GetOwnDescriptorByKey for a symbol key. So
+// Object.getOwnPropertyDescriptor(regexOrBoundFn, sym) always answered
+// undefined for a real own symbol property, even though `in`/Reflect.has
+// already found it correctly.
+const checks: boolean[] = [];
+
+function hasDataDesc(
+  desc: any,
+  value: unknown,
+  writable: boolean,
+  enumerable: boolean,
+  configurable: boolean
+): boolean {
+  return (
+    desc !== undefined &&
+    desc.value === value &&
+    desc.writable === writable &&
+    desc.enumerable === enumerable &&
+    desc.configurable === configurable
+  );
+}
+
+// --- RegExp: an own symbol property set via bracket-notation assignment ---
+const sym = Symbol("k");
+const r: any = /x/g;
+r[sym] = 4;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(r, sym), 4, true, true, true));
+checks.push(sym in r && Reflect.has(r, sym));
+
+// --- RegExp: a genuinely absent symbol key ---
+checks.push(Object.getOwnPropertyDescriptor(r, Symbol("absent")) === undefined);
+
+// --- RegExp: "lastIndex" (a real own property, but never a symbol) is
+// unaffected by routing symbol keys to the side table first ---
+const lastIndexDesc: any = Object.getOwnPropertyDescriptor(r, "lastIndex");
+checks.push(hasDataDesc(lastIndexDesc, 0, true, false, false));
+
+// --- RegExp: a symbol-keyed accessor (set via Object.defineProperty,
+// since bracket-assignment through an accessor has its own separate,
+// unrelated pre-existing gap) ---
+const r2: any = /y/g;
+Object.defineProperty(r2, sym, {
+  get() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const r2Desc: any = Object.getOwnPropertyDescriptor(r2, sym);
+checks.push(
+  r2Desc !== undefined &&
+    typeof r2Desc.get === "function" &&
+    r2Desc.get() === 42 &&
+    r2Desc.set === undefined &&
+    r2Desc.enumerable === true &&
+    r2Desc.configurable === true
+);
+
+// --- BoundFunction: an own symbol property set via bracket-notation
+// assignment. Only Reflect.has is checked (not `in`): the `in` operator's
+// symbol-key dispatch has its own, separate, still-open gap for
+// BoundFunction (tracked independently) - unrelated to this
+// getOwnPropertyDescriptor fix, which this test is actually about. ---
+function fn() {}
+const bound: any = fn.bind(null);
+bound[sym] = 5;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptor(bound, sym), 5, true, true, true));
+checks.push(Reflect.has(bound, sym));
+
+// --- BoundFunction: a genuinely absent symbol key ---
+checks.push(Object.getOwnPropertyDescriptor(bound, Symbol("absent")) === undefined);
+
+// --- BoundFunction: "name"/"length" (real own properties, but never a
+// symbol) are unaffected ---
+const boundNameDesc: any = Object.getOwnPropertyDescriptor(bound, "name");
+checks.push(
+  boundNameDesc !== undefined &&
+    boundNameDesc.value === "bound fn" &&
+    boundNameDesc.writable === false &&
+    boundNameDesc.enumerable === false &&
+    boundNameDesc.configurable === true
+);
+
+// --- BoundFunction: a symbol-keyed accessor ---
+const bound2: any = fn.bind(null);
+Object.defineProperty(bound2, sym, {
+  get() {
+    return 43;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const bound2Desc: any = Object.getOwnPropertyDescriptor(bound2, sym);
+checks.push(
+  bound2Desc !== undefined &&
+    typeof bound2Desc.get === "function" &&
+    bound2Desc.get() === 43 &&
+    bound2Desc.set === undefined &&
+    bound2Desc.enumerable === true &&
+    bound2Desc.configurable === true
+);
+
+checks.every((c) => c === true);

--- a/tests/scripts/get_own_property_descriptors_exotic.ts
+++ b/tests/scripts/get_own_property_descriptors_exotic.ts
@@ -1,0 +1,91 @@
+// expect: true
+// Object.getOwnPropertyDescriptors collected its keys via its own local
+// switch on obj.Type() (separate from the single-key
+// Object.getOwnPropertyDescriptor) - it had no case at all for
+// TypeRegExp/TypeMap/TypeSet/TypePromise, so stringKeys/symbolKeys stayed
+// empty and it always returned {} for one of these four kinds, even after
+// a real own property had been defined or assigned on it, despite the
+// single-key getOwnPropertyDescriptor already answering correctly for the
+// exact same property (paserati#329).
+const checks: boolean[] = [];
+
+function hasDataDesc(
+  descs: any,
+  key: string,
+  value: unknown,
+  writable: boolean,
+  enumerable: boolean,
+  configurable: boolean
+): boolean {
+  const d = descs[key];
+  return (
+    d !== undefined &&
+    d.value === value &&
+    d.writable === writable &&
+    d.enumerable === enumerable &&
+    d.configurable === configurable
+  );
+}
+
+// --- RegExp with no custom property still reports "lastIndex" (a real
+// own property that lives on the RegExpObject itself, not the side
+// table - the only kind of these four with an intrinsic own property to
+// add alongside whatever the side table holds) ---
+const descsEmpty: any = Object.getOwnPropertyDescriptors(/x/g);
+checks.push(
+  Object.keys(descsEmpty).length === 1 &&
+    hasDataDesc(descsEmpty, "lastIndex", 0, true, false, false)
+);
+
+// --- RegExp with a custom property reports both ---
+const r: any = /y/g;
+r.custom = 1;
+const descsR: any = Object.getOwnPropertyDescriptors(r);
+checks.push(
+  hasDataDesc(descsR, "lastIndex", 0, true, false, false) &&
+    hasDataDesc(descsR, "custom", 1, true, true, true)
+);
+
+// --- Map/Set/Promise with a custom property ---
+const m: any = new Map();
+m.custom = 2;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(m), "custom", 2, true, true, true));
+
+const s: any = new Set();
+s.custom = 3;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(s), "custom", 3, true, true, true));
+
+const p: any = Promise.resolve(1);
+p.custom = 4;
+checks.push(hasDataDesc(Object.getOwnPropertyDescriptors(p), "custom", 4, true, true, true));
+
+// --- a symbol key round-trips too (via Object.defineProperty - bracket
+// assignment with a computed key on these kinds has its own, separate,
+// unrelated pre-existing gap) ---
+const m2: any = new Map();
+const sym = Symbol("k");
+Object.defineProperty(m2, sym, {
+  value: 5,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+const descsSym: any = Object.getOwnPropertyDescriptors(m2);
+checks.push(
+  descsSym[sym] !== undefined &&
+    descsSym[sym].value === 5 &&
+    descsSym[sym].writable &&
+    descsSym[sym].enumerable &&
+    descsSym[sym].configurable
+);
+
+// --- a Map/Set/Promise with nothing custom on it reports no custom keys
+// (Map/Set's own "size" isn't an own property, it's an accessor on
+// Map.prototype/Set.prototype). Object.keys on the *result* object counts
+// string keys only - fine here since none of these three fixtures carry
+// a symbol; the m2 case above is what covers symbol-key round-tripping. ---
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(new Map())).length === 0);
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(new Set())).length === 0);
+checks.push(Object.keys(Object.getOwnPropertyDescriptors(Promise.resolve(1))).length === 0);
+
+checks.every((c) => c === true);

--- a/tests/scripts/getownpropertynames_prototype_guard.ts
+++ b/tests/scripts/getownpropertynames_prototype_guard.ts
@@ -1,0 +1,110 @@
+// expect: true
+// Object.getOwnPropertyNames's TypeFunction and TypeClosure cases both
+// unconditionally appended a synthesized "prototype" own key at the end
+// whenever "prototype" wasn't already a real, explicit own property in the
+// function's Properties table - regardless of whether the function was
+// actually constructible:
+//
+//   Object.getOwnPropertyNames(() => {});           // before: ["length","name","prototype"] - Node: ["length","name"]
+//   async function asy() {}
+//   Object.getOwnPropertyNames(asy);                // before: ["length","name","prototype"] - Node: ["length","name"]
+//
+// Per spec, a function has an own "prototype" property only when it's
+// actually constructible - an ordinary function, a generator function, and
+// an async generator function all have one; an arrow function and a plain
+// (non-generator) async function do not (verified against Node - see the
+// full matrix in the checks below).
+//
+// Fixed with a one-line guard: vm.VM.IsConstructor(obj) already implements
+// exactly this rule for TypeFunction/TypeClosure
+// (!IsArrowFunction && !(IsAsync && !IsGenerator)) - reused instead of
+// duplicated. The OTHER "prototype" branch (when "prototype" is already a
+// real, explicit own property - e.g. after a prior `.prototype` access
+// lazily created it, or user code explicitly assigned one) is untouched:
+// an explicitly-created property is always listed regardless of
+// constructibility.
+//
+// Reflect.ownKeys delegates to this same function for these two kinds
+// (task_06547fb2's fix), so the identical bug affected it too - covered
+// here as well, not just Object.getOwnPropertyNames.
+
+const checks: boolean[] = [];
+
+// --- 1. Arrow function: no "prototype" (the bug's main repro). ---
+{
+  const arrow = () => {};
+  const keys = Object.getOwnPropertyNames(arrow);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 2. Plain (non-generator) async function: no "prototype" either. ---
+{
+  async function asy() {}
+  const keys = Object.getOwnPropertyNames(asy);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 3. Generator function: HAS "prototype" - must not regress (a naive
+// "just remove the unconditional append" fix would have broken this).
+// vm.VM.IsConstructor(obj) - the predicate this fix reuses - answers
+// `true` for a generator function, which happens to be exactly the
+// has-"prototype" rule this check needs, but is NOT the same question as
+// "is this actually usable with `new`": `new (function*(){})()` throws
+// per spec, and pkg/builtins/reflect_init.go's own separate, differently-
+// named isConstructor(v) helper (used by Reflect.construct to decide
+// whether to throw) correctly returns false for a generator. This fix
+// depends on vm.IsConstructor's non-spec-constructibility answer staying
+// exactly as it is for generators/async generators - if that helper is
+// ever made spec-correct for its ACTUAL callers (e.g. OpValidateSuperclass,
+// which likely wrongly allows `class X extends function*(){}` today - see
+// the follow-up chip), this guard and check 3/4 here will need to switch
+// to a distinct has-"prototype" predicate instead. ---
+{
+  function* gen() {}
+  const keys = Object.getOwnPropertyNames(gen);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 4. Async generator function: HAS "prototype" too - the other half of
+// the same regression risk as check 3. ---
+{
+  async function* asyncGen() {}
+  const keys = Object.getOwnPropertyNames(asyncGen);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 5. A plain function declaration: HAS "prototype" - the ordinary,
+// most common case, must not regress. ---
+{
+  function fn(a: number, b: number) {
+    return a + b;
+  }
+  const keys = Object.getOwnPropertyNames(fn);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 6. A class (compiles to TypeClosure, same code path as check 5's
+// TypeFunction sibling through different surface syntax): HAS "prototype". ---
+{
+  class C {}
+  const keys = Object.getOwnPropertyNames(C);
+  checks.push(keys.length === 3 && keys[0] === "length" && keys[1] === "name" && keys[2] === "prototype");
+}
+
+// --- 7. Reflect.ownKeys on an arrow function agrees with
+// Object.getOwnPropertyNames (it delegates to the same fixed function per
+// task_06547fb2) - no "prototype" here either. ---
+{
+  const arrow2 = () => {};
+  const keys = Reflect.ownKeys(arrow2 as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 8. Reflect.ownKeys on a plain async function agrees too. ---
+{
+  async function asy2() {}
+  const keys = Reflect.ownKeys(asy2 as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/getownpropertynames_proxy.ts
+++ b/tests/scripts/getownpropertynames_proxy.ts
@@ -1,0 +1,265 @@
+// expect: true
+// Object.getOwnPropertyNames had no `case vm.TypeProxy:` at all in its
+// switch - it fell to `default: return arr, nil` (empty array) for ANY
+// Proxy target, regardless of what the proxy's target actually had:
+//
+//   const target = { a: 1 };
+//   Object.getOwnPropertyNames(new Proxy(target, {})); // before: [] - Node: ["a"]
+//   Reflect.ownKeys(new Proxy(target, {}));             // before: [] - Node: ["a"]
+//
+// This was more severe than it first looked: Reflect.ownKeys's own
+// TypeProxy case already had a comment claiming it "delegate[s] to
+// Object.getOwnPropertyNames + getOwnPropertySymbols" as "a
+// simplification" (implying it was APPROXIMATELY correct, just missing
+// the real ownKeys trap's invariant checking) - but that delegation
+// target itself had no Proxy support whatsoever, so the "simplification"
+// was a complete no-op: Reflect.ownKeys on literally any Proxy, trap or
+// no trap, always returned [] before this fix.
+//
+// Fixed via proxyOwnPropertyKeys (pkg/builtins/object_init.go), a shared
+// ECMA-262 10.5.11 [[OwnPropertyKeys]] implementation that
+// Object.getOwnPropertyNames, Object.getOwnPropertySymbols, and
+// Reflect.ownKeys all delegate to and then filter differently (per spec,
+// they all call the same internal method and filter its result - not
+// each invoking a possibly-side-effecting trap separately). Implements:
+// revoked check (throws), the "ownKeys" trap if present (its result
+// validated for String|Symbol-only elements and no duplicates, per
+// CreateListFromArrayLike and step 7 - but NOT the fuller
+// extensibility/configurable-key invariant validation ECMA-262 10.5.11
+// steps 8-16 require of a well-behaved trap's result against its target -
+// deliberately deferred, see the follow-up chip this was flagged with),
+// or delegation to the proxy's own target when no trap is present.
+//
+// Fixing this also required fixing a second, independent, pre-existing
+// bug the new Proxy delegation would otherwise have silently inherited:
+// Object.getOwnPropertyNames's TypeObject case had dead code - an
+// unreachable `else if obj.Type() == vm.TypeDictObject` nested INSIDE the
+// `case vm.TypeObject:` body, where obj.Type() is always TypeObject, so
+// the DictObject branch could never run. A DictObject backs a TypeScript
+// `enum` and a module namespace object - both reachable from ordinary
+// user code - so `Object.getOwnPropertyNames(SomeEnum)` was already []
+// even with no Proxy involved at all; fixed by splitting it into its own
+// `case vm.TypeDictObject:` (see check 6 below).
+
+const checks: boolean[] = [];
+
+// --- 1. No trap, plain object target: delegates through, both
+// Object.getOwnPropertyNames and Reflect.ownKeys agree. ---
+{
+  const target: any = { a: 1, b: 2 };
+  const p = new Proxy(target, {});
+  const names = Object.getOwnPropertyNames(p);
+  const keys = Reflect.ownKeys(p);
+  checks.push(
+    names.length === 2 &&
+      names[0] === "a" &&
+      names[1] === "b" &&
+      keys.length === 2 &&
+      keys[0] === "a" &&
+      keys[1] === "b"
+  );
+}
+
+// --- 2. No trap, array target. ---
+{
+  const target2: any = [1, 2, 3];
+  const p2 = new Proxy(target2, {});
+  const names = Object.getOwnPropertyNames(p2);
+  checks.push(names.length === 4 && names[0] === "0" && names[1] === "1" && names[2] === "2" && names[3] === "length");
+}
+
+// --- 3. No trap, function target - exercises the callable-kind
+// delegation chain (task_06547fb2) through a Proxy wrapper too. ---
+{
+  function fn3(a: number) {
+    return a;
+  }
+  const p3: any = new Proxy(fn3, {});
+  const names = Object.getOwnPropertyNames(p3);
+  checks.push(names.length === 3 && names[0] === "length" && names[1] === "name" && names[2] === "prototype");
+}
+
+// --- 4. No trap, native function target (Array.prototype.slice-style,
+// non-constructor - no "prototype"). ---
+{
+  const p4: any = new Proxy(Array.prototype.slice as any, {});
+  const names = Object.getOwnPropertyNames(p4);
+  checks.push(names.length === 2 && names[0] === "length" && names[1] === "name");
+}
+
+// --- 5. No trap, bound function target. ---
+{
+  function orig5() {}
+  const bound5 = orig5.bind(null);
+  const p5: any = new Proxy(bound5, {});
+  const names = Object.getOwnPropertyNames(p5);
+  checks.push(names.length === 2 && names[0] === "length" && names[1] === "name");
+}
+
+// --- 6. The DictObject dead-code fix: a TypeScript `enum` compiles to a
+// DictObject (pkg/compiler/compile_enum.go), reachable from ordinary user
+// code with no Proxy involved at all - this is the form the bug actually
+// shipped as (Object.getOwnPropertyNames(SomeEnum) was already [] on its
+// own), checked directly first, then again through a Proxy wrapper to
+// confirm the new Proxy delegation doesn't silently reintroduce the same
+// [] answer for this one target kind while every other kind above works. ---
+{
+  enum Color6 {
+    Red,
+    Green,
+  }
+  const namesDirect = Object.getOwnPropertyNames(Color6);
+  // DictObject's own key ORDER isn't guaranteed/tested here (a
+  // pre-existing, separate limitation, not part of this fix's scope) -
+  // just that the real keys come back at all instead of [].
+  const directOk =
+    namesDirect.length === 4 &&
+    namesDirect.includes("Red") &&
+    namesDirect.includes("Green") &&
+    namesDirect.includes("0") &&
+    namesDirect.includes("1");
+
+  const p6: any = new Proxy(Color6 as any, {});
+  const namesViaProxy = Object.getOwnPropertyNames(p6);
+  const viaProxyOk =
+    namesViaProxy.length === 4 &&
+    namesViaProxy.includes("Red") &&
+    namesViaProxy.includes("Green") &&
+    namesViaProxy.includes("0") &&
+    namesViaProxy.includes("1");
+
+  checks.push(directOk && viaProxyOk);
+}
+
+// --- 7. Trap present, well-behaved: returns a completely different key
+// list than the target actually has - the trap's raw result comes back
+// verbatim (this fix does NOT validate it against the target's own
+// configurable/extensible invariants - see the follow-up chip). ---
+{
+  const target7: any = { a: 1 };
+  const p7 = new Proxy(target7, {
+    ownKeys() {
+      return ["b", "c"];
+    },
+  });
+  const keys = Reflect.ownKeys(p7);
+  checks.push(keys.length === 2 && keys[0] === "b" && keys[1] === "c");
+}
+
+// --- 8. Trap present, mixed string and symbol keys - both halves of
+// CreateListFromArrayLike's String|Symbol element restriction are
+// exercised, and Reflect.ownKeys returns the trap's result unfiltered. ---
+{
+  const sym8 = Symbol("s8");
+  const target8: any = {};
+  const p8: any = new Proxy(target8, {
+    ownKeys() {
+      return ["x", sym8];
+    },
+  });
+  const keys = Reflect.ownKeys(p8);
+  checks.push(keys.length === 2 && keys[0] === "x" && keys[1] === sym8);
+}
+
+// --- 9. Trap returns an element that is neither a string nor a symbol:
+// CreateListFromArrayLike's element-type restriction throws a TypeError. ---
+{
+  const p9: any = new Proxy(
+    {},
+    {
+      ownKeys() {
+        return ["a", 42];
+      },
+    }
+  );
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(p9);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 10. Trap returns duplicate keys: ECMA-262 10.5.11 step 7 throws a
+// TypeError unconditionally, regardless of the target's own state. ---
+{
+  const p10: any = new Proxy(
+    {},
+    {
+      ownKeys() {
+        return ["a", "a"];
+      },
+    }
+  );
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(p10);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 10a. Same as check 10, but with a RUNTIME-BUILT duplicate string
+// (`k + ""`) rather than two identical literals - dedup keyed on the raw
+// value instead of string CONTENT would miss this, since two
+// independently-constructed string values holding the same text aren't
+// guaranteed to compare equal directly (verified: this exact repro
+// initially let the duplicate through unnoticed until dedup was keyed on
+// `.ToString()` for strings / the underlying symbol pointer for symbols
+// instead). ---
+{
+  const k10a = "a" + "";
+  const p10a: any = new Proxy(
+    {},
+    {
+      ownKeys() {
+        return [k10a, "a"];
+      },
+    }
+  );
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(p10a);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 11. A revoked Proxy throws a TypeError, trap or no trap. ---
+{
+  const { proxy, revoke } = (Proxy as any).revocable({}, {});
+  revoke();
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.ownKeys(proxy);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 12. Object.getOwnPropertySymbols on a no-trap Proxy over a target
+// with a real symbol-keyed own property - the OTHER new TypeProxy case
+// (objectGetOwnPropertySymbolsWithVM), distinct target from check 8's
+// per this session's "distinct target per assertion" convention. ---
+{
+  const sym12 = Symbol("s12");
+  const target12: any = {};
+  target12[sym12] = 1;
+  const p12: any = new Proxy(target12, {});
+  const syms = Object.getOwnPropertySymbols(p12);
+  checks.push(syms.length === 1 && syms[0] === sym12);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/in_symbol_boundfn_nativefn.ts
+++ b/tests/scripts/in_symbol_boundfn_nativefn.ts
@@ -66,20 +66,45 @@ checks.push("name" in bound && Reflect.has(bound, "name"));
 checks.push("name" in Arr && Reflect.has(Arr, "name"));
 checks.push("call" in nf && Reflect.has(nf, "call"));
 
-// --- Known, separately-tracked divergence risk: `in`'s new case here
-// walks vm.FunctionPrototype for an *inherited* symbol property (e.g.
-// Symbol.hasInstance), same as the pre-existing TypeFunction/TypeClosure
-// cases it mirrors - but Reflect.has (pkg/builtins/reflect_has.go)
-// unconditionally skips that walk for a symbol key on any callable. The
-// two agree today ONLY because the walk itself doesn't actually find
-// Function.prototype[Symbol.hasInstance] yet - a separate, pre-existing
-// bug (task_92b7c9d4, reproduces identically for a plain function, so
-// unrelated to this fix). Both sides are false today; this assertion
-// pins that agreement (NOT Node parity - Node has both true) so that
-// fixing the walk without also adding Reflect.has's matching
-// FunctionPrototype fallback flips this and fails loudly instead of
-// silently reintroducing the exact "in disagrees with Reflect.has" class
-// of bug this whole session has been fixing one kind at a time. ---
-checks.push((Symbol.hasInstance in bound) === Reflect.has(bound, Symbol.hasInstance));
+// --- `in`'s FunctionPrototype walk (used above by BoundFunction) also
+// correctly finds an *inherited* symbol property, e.g.
+// Function.prototype[Symbol.hasInstance], and Reflect.has agrees - both
+// now true, matching Node. (This assertion previously pinned a
+// false/false agreement caused by two compounding pre-existing bugs: the
+// walk itself couldn't find FunctionPrototype's own properties at all,
+// since vm.FunctionPrototype is a TypeNativeFunctionWithProps at runtime
+// rather than a bare PlainObject, and Reflect.has unconditionally skipped
+// the walk for any symbol key. Both are fixed now - see
+// hasFunctionPrototypeSymbolProperty's doc comment in pkg/vm/vm.go.) ---
+checks.push(Symbol.hasInstance in bound && Reflect.has(bound, Symbol.hasInstance));
+
+// --- Same inherited-symbol lookup for a plain function and a class,
+// verified to match Node (both true). ---
+function plainFn() {}
+checks.push(Symbol.hasInstance in plainFn && Reflect.has(plainFn, Symbol.hasInstance));
+
+class SomeClass {}
+checks.push(Symbol.hasInstance in SomeClass && Reflect.has(SomeClass, Symbol.hasInstance));
+
+// --- The walk doesn't stop at Function.prototype - it continues up to
+// Function.prototype's own [[Prototype]] (Object.prototype) too, for a
+// symbol property that lives there instead. Confirms the fix's shared
+// helper (hasFunctionPrototypeSymbolProperty) walks the full chain, not
+// just its first step. ---
+const inheritedFromObjectProto = Symbol("inheritedFromObjectProto");
+(Object.prototype as any)[inheritedFromObjectProto] = 1;
+checks.push(
+  inheritedFromObjectProto in plainFn && Reflect.has(plainFn, inheritedFromObjectProto)
+);
+
+// --- A class that overrides Symbol.hasInstance as its own static
+// property is still found via the own-table check, same as before -
+// unaffected by the FunctionPrototype walk fix. ---
+class OverridesHasInstance {
+  static [Symbol.hasInstance](_x: unknown) {
+    return true;
+  }
+}
+checks.push(Symbol.hasInstance in OverridesHasInstance && Reflect.has(OverridesHasInstance, Symbol.hasInstance));
 
 checks.every((c) => c === true);

--- a/tests/scripts/in_symbol_boundfn_nativefn.ts
+++ b/tests/scripts/in_symbol_boundfn_nativefn.ts
@@ -1,0 +1,85 @@
+// expect: true
+// OpIn's symbol-key switch (pkg/vm/vm.go, `if propVal.Type() == TypeSymbol`
+// then `switch objVal.Type()`) had cases for TypeObject, TypeDictObject,
+// TypeArray, TypeSet, TypeMap, TypeArguments, TypePromise, TypeRegExp,
+// TypeFunction, and TypeClosure - but nothing for TypeBoundFunction,
+// TypeNativeFunction, or TypeNativeFunctionWithProps, so a symbol-keyed `in`
+// check on any of those three fell through to `default: hasProperty =
+// false`, even for a real own symbol property that Reflect.has (and the
+// underlying Properties side table itself) already found correctly:
+//
+//   const bound = (function () {}).bind(null);
+//   bound[Symbol("k")] = 99;
+//   Reflect.has(bound, sym); // true (correct)
+//   sym in bound;            // false (WRONG) - Node: true
+//
+// Fixed by adding a case for all three, mirroring the existing
+// TypeFunction/TypeClosure cases: own Properties table first (via the
+// generic OwnPropertiesTable helper, since all three carry one - see
+// pkg/vm/properties_table.go's ownPropertiesSlot), then walk
+// vm.FunctionPrototype's chain for an inherited symbol property.
+
+const checks: boolean[] = [];
+
+// --- BoundFunction: an own symbol property set via bracket-notation
+// assignment must be found by both `in` and Reflect.has. ---
+function fn() {}
+const bound: any = fn.bind(null);
+const sym = Symbol("k");
+bound[sym] = 99;
+checks.push(sym in bound);
+checks.push(Reflect.has(bound, sym));
+
+// --- BoundFunction: a genuinely absent symbol key. ---
+checks.push(!(Symbol("absent") in bound));
+checks.push(!Reflect.has(bound, Symbol("absent")));
+
+// --- NativeFunctionWithProps (a native constructor, e.g. Array): an own
+// symbol property must be found by both. ---
+const sym2 = Symbol("k2");
+const Arr: any = Array;
+Arr[sym2] = 6;
+checks.push(sym2 in Arr);
+checks.push(Reflect.has(Arr, sym2));
+
+// --- NativeFunctionWithProps: a genuinely absent symbol key. ---
+checks.push(!(Symbol("absent2") in Arr));
+checks.push(!Reflect.has(Arr, Symbol("absent2")));
+
+// --- NativeFunction (a plain native method): its Properties table isn't
+// allocated until the first property is set on it - own symbol property
+// must still be found by both afterward. ---
+const sym3 = Symbol("k3");
+const nf: any = Array.prototype.push;
+nf[sym3] = 1;
+checks.push(sym3 in nf);
+checks.push(Reflect.has(nf, sym3));
+
+// --- NativeFunction: a genuinely absent symbol key on a function whose
+// Properties table has never been allocated at all. ---
+const nf2: any = Array.prototype.pop;
+checks.push(!(Symbol("absent3") in nf2));
+checks.push(!Reflect.has(nf2, Symbol("absent3")));
+
+// --- String keys on all three kinds are unaffected by this fix. ---
+checks.push("name" in bound && Reflect.has(bound, "name"));
+checks.push("name" in Arr && Reflect.has(Arr, "name"));
+checks.push("call" in nf && Reflect.has(nf, "call"));
+
+// --- Known, separately-tracked divergence risk: `in`'s new case here
+// walks vm.FunctionPrototype for an *inherited* symbol property (e.g.
+// Symbol.hasInstance), same as the pre-existing TypeFunction/TypeClosure
+// cases it mirrors - but Reflect.has (pkg/builtins/reflect_has.go)
+// unconditionally skips that walk for a symbol key on any callable. The
+// two agree today ONLY because the walk itself doesn't actually find
+// Function.prototype[Symbol.hasInstance] yet - a separate, pre-existing
+// bug (task_92b7c9d4, reproduces identically for a plain function, so
+// unrelated to this fix). Both sides are false today; this assertion
+// pins that agreement (NOT Node parity - Node has both true) so that
+// fixing the walk without also adding Reflect.has's matching
+// FunctionPrototype fallback flips this and fails loudly instead of
+// silently reintroducing the exact "in disagrees with Reflect.has" class
+// of bug this whole session has been fixing one kind at a time. ---
+checks.push((Symbol.hasInstance in bound) === Reflect.has(bound, Symbol.hasInstance));
+
+checks.every((c) => c === true);

--- a/tests/scripts/in_symbol_proxy.ts
+++ b/tests/scripts/in_symbol_proxy.ts
@@ -17,13 +17,11 @@
 // 10.5.7 step 11 invariant checks (non-configurable own property /
 // non-extensible target), and - when no trap is present - a fallback to
 // target.[[HasProperty]] via a new proxyHasSymbolPropertyFallback,
-// mirroring the existing string-key proxyHasPropertyFallback's exact
-// type coverage (TypeProxy/TypeObject/TypeDictObject/TypeArray/TypeRegExp/
-// TypeFunction/TypeClosure, default false) rather than OpIn's fuller
-// direct-target coverage (which also handles Map/Set/Promise/
-// BoundFunction/NativeFunction/NativeFunctionWithProps/Arguments) - see
-// check 11 below for the resulting, pre-existing, shared gap this
-// intentionally leaves in place for both key kinds.
+// which at the time only mirrored the existing string-key
+// proxyHasPropertyFallback's then-narrower type coverage (TypeObject/
+// TypeArray/TypeRegExp/TypeFunction/TypeClosure) rather than OpIn's fuller
+// direct-target coverage - see check 11 below, updated by a follow-up fix
+// (task_125640b9) once that gap was closed for both key paths together.
 //
 // While implementing the trap lookup, found and fixed two spec
 // conformance bugs in the process (not present in the task description,
@@ -37,14 +35,11 @@
 //     namespace or TS enum passed as the handler - not reachable through
 //     ordinary object-literal syntax, so not itself exercised here) would
 //     otherwise panic in Value.AsPlainObject().
-// Both of these bugs equally affect the pre-existing STRING-key TypeProxy
-// case just below the new one - deliberately left alone here (fixing it
-// changes established behavior on a path this task didn't ask about) and
-// flagged as a separate follow-up task alongside check 11's fallback-
-// coverage gap (one task, three bullets: the string-key case's own-only
-// trap lookup, its unguarded AsPlainObject panic on a TypeDictObject
-// handler, and the Map/Set/Promise/callable fallback coverage gap shared
-// by both key paths).
+// Both of these bugs equally affected the pre-existing STRING-key
+// TypeProxy case just below this one at the time - flagged as a follow-up
+// (task_125640b9) rather than fixed as a drive-by here, and since fixed
+// there (same trap-lookup helper, proxyGetTrap, now shared by both key
+// paths' TypeProxy cases) - see check 11 below.
 
 const checks: boolean[] = [];
 
@@ -156,29 +151,30 @@ const checks: boolean[] = [];
   checks.push(Reflect.has(p10, Symbol("inherited")) === true);
 }
 
-// --- 11. KNOWN, PRE-EXISTING, SHARED GAP (both key kinds) - pinned, not
-// fixed here: a Proxy with no trap wrapping a Map target disagrees with
-// Reflect.has, because proxyHasSymbolPropertyFallback (and its
-// pre-existing string-key sibling, proxyHasPropertyFallback) only covers
-// TypeObject/TypeArray/TypeRegExp/TypeFunction/TypeClosure as fallback
-// target kinds, not OpIn's fuller direct-target switch (which also
-// handles Map/Set/Promise/BoundFunction/NativeFunction/
-// NativeFunctionWithProps/Arguments). Verified here for Map specifically;
-// by inspection (not individually asserted) the same fallback gap applies
-// to the other six kinds too, for the identical reason. Node agrees `in`
-// and Reflect.has here; paserati does not yet. This assertion pins
-// TODAY's divergence explicitly (matching the established pattern for a
-// still-open gap - see the history of the now-fixed pinned assertion in
-// in_symbol_boundfn_nativefn.ts) so a future fix has to touch this file
-// instead of silently leaving stale documentation.
+// --- 11. FIXED (was a known, pinned divergence): a Proxy with no trap
+// wrapping a Map target now agrees with Reflect.has. proxyHasSymbolPropertyFallback
+// (and its string-key sibling, proxyHasPropertyFallback) originally only
+// covered TypeObject/TypeArray/TypeRegExp/TypeFunction/TypeClosure as
+// fallback target kinds, unlike OpIn's fuller direct-target switch (which
+// also handles Map/Set/Promise/BoundFunction/NativeFunction/
+// NativeFunctionWithProps/Arguments) - task_125640b9 extended both
+// fallback functions with all seven of those kinds, mirroring the
+// existing own-table-then-prototype-chain logic OpIn's direct-target
+// cases already had for each. This assertion originally pinned the
+// pre-fix divergence explicitly (`inCheck === false && reflectCheck ===
+// true`) and is flipped here to assert genuine agreement instead - same
+// history as in_symbol_boundfn_nativefn.ts's own pinned-then-flipped
+// assertion (PR #338). See proxy_has_string_key_fixes.ts for per-kind
+// coverage of the other six kinds this same fix closed, plus the two
+// spec-conformance bugs shared with the string-key TypeProxy case. ---
 {
   const m: any = new Map();
   const sym = Symbol("m");
   Object.defineProperty(m, sym, { value: 1, configurable: true });
   const p11: any = new Proxy(m, {});
-  const inCheck = sym in p11; // paserati: false (gap) - Node: true
-  const reflectCheck = Reflect.has(p11, sym); // true on both
-  checks.push(inCheck === false && reflectCheck === true);
+  const inCheck = sym in p11;
+  const reflectCheck = Reflect.has(p11, sym);
+  checks.push(inCheck === true && reflectCheck === true);
 }
 
 checks.every((c) => c === true);

--- a/tests/scripts/in_symbol_proxy.ts
+++ b/tests/scripts/in_symbol_proxy.ts
@@ -1,0 +1,184 @@
+// expect: true
+// OpIn's symbol-key switch (pkg/vm/vm.go) had no `case TypeProxy` at all -
+// any symbol-keyed `in` check on a Proxy fell to the default case and
+// answered false unconditionally, regardless of a `has` trap or what the
+// proxy's target actually has - even though the non-symbol switch's own
+// TypeProxy case (same function, just below) already handled this
+// correctly, and Reflect.has (proxyReflectHas, pkg/builtins/
+// reflect_has.go) already agreed with the target's real answer.
+//
+//   function fn() {}
+//   const p = new Proxy(fn, {});
+//   Symbol.hasInstance in p;            // paserati (before): false - Node: true
+//   Reflect.has(p, Symbol.hasInstance); // paserati (before): true (correct)
+//
+// Fixed by adding a symbol-key TypeProxy case mirroring the non-symbol one
+// exactly: revoked-proxy TypeError, `has` trap invocation with the
+// 10.5.7 step 11 invariant checks (non-configurable own property /
+// non-extensible target), and - when no trap is present - a fallback to
+// target.[[HasProperty]] via a new proxyHasSymbolPropertyFallback,
+// mirroring the existing string-key proxyHasPropertyFallback's exact
+// type coverage (TypeProxy/TypeObject/TypeDictObject/TypeArray/TypeRegExp/
+// TypeFunction/TypeClosure, default false) rather than OpIn's fuller
+// direct-target coverage (which also handles Map/Set/Promise/
+// BoundFunction/NativeFunction/NativeFunctionWithProps/Arguments) - see
+// check 11 below for the resulting, pre-existing, shared gap this
+// intentionally leaves in place for both key kinds.
+//
+// While implementing the trap lookup, found and fixed two spec
+// conformance bugs in the process (not present in the task description,
+// found by testing against Node rather than only against the sibling
+// string-key case being mirrored):
+//   - the trap lookup must accept an INHERITED "has" method (GetMethod
+//     semantics, ECMA-262 10.5.7 step 4), not just an own one - see check
+//     10.
+//   - the trap lookup must not assume the handler is specifically a
+//     TypeObject; a handler that happens to be a TypeDictObject (a module
+//     namespace or TS enum passed as the handler - not reachable through
+//     ordinary object-literal syntax, so not itself exercised here) would
+//     otherwise panic in Value.AsPlainObject().
+// Both of these bugs equally affect the pre-existing STRING-key TypeProxy
+// case just below the new one - deliberately left alone here (fixing it
+// changes established behavior on a path this task didn't ask about) and
+// flagged as a separate follow-up task alongside check 11's fallback-
+// coverage gap (one task, three bullets: the string-key case's own-only
+// trap lookup, its unguarded AsPlainObject panic on a TypeDictObject
+// handler, and the Map/Set/Promise/callable fallback coverage gap shared
+// by both key paths).
+
+const checks: boolean[] = [];
+
+// --- 1. No trap, target is a plain function: Symbol.hasInstance found via
+// the FunctionPrototype fallback walk (proxyHasSymbolPropertyFallback's
+// TypeFunction case, reusing hasFunctionPrototypeSymbolProperty). ---
+{
+  function fn() {}
+  const p: any = new Proxy(fn, {});
+  checks.push(Symbol.hasInstance in p);
+  checks.push(Reflect.has(p, Symbol.hasInstance));
+}
+
+// --- 2. A `has` trap that always returns true is actually invoked. ---
+{
+  const p2: any = new Proxy({}, { has(_target: any, _key: any) { return true; } });
+  checks.push(Symbol("x") in p2);
+}
+
+// --- 3. A `has` trap returning false, with the target genuinely lacking
+// the property, answers false without throwing (no invariant violated). ---
+{
+  const p3: any = new Proxy({}, { has() { return false; } });
+  checks.push(!(Symbol("y") in p3));
+}
+
+// --- 4. No trap: an own symbol property on the target is found directly
+// via the fallback's TypeObject case. ---
+{
+  const sym = Symbol("own");
+  const target: any = {};
+  Object.defineProperty(target, sym, { value: 1, configurable: true });
+  const p4: any = new Proxy(target, {});
+  checks.push(sym in p4);
+}
+
+// --- 5. A revoked proxy throws a TypeError for a symbol key, same as the
+// existing string-key case. ---
+{
+  const { proxy, revoke } = (Proxy as any).revocable({}, {});
+  revoke();
+  let threw = false;
+  try {
+    Symbol.iterator in proxy;
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+}
+
+// --- 6. A `has` trap returning falsy for a non-configurable own property
+// on the target throws (ECMA-262 10.5.7 step 11 invariant). ---
+{
+  const sym = Symbol("nc");
+  const target: any = {};
+  Object.defineProperty(target, sym, { value: 1, configurable: false });
+  const p6: any = new Proxy(target, { has() { return false; } });
+  let threw = false;
+  try {
+    sym in p6;
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+}
+
+// --- 7. A nested proxy (no trap at either level) still finds a symbol
+// property on the innermost real target - the fallback recurses through
+// TypeProxy targets, not just non-Proxy ones. ---
+{
+  const sym = Symbol("nested");
+  const inner: any = {};
+  Object.defineProperty(inner, sym, { value: 1, configurable: true });
+  const middle: any = new Proxy(inner, {});
+  const outer: any = new Proxy(middle, {});
+  checks.push(sym in outer);
+}
+
+// --- 8. Symbol.hasInstance on a class wrapped in a no-trap proxy: confirms
+// this fix composes correctly with the FunctionPrototype-symbol-walk fix
+// from an earlier PR in this stack. ---
+{
+  class C {}
+  const p8: any = new Proxy(C, {});
+  checks.push(Symbol.hasInstance in p8);
+}
+
+// --- 9. A TypeDictObject value (a TS enum, at runtime - pkg/vm/object.go's
+// NewDictObject) used as a Proxy handler must not panic. Before the
+// proxyGetHasTrap fix, `proxy.handler.AsPlainObject()` was called
+// unconditionally, and Value.AsPlainObject() panics for any non-TypeObject
+// value - confirmed via this exact reproducer, which crashed the whole
+// process (not a catchable JS exception) prior to this fix. The enum has
+// no "has" member, so the fallback correctly runs against the {} target
+// and finds nothing there either - result is `false`, not a crash. ---
+{
+  enum DictHandler { A, B }
+  const p9: any = new Proxy({}, DictHandler as any);
+  checks.push((Symbol("dict") in p9) === false);
+}
+
+// --- 10. The has trap is found via GetMethod semantics: an INHERITED trap
+// counts, not just an own one (ECMA-262 10.5.7 step 4) - matching
+// Reflect.has's existing, already-correct behavior here. ---
+{
+  const base = { has() { return true; } };
+  const p10: any = new Proxy({}, Object.create(base));
+  checks.push(Symbol("inherited") in p10);
+  checks.push(Reflect.has(p10, Symbol("inherited")) === true);
+}
+
+// --- 11. KNOWN, PRE-EXISTING, SHARED GAP (both key kinds) - pinned, not
+// fixed here: a Proxy with no trap wrapping a Map target disagrees with
+// Reflect.has, because proxyHasSymbolPropertyFallback (and its
+// pre-existing string-key sibling, proxyHasPropertyFallback) only covers
+// TypeObject/TypeArray/TypeRegExp/TypeFunction/TypeClosure as fallback
+// target kinds, not OpIn's fuller direct-target switch (which also
+// handles Map/Set/Promise/BoundFunction/NativeFunction/
+// NativeFunctionWithProps/Arguments). Verified here for Map specifically;
+// by inspection (not individually asserted) the same fallback gap applies
+// to the other six kinds too, for the identical reason. Node agrees `in`
+// and Reflect.has here; paserati does not yet. This assertion pins
+// TODAY's divergence explicitly (matching the established pattern for a
+// still-open gap - see the history of the now-fixed pinned assertion in
+// in_symbol_boundfn_nativefn.ts) so a future fix has to touch this file
+// instead of silently leaving stale documentation.
+{
+  const m: any = new Map();
+  const sym = Symbol("m");
+  Object.defineProperty(m, sym, { value: 1, configurable: true });
+  const p11: any = new Proxy(m, {});
+  const inCheck = sym in p11; // paserati: false (gap) - Node: true
+  const reflectCheck = Reflect.has(p11, sym); // true on both
+  checks.push(inCheck === false && reflectCheck === true);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/nativefunction_get_and_enumerate.ts
+++ b/tests/scripts/nativefunction_get_and_enumerate.ts
@@ -1,0 +1,199 @@
+// expect: true
+// Following the fix to Object.defineProperty (and OpIn/getOwnPropertyDescriptor)
+// for plain TypeNativeFunction values (defineproperty_native_function.ts),
+// several more places still didn't see a native function's custom own
+// properties. All three are fixed here:
+//
+//   1. opGetPropSymbol (pkg/vm/op_getprop.go) had no `case TypeNativeFunction`
+//      at all - reading any symbol-keyed own property via `nf[sym]` (or
+//      Reflect.get, though that has its own separate, much larger gap -
+//      see below) returned undefined even though
+//      Object.getOwnPropertyDescriptor already showed it existed.
+//
+//      Fixing this surfaced an asymmetry a first pass introduced: the
+//      sibling string-key fix below (opGetProp's TypeNativeFunction block)
+//      invokes an own accessor's getter, so this symbol-key case invokes
+//      it too - otherwise `nf.custom` would call the getter while `nf[sym]`
+//      would not, on the very same value. TypeFunction/TypeClosure/
+//      TypeBoundFunction/TypeNativeFunctionWithProps's symbol-key cases
+//      still do NOT invoke an own accessor's getter (none of the four
+//      ever have) - that remains a real, separate, still-open gap.
+//
+//   2. opGetProp's existing TypeNativeFunction block (string keys) only
+//      ever called Properties.GetOwn, which never detects or invokes an
+//      accessor's getter - PlainObject.DefineAccessorProperty appends a
+//      placeholder Undefined properties slot for an accessor field, so
+//      GetOwn(name) returns (Undefined, true) for one instead of
+//      (_, false). This silently made `nf.custom` read as undefined
+//      instead of calling the getter, even though the very same
+//      accessor's *setter* already ran correctly via `nf.custom = v`.
+//
+//   3. Object.keys, Object.getOwnPropertyDescriptors, and OpGetOwnKeys
+//      (for-in, pkg/vm/vm.go) all skipped a native function's own
+//      enumerable custom properties entirely - their switches never had a
+//      TypeNativeFunction case. TypeNativeFunctionWithProps (e.g. `Boolean`,
+//      `Number`) had the identical gap in the same switches, found and
+//      fixed alongside it since the case bodies already used the generic
+//      OwnPropertiesTable/`nfp.Properties` machinery and needed no new code,
+//      only the additional case label.
+//
+// Each assertion below uses its own Array.prototype method (or, for the
+// NativeFunctionWithProps checks, a distinct global constructor) - these
+// are real shared intrinsics with no reset between assertions in the same
+// test file, so reusing one across assertions would let one mutation leak
+// into another's expectations. The three NativeFunctionWithProps checks
+// (6, 8, 13) deliberately use three different constructors (Boolean,
+// Number, String) for the same reason - consolidating them onto one
+// constructor would silently couple those three checks together.
+//
+// While fixing (3), found the TypeNativeFunctionWithProps branch of
+// Object.getOwnPropertyDescriptors also dropped symbol keys entirely
+// (only the new TypeNativeFunction branch collected them) - fixed
+// alongside it, same one-line fix on the identical *PlainObject side
+// table (check 13 below).
+//
+// Found but NOT fixed here (flagged as separate follow-ups):
+//   - Reflect.get is almost entirely non-functional beyond TypeObject/
+//     TypeDictObject/TypeArray, and unconditionally stringifies its key
+//     even for a Symbol - a large, pre-existing, unrelated gap.
+//   - Object.getOwnPropertyDescriptors has no TypeBoundFunction case at
+//     all (returns {} - missing even name/length).
+//   - Object.getOwnPropertySymbols has no TypeNativeFunction case (misses
+//     a symbol property that getOwnPropertyDescriptor already reports).
+
+const checks: boolean[] = [];
+
+// --- 1. Symbol-keyed data property read back via bracket notation ---
+{
+  const nf: any = Array.prototype.shift;
+  const sym = Symbol("k1");
+  Object.defineProperty(nf, sym, { value: 2, enumerable: true, configurable: true });
+  checks.push(nf[sym] === 2);
+}
+
+// --- 2. Symbol-keyed data property set via bracket notation, read back ---
+{
+  const nf: any = Array.prototype.pop;
+  const sym = Symbol("k2");
+  nf[sym] = 5;
+  checks.push(nf[sym] === 5);
+}
+
+// --- 3. String-keyed accessor: getter invoked via direct property access ---
+{
+  const nf: any = Array.prototype.unshift;
+  let backing = 0;
+  Object.defineProperty(nf, "custom", {
+    get() { return backing; },
+    set(v: number) { backing = v; },
+    configurable: true,
+  });
+  nf.custom = 100;
+  checks.push(backing === 100);
+  checks.push(nf.custom === 100);
+}
+
+// --- 4. Symbol-keyed accessor: getter invoked via bracket access. This is
+// the case that would have been silently inconsistent with #3 above (same
+// kind, same commit) had the accessor check been added only on the
+// string-key path. ---
+{
+  const nf: any = Array.prototype.slice;
+  let backing = 0;
+  const sym = Symbol("k4");
+  Object.defineProperty(nf, sym, {
+    get() { return backing; },
+    set(v: number) { backing = v; },
+    configurable: true,
+  });
+  nf[sym] = 200;
+  checks.push(backing === 200);
+  checks.push(nf[sym] === 200);
+}
+
+// --- 5. Object.keys sees an enumerable custom property (string key) ---
+{
+  const nf: any = Array.prototype.concat;
+  Object.defineProperty(nf, "vis", { value: 1, enumerable: true, configurable: true });
+  checks.push(JSON.stringify(Object.keys(nf)) === JSON.stringify(["vis"]));
+}
+
+// --- 6. Object.keys on TypeNativeFunctionWithProps (a native constructor) ---
+{
+  Object.defineProperty(Boolean, "visCtor", { value: 1, enumerable: true, configurable: true });
+  checks.push(Object.keys(Boolean).includes("visCtor"));
+}
+
+// --- 7. for-in enumerates the same enumerable custom property ---
+{
+  const nf: any = Array.prototype.indexOf;
+  Object.defineProperty(nf, "vis2", { value: 1, enumerable: true, configurable: true });
+  const seen: string[] = [];
+  for (const k in nf) seen.push(k);
+  checks.push(JSON.stringify(seen) === JSON.stringify(["vis2"]));
+}
+
+// --- 8. for-in on TypeNativeFunctionWithProps ---
+{
+  Object.defineProperty(Number, "visCtor2", { value: 1, enumerable: true, configurable: true });
+  const seen: string[] = [];
+  for (const k in Number) seen.push(k);
+  checks.push(seen.includes("visCtor2"));
+}
+
+// --- 9. Object.getOwnPropertyDescriptors reports the same custom property ---
+{
+  const nf: any = Array.prototype.lastIndexOf;
+  Object.defineProperty(nf, "vis3", { value: 1, enumerable: true, configurable: true });
+  const descs: any = Object.getOwnPropertyDescriptors(nf);
+  checks.push(!!descs.vis3 && descs.vis3.value === 1);
+}
+
+// --- 10. A non-enumerable custom property is correctly excluded from
+// Object.keys/for-in but still present in getOwnPropertyDescriptors ---
+{
+  const nf: any = Array.prototype.includes;
+  Object.defineProperty(nf, "hidden", { value: 1, enumerable: false, configurable: true });
+  checks.push(!Object.keys(nf).includes("hidden"));
+  let seenHidden = false;
+  for (const k in nf) if (k === "hidden") seenHidden = true;
+  checks.push(!seenHidden);
+  checks.push((Object.getOwnPropertyDescriptors(nf) as any).hidden !== undefined);
+}
+
+// --- 11. name/length are still correctly excluded from Object.keys/for-in
+// (non-enumerable synthesized intrinsics, not side-table entries) ---
+{
+  const nf: any = Array.prototype.join;
+  checks.push(!Object.keys(nf).includes("name"));
+  checks.push(!Object.keys(nf).includes("length"));
+}
+
+// --- 12. Repeated string-key accessor read at the same call site: opGetProp's
+// TypeNativeFunction accessor check runs before the normal inline-cache path
+// used for plain objects, so a monomorphic repeated read must still call the
+// getter every time, not just once. ---
+{
+  const nf: any = Array.prototype.reverse;
+  let n = 0;
+  Object.defineProperty(nf, "counter", {
+    get() { return ++n; },
+    configurable: true,
+  });
+  const seenVals: number[] = [];
+  for (let i = 0; i < 3; i++) seenVals.push(nf.counter);
+  checks.push(JSON.stringify(seenVals) === JSON.stringify([1, 2, 3]));
+}
+
+// --- 13. Object.getOwnPropertyDescriptors reports a symbol-keyed property
+// on TypeNativeFunctionWithProps too (found while fixing (3)'s
+// TypeNativeFunction sibling - the WithProps branch collected string keys
+// but never symbol keys, from the same *PlainObject side table). ---
+{
+  const sym = Symbol("k13");
+  Object.defineProperty(String, sym, { value: 9, enumerable: true, configurable: true });
+  const descs: any = Object.getOwnPropertyDescriptors(String);
+  checks.push(!!descs[sym] && descs[sym].value === 9);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/object_spread_proxy_no_ownkeys_trap.ts
+++ b/tests/scripts/object_spread_proxy_no_ownkeys_trap.ts
@@ -1,0 +1,131 @@
+// expect: true
+// OpObjectSpread's Proxy handling (pkg/vm/vm.go, `case OpObjectSpread:`,
+// backing `{...proxy}`) checks for an `ownKeys` trap via proxyGetTrap and,
+// if found and callable, spreads using it - but when the handler has NO
+// `ownKeys` trap at all (a plain `{}` handler, or a TypeDictObject handler
+// like a TS enum with no `ownKeys` member), the whole Proxy-handling block
+// used to just `continue` past the spread entirely instead of falling back
+// to the target's own [[OwnPropertyKeys]] (per ECMA-262 10.5.11 step 5):
+//
+//   const target = { a: 1, b: 2 };
+//   const p = new Proxy(target, {}); // no ownKeys trap
+//   const spread = { ...p };
+//   spread; // was {} - now correctly { a: 1, b: 2 }, matching Node
+//
+// Fixed by proxyOwnKeysFallback (pkg/vm/vm.go): when the top-level
+// handler has no ownKeys trap, recurse into proxy.Target()'s own keys -
+// checking a further-nested Proxy target's OWN ownKeys trap first, not
+// just falling through further - the same recursion
+// pkg/builtins/json_init.go's getProxyOwnKeys and object_init.go's
+// proxyOwnPropertyKeys already do for their own no-ownKeys-trap case
+// (pkg/vm can't import pkg/builtins to reuse either directly, so this is
+// their pkg/vm-local twin). The resulting key list still goes through the
+// EXISTING per-key getOwnPropertyDescriptor/get trap consultation against
+// the ORIGINAL top-level proxy's handler - confirmed against Node that
+// GetMethod([[OwnPropertyKeys]]) and GetMethod([[Get]]) are independent:
+// a Proxy with a `get` trap but no `ownKeys` trap still has that `get`
+// trap called during a spread (check 3), same for
+// `getOwnPropertyDescriptor` (check 4).
+//
+// Not fixed here (two separate, pre-existing bugs found while writing
+// these checks, confirmed independent - both reproduce with an explicit
+// ownKeys trap too, bypassing this fix entirely - and filed as
+// follow-ups):
+//   - The per-key loop's OWN "no get trap, fall back to target" branch
+//     only handles a TypeObject/TypeDictObject target directly, not a
+//     further-nested Proxy target - `new Proxy(new Proxy(x, {}), {
+//     ownKeys(){...} })` silently reads `undefined` for every key. Check
+//     1 below sidesteps this by giving the OUTER proxy an explicit `get`
+//     trap (which forwards via Reflect.get, itself already
+//     nested-Proxy-aware per PR #341), so the value fetch never falls
+//     into that fallback branch - isolating the ownKeys recursion fix
+//     this file is actually testing.
+//   - proxyOwnKeysFallback's real-object case uses PlainObject.OwnKeys()
+//     (enumerable keys only, matching its two pkg/builtins siblings'
+//     identical choice), not a "get every own key, filter by
+//     descriptor.enumerable afterward" pass - so a non-enumerable own
+//     property on a real target is excluded before the
+//     getOwnPropertyDescriptor trap even sees it, rather than being
+//     excluded BY that trap's answer. Same end result as Node for a real
+//     object target (check 4's "hidden" key), reached via a different
+//     mechanism - not asserting the trap is asked about "hidden", only
+//     that the answer excludes it.
+
+const checks: boolean[] = [];
+
+// --- 1. Basic repro: a plain, trap-less handler must spread the
+// target's own enumerable properties instead of {}. ---
+{
+  const target: any = { a: 1, b: 2 };
+  const p: any = new Proxy(target, {});
+  const spread: any = { ...p };
+  checks.push(spread.a === 1 && spread.b === 2);
+}
+
+// --- 2. Nested Proxy target, no ownKeys trap anywhere: key-list
+// resolution recurses through the inner Proxy correctly (see header for
+// why the outer proxy needs its own `get` trap here). ---
+{
+  const inner: any = { c: 3 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {
+    get(t: any, k: any, r: any) {
+      return Reflect.get(t, k, r);
+    },
+  });
+  const spread: any = { ...p2 };
+  checks.push(spread.c === 3);
+}
+
+// --- 3. get trap still fires per key even though there's no ownKeys
+// trap - independent traps per spec. ---
+{
+  const log: string[] = [];
+  const target: any = { a: 1, b: 2 };
+  const p: any = new Proxy(target, {
+    get(t: any, k: any) {
+      log.push(String(k));
+      return Reflect.get(t, k);
+    },
+  });
+  const spread: any = { ...p };
+  checks.push(spread.a === 1 && spread.b === 2);
+  checks.push(log.indexOf("a") !== -1 && log.indexOf("b") !== -1);
+}
+
+// --- 4. getOwnPropertyDescriptor trap still fires per (enumerable) key
+// even with no ownKeys trap; a non-enumerable own property on the real
+// target is excluded either way (see header for the "how"). ---
+{
+  const log: string[] = [];
+  const target: any = { a: 1 };
+  Object.defineProperty(target, "hidden", {
+    value: 9,
+    enumerable: false,
+    configurable: true,
+  });
+  const p: any = new Proxy(target, {
+    getOwnPropertyDescriptor(t: any, k: any) {
+      log.push(String(k));
+      return Reflect.getOwnPropertyDescriptor(t, k);
+    },
+  });
+  const spread: any = { ...p };
+  checks.push(spread.a === 1 && spread.hidden === undefined);
+  checks.push(log.indexOf("a") !== -1);
+}
+
+// --- 5. A TypeDictObject handler (a TS enum at runtime) with no
+// ownKeys trap must not panic and must still spread the target. ---
+{
+  enum DictHandler5 {
+    A,
+    B,
+  }
+  const target: any = { x: 5, y: 6 };
+  const p: any = new Proxy(target, DictHandler5 as any);
+  const spread: any = { ...p };
+  checks.push(spread.x === 5 && spread.y === 6);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_builtins_trap_lookup_fixes.ts
+++ b/tests/scripts/proxy_builtins_trap_lookup_fixes.ts
@@ -1,0 +1,320 @@
+// expect: true
+// Following the pkg/vm sweep in tests/scripts/proxy_trap_lookup_fixes.ts
+// and tests/scripts/proxy_with_trap_lookup_fixes.ts, the same two bugs
+// (own-only trap lookup instead of GetMethod-inherited, and an unguarded
+// AsPlainObject() panic on a TypeDictObject handler) turned up in
+// pkg/builtins too - both as the literal `handler.AsPlainObject()` grep
+// pattern and, less literally, as `proxy.Handler().AsPlainObject()`
+// (`.Handler()` called inline rather than through a `handler` local),
+// which the original grep for the exact substring missed:
+//
+//   - object_init.go: getPrototypeOf, setPrototypeOf (two separate sites -
+//     Object.setPrototypeOf and the `__proto__` setter each have their
+//     own), defineProperty, getOwnPropertyDescriptor, isExtensible,
+//     preventExtensions, and the `get` trap in lookupSymbolProp (backing
+//     Symbol.toStringTag lookup, e.g. for Object.prototype.toString).
+//   - function_init.go: getPrototypeOf (a second, different site -
+//     getPrototypeOfValue, used internally rather than by
+//     Object.getPrototypeOf directly).
+//   - array_generic.go: has (arrayLikeGetProxy, backing e.g.
+//     Array.prototype.includes/indexOf on a Proxy) and deleteProperty
+//     (arrayLikeDelete's Proxy case, backing pop/shift/splice/
+//     copyWithin-style methods - NOT the bare `delete` operator, which
+//     goes through the separate, already-covered OpDeleteProp site).
+//   - vm.go's OpObjectSpread Proxy handling (pkg/vm, not pkg/builtins -
+//     included here since it was found by the same broader
+//     `proxy.Handler().AsPlainObject()` search and backs `{...proxy}`):
+//     ownKeys, getOwnPropertyDescriptor, and get.
+//   - vm.go's construct trap (OpNew's Proxy case) - already guarded
+//     against the panic (an inline TypeObject/TypeDictObject switch), so
+//     only had the own-only bug.
+//
+// Also fixed, a real (not just theoretical) TypeObject-only guard rather
+// than an unguarded panic - a handler that IS a TypeDictObject was
+// silently treated as trap-less instead of being consulted at all:
+// object_init.go's setPrototypeOf (the `__proto__` setter path) and
+// json_init.go's getProxyOwnKeys (JSON.stringify's ownKeys trap, covered
+// separately by check 11's TypeDictObject-with-an-ownKeys-trap case,
+// since a TS enum's own no-ownKeys-trap case would hit a different,
+// pre-existing, out-of-scope gap - see the follow-up filed for it: a
+// no-ownKeys-trap Proxy of any kind currently spreads to {} via
+// OpObjectSpread instead of falling back to the target's own keys).
+//
+// Fixed every site via vmInstance.ProxyGetTrap (the exported wrapper
+// pkg/vm's proxyGetTrap gained in the PR immediately before this one, for
+// pkg/builtins - which imports pkg/vm but not vice versa - to reuse) or,
+// for the two pkg/vm sites, proxyGetTrap directly.
+//
+// checks 1-9, 12: an inherited trap (defined on the handler's prototype
+// via Object.create) is found for each site.
+// check 10: TypeDictObject handler safety for every site at once (no
+// panic; each falls through to "no trap" -> delegate to target, except
+// where noted).
+// check 11: a TypeDictObject handler WITH an ownKeys trap explicitly
+// defined on it, for OpObjectSpread - isolates the trap-lookup fix from
+// the separate no-trap-fallback gap noted above.
+
+const checks: boolean[] = [];
+
+// --- 1. getPrototypeOf (object_init.go, Object.getPrototypeOf path):
+// inherited trap. ---
+{
+  const proto = { marker: 1 };
+  const base = {
+    getPrototypeOf(_t: any) {
+      return proto;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  checks.push(Object.getPrototypeOf(p) === proto);
+}
+
+// --- 2. getPrototypeOf (function_init.go's getPrototypeOfValue, a
+// second, internal-use site): inherited trap, exercised via
+// Object.prototype.toString's own [[GetPrototypeOf]] consultation. ---
+{
+  const proto2 = { marker: 2 };
+  const base = {
+    getPrototypeOf(_t: any) {
+      return proto2;
+    },
+  };
+  function orig() {}
+  const p: any = new Proxy(orig, Object.create(base));
+  checks.push(Object.getPrototypeOf(p) === proto2);
+}
+
+// --- 3. setPrototypeOf via Object.setPrototypeOf: inherited trap. ---
+{
+  const log: string[] = [];
+  const base = {
+    setPrototypeOf(_t: any, _proto: any) {
+      log.push("called");
+      return true;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  Object.setPrototypeOf(p, { x: 1 });
+  checks.push(log.indexOf("called") !== -1);
+}
+
+// --- 4. setPrototypeOf via the `__proto__` setter - a separate site
+// from check 3: inherited trap. ---
+{
+  const log: string[] = [];
+  const base = {
+    setPrototypeOf(_t: any, _proto: any) {
+      log.push("called");
+      return true;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  (p as any).__proto__ = { x: 1 };
+  checks.push(log.indexOf("called") !== -1);
+}
+
+// --- 5. defineProperty: inherited trap. ---
+{
+  const log: string[] = [];
+  const base = {
+    defineProperty(_t: any, k: string, _d: any) {
+      log.push("define:" + k);
+      return true;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  Object.defineProperty(p, "z", { value: 1, configurable: true });
+  checks.push(log.indexOf("define:z") !== -1);
+}
+
+// --- 6. getOwnPropertyDescriptor: inherited trap. ---
+{
+  const base = {
+    getOwnPropertyDescriptor(_t: any, k: string) {
+      return k === "y"
+        ? { value: 7, configurable: true, enumerable: true, writable: true }
+        : undefined;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  const desc = Object.getOwnPropertyDescriptor(p, "y");
+  checks.push(desc !== undefined && desc.value === 7);
+}
+
+// --- 7. isExtensible: inherited trap (must agree with the target's
+// real extensibility per the trap-result invariant). ---
+{
+  const log: string[] = [];
+  const target = Object.preventExtensions({});
+  const base = {
+    isExtensible(_t: any) {
+      log.push("called");
+      return false;
+    },
+  };
+  const p: any = new Proxy(target, Object.create(base));
+  checks.push(Object.isExtensible(p) === false && log.indexOf("called") !== -1);
+}
+
+// --- 8. preventExtensions: inherited trap (must actually make the
+// target non-extensible, per the trap-result invariant). ---
+{
+  const log: string[] = [];
+  const target = {};
+  const base = {
+    preventExtensions(t: any) {
+      log.push("called");
+      Object.preventExtensions(t);
+      return true;
+    },
+  };
+  const p: any = new Proxy(target, Object.create(base));
+  Object.preventExtensions(p);
+  checks.push(log.indexOf("called") !== -1);
+}
+
+// --- 9. array-generic `has` (arrayLikeGetProxy, via
+// Array.prototype.includes on a Proxy): inherited trap. ---
+{
+  const base = {
+    has(_t: any, k: string) {
+      return k === "1";
+    },
+  };
+  const p: any = new Proxy([9, 9, 9], Object.create(base));
+  checks.push(Array.prototype.includes.call(p, 9) === true);
+}
+
+// --- Also 9b (same numbered concern): the `get` trap in lookupSymbolProp
+// (object_init.go), backing Symbol.toStringTag - inherited trap. ---
+{
+  const base = {
+    get(_t: any, k: any) {
+      return k === Symbol.toStringTag ? "Widget" : undefined;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  checks.push(Object.prototype.toString.call(p) === "[object Widget]");
+}
+
+// --- array-generic `deleteProperty` (arrayLikeDelete's Proxy case, used
+// by pop/shift/splice/copyWithin-style methods - not the bare `delete`
+// operator, which goes through the separate OpDeleteProp site already
+// covered by tests/scripts/proxy_trap_lookup_fixes.ts): inherited trap. ---
+{
+  const log: string[] = [];
+  const base = {
+    deleteProperty(_t: any, k: string) {
+      log.push("delete:" + k);
+      return true;
+    },
+  };
+  const p: any = new Proxy([1, 2, 3], Object.create(base));
+  Array.prototype.pop.call(p);
+  checks.push(log.indexOf("delete:2") !== -1);
+}
+
+// --- OpObjectSpread's ownKeys/getOwnPropertyDescriptor/get (pkg/vm,
+// included here - see header): inherited traps. ---
+{
+  const base = {
+    ownKeys(_t: any) {
+      return ["m", "n"];
+    },
+    get(_t: any, k: string) {
+      return k === "m" ? 1 : 2;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  const spread: any = { ...p };
+  checks.push(spread.m === 1 && spread.n === 2);
+}
+
+// --- construct trap (pkg/vm's OpNew Proxy case): inherited trap. ---
+{
+  const base = {
+    construct(_t: any, args: any[]) {
+      return { a: args[0] * 100 };
+    },
+  };
+  function Orig(this: any, a: number) {
+    this.a = a;
+  }
+  const p: any = new Proxy(Orig, Object.create(base));
+  const inst = new (p as any)(3);
+  checks.push(inst.a === 300);
+}
+
+// --- 10. A TypeDictObject handler (a TS enum at runtime) must not panic
+// for any of getPrototypeOf/setPrototypeOf/isExtensible/
+// preventExtensions/defineProperty/getOwnPropertyDescriptor (all no
+// trap -> delegate to target), nor for array-generic has/deleteProperty,
+// nor for the construct trap. ---
+{
+  const results: boolean[] = [];
+  enum DictHandler10 {
+    A,
+    B,
+  }
+  const p: any = new Proxy({ v: 1 }, DictHandler10 as any);
+  results.push(Object.getPrototypeOf(p) === Object.getPrototypeOf({}));
+  Object.setPrototypeOf(p, { x: 1 });
+  results.push(Object.getPrototypeOf(p).x === 1);
+  results.push(Object.isExtensible(p) === true);
+  Object.defineProperty(p, "w", {
+    value: 2,
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  });
+  results.push((p as any).w === 2);
+  const desc = Object.getOwnPropertyDescriptor(p, "v");
+  results.push(desc !== undefined && desc.value === 1);
+  Object.preventExtensions(p);
+  results.push(Object.isExtensible(p) === false);
+
+  const arr: any = [1, 2, 3];
+  const p2: any = new Proxy(arr, DictHandler10 as any);
+  results.push(Array.prototype.includes.call(p2, 2) === true);
+  // Only asserting the deleted element is gone, not that arr.length
+  // shrinks afterward - that part is a separate, pre-existing,
+  // unrelated-to-Proxy-traps bug (arrayLikeSetLength's length write for
+  // a Proxy `this` doesn't reach the target - reproduces with a plain
+  // no-trap Proxy over an array too - filed as a follow-up).
+  results.push(Array.prototype.pop.call(p2) === 3);
+
+  function Orig10(this: any, a: number) {
+    this.a = a;
+  }
+  const p4: any = new Proxy(Orig10, DictHandler10 as any);
+  const inst = new (p4 as any)(9);
+  results.push(inst.a === 9);
+
+  checks.push(results.every((c) => c === true));
+}
+
+// --- 11. A TypeDictObject handler WITH an ownKeys trap explicitly
+// defined on it - isolates OpObjectSpread's trap-lookup fix from the
+// separate, out-of-scope, no-ownKeys-trap-at-all fallback gap (a Proxy
+// with literally no ownKeys trap currently spreads to {} regardless of
+// handler kind - filed as a follow-up, not fixed here). ---
+{
+  const dictHandler: any = (() => {
+    enum DictHandler11 {
+      A,
+      B,
+    }
+    return DictHandler11 as any;
+  })();
+  dictHandler.ownKeys = function (_t: any) {
+    return ["q"];
+  };
+  dictHandler.get = function (_t: any, k: string) {
+    return k === "q" ? 5 : undefined;
+  };
+  const p3: any = new Proxy({ q: 5 }, dictHandler);
+  const spread: any = { ...p3 };
+  checks.push(spread.q === 5);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_has_property_fallback_function_prototype.ts
+++ b/tests/scripts/proxy_has_property_fallback_function_prototype.ts
@@ -1,0 +1,52 @@
+// expect: true
+// vm.proxyHasPropertyFallback's TypeFunction/TypeClosure cases (pkg/vm/vm.go)
+// used to guard the FunctionPrototype lookup with
+// `if vm.FunctionPrototype.Type() == TypeObject { ... }; return false` -
+// silently false whenever FunctionPrototype is (as it always is at
+// runtime, per pkg/builtins/function_init.go) a TypeNativeFunctionWithProps
+// rather than a TypeObject. This fallback is what `in`/Reflect.has use for
+// a Proxy wrapping a Function/Closure with no `has` trap, so a
+// STRING-keyed property that only exists on Function.prototype (e.g.
+// "call") was invisible through such a proxy even though it's found
+// correctly on the unwrapped function itself.
+//
+// Fixed by reusing hasFunctionPrototypeProperty here too, instead of a
+// duplicated, incomplete inline check.
+//
+// This covers string keys only: OpIn's SYMBOL-key switch has no
+// `case TypeProxy` at all (a separate, much larger pre-existing gap -
+// `anySymbol in proxyObject` is unconditionally false regardless of a
+// `has` trap or the target's own properties - flagged independently, not
+// fixed here, tracked as task_42fe36b9).
+
+const checks: boolean[] = [];
+
+function fn() {}
+const proxiedFn: any = new Proxy(fn, {});
+
+// --- A string-keyed FunctionPrototype method, through the fallback
+// (no `has` trap on this proxy). `in` was the broken half before this fix
+// (unconditionally false here); Reflect.has(proxiedFn, "call") went
+// through the separate proxyReflectHas path and was already correct, so
+// it doesn't by itself exercise this fix - the first assertion below
+// does. ---
+checks.push("call" in proxiedFn);
+checks.push(Reflect.has(proxiedFn, "call"));
+checks.push("apply" in proxiedFn);
+
+// --- A genuinely absent property is still false through the fallback. ---
+checks.push(!("nonexistentMethod" in proxiedFn));
+
+// --- The same, wrapping a Closure (a function with an upvalue) instead of
+// a plain Function. ---
+function makeClosure() {
+  let captured = 1;
+  return function closureFn() {
+    return captured;
+  };
+}
+const proxiedClosure: any = new Proxy(makeClosure(), {});
+checks.push("call" in proxiedClosure);
+checks.push(!("nonexistentMethod2" in proxiedClosure));
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_has_string_key_fixes.ts
+++ b/tests/scripts/proxy_has_string_key_fixes.ts
@@ -1,0 +1,192 @@
+// expect: true
+// Three related, pre-existing bugs in OpIn's STRING-key TypeProxy case
+// (pkg/vm/vm.go, under `propKey := propVal.ToString()`) and its
+// supporting proxyHasPropertyFallback, found while adding the symbol-key
+// sibling of this exact case in an earlier PR in this stack (#340) and
+// deliberately left unfixed there since fixing them changes established
+// `in`/Reflect.has behavior on a path that PR wasn't scoped to touch.
+//
+//   1. Own-only trap lookup, not GetMethod-inherited. The case did
+//      `proxy.handler.AsPlainObject().GetOwn("has")` - own-only, but per
+//      ECMA-262 10.5.7 step 4 the trap comes from GetMethod(handler,
+//      "has"), which walks the handler's prototype chain. An inherited
+//      `has` trap was invisible to `in` even though Reflect.has
+//      (proxyReflectHas, pkg/builtins/reflect_has.go) already used
+//      .Get, not .GetOwn, and so already found it - see checks 1-2.
+//
+//   2. Unguarded AsPlainObject() panics on a TypeDictObject handler. The
+//      same line assumed the handler is specifically a TypeObject. A
+//      handler that happens to be a TypeDictObject (a TS enum or module
+//      namespace value at runtime - pkg/vm/object.go's NewDictObject)
+//      made Value.AsPlainObject() panic the entire process - not a
+//      catchable JS exception - instead of just answering false (an
+//      enum has no "has" member) or falling through to the trap-lookup
+//      logic correctly. See check 3.
+//
+//   3. Fallback coverage gap shared by both key paths.
+//      proxyHasPropertyFallback (string keys) and its symbol-key sibling
+//      proxyHasSymbolPropertyFallback (added in #340) both only covered
+//      TypeProxy/TypeObject/TypeDictObject/TypeArray/TypeRegExp/
+//      TypeFunction/TypeClosure as fallback target kinds when a Proxy has
+//      no `has` trap - unlike OpIn's own fuller direct-target switch,
+//      which also handles Map/Set/Promise/BoundFunction/NativeFunction/
+//      NativeFunctionWithProps/Arguments. A no-trap Proxy wrapping one of
+//      those seven kinds disagreed with Reflect.has (whose
+//      proxyReflectHas correctly recurses into the fully general
+//      reflectHas for a no-trap fallback, pkg/builtins/reflect_has.go).
+//      See checks 4-10, one per kind, both key kinds where relevant.
+//
+// Fixed via:
+//   - proxy.handler.AsPlainObject().GetOwn("has") replaced with
+//     proxyGetTrap(proxy.handler, "has") in OpIn's string-key TypeProxy
+//     case (and in proxyHasPropertyFallback's own nested TypeProxy case,
+//     for a chain of proxies with no trap anywhere) - the same helper
+//     #340 already introduced for the symbol-key path, so both key kinds
+//     now share one spec-correct trap-lookup implementation instead of
+//     two independently-bugged ones.
+//   - proxyHasPropertyFallback and proxyHasSymbolPropertyFallback both
+//     extended with TypeMap/TypeSet/TypePromise/TypeBoundFunction/
+//     TypeNativeFunction/TypeNativeFunctionWithProps/TypeArguments cases,
+//     copying the existing own-table-then-prototype-chain logic from
+//     OpIn's own direct-target switches (both key kinds, same function)
+//     for each of those kinds - not new logic, the same logic already
+//     proven correct for a non-Proxy target of each kind.
+//
+// tests/scripts/in_symbol_proxy.ts's check 11 (from #340) originally
+// pinned the Map-target divergence for a SYMBOL key explicitly; it is
+// updated in this same commit to assert the fixed (agreeing) behavior,
+// same history as in_symbol_boundfn_nativefn.ts's own pinned-then-flipped
+// assertion (PR #338).
+
+const checks: boolean[] = [];
+
+// --- 1. Inherited `has` trap (GetMethod semantics) is found for a
+// string key - matches Reflect.has, which already worked here. ---
+{
+  const base1 = { has() { return true; } };
+  const p1: any = new Proxy({}, Object.create(base1));
+  checks.push("x" in p1);
+  checks.push(Reflect.has(p1, "x") === true);
+}
+
+// --- 2. An own (non-inherited) trap still works after the fix - the
+// common case must not regress while fixing the inherited one. ---
+{
+  const p2: any = new Proxy({}, { has() { return true; } });
+  checks.push("y" in p2);
+}
+
+// --- 3. A TypeDictObject handler (a TS enum at runtime) must not panic
+// for a string key, same as the symbol-key case already fixed in #340
+// (tests/scripts/in_symbol_proxy.ts, check 9). The enum has no "has"
+// member, so this exercises the trap-lookup's TypeDictObject branch and
+// falls through to the no-trap fallback against the {} target. ---
+{
+  enum DictHandler3 { A, B }
+  const p3: any = new Proxy({}, DictHandler3 as any);
+  checks.push(("x" in p3) === false);
+}
+
+// --- 4. Map: own custom property (string key) and "size" itself, both
+// via the no-trap fallback. ---
+{
+  const m4: any = new Map();
+  Object.defineProperty(m4, "vis", { value: 1, configurable: true });
+  const p4: any = new Proxy(m4, {});
+  checks.push("vis" in p4);
+  checks.push(Reflect.has(p4, "vis") === true);
+  checks.push("size" in new Proxy(new Map([[1, 2]]), {}));
+}
+
+// --- 4b. Map: the identical own-custom-property check for a Symbol key -
+// this is the exact scenario in_symbol_proxy.ts's check 11 was pinned
+// against before this fix. ---
+{
+  const m4b: any = new Map();
+  const sym4b = Symbol("m4b");
+  Object.defineProperty(m4b, sym4b, { value: 1, configurable: true });
+  const p4b: any = new Proxy(m4b, {});
+  checks.push(sym4b in p4b);
+  checks.push(Reflect.has(p4b, sym4b) === true);
+}
+
+// --- 5. Set: own custom property and "size" through the no-trap
+// fallback, for both key kinds. ---
+{
+  const s5: any = new Set();
+  Object.defineProperty(s5, "vis", { value: 1, configurable: true });
+  const p5: any = new Proxy(s5, {});
+  checks.push("vis" in p5, Reflect.has(p5, "vis") === true);
+  const sym5 = Symbol("s5");
+  Object.defineProperty(s5, sym5, { value: 1, configurable: true });
+  const p5b: any = new Proxy(s5, {});
+  checks.push(sym5 in p5b, Reflect.has(p5b, sym5) === true);
+  checks.push("size" in new Proxy(new Set([1, 2]), {}));
+}
+
+// --- 6. Promise: an own property assigned directly onto the instance
+// (Promise has no intrinsic own state, but this is still possible), plus
+// an inherited method ("then") through the fallback's prototype walk. ---
+{
+  const pr6: any = Promise.resolve(1);
+  pr6.vis = 1;
+  const p6: any = new Proxy(pr6, {});
+  checks.push("vis" in p6, Reflect.has(p6, "vis") === true);
+  const sym6 = Symbol("pr6");
+  pr6[sym6] = 1;
+  const p6b: any = new Proxy(pr6, {});
+  checks.push(sym6 in p6b, Reflect.has(p6b, sym6) === true);
+  checks.push("then" in new Proxy(Promise.resolve(1), {}));
+}
+
+// --- 7. BoundFunction: an own custom property, for both key kinds. ---
+{
+  function orig7(a: number, b: number) {}
+  const bound7: any = orig7.bind(null, 1);
+  bound7.vis = 1;
+  const p7: any = new Proxy(bound7, {});
+  checks.push("vis" in p7, Reflect.has(p7, "vis") === true);
+  const sym7 = Symbol("bf7");
+  bound7[sym7] = 1;
+  const p7b: any = new Proxy(bound7, {});
+  checks.push(sym7 in p7b, Reflect.has(p7b, sym7) === true);
+}
+
+// --- 8. A plain native function (Array.prototype.*-style): an own
+// custom property via Object.defineProperty, for both key kinds. ---
+{
+  const nf8: any = Array.prototype.push;
+  Object.defineProperty(nf8, "vis8", { value: 1, configurable: true });
+  const p8: any = new Proxy(nf8, {});
+  checks.push("vis8" in p8, Reflect.has(p8, "vis8") === true);
+  const sym8 = Symbol("nf8");
+  Object.defineProperty(nf8, sym8, { value: 1, configurable: true });
+  const p8b: any = new Proxy(nf8, {});
+  checks.push(sym8 in p8b, Reflect.has(p8b, sym8) === true);
+}
+
+// --- 9. A native function with props (a global constructor, e.g.
+// Boolean): an own custom property, for both key kinds. ---
+{
+  Object.defineProperty(Boolean, "vis9", { value: 1, configurable: true });
+  const p9: any = new Proxy(Boolean, {});
+  checks.push("vis9" in p9, Reflect.has(p9, "vis9") === true);
+  const sym9 = Symbol("nfwp9");
+  Object.defineProperty(Boolean, sym9, { value: 1, configurable: true });
+  const p9b: any = new Proxy(Boolean, {});
+  checks.push(sym9 in p9b, Reflect.has(p9b, sym9) === true);
+}
+
+// --- 10. Arguments: "length", a numeric index, and an inherited method
+// (Object.prototype.toString), all through the no-trap fallback. ---
+{
+  function f10(a: number, b: number) {
+    const p10: any = new Proxy(arguments, {});
+    checks.push("length" in p10, Reflect.has(p10, "length") === true);
+    checks.push(0 in p10, Reflect.has(p10, 0 as any) === true);
+    checks.push("toString" in p10);
+  }
+  f10(1, 2);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_native_length_get_set.ts
+++ b/tests/scripts/proxy_native_length_get_set.ts
@@ -1,0 +1,141 @@
+// expect: true
+// Two related bugs in the NATIVE/Go-level property access entry points
+// pkg/builtins uses (vm.GetProperty/getPropertyWithReceiver and
+// vm.SetProperty, pkg/vm/vm_init.go) - as opposed to the bytecode-compiled
+// OpGetProp/OpSetProp paths, which already handled these cases correctly -
+// found while regression-testing the pkg/vm Proxy trap-lookup fixes
+// earlier in this stack:
+//
+//   1. vm.SetProperty had NO `case TypeProxy` at all - a TypeProxy `obj`
+//      fell straight to `default: return nil` (a silent no-op). Every
+//      native Go caller that writes a property via SetProperty on a
+//      Proxy did nothing, most visibly
+//      pkg/builtins/array_generic.go's arrayLikeSetLength (used by
+//      Array.prototype.pop/shift/splice/copyWithin to shrink `.length`
+//      after removing an element): `Array.prototype.pop.call(new
+//      Proxy(realArray, {}))` deleted the right element but never
+//      updated realArray.length, even though ordinary `proxy.length = n`
+//      assignment syntax (bytecode OpSetProp, op_setprop.go) already
+//      worked correctly for the exact same proxy and key.
+//
+//   2. op_getprop.go's opGetProp (bytecode OpGetProp, `proxy.prop`) had a
+//      "no get trap, fallback to target" branch that only ever handled a
+//      TypeObject/TypeDictObject/callable target - every other legal
+//      proxy.target kind (TypeArray, TypeMap, TypeSet, TypePromise,
+//      TypeRegExp, TypeGenerator, TypeBoundFunction, TypeNativeFunction,
+//      TypeNativeFunctionWithProps, TypeArguments, a further-nested
+//      Proxy, ...) fell to a bare `*dest = Undefined`. Two helper calls
+//      in that branch (handleSpecialProperties, handlePrimitiveMethod)
+//      switch on the TARGET's own kind (TypeArray/TypeMap/TypeString/...)
+//      but were only ever reached once target.Type() == TypeObject was
+//      already established - so neither call could ever actually match
+//      anything at that call site; both were dead code there. Most
+//      visibly: `new Proxy(realArray, {})` (no get trap, a real Array
+//      target) silently read `undefined` for EVERY property, including
+//      "length" itself.
+//
+// Fixed via:
+//   - SetProperty gained a `case TypeProxy` mirroring op_setprop.go's own
+//     TypeProxy case: GetMethod(handler, "set") via getInheritedGeneric
+//     (an inherited trap counts), and a no-trap fallback that recurses
+//     into SetProperty on the target - reaching the existing
+//     TypeArray/TypeObject/TypeDictObject/TypeArguments/TypeRegExp cases
+//     (including "length" on a real Array) automatically, plus a
+//     further-nested Proxy target (recursing through this same switch
+//     again).
+//   - opGetProp's "no get trap" branch now delegates to
+//     getPropertyWithReceiver (pkg/vm/vm_init.go) instead of its own
+//     partial reimplementation - that function already handles every
+//     Value kind (including TypeArray's "length", and recursing through
+//     a further-nested Proxy) and already threads the receiver through
+//     any accessor/trap found along the way, matching how this same
+//     function's get-trap-call branch already does.
+//
+// Not fixed here (a separate, pre-existing, confirmed-independent bug
+// filed as a follow-up): OpGetIndex (bracket notation, `proxy[key]`) has
+// its OWN "no get trap, fallback to target" switch with the same
+// incompleteness, but for a different opcode - `new Proxy(arguments, {})`
+// reads its own `.length` correctly (dot notation, opGetProp, fixed
+// above) but `p[0]`/`p[1]` (bracket notation, OpGetIndex) still read
+// `undefined`. Not covered by this file.
+
+const checks: boolean[] = [];
+
+// --- 1. Array.prototype.pop via .call() on a plain, trap-less
+// array-wrapping Proxy: deletes the right element AND shrinks the real
+// array's length (arrayLikeSetLength -> SetProperty -> the new TypeProxy
+// case -> the target's own "length" case). Matches Node exactly. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  const popped = Array.prototype.pop.call(p);
+  checks.push(popped === 3 && arr.length === 2);
+}
+
+// --- 2. Array.prototype.shift via .call(): same shape, a different
+// arrayLikeDelete/arrayLikeSetLength call site. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  const shifted = Array.prototype.shift.call(p);
+  checks.push(shifted === 1 && arr.length === 2 && arr[0] === 2 && arr[1] === 3);
+}
+
+// --- 3. Reading `.length` directly off a trap-less array-wrapping Proxy
+// (dot notation, opGetProp's fixed fallback) - was `undefined` before
+// this fix, regardless of any prior mutation. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  checks.push(p.length === 3 && p[0] === 1 && p[1] === 2);
+}
+
+// --- 4. Same read, immediately after a native-path mutation (pop),
+// isolating the get-path fix from the set-path fix (check 1 already
+// covers arr.length directly; this covers reading it back through the
+// proxy too). ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  Array.prototype.pop.call(p);
+  checks.push(p.length === 2);
+}
+
+// --- 5. `.length` write via ordinary assignment syntax (bytecode
+// OpSetProp, already correct before this fix) still agrees with the
+// now-fixed native path - not a regression check for something new,
+// just confirming both paths land on the same real array state. ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  p.length = 1;
+  checks.push(arr.length === 1 && p.length === 1);
+}
+
+// --- 6. opGetProp's fallback extension beyond TypeArray: RegExp
+// lastIndex through a trap-less Proxy (was already reachable via a
+// TypeObject-adjacent path before, but exercised here as a second
+// non-TypeObject/TypeDictObject/callable target kind, for coverage
+// alongside check 3's Array case). ---
+{
+  const re: any = /a/g;
+  const p: any = new Proxy(re, {});
+  re.lastIndex = 5;
+  checks.push(p.lastIndex === 5);
+}
+
+// --- 7. A TypeDictObject handler (a TS enum at runtime) must still not
+// panic for either the fixed get or set path. ---
+{
+  enum DictHandler7 {
+    A,
+    B,
+  }
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, DictHandler7 as any);
+  checks.push(p.length === 3);
+  const popped = Array.prototype.pop.call(p);
+  checks.push(popped === 3 && arr.length === 2);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_nested_target_delete_symbolset_unscopables.ts
+++ b/tests/scripts/proxy_nested_target_delete_symbolset_unscopables.ts
@@ -1,0 +1,83 @@
+// expect: true
+// Three more sites from the same audit as
+// tests/scripts/proxy_with_statement_nested_target_has_fallback.ts (see
+// its header for the full background), each a different trap:
+//
+//   1. OpDeleteProp's Proxy case ("No delete trap, fallback to target"):
+//      only handled TypeObject/TypeDictObject directly - `delete
+//      proxy.prop` where the target is another trap-less Proxy silently
+//      did nothing (`success` stayed whatever it defaulted to) instead
+//      of resolving through it. Fixed via the new proxyDeleteFallback
+//      helper (pkg/vm/vm.go), mirroring proxyHasPropertyFallback's own
+//      TypeProxy recursion for the analogous "has" case.
+//
+//   2. opSetPropSymbol's Proxy case ("No set trap, fallback to target -
+//      implement directly to avoid recursion", pkg/vm/op_setprop.go):
+//      only handled TypeObject - a nested Proxy target silently did
+//      nothing, not even a write. Its STRING-key sibling (opSetProp)
+//      already correctly recursed via `if target.Type() == TypeProxy {
+//      return vm.opSetProp(ip, &target, propName, valueToSet) }`; this
+//      symbol-key twin never got the same fix. Fixed the same way:
+//      `if target.Type() == TypeProxy { return vm.opSetPropSymbol(ip,
+//      &target, symKey, valueToSet) }`.
+//
+//   3. isUnscopable's own Proxy branch ("No get trap, fallback to
+//      target", backing @@unscopables consultation during a
+//      `with`-statement): gated behind `if proxy.target.Type() ==
+//      TypeObject`, so a nested Proxy target's own @@unscopables was
+//      never even asked about - the `with` binding always won,
+//      regardless of what the target declared unscopable. Fixed via
+//      getSymbolPropertyWithReceiver (pkg/vm/vm_init.go, the symbol-key
+//      twin of getPropertyWithReceiver - NOT GetSymbolPropertyWithGetter,
+//      which despite its name only ever handles a TypeObject or
+//      TypeRegExp obj directly and does not recurse through a Proxy
+//      target at all, an earlier version of this fix wrongly assumed
+//      otherwise and had to be corrected after this exact check still
+//      failed).
+//
+// All verified against real Node output.
+
+const checks: boolean[] = [];
+
+// --- 1. delete through a nested trap-less Proxy target. ---
+{
+  const inner: any = { d: 1 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  const deleted = delete p2.d;
+  checks.push(deleted === true && "d" in inner === false);
+}
+
+// --- 2. symbol-keyed property set through a nested trap-less Proxy
+// target. ---
+{
+  const sym = Symbol("s");
+  const inner: any = {};
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  p2[sym] = 42;
+  checks.push(inner[sym] === 42);
+}
+
+// --- 3. Symbol.unscopables lookup through a nested trap-less Proxy
+// target during a `with`-statement: the with-object must honor the
+// REAL target's @@unscopables and skip the property, leaving the local
+// variable untouched. ---
+{
+  const inner: any = { z: 999 };
+  Object.defineProperty(inner, Symbol.unscopables, {
+    value: { z: true },
+    configurable: true,
+  });
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let z = "local";
+    with (p2) {
+      return z;
+    }
+  }
+  checks.push(f() === "local");
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_nested_target_get_fallback.ts
+++ b/tests/scripts/proxy_nested_target_get_fallback.ts
@@ -1,0 +1,107 @@
+// expect: true
+// OpObjectSpread's per-key "no get trap" fallback (pkg/vm/vm.go, the
+// Proxy-handling block inside `case OpObjectSpread:`, backing
+// `{...proxy}`) fetched each value directly from `proxy.Target()`, but
+// only handled a TypeObject/TypeDictObject target:
+//
+//   target := proxy.Target()
+//   if target.Type() == TypeObject {
+//       value, _ = target.AsPlainObject().GetOwn(keyStr)
+//   } else if target.Type() == TypeDictObject {
+//       value, _ = target.AsDictObject().GetOwn(keyStr)
+//   } else {
+//       value = Undefined
+//   }
+//
+// A target that is itself a Proxy (neither level with a `get` trap)
+// silently answered `undefined` for every key instead of recursing into
+// that inner proxy's own [[Get]] (trap-or-target, recursively):
+//
+//   const inner = { c: 3 };
+//   const p1 = new Proxy(inner, {});
+//   const p2 = new Proxy(p1, { ownKeys() { return ["c"]; } });
+//   ({...p2}); // was {} - now { c: 3 }, matching Node
+//
+// The same shape of bug was independently confirmed via plain property
+// access (`p2b.c` where p2b wraps a trap-less Proxy wrapping a plain
+// object) in opGetProp's OWN "no get trap" fallback - already fixed by
+// routing that one through GetPropertyWithReceiver in the immediately
+// preceding PR in this stack (which gave general nested-Proxy-target
+// support to that call site as a side effect of a different, unrelated
+// fix). This PR's fix does the equivalent for OpObjectSpread's site:
+// GetPropertyWithReceiver(proxy.Target(), keyStr, sourceVal) instead of
+// the bare GetOwn - receiver stays sourceVal (the ORIGINAL top-level
+// proxy the spread started from), matching how the sibling get-trap-call
+// branch just above already passes sourceVal as the trap's own receiver
+// argument.
+//
+// checks 1-2: the OpObjectSpread repro above, both with and without an
+// ownKeys trap on the OUTER proxy (isolating this fix from the separate
+// ownKeys-fallback fix from an earlier PR in this stack).
+// check 3: the plain-property-access repro (already fixed, pinned here
+// too since it's the same conceptual bug and the task that reported this
+// asked for both).
+// check 4: three trap-less Proxy levels deep, for both access styles.
+// check 5: a `get` trap partway down a longer chain still fires (the
+// recursion doesn't just skip past every level to the innermost target).
+
+const checks: boolean[] = [];
+
+// --- 1. Nested trap-less Proxy target, outer proxy HAS an ownKeys
+// trap. ---
+{
+  const inner: any = { c: 3 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {
+    ownKeys() {
+      return ["c"];
+    },
+  });
+  const spread: any = { ...p2 };
+  checks.push(spread.c === 3);
+}
+
+// --- 2. Nested trap-less Proxy target, outer proxy has NO ownKeys trap
+// either (both fixes composing together). ---
+{
+  const inner: any = { d: 4 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  const spread: any = { ...p2 };
+  checks.push(spread.d === 4);
+}
+
+// --- 3. Plain property access (dot notation) through a nested
+// trap-less Proxy chain. ---
+{
+  const p2b: any = new Proxy(new Proxy({ c: 3 }, {}), {});
+  checks.push(p2b.c === 3);
+}
+
+// --- 4. Three levels deep, still trap-less throughout, both spread and
+// dot-notation access. ---
+{
+  const p3: any = new Proxy(new Proxy(new Proxy({ e: 5 }, {}), {}), {});
+  checks.push(p3.e === 5);
+  const spread: any = { ...p3 };
+  checks.push(spread.e === 5);
+}
+
+// --- 5. A `get` trap partway down a longer chain still fires - the
+// recursion checks each level's own trap, it doesn't just delegate all
+// the way to the innermost real target. ---
+{
+  const log: string[] = [];
+  const innermost: any = { f: 6 };
+  const mid: any = new Proxy(innermost, {
+    get(t: any, k: any) {
+      log.push(String(k));
+      return Reflect.get(t, k);
+    },
+  });
+  const outer: any = new Proxy(mid, {});
+  checks.push(outer.f === 6);
+  checks.push(log.indexOf("f") !== -1);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_opgetindex_target_fallback.ts
+++ b/tests/scripts/proxy_opgetindex_target_fallback.ts
@@ -1,0 +1,111 @@
+// expect: true
+// OpGetIndex's Proxy handling (pkg/vm/vm.go, `case OpGetIndex:`, backing
+// bracket-notation `proxy[key]`) had its OWN "no get trap, fallback to
+// target" switch, separate from opGetProp's (dot notation, `proxy.prop`,
+// already fixed for the same shape of bug two commits back on this
+// branch):
+//
+//   targetBase := proxy.target
+//   switch targetBase.Type() {
+//   case TypeArray:
+//       ... (numeric fast path, string/symbol index delegates to opGetProp)
+//   case TypeObject, TypeDictObject:
+//       ... delegates to opGetProp for the key ...
+//   default:
+//       registers[destReg] = Undefined
+//   }
+//
+// Every proxy.target kind besides TypeArray/TypeObject/TypeDictObject -
+// TypeArguments, TypeMap, TypeSet, TypePromise, TypeRegExp, TypeGenerator,
+// TypeBoundFunction, TypeNativeFunction, TypeNativeFunctionWithProps, a
+// further-nested TypeProxy, ... - fell to that bare `default:` and
+// silently read `undefined` for every bracket-accessed key, even though
+// the identical key read via dot notation (opGetProp's own fallback,
+// already correct) worked fine:
+//
+//   function f(a, b) {
+//     const p = new Proxy(arguments, {});
+//     return [p.length, p[0], p[1]]; // was [2, undefined, undefined]
+//   }
+//   f(10, 20); // now [2, 10, 20], matching Node
+//
+// Fixed by widening the `default:` case to delegate to
+// getPropertyWithReceiver (pkg/vm/vm_init.go) instead of doing nothing -
+// the same helper vm.GetProperty and opGetProp's own fallback are already
+// built on, and it already handles every one of these kinds completely,
+// INCLUDING TypeArguments's numeric-index case (which opGetProp itself
+// does NOT handle - opGetProp's TypeArguments branch only ever resolves
+// "length"/"callee"/named overflow properties, never a plain numeric
+// index like "0"; that resolution lives separately in OpGetIndex's own
+// direct, non-Proxy TypeArguments case via vm.argumentsGet - delegating
+// this fallback to opGetProp instead of getPropertyWithReceiver, as an
+// earlier version of this fix did, would have looked plausible and
+// fixed every OTHER kind while leaving TypeArguments's numeric index
+// broken). TypeArray keeps its own direct handling (a hand-rolled dense-
+// element fast path for the numeric case), unchanged - only the
+// `default:` arm changed.
+//
+// checks 1-2: the task's own repro (numeric index, "length" as a
+// bracket key) and a RegExp `.lastIndex` bracket read - two kinds that
+// used to fall to `default:`.
+// check 3: nested trap-less Proxy target via bracket notation (the
+// OpGetIndex counterpart to the earlier OpObjectSpread/opGetProp fix for
+// the same shape of bug via dot notation).
+// check 4: TypeArray target still works via bracket notation (the
+// numeric fast path this fix did NOT touch, confirming no regression).
+// check 5: a TypeDictObject handler (a TS enum at runtime) must not
+// panic for the extended default case.
+
+const checks: boolean[] = [];
+
+// --- 1. Arguments via bracket notation: numeric index and "length" as
+// an explicit bracket key. ---
+{
+  function f(a: number, b: number) {
+    const p: any = new Proxy(arguments, {});
+    return [p[0], p[1], p["length"]];
+  }
+  const [a0, a1, alen] = f(10, 20);
+  checks.push(a0 === 10 && a1 === 20 && alen === 2);
+}
+
+// --- 2. RegExp lastIndex via bracket notation through a no-trap
+// proxy. ---
+{
+  const re: any = /a/g;
+  re.lastIndex = 3;
+  const pr: any = new Proxy(re, {});
+  checks.push(pr["lastIndex"] === 3);
+}
+
+// --- 3. Nested trap-less Proxy target via bracket notation. ---
+{
+  const inner: any = { c: 3 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  const key = "c";
+  checks.push(p2[key] === 3);
+}
+
+// --- 4. TypeArray target still works via bracket notation (the
+// existing numeric fast path and string-key array delegation, both
+// left untouched by this fix). ---
+{
+  const arr: any = [1, 2, 3];
+  const p: any = new Proxy(arr, {});
+  checks.push(p[0] === 1 && p[1] === 2 && p["length"] === 3);
+}
+
+// --- 5. A TypeDictObject handler (a TS enum at runtime) must not panic
+// for the extended default case. ---
+{
+  enum DictHandler5 {
+    A,
+    B,
+  }
+  const re2: any = /b/;
+  const pr2: any = new Proxy(re2, DictHandler5 as any);
+  checks.push(pr2["lastIndex"] === 0);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_trap_lookup_fixes.ts
+++ b/tests/scripts/proxy_trap_lookup_fixes.ts
@@ -1,0 +1,161 @@
+// expect: true
+// The remaining `handler.AsPlainObject().GetOwn(<trap>)` sites turned up by
+// auditing pkg/vm and pkg/builtins for the same pattern #342 fixed for
+// OpIn's `has` lookup - the `with`-statement sites are covered separately
+// in tests/scripts/proxy_with_trap_lookup_fixes.ts. Each of these had the
+// same two bugs:
+//
+//   1. Own-only trap lookup, not GetMethod-inherited (`.GetOwn` instead of
+//      `.Get`/proxyGetTrap) - an inherited trap on the handler's own
+//      [[Prototype]] chain was invisible.
+//   2. Unguarded AsPlainObject() panics on a TypeDictObject handler (a TS
+//      enum or module namespace value at runtime).
+//
+// Fixed via proxyGetTrap (pkg/vm/vm.go), reused at every site below:
+//   - opGetProp (pkg/vm/op_getprop.go): plain property read, `obj.prop`.
+//   - OpGetIndex (pkg/vm/vm.go): computed property read, `obj[key]`.
+//   - OpDeleteProp (pkg/vm/vm.go): `delete obj.prop`.
+//   - vm.Call's TypeProxy case (pkg/vm/vm_init.go) and
+//     prepareCallWithGeneratorMode's TypeProxy case (pkg/vm/call.go): the
+//     `apply` trap for, respectively, a native call path (Reflect.apply)
+//     and a direct call expression (`proxy(...)`).
+//
+// call.go's site additionally used to have a THIRD divergent behavior:
+// a `default: throw "Proxy handler is not an object"` for any handler
+// kind besides TypeObject/TypeDictObject (e.g. a Map or Array - both
+// legal per the Proxy constructor's own validation, which only requires
+// IsObject()). vm.Call's sibling site never threw for this and instead
+// silently treated it as "no apply trap" (delegate to target) - the two
+// entry points for calling the very same proxy disagreed. Fixed by
+// dropping call.go's throw in favor of matching vm.Call (check 6).
+//
+// Also fixed in this same commit (not a trap-lookup bug, but touched
+// while reviewing the same file, pkg/vm/vm.go's proxyHasPropertyFallback):
+// the TypeArray case used `index < arrayObj.Length()` instead of
+// ArrayHasOwnIndex to decide whether a numeric index is an own property -
+// wrong per paserati#176/#178, since `.length` can be inflated by an
+// unrelated defineProperty at a distant index without this index itself
+// being set. Now matches OpIn's own TypeArray case: checks
+// ArrayHasOwnIndex first, and falls through to the prototype chain
+// (Array.prototype) on a miss instead of answering outright (checks 7-8).
+
+const checks: boolean[] = [];
+
+// --- 1. opGetProp: inherited `get` trap. ---
+{
+  const base = {
+    get(_t: any, k: string) {
+      return k === "a" ? 42 : undefined;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  checks.push(p.a === 42);
+}
+
+// --- 2. OpGetIndex: inherited `get` trap. ---
+{
+  const base = {
+    get(_t: any, k: string) {
+      return k === "b" ? 43 : undefined;
+    },
+  };
+  const p: any = new Proxy({}, Object.create(base));
+  const key = "b";
+  checks.push(p[key] === 43);
+}
+
+// --- 3. OpDeleteProp: inherited `deleteProperty` trap. ---
+{
+  const base = {
+    deleteProperty(_t: any, k: string) {
+      return k === "c";
+    },
+  };
+  const p: any = new Proxy({ c: 1 }, Object.create(base));
+  checks.push(delete p.c);
+}
+
+// --- 4. A TypeDictObject handler must not panic for opGetProp/OpGetIndex/
+// OpDeleteProp - no trap is found (an enum has no such members), so each
+// falls through to the target. ---
+{
+  enum DictHandler4 {
+    X,
+    Y,
+  }
+  const p: any = new Proxy({ v: 9 }, DictHandler4 as any);
+  checks.push(p.v === 9);
+  checks.push(p["v"] === 9);
+  checks.push(delete p.v);
+}
+
+// --- 5. apply trap, inherited: both call surfaces for the same proxy -
+// a direct call expression (call.go) and Reflect.apply (vm.Call, via
+// vm_init.go) - must agree. ---
+{
+  const base = {
+    apply(_t: any, _thisArg: any, args: any[]) {
+      return args[0] + args[1] + 1000;
+    },
+  };
+  function orig(a: number, b: number) {
+    return a + b;
+  }
+  const p: any = new Proxy(orig, Object.create(base));
+  checks.push(p(1, 2) === 1003);
+  checks.push(Reflect.apply(p, undefined, [1, 2]) === 1003);
+}
+
+// --- 6. A handler that is a legal Proxy handler (IsObject()) but neither
+// TypeObject nor TypeDictObject (here: an Array) must not throw for a
+// direct call - matches Reflect.apply on the same proxy (no apply trap
+// found either way, so both delegate to the target). ---
+{
+  function orig6(a: number) {
+    return a + 1;
+  }
+  const p: any = new Proxy(orig6, [] as any);
+  checks.push(p(4) === 5);
+  checks.push(Reflect.apply(p, undefined, [4]) === 5);
+}
+
+// --- 6b. A TypeDictObject handler must not panic for a direct call or
+// Reflect.apply either (no apply trap -> delegate to target). ---
+{
+  enum DictHandler6b {
+    X,
+    Y,
+  }
+  function orig6b(a: number) {
+    return a + 1;
+  }
+  const p: any = new Proxy(orig6b, DictHandler6b as any);
+  checks.push(p(4) === 5);
+  checks.push(Reflect.apply(p, undefined, [4]) === 5);
+}
+
+// --- 7. proxyHasPropertyFallback's TypeArray case: an in-range index
+// that isn't actually own (length inflated by a distant defineProperty)
+// must NOT be reported present through a no-trap Proxy. ---
+{
+  const arr: any = [1, 2, 3];
+  Object.defineProperty(arr, "100", { value: "x", configurable: true });
+  const p: any = new Proxy(arr, {});
+  checks.push(5 in p === false); // in range (length=101) but not own
+  checks.push(100 in p === true); // the actually-defined index
+}
+
+// --- 8. Same fallback: an inherited index on Array.prototype must still
+// be found via the prototype-chain walk on a miss (matches OpIn). ---
+{
+  (Array.prototype as any)[5] = "proto-value";
+  try {
+    const arr2: any = [1, 2, 3];
+    const p2: any = new Proxy(arr2, {});
+    checks.push(5 in p2 === true);
+  } finally {
+    delete (Array.prototype as any)[5];
+  }
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_with_statement_nested_target_has_fallback.ts
+++ b/tests/scripts/proxy_with_statement_nested_target_has_fallback.ts
@@ -1,0 +1,143 @@
+// expect: true
+// Follow-up filed while regression-testing earlier PRs in this stack: an
+// audit of pkg/vm/vm.go for the same "no trap, fall back to target
+// directly, only handles TypeObject/TypeDictObject" shape that affected
+// the `get` trap (OpObjectSpread, opGetProp, OpGetIndex - all fixed by
+// prior commits on this branch) turned up SEVEN more sites, all backing
+// the `has` trap's no-trap fallback for every `with`-statement opcode:
+// OpGetWithProperty, OpSetWithProperty, OpGetWithOrLocal,
+// OpSetWithOrLocal, OpResolveWithBinding (the checkWithObjProperty
+// closure), OpSetWithByBinding, and OpGetWithByBinding. Each checked
+// `proxy.target.Type() == TypeObject` (a couple also TypeDictObject) and
+// silently answered "property not present" for any other kind, including
+// a further-nested trap-less Proxy target:
+//
+//   const inner = { x: 5 };
+//   const p1 = new Proxy(inner, {});
+//   const p2 = new Proxy(p1, {}); // no has trap; p1 has none either
+//   function f() {
+//     let x = 1;
+//     with (p2) { x = 99; } // p2 claims "x" only if it can see inner.x
+//     return [x, inner.x];
+//   }
+//   f(); // was [99, 1] (with-object never claimed the binding) -
+//        // now [1, 99], matching Node
+//
+// Fixed by routing every site through proxyHasPropertyFallback (the
+// helper an earlier PR in this stack introduced and already used for
+// OpIn's own `has` fallback) instead of each site's own hand-rolled
+// TypeObject/TypeDictObject-only check - it already recurses through a
+// nested Proxy target (checking that inner proxy's own has trap first)
+// and covers several other target kinds these sites didn't (TypeArray,
+// TypeMap, TypeSet, TypeRegExp, TypePromise, ...). Two of the seven
+// sites (OpSetWithByBinding, OpGetWithByBinding) keep their own
+// deliberate "unhandled kind -> assume still bound, don't throw"
+// default for SetMutableBinding's step-2 check (a design choice
+// predating this fix, not something this fix changes) - only their
+// TypeProxy case was added, delegating to proxyHasPropertyFallback for
+// that one kind specifically.
+//
+// Each check below exercises a different one of the seven opcodes,
+// verified against real Node output. All use the same shape: a nested,
+// fully trap-less Proxy chain wrapping a real object, so `with` can only
+// correctly claim the binding by resolving all the way through.
+
+const checks: boolean[] = [];
+declare var gRead: any;
+declare var gWrite: any;
+declare var gCompound: any;
+
+// --- 1. OpGetWithProperty: reading a global variable inside `with`. ---
+{
+  const inner: any = { gRead: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  (globalThis as any).gRead = 1;
+  function readGlobal() {
+    with (p2) {
+      return gRead;
+    }
+  }
+  checks.push(readGlobal() === 5);
+}
+
+// --- 2. OpSetWithProperty: writing a global variable inside `with`. ---
+{
+  const inner: any = { gWrite: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  (globalThis as any).gWrite = 1;
+  function writeGlobal() {
+    with (p2) {
+      gWrite = 42;
+    }
+  }
+  writeGlobal();
+  checks.push((globalThis as any).gWrite === 1 && inner.gWrite === 42);
+}
+
+// --- 3. OpGetWithOrLocal: reading a local variable inside `with` - the
+// with-object must take priority over the local. ---
+{
+  const inner: any = { x: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let x = 1;
+    with (p2) {
+      return x;
+    }
+  }
+  checks.push(f() === 5);
+}
+
+// --- 4. OpSetWithOrLocal: writing a local variable inside `with` - the
+// with-object must claim the binding, leaving the local untouched. ---
+{
+  const inner: any = { x: 5 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let x = 1;
+    with (p2) {
+      x = 99;
+    }
+    return [x, inner.x];
+  }
+  const [x, ix] = f();
+  checks.push(x === 1 && ix === 99);
+}
+
+// --- 5-7. OpResolveWithBinding + OpSetWithByBinding + OpGetWithByBinding:
+// a compound assignment inside `with`, for both a local and a global
+// variable - exercises all three opcodes together (resolving which
+// binding to use, then the get-then-set halves of the compound op). ---
+{
+  const inner: any = { lx: 10 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  function f() {
+    let lx = 1;
+    with (p2) {
+      lx += 5;
+    }
+    return [lx, inner.lx];
+  }
+  const [lx, ilx] = f();
+  checks.push(lx === 1 && ilx === 15);
+}
+{
+  const inner: any = { gCompound: 10 };
+  const p1: any = new Proxy(inner, {});
+  const p2: any = new Proxy(p1, {});
+  (globalThis as any).gCompound = 1;
+  function f() {
+    with (p2) {
+      gCompound += 5;
+    }
+  }
+  f();
+  checks.push((globalThis as any).gCompound === 1 && inner.gCompound === 15);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/proxy_with_trap_lookup_fixes.ts
+++ b/tests/scripts/proxy_with_trap_lookup_fixes.ts
@@ -1,0 +1,181 @@
+// expect: true
+// Two bugs shared by every `with`-statement Proxy trap lookup in the
+// run() interpreter loop (pkg/vm/vm.go), found while auditing every
+// `proxy.handler.AsPlainObject().GetOwn(<trap>)` call site after #342
+// fixed this exact pattern for OpIn's `has` lookup:
+//
+//   1. Own-only trap lookup, not GetMethod-inherited. Each site did
+//      `proxy.handler.AsPlainObject().GetOwn(<trap>)` - own-only - instead
+//      of GetMethod(handler, <trap>) per spec, which walks the handler's
+//      own [[Prototype]] chain. An inherited trap (e.g. `Object.create({
+//      has() {...} })` as a handler) was invisible on every `with`-object
+//      code path: OpGetWithProperty/OpSetWithProperty (a global variable
+//      read/write inside `with`), OpGetWithOrLocal/OpSetWithOrLocal (same,
+//      for a variable that's also a local in the current function),
+//      OpResolveWithBinding/OpGetWithByBinding/OpSetWithByBinding (a
+//      compound assignment's pre-resolved binding), and isUnscopable's own
+//      Proxy branch (checking @@unscopables on a `with`-object during any
+//      of the above).
+//
+//   2. Unguarded AsPlainObject() panics on a TypeDictObject handler. Every
+//      one of those sites assumed the handler is specifically a
+//      TypeObject. A handler that happens to be a TypeDictObject (a TS
+//      enum or module namespace value at runtime) made Value.AsPlainObject()
+//      panic the entire process - not a catchable JS exception.
+//
+// Fixed by routing every one of these sites through proxyGetTrap (the
+// helper #342 already introduced for OpIn's `has` case), which branches on
+// TypeObject/TypeDictObject and uses .Get (not .GetOwn) for both.
+//
+// checks 1-2: OpGetWithProperty / OpSetWithProperty (global variable).
+// checks 3-4: OpGetWithOrLocal / OpSetWithOrLocal (local variable, with
+//             the with-object taking priority per `with` semantics - the
+//             local must NOT be touched when the with-object claims the
+//             binding via an inherited `has`).
+// checks 5-6: compound assignment (OpResolveWithBinding + OpGetWithByBinding
+//             + OpSetWithByBinding), inherited get/set traps.
+// check 7:    a TypeDictObject handler must not panic on any `with` path.
+
+const checks: boolean[] = [];
+
+// --- 1. Global variable read inside `with`, inherited `get`/`has` traps. ---
+var wGlobal = 1;
+{
+  const base = {
+    has(_t: any, k: string) {
+      return k === "wGlobal";
+    },
+    get(_t: any, k: string) {
+      return k === "wGlobal" ? 111 : undefined;
+    },
+  };
+  const handler: any = Object.create(base);
+  function readGlobal() {
+    with (new Proxy({}, handler) as any) {
+      return wGlobal;
+    }
+  }
+  checks.push(readGlobal() === 111);
+}
+
+// --- 2. Global variable write inside `with`, inherited `has`/`set` traps. ---
+{
+  const log: string[] = [];
+  const base = {
+    has(_t: any, k: string) {
+      log.push("has:" + k);
+      return k === "wGlobal";
+    },
+    set(_t: any, k: string, v: any) {
+      log.push("set:" + k + "=" + v);
+      return true;
+    },
+  };
+  const handler: any = Object.create(base);
+  function writeGlobal() {
+    with (new Proxy({}, handler) as any) {
+      wGlobal = 222;
+    }
+  }
+  writeGlobal();
+  checks.push(log.indexOf("set:wGlobal=222") !== -1);
+}
+
+// --- 3. Local variable read inside `with` (OpGetWithOrLocal): the
+// with-object's inherited `has`/`get` traps must take priority over the
+// local, per `with` dynamic-scoping semantics. ---
+{
+  const base = {
+    has(_t: any, k: string) {
+      return k === "lx";
+    },
+    get(_t: any, k: string) {
+      return k === "lx" ? 333 : undefined;
+    },
+  };
+  const handler: any = Object.create(base);
+  function readLocal() {
+    let lx = 1;
+    with (new Proxy({}, handler) as any) {
+      return lx;
+    }
+  }
+  checks.push(readLocal() === 333);
+}
+
+// --- 4. Local variable write inside `with` (OpSetWithOrLocal): an
+// inherited `has` trap must still be found so the with-object's `set`
+// trap runs instead of silently falling back to the local. ---
+{
+  const log: string[] = [];
+  const base = {
+    has(_t: any, k: string) {
+      return k === "lx";
+    },
+  };
+  const handler: any = Object.create(base);
+  handler.set = function (_t: any, k: string, v: any) {
+    log.push("set:" + k + "=" + v);
+    return true;
+  };
+  function writeLocal() {
+    let lx = 1;
+    with (new Proxy({}, handler) as any) {
+      lx = 444;
+    }
+    return lx; // must be untouched: the with-object claimed the binding
+  }
+  checks.push(writeLocal() === 1);
+  checks.push(log.indexOf("set:lx=444") !== -1);
+}
+
+// --- 5-6. Compound assignment inside `with` (OpResolveWithBinding then
+// OpGetWithByBinding/OpSetWithByBinding), inherited get/has/set traps. ---
+{
+  const log: string[] = [];
+  const base = {
+    has(_t: any, k: string) {
+      return k === "lx";
+    },
+    get(_t: any, k: string) {
+      return k === "lx" ? 10 : undefined;
+    },
+    set(_t: any, k: string, v: any) {
+      log.push("set:" + k + "=" + v);
+      return true;
+    },
+  };
+  const handler: any = Object.create(base);
+  function compound() {
+    let lx = 1;
+    with (new Proxy({}, handler) as any) {
+      lx += 5;
+    }
+    return lx;
+  }
+  checks.push(compound() === 1); // local untouched
+  checks.push(log.indexOf("set:lx=15") !== -1); // 10 (from get) + 5
+}
+
+// --- 7. A TypeDictObject handler (a TS enum at runtime) must not panic
+// on any `with` path (global read/write, local read/write, compound). ---
+{
+  enum DictHandler7 {
+    A,
+    B,
+  }
+  function useDictHandler() {
+    let lx = 1;
+    with (new Proxy({ wGlobal: 5, lx: 6 }, DictHandler7 as any) as any) {
+      wGlobal;
+      wGlobal = 9;
+      lx;
+      lx = 9;
+      lx += 1;
+    }
+    return "no-panic";
+  }
+  checks.push(useDictHandler() === "no-panic");
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/reflect_get_general.ts
+++ b/tests/scripts/reflect_get_general.ts
@@ -1,0 +1,249 @@
+// expect: true
+// Reflect.get (pkg/builtins/reflect_init.go) used to only handle
+// target.Type() == TypeObject/TypeDictObject/TypeArray - every other kind
+// (Function, Closure, Map, Set, RegExp, BoundFunction, NativeFunction,
+// NativeFunctionWithProps, Promise, TypedArray, Proxy, ...) silently fell
+// through and returned undefined instead of actually reading the
+// property. It also unconditionally stringified the key
+// (`args[1].ToString()`), so Reflect.get(anything, someSymbol) never
+// worked correctly except via incidental string coercion:
+//
+//   function fn() {}
+//   Reflect.get(fn, "name");        // before: undefined - Node: "fn"
+//   Reflect.get(fn, "call");        // before: undefined - Node: [Function: call]
+//   Reflect.get(new Map(), "size"); // before: undefined - Node: 0
+//   Reflect.get({x: 1}, "x");       // before: 1 (correct) - Node: 1
+//
+// Fixed by rewriting Reflect.get to delegate to two new general-purpose
+// VM helpers (pkg/vm/vm_init.go) instead of re-implementing per-kind
+// property lookup a third time (opGetProp/opGetPropSymbol already do this
+// for bytecode dispatch, and GetProperty already did a narrower version
+// for a handful of other native-function call sites):
+//   - GetPropertyWithReceiver (string keys) - an existing GetProperty
+//     function, extended with a `receiver` parameter (threaded through
+//     every accessor-getter call and prototype-chain recursion) and two
+//     missing kinds (TypeNativeFunction, TypeDictObject).
+//   - ReflectGetSymbolPropertyWithReceiver (symbol keys) - new, mirroring
+//     GetPropertyWithReceiver's same per-kind case list with the
+//     string-keyed PlainObject methods swapped for their *ByKey
+//     counterparts.
+// receiver is Reflect.get's optional third argument - the spec's `this`
+// for any accessor's getter along the way, independent of which object
+// on the prototype chain the getter was actually found on. Reflect.get's
+// declared type signature only allowed 2 arguments before this fix
+// (Reflect.set/Reflect.construct have the identical gap for their own
+// optional trailing parameters - not fixed here, flagged as a follow-up).
+//
+// Found and fixed alongside the above, in the same commit (same file,
+// same switch statements, the same missing-side-table-check bug already
+// fixed for other kinds in earlier PRs in this stack):
+//   - TypeSet/TypeMap/TypePromise's own custom properties (a plain
+//     `m.custom = 1` or Object.defineProperty) were invisible to
+//     GetProperty/Reflect.get entirely - only the prototype chain (for
+//     `size`, etc.) was ever checked.
+//   - A value's [[Prototype]] chain passing through a callable
+//     (Object.create(someFunction), or a class extending a native
+//     constructor) stopped the walk early and answered "not found" even
+//     when the callable had the property in its own Properties side
+//     table - because the walk's continuation check used IsObject(),
+//     which is FALSE for every callable ValueType (they sort before
+//     TypeObject in the enum, pkg/vm/value.go) - this bug appeared (and
+//     was caught and fixed) in an earlier draft of this exact fix, so
+//     it's pinned explicitly below (check 18) rather than only in a code
+//     comment.
+//
+// Each assertion below uses its own object/function/collection instance -
+// no shared-mutable-intrinsic hazard here, unlike the native-function
+// tests earlier in this stack (Array.prototype.* is a real shared
+// intrinsic; a fresh literal or `new` expression is not).
+
+const checks: boolean[] = [];
+
+// --- 1. Plain function: name/length/call (string keys). ---
+{
+  function fn(a: number, b: number) {}
+  checks.push(Reflect.get(fn, "name") === "fn");
+  checks.push(Reflect.get(fn, "length") === 2);
+  checks.push(typeof Reflect.get(fn, "call") === "function");
+}
+
+// --- 2. Map: size (an accessor on Map.prototype), and a custom own
+// property (the side-table gap found while fixing this). ---
+{
+  const m: any = new Map([[1, 2]]);
+  checks.push(Reflect.get(m, "size") === 1);
+  m.custom = 42;
+  checks.push(Reflect.get(m, "custom") === 42);
+}
+
+// --- 3. Set: size, and a custom own property. ---
+{
+  const s: any = new Set([1, 2, 3]);
+  checks.push(Reflect.get(s, "size") === 3);
+  s.custom = "hi";
+  checks.push(Reflect.get(s, "custom") === "hi");
+}
+
+// --- 4. RegExp: source (own field) and lastIndex (own, writable). ---
+{
+  const re: any = /abc/gi;
+  checks.push(Reflect.get(re, "source") === "abc");
+  re.lastIndex = 3;
+  checks.push(Reflect.get(re, "lastIndex") === 3);
+}
+
+// --- 5. BoundFunction: name/length (synthesized), and a custom own
+// property. ---
+{
+  function orig(a: number, b: number, c: number) {}
+  const bound: any = orig.bind(null, 1);
+  checks.push(Reflect.get(bound, "name") === "bound orig");
+  checks.push(Reflect.get(bound, "length") === 2);
+  bound.custom = "b";
+  checks.push(Reflect.get(bound, "custom") === "b");
+}
+
+// --- 6. A plain native function (Array.prototype.push-style): name/
+// length, and a custom own property via Object.defineProperty. ---
+{
+  const nf: any = Array.prototype.slice;
+  checks.push(Reflect.get(nf, "name") === "slice");
+  checks.push(typeof Reflect.get(nf, "length") === "number");
+  Object.defineProperty(nf, "custom6", { value: 7, configurable: true });
+  checks.push(Reflect.get(nf, "custom6") === 7);
+}
+
+// --- 7. A class: name, an inherited static property, an instance
+// method found through the prototype chain. ---
+{
+  class Base7 {
+    static staticProp = 10;
+    method() { return 1; }
+  }
+  class Derived7 extends Base7 {}
+  const Derived7Any: any = Derived7;
+  checks.push(Reflect.get(Derived7Any, "name") === "Derived7");
+  checks.push(Reflect.get(Derived7Any, "staticProp") === 10);
+  checks.push(typeof Reflect.get(Derived7Any.prototype, "method") === "function");
+}
+
+// --- 8. An accessor property invoked with the correct receiver
+// argument (per spec, the getter's `this`), and the default-to-target
+// behavior when receiver is omitted. ---
+{
+  const proto8 = {
+    get val(): number { return (this as any).backing; },
+    set val(v: number) { (this as any).backing = v; },
+  };
+  const receiver8: any = { backing: 5 };
+  checks.push(Reflect.get(proto8, "val", receiver8) === 5);
+  const obj8: any = Object.create(proto8);
+  obj8.backing = 9;
+  checks.push(Reflect.get(obj8, "val") === 9);
+}
+
+// --- 9. String and Symbol keys on the same plain object, including an
+// own accessor keyed by a Symbol. ---
+{
+  const sym9 = Symbol("k9");
+  let backing9 = 0;
+  const obj9: any = {
+    get [sym9]() { return backing9; },
+    set [sym9](v: number) { backing9 = v; },
+    plain: "p",
+  };
+  obj9[sym9] = 55;
+  checks.push(Reflect.get(obj9, sym9) === 55);
+  checks.push(Reflect.get(obj9, "plain") === "p");
+}
+
+// --- 10. Symbol key as an own property on a native function. ---
+{
+  const nf2: any = Array.prototype.unshift;
+  const sym10 = Symbol("k10");
+  Object.defineProperty(nf2, sym10, { value: 100, configurable: true });
+  checks.push(Reflect.get(nf2, sym10) === 100);
+}
+
+// --- 11. Symbol key inherited via the prototype chain
+// (Symbol.hasInstance on Function.prototype, for a plain function). ---
+{
+  function plainFn11() {}
+  checks.push(typeof Reflect.get(plainFn11, Symbol.hasInstance) === "function");
+}
+
+// --- 12. Symbol key as a custom own property on a Map. ---
+{
+  const m2: any = new Map();
+  const sym12 = Symbol("k12");
+  Object.defineProperty(m2, sym12, { value: "sym-on-map", configurable: true });
+  checks.push(Reflect.get(m2, sym12) === "sym-on-map");
+}
+
+// --- 13. TypedArray: numeric index, "length", and an inherited method. ---
+{
+  const ta: any = new Int32Array([10, 20, 30]);
+  checks.push(Reflect.get(ta, "0") === 10);
+  checks.push(Reflect.get(ta, "length") === 3);
+  checks.push(typeof Reflect.get(ta, "map") === "function");
+}
+
+// --- 14. Proxy: the get trap is invoked as handler.get(target, key,
+// receiver) for both a string and a Symbol key, with the actual
+// receiver argument passed through (not the proxy itself when a
+// distinct receiver is given). ---
+{
+  let seenReceiver14: any = null;
+  const target14: any = {};
+  const handler14 = {
+    get(t: any, k: any, r: any) {
+      seenReceiver14 = r;
+      return "trapped:" + String(k);
+    },
+  };
+  const p14: any = new Proxy(target14, handler14);
+  const rcv14 = {};
+  checks.push(Reflect.get(p14, "x", rcv14) === "trapped:x");
+  checks.push(seenReceiver14 === rcv14);
+  const sym14 = Symbol("k14");
+  checks.push(Reflect.get(p14, sym14) === "trapped:Symbol(k14)");
+}
+
+// --- 15. Proxy with no trap: falls through to the target. ---
+{
+  const target15: any = { y: 123 };
+  const p15: any = new Proxy(target15, {});
+  checks.push(Reflect.get(p15, "y") === 123);
+}
+
+// --- 16. Absent property on a plain object answers undefined, no throw. ---
+{
+  checks.push(Reflect.get({}, "nope") === undefined);
+}
+
+// --- 17. Enum (a TypeDictObject at runtime) as a Reflect.get target -
+// this case didn't exist at all before this fix, so this exercises it
+// directly rather than only via the shared machinery's other callers. ---
+{
+  enum Color17 { Red, Green, Blue }
+  checks.push(Reflect.get(Color17 as any, "Red") === 0);
+  checks.push(Reflect.get(Color17 as any, "Blue") === 2);
+}
+
+// --- 18. A value's own [[Prototype]] chain passes through a callable
+// (Object.create(fn)) - both key kinds must still find an own property
+// on that callable's own table, not stop early. This is the bug an
+// earlier draft of this fix had (the walk's continuation check used
+// IsObject(), which is false for every callable kind - see this file's
+// header comment) - pinned explicitly here, not just documented in code. ---
+{
+  function base18() {}
+  (base18 as any).regular = "r";
+  const sym18 = Symbol("s18");
+  (base18 as any)[sym18] = "found18";
+  const inst18: any = Object.create(base18);
+  checks.push(Reflect.get(inst18, "regular") === "r");
+  checks.push(Reflect.get(inst18, sym18) === "found18");
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/reflect_ownkeys_callable.ts
+++ b/tests/scripts/reflect_ownkeys_callable.ts
@@ -1,0 +1,169 @@
+// expect: true
+// Reflect.ownKeys had two independent problems, found while verifying
+// paserati PR #343:
+//
+// 1. Its object-gate threw on any callable target. Unlike every other
+//    Reflect method in this file (get/set/has/apply/construct/...), which
+//    all correctly gate on `!target.IsObject() && !target.IsCallable()`,
+//    ownKeys gated on `!target.IsObject()` alone - so it threw a TypeError
+//    outright for a plain function, a native function, a bound function,
+//    or a class, even though every other Reflect method here already
+//    accepts them:
+//
+//      Reflect.ownKeys(Array.prototype.slice); // before: threw - Node: ["length", "name"]
+//
+// 2. Even past that gate, the switch had no case at all for any callable
+//    kind (TypeFunction/TypeClosure/TypeNativeFunction/
+//    TypeNativeFunctionWithProps/TypeBoundFunction) - so fixing (1) alone
+//    would just fall through and answer [] instead of throwing.
+//
+// Rather than hand-rolling a third independent per-kind name/length/
+// prototype synthesis switch (this codebase's dominant recurring bug
+// class this whole multi-PR effort has been chasing down - N independent
+// copies of the same per-kind dispatch slowly drifting apart), these five
+// kinds now delegate straight to Object.getOwnPropertyNames +
+// Object.getOwnPropertySymbols (concatenated - which is exactly the
+// ECMA-262 10.1.11 OrdinaryOwnPropertyKeys order Reflect.ownKeys itself
+// requires: integer indices, then string keys, then symbol keys, all in
+// creation order). TypeObject/TypeDictObject/TypeArray/TypeProxy keep
+// their own pre-existing, already-correct logic untouched.
+//
+// Object.getOwnPropertyNames itself had no case at all for
+// TypeNativeFunction (a plain, non-Props native function like
+// Array.prototype.slice) or TypeBoundFunction either - the same "kind
+// missing from a switch" gap, one level down, fixed in the same commit
+// since Reflect.ownKeys's delegation depends on it for exactly those two
+// kinds.
+//
+// Found while verifying, NOT fixed here - a real, narrower, pre-existing
+// bug in the untouched TypeFunction/TypeClosure cases, deliberately
+// deferred as a follow-up: they synthesize "prototype" unconditionally
+// whenever it isn't already a real, explicit own property - even for an
+// arrow function or a plain (non-generator) async function, neither of
+// which has a "prototype" own property at all per spec (verified against
+// Node). Not touched here since it's unrelated to the callable-kind gate/
+// switch bug this task is about, and none of Node, this task's stated
+// scope, or its listed test targets involve arrow/async functions.
+
+const checks: boolean[] = [];
+
+// --- 1. A plain function: length, name, prototype (the gate no longer
+// throws, and TypeFunction/TypeClosure already had correct per-kind
+// synthesis via Object.getOwnPropertyNames). ---
+{
+  function fn(a: number, b: number) { return a + b; }
+  const keys = Reflect.ownKeys(fn as any);
+  checks.push(
+    keys.length === 3 &&
+      keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype"
+  );
+}
+
+// --- 2. A class (compiles to TypeClosure, same shape as check 1 through
+// a different surface syntax). ---
+{
+  class C {}
+  const keys = Reflect.ownKeys(C as any);
+  checks.push(
+    keys.length === 3 &&
+      keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype"
+  );
+}
+
+// --- 3. A native function that is NOT a constructor
+// (TypeNativeFunction) - no "prototype" (Node agrees: Array.prototype.slice
+// has none). This is one of the two kinds that had NO case at all in
+// Object.getOwnPropertyNames before this fix - previously silently []. ---
+{
+  const keys = Reflect.ownKeys(Array.prototype.slice as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 4. A native constructor (TypeNativeFunctionWithProps,
+// IsConstructor === true) - HAS "prototype", unlike check 3's non-
+// constructor native function. Not asserting the full key list here:
+// paserati's own Array bootstrap registers its statics in a different
+// order than Node's (isArray/from/of/fromAsync vs Node's isArray/from/
+// fromAsync/of) - an engine implementation detail, not a spec
+// requirement, and not something this fix controls (it only touches
+// synthesis of length/name/prototype, not the order user code registers
+// its own statics in). Asserting the length/name/prototype prefix and
+// that more keys follow is what's actually spec-fixed and
+// engine-independent. ---
+{
+  const keys = Reflect.ownKeys(Array as any);
+  checks.push(
+    keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype" &&
+      keys.length > 3
+  );
+}
+
+// --- 5. A bound function (TypeBoundFunction) - the OTHER kind that had
+// no case at all in Object.getOwnPropertyNames before this fix. Per PR
+// #343, "name"/"length" are REAL own properties set at bind time (not
+// synthesized), and a bound function never has its own "prototype"
+// regardless of whether its target is a constructor - verified against
+// Node for both a bound plain function AND a bound class. ---
+{
+  function orig() {}
+  const bound = orig.bind(null);
+  const keys = Reflect.ownKeys(bound as any);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+{
+  class D {}
+  const boundClass = (D as any).bind(null);
+  const keys = Reflect.ownKeys(boundClass);
+  checks.push(keys.length === 2 && keys[0] === "length" && keys[1] === "name");
+}
+
+// --- 6. The symbol half of the delegation actually fires: a symbol
+// property added to a plain function (own local function, not a shared
+// intrinsic, so this can't collide with any other test file's own
+// mutations of a real global) shows up in Reflect.ownKeys, positioned
+// after every string key per ECMA-262 10.1.11 OrdinaryOwnPropertyKeys.
+// Not comparing this against Object.getOwnPropertyNames +
+// getOwnPropertySymbols the way checks 1-5 implicitly do (via the fixed
+// implementation itself calling exactly those two functions) - doing so
+// here would just be asserting the delegation agrees with itself. This
+// checks an actual value: the symbol is present, and it comes last. ---
+{
+  function fn6(a: number) { return a; }
+  const sym6 = Symbol("custom6");
+  Object.defineProperty(fn6, sym6, {
+    value: 1,
+    enumerable: false,
+    configurable: true,
+  });
+  const keys = Reflect.ownKeys(fn6 as any);
+  checks.push(
+    keys.length === 4 &&
+      keys[0] === "length" &&
+      keys[1] === "name" &&
+      keys[2] === "prototype" &&
+      keys[3] === sym6
+  );
+}
+
+// --- 7. The gate itself: before this fix, ALL of the calls above would
+// have thrown a TypeError instead of returning key lists - explicitly
+// confirm a callable target no longer throws, and a genuinely
+// non-object, non-callable primitive still correctly does (per spec,
+// Reflect.ownKeys's target must be an object). ---
+{
+  let threw = false;
+  try {
+    Reflect.ownKeys(42 as any);
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/reflect_set_construct_optional_args.ts
+++ b/tests/scripts/reflect_set_construct_optional_args.ts
@@ -1,0 +1,166 @@
+// expect: true
+// Reflect.set and Reflect.construct were both declared with fewer
+// parameters than their runtime implementations actually accepted, so a
+// call using their spec'd optional trailing argument failed type checking
+// even though it ran fine with --no-typecheck - the same gap PR #341
+// already fixed for Reflect.get's optional third `receiver` argument:
+//
+//   const target: any = {};
+//   Reflect.set(target, "x", 1, target); // before: TS2554 "Expected 3 arguments, but got 4."
+//
+// Both fixed the same way as Reflect.get: types.NewOptionalFunction
+// instead of types.NewSimpleFunction, with the trailing argument(s)
+// marked optional.
+//
+// Fixing Reflect.construct's signature to actually ALLOW a distinct
+// newTarget argument immediately surfaced that the runtime feature behind
+// it was itself broken for almost every real newTarget - not just a type
+// declaration gap, a genuine runtime bug, found and fixed in the same
+// commit since testing the newly-typecheckable 3rd argument is what
+// caught it:
+//
+//   function C(a) { this.a = a; }
+//   function D() {}
+//   D.prototype = { fromD: true };
+//   Object.getPrototypeOf(Reflect.construct(C, [1], D)) === D.prototype; // before: false - Node: true
+//
+// Root cause: ConstructWithNewTarget (pkg/vm/vm_init.go) unwrapped a
+// TypeClosure newTarget straight to its underlying, SHARED
+// *FunctionObject (newTarget.AsClosure().Fn) and read/created "prototype"
+// there - but `someClosure.prototype = x` (op_setprop.go) writes into
+// closure.Properties, a per-CLOSURE-INSTANCE side table that shadows the
+// shared Fn's, exactly like the closure's ordinary property-read path
+// already respects. So any newTarget whose .prototype had been reassigned
+// (including a class, which compiles to TypeClosure) silently got the
+// stale, unshadowed default instead. Fixed by using
+// ClosureObject.GetPrototypeWithVM (pkg/vm/function.go) - the same method
+// `class X extends Y` (OpValidateSuperclass, pkg/vm/vm.go) already uses
+// for the identical purpose - instead of reaching past the closure
+// wrapper. A bound-function or native-constructor newTarget had the
+// identical "falls back to constructor's own prototype, not newTarget's"
+// bug via the same code path - fixed by routing those through
+// GetPrototypeFromConstructor instead, which already reads their real,
+// non-lazily-created "prototype" property correctly (unlike
+// TypeFunction/TypeClosure's synthesized-on-first-access one, which is
+// why they need the ClosureObject/FunctionObject-specific methods instead).
+//
+// Found while testing, NOT fixed here - a real, separate, pre-existing
+// runtime bug, deliberately deferred as a follow-up: Reflect.set ignores
+// a non-Proxy receiver argument distinct from target when target lacks
+// the property being set - it always writes to target regardless. Only
+// the receiver === target form (the common case, and the one this fix's
+// own type-signature change most directly unblocks) works correctly.
+// Pinned explicitly below (check 3) rather than silently left
+// undocumented - see its own comment for the repro and the reasoning for
+// deferring it. Flagged as a follow-up chip.
+
+const checks: boolean[] = [];
+
+// --- 1. Reflect.set with all 4 arguments, receiver === target (the
+// common/simple form) - already worked at runtime before this fix; this
+// confirms the type-signature change didn't perturb it. ---
+{
+  const target1: any = {};
+  const ok = Reflect.set(target1, "x", 1, target1);
+  checks.push(ok === true && target1.x === 1);
+}
+
+// --- 2. Reflect.set omitting only the trailing `receiver` (the ONLY
+// optional parameter per spec - lib.es2015.reflect.d.ts declares
+// `set(target, propertyKey, value, receiver?)`; `value` is required, so
+// passing `undefined` for it explicitly is the correct way to exercise
+// "value omitted at the value level" - a bare 2-arg call would be a type
+// error, correctly, and isn't what "receiver is optional" means). ---
+{
+  const target2: any = {};
+  const ok = Reflect.set(target2, "z", undefined);
+  checks.push(ok === true && target2.z === undefined);
+}
+
+// --- 3. KNOWN, PRE-EXISTING GAP (not fixed here, flagged as a follow-up):
+// Reflect.set with a receiver DISTINCT from target, where target lacks
+// the property, should write to the RECEIVER per ECMA-262 10.1.9.2
+// OrdinarySetWithOwnDescriptor - paserati instead writes to target. This
+// assertion pins TODAY's wrong behavior explicitly (matching the
+// established pattern for a still-open gap - see in_symbol_proxy.ts's
+// history) so a future fix has to touch this file instead of silently
+// leaving stale documentation. Node: ok === true, receiver3.y === 5,
+// "y" in target3 === false. ---
+{
+  const target3: any = {};
+  const receiver3: any = {};
+  const ok = Reflect.set(target3, "y", 5, receiver3);
+  checks.push(ok === true && target3.y === 5 && receiver3.y === undefined);
+}
+
+// --- 4. Reflect.construct with 2 arguments (newTarget defaults to
+// target) - already worked; confirms no regression. ---
+{
+  function C4(a: number) { (this as any).a = a; }
+  const inst: any = Reflect.construct(C4 as any, [3]);
+  checks.push(inst.a === 3 && inst instanceof (C4 as any));
+}
+
+// --- 5. Reflect.construct with a distinct newTarget whose .prototype was
+// reassigned to a fresh object - the exact bug this fix closes. Not
+// asserting `inst.constructor === D5`: replacing .prototype with a plain
+// object literal has no "constructor" backlink to begin with (Node
+// agrees - inst.constructor is Object there, not D5), so that would be a
+// wrong assertion, not a discriminating one. The prototype-identity check
+// is what actually distinguishes the fix. ---
+{
+  function C5(a: number) { (this as any).a = a; }
+  function D5() {}
+  (D5 as any).prototype = { fromD5: true };
+  const inst: any = Reflect.construct(C5 as any, [4], D5 as any);
+  checks.push(inst.a === 4 && Object.getPrototypeOf(inst) === (D5 as any).prototype);
+}
+
+// --- 6. Reflect.construct with a class as newTarget (classes compile to
+// TypeClosure too - same code path as check 5, different surface syntax). ---
+{
+  function C6(a: number) { (this as any).a = a; }
+  class D6 {}
+  const inst: any = Reflect.construct(C6 as any, [6], D6 as any);
+  checks.push(inst.a === 6 && Object.getPrototypeOf(inst) === (D6 as any).prototype);
+}
+
+// --- 7. Reflect.construct with a bound function as newTarget, custom
+// prototype - the TypeBoundFunction half of the same bug class. ---
+{
+  function C7(a: number) { (this as any).a = a; }
+  function E7() {}
+  const bound7: any = E7.bind(null);
+  bound7.prototype = { fromBound7: true };
+  const inst: any = Reflect.construct(C7 as any, [7], bound7);
+  checks.push(inst.a === 7 && Object.getPrototypeOf(inst) === bound7.prototype);
+}
+
+// --- 8. Reflect.construct with a fresh (never-touched) function
+// newTarget: the auto-vivified default prototype, WITH its constructor
+// backlink, must still work exactly as before this fix (a regression
+// guard - this is the one case that happened to already work, since
+// there's no divergence between the shared FunctionObject and a
+// never-created closure-instance override). ---
+{
+  function C8(a: number) { (this as any).a = a; }
+  function Fresh8() {}
+  const inst: any = Reflect.construct(C8 as any, [8], Fresh8 as any);
+  checks.push(
+    inst.a === 8 &&
+      Object.getPrototypeOf(inst) === (Fresh8 as any).prototype &&
+      inst.constructor === Fresh8
+  );
+}
+
+// --- 9. Reflect.construct omitting newTarget entirely: defaults to
+// target, constructor backlink intact - confirms the 3-arg overload
+// (added by this fix's type-signature change) doesn't disturb the
+// pre-existing 2-arg form. ---
+{
+  function C9(a: number) { (this as any).a = a; }
+  const inst: any = Reflect.construct(C9 as any, [9]);
+  checks.push(inst.a === 9 && inst.constructor === C9);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/reflect_set_construct_optional_args.ts
+++ b/tests/scripts/reflect_set_construct_optional_args.ts
@@ -44,15 +44,16 @@
 // TypeFunction/TypeClosure's synthesized-on-first-access one, which is
 // why they need the ClosureObject/FunctionObject-specific methods instead).
 //
-// Found while testing, NOT fixed here - a real, separate, pre-existing
-// runtime bug, deliberately deferred as a follow-up: Reflect.set ignores
-// a non-Proxy receiver argument distinct from target when target lacks
-// the property being set - it always writes to target regardless. Only
-// the receiver === target form (the common case, and the one this fix's
-// own type-signature change most directly unblocks) works correctly.
-// Pinned explicitly below (check 3) rather than silently left
-// undocumented - see its own comment for the repro and the reasoning for
-// deferring it. Flagged as a follow-up chip.
+// Found while testing (and flagged as a follow-up chip, task_cd1507d7) -
+// then fixed in a later PR: Reflect.set used to ignore a non-Proxy
+// receiver argument distinct from target when target lacked the property
+// being set, always writing to target regardless. Check 3 below used to
+// pin that wrong behavior explicitly; it's flipped now that
+// pkg/builtins/reflect_init.go's "set" closure implements the real
+// ECMA-262 10.1.9/10.1.9.2 OrdinarySet(WithOwnDescriptor) algorithm
+// (reflectOrdinarySet), which also fixed a second bug found in the same
+// pass: Reflect.set never invoked an own or inherited accessor's setter
+// at all, even for the common receiver === target case (see check 3a).
 
 const checks: boolean[] = [];
 
@@ -77,20 +78,45 @@ const checks: boolean[] = [];
   checks.push(ok === true && target2.z === undefined);
 }
 
-// --- 3. KNOWN, PRE-EXISTING GAP (not fixed here, flagged as a follow-up):
-// Reflect.set with a receiver DISTINCT from target, where target lacks
-// the property, should write to the RECEIVER per ECMA-262 10.1.9.2
-// OrdinarySetWithOwnDescriptor - paserati instead writes to target. This
-// assertion pins TODAY's wrong behavior explicitly (matching the
-// established pattern for a still-open gap - see in_symbol_proxy.ts's
-// history) so a future fix has to touch this file instead of silently
-// leaving stale documentation. Node: ok === true, receiver3.y === 5,
-// "y" in target3 === false. ---
+// --- 3. Reflect.set with a receiver DISTINCT from target, where target
+// lacks the property: writes to the RECEIVER per ECMA-262 10.1.9.2
+// OrdinarySetWithOwnDescriptor's final CreateDataProperty(Receiver, ...)
+// step - flipped from pinning the pre-existing wrong (writes-to-target)
+// behavior once reflectOrdinarySet fixed it (mirrors the
+// in_symbol_proxy.ts check-11 precedent: pin a known gap explicitly, flip
+// the assertion in the same test file once it closes). Verified against
+// Node: ok === true, receiver3.y === 5, "y" in target3 === false. ---
 {
   const target3: any = {};
   const receiver3: any = {};
   const ok = Reflect.set(target3, "y", 5, receiver3);
-  checks.push(ok === true && target3.y === 5 && receiver3.y === undefined);
+  checks.push(ok === true && receiver3.y === 5 && !("y" in target3));
+}
+
+// --- 3a. The second bug found alongside check 3's: Reflect.set didn't
+// invoke an own accessor's setter at all, even for the common
+// receiver === target form - it silently clobbered/no-opped instead of
+// calling the setter (verified against Node, which does call it, with
+// `this` bound to the receiver). Fixing the general-receiver case
+// required walking descriptors either way, so this shares the same fix. ---
+{
+  const obj: any = {};
+  let setterCalled = false;
+  let receivedValue: any = null;
+  let receivedThisIsObj = false;
+  Object.defineProperty(obj, "y", {
+    get() {
+      return 1;
+    },
+    set(v: any) {
+      setterCalled = true;
+      receivedValue = v;
+      receivedThisIsObj = this === obj;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(obj, "y", 99);
+  checks.push(ok === true && setterCalled && receivedValue === 99 && receivedThisIsObj);
 }
 
 // --- 4. Reflect.construct with 2 arguments (newTarget defaults to

--- a/tests/scripts/reflect_set_proxy_target.ts
+++ b/tests/scripts/reflect_set_proxy_target.ts
@@ -1,0 +1,236 @@
+// expect: true
+// Reflect.set's "set" closure (pkg/builtins/reflect_init.go) had no
+// handling at all for `target` being a Proxy: `target.Type() == TypeProxy`
+// passes the gate (Value.IsObject() is a contiguous [TypeObject, TypeProxy]
+// range check, so it's true for a Proxy), but neither the old isDataProp
+// computation nor the final target-kind switch had a case for TypeProxy -
+// so it fell through to an unconditional `return false`, silently doing
+// nothing for ANY Proxy target, with or without a `set` trap:
+//
+//   const target = {};
+//   const p = new Proxy(target, {});
+//   Reflect.set(p, "x", 5); // before: false, target.x stayed undefined - Node: true, target.x === 5
+//
+// Fixed via reflectProxySet (mirrors op_setprop.go's opSetProp TypeProxy
+// handling - the bytecode `obj.x = v` path, which already got this right
+// for that narrower case - but forwards Reflect.set's own `receiver`
+// argument to the trap, not necessarily the proxy itself).
+//
+// Fixing this also required completing the receiver-side half for a
+// receiver that itself turns out to be a Proxy - the single most common
+// call, Reflect.set(someProxy, key, value) with receiver OMITTED, defaults
+// receiver to the proxy itself, so even the "target is a plain object,
+// nothing exotic going on" recursive case now routes through a Proxy
+// receiver. reflectProxyDefineDataProperty implements that: the receiver
+// Proxy's own defineProperty trap if present, else delegate straight to
+// CreateDataProperty on ITS OWN target. This superseded (not patched) an
+// old inline "receiver is a distinct Proxy" special case that only handled
+// a receiver-Proxy WITH a defineProperty trap and otherwise silently fell
+// through to the exact task_cd1507d7 bug this file's sibling test already
+// covers for other receiver kinds - removed rather than left to keep
+// intercepting upstream of the real fix.
+//
+// Found while fixing this, NOT fixed here (flagged as a follow-up chip):
+// Reflect.set's propKey := args[1].ToString() stringifies a Symbol key
+// before it ever reaches a Proxy's `set` trap, so
+// Reflect.set(proxy, Symbol.iterator, v) hands the trap the string
+// "Symbol(Symbol.iterator)" instead of the real Symbol - pre-existing,
+// unrelated to target-being-a-Proxy, but this fix is the first place that
+// mangled key becomes externally observable to user code (a trap
+// function) rather than just internally wrong.
+//
+// Every check here was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Proxy WITH a set trap: the trap receives (target, key, value,
+// receiver) - `receiver` is the ORIGINAL Reflect.set receiver argument,
+// not the proxy itself - and a well-behaved trap's own write is observed. ---
+{
+  const target: any = {};
+  const receiver: any = { tag: "custom-receiver" };
+  let seenTargetMatches = false;
+  let seenKey: any = null;
+  let seenValue: any = null;
+  let seenReceiverMatches = false;
+  const p: any = new Proxy(target, {
+    set(t: any, k: any, v: any, r: any) {
+      seenTargetMatches = t === target;
+      seenKey = k;
+      seenValue = v;
+      seenReceiverMatches = r === receiver;
+      Reflect.set(t, k, v);
+      return true;
+    },
+  });
+  const ok = Reflect.set(p, "x", 5, receiver);
+  checks.push(
+    ok === true &&
+      seenTargetMatches &&
+      seenKey === "x" &&
+      seenValue === 5 &&
+      seenReceiverMatches &&
+      target.x === 5
+  );
+}
+
+// --- 2. Proxy WITHOUT a set trap, distinct plain receiver: delegates to
+// the target, and the receiver-bug fix (task_cd1507d7) still applies -
+// the write lands on the receiver, not target. ---
+{
+  const target2: any = {};
+  const p2: any = new Proxy(target2, {});
+  const receiver2: any = {};
+  const ok = Reflect.set(p2, "y", 7, receiver2);
+  checks.push(ok === true && receiver2.y === 7 && !("y" in target2));
+}
+
+// --- 3. Proxy WITHOUT a set trap, receiver OMITTED (defaults to the proxy
+// itself) - the single most common way to call Reflect.set on a Proxy at
+// all. Since a Proxy has no data storage of its own, CreateDataProperty on
+// the proxy-as-receiver recurses into its own (trap-less) defineProperty
+// delegation, landing on the underlying target. ---
+{
+  const target3: any = {};
+  const p3: any = new Proxy(target3, {});
+  const ok = Reflect.set(p3, "z", 9);
+  checks.push(ok === true && target3.z === 9 && p3.z === 9);
+}
+
+// --- 4. A revoked proxy throws a TypeError. ---
+{
+  const { proxy, revoke } = (Proxy as any).revocable({}, {});
+  revoke();
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.set(proxy, "x", 1);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+// --- 5. A trap returning truish for a target property that is
+// non-configurable, non-writable, and already a DIFFERENT value is an
+// ECMA-262 10.5.9 invariant violation - throws a TypeError rather than
+// silently succeeding. ---
+{
+  const target4: any = {};
+  Object.defineProperty(target4, "x", { value: 1, writable: false, configurable: false });
+  const p4: any = new Proxy(target4, {
+    set() {
+      return true;
+    },
+  });
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.set(p4, "x", 2);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError && target4.x === 1);
+}
+
+// --- 6. A trap returning falsish means the set failed - false, no throw,
+// and no write happens. ---
+{
+  const target5: any = {};
+  const p5: any = new Proxy(target5, {
+    set() {
+      return false;
+    },
+  });
+  const ok = Reflect.set(p5, "x", 1);
+  checks.push(ok === false && target5.x === undefined);
+}
+
+// --- 7. receiver is a DISTINCT Proxy with a defineProperty trap: both the
+// getOwnPropertyDescriptor trap (side-effect parity) and the
+// defineProperty trap fire, with the exact CreateDataProperty-shaped
+// descriptor ({value, writable: true, enumerable: true, configurable:
+// true}). Distinct target6/receiverProxy6 from checks 1-6 per this
+// session's "distinct target per assertion" convention. ---
+{
+  const target6: any = {};
+  let getOwnPropDescCalled = false;
+  let definePropCalled = false;
+  let definePropKey: any = null;
+  let definePropValue: any = null;
+  let definePropWritable: any = null;
+  let definePropEnumerable: any = null;
+  let definePropConfigurable: any = null;
+  const receiverProxy6: any = new Proxy(
+    {},
+    {
+      getOwnPropertyDescriptor() {
+        getOwnPropDescCalled = true;
+        return undefined;
+      },
+      defineProperty(t: any, k: any, desc: any) {
+        definePropCalled = true;
+        definePropKey = k;
+        definePropValue = desc.value;
+        definePropWritable = desc.writable;
+        definePropEnumerable = desc.enumerable;
+        definePropConfigurable = desc.configurable;
+        Object.defineProperty(t, k, desc);
+        return true;
+      },
+    }
+  );
+  const ok = Reflect.set(target6, "y", 5, receiverProxy6);
+  checks.push(
+    ok === true &&
+      getOwnPropDescCalled &&
+      definePropCalled &&
+      definePropKey === "y" &&
+      definePropValue === 5 &&
+      definePropWritable === true &&
+      definePropEnumerable === true &&
+      definePropConfigurable === true &&
+      receiverProxy6.y === 5
+  );
+}
+
+// --- 8. receiver is a DISTINCT Proxy with only a getOwnPropertyDescriptor
+// trap (no defineProperty trap): falls back to CreateDataProperty on the
+// receiver-proxy's OWN target directly. ---
+{
+  const target7: any = {};
+  let called = false;
+  const receiverProxy7: any = new Proxy(
+    {},
+    {
+      getOwnPropertyDescriptor() {
+        called = true;
+        return undefined;
+      },
+    }
+  );
+  const ok = Reflect.set(target7, "z", 9, receiverProxy7);
+  checks.push(ok === true && called && receiverProxy7.z === 9);
+}
+
+// --- 9. A revoked receiver-Proxy (target is a plain object; the
+// RECEIVER is the revoked one) also throws a TypeError - not the same
+// code path as check 4's revoked target, but the same outcome (verified
+// against Node). ---
+{
+  const { proxy, revoke } = (Proxy as any).revocable({}, {});
+  revoke();
+  let threw = false;
+  let isTypeError = false;
+  try {
+    Reflect.set({}, "y", 5, proxy);
+  } catch (e) {
+    threw = true;
+    isTypeError = e instanceof TypeError;
+  }
+  checks.push(threw && isTypeError);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/reflect_set_receiver_and_accessors.ts
+++ b/tests/scripts/reflect_set_receiver_and_accessors.ts
@@ -1,0 +1,186 @@
+// expect: true
+// Reflect.set's "set" closure (pkg/builtins/reflect_init.go) used to have
+// a "Simple property set on target" fallback that unconditionally called
+// target.AsPlainObject().SetOwn(...) / target.AsDictObject().SetOwn(...) /
+// arr.Set(idx, ...) directly, regardless of:
+//
+//  - `receiver` being distinct from `target` (a Proxy receiver was
+//    special-cased above it; any OTHER kind of distinct receiver - the
+//    common case, a plain object - fell straight through to the
+//    always-writes-to-target fallback), and
+//  - `target` (or its prototype chain) having an own or inherited
+//    accessor at all - the fallback never checked, so even the ordinary
+//    receiver === target form silently clobbered/no-opped an existing
+//    setter instead of calling it.
+//
+// Both are the same root cause (the fallback had no descriptor awareness
+// whatsoever) and are fixed together by reflectOrdinarySet, a real
+// implementation of ECMA-262 10.1.9 OrdinarySet / 10.1.9.2
+// OrdinarySetWithOwnDescriptor: walk target's own property, then its
+// whole [[Prototype]] chain, for the first applicable descriptor - an
+// accessor's setter is invoked with `receiver` as `this` wherever in the
+// chain it's found; a data descriptor's actual write always lands on
+// `receiver` (via reflectCreateOrUpdateDataProperty), never on whichever
+// object in target's chain the descriptor happened to be found on.
+//
+// Every check here was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Distinct plain-object receiver, property absent on target and
+// its whole prototype chain: per 10.1.9.2's final
+// CreateDataProperty(Receiver, ...) step, the write lands on `receiver`,
+// not `target` - the core bug this fix closes. ---
+{
+  const target: any = {};
+  const receiver: any = {};
+  const ok = Reflect.set(target, "y", 5, receiver);
+  checks.push(ok === true && receiver.y === 5 && !("y" in target));
+}
+
+// --- 2. receiver === target (the common/simple form) must not regress. ---
+{
+  const target2: any = {};
+  const ok = Reflect.set(target2, "x", 1, target2);
+  checks.push(ok === true && target2.x === 1);
+}
+
+// --- 3. receiver already has its own (writable, non-accessor) property
+// for the same key: the write updates the RECEIVER's existing property in
+// place (not the target, which still must not gain the key at all). ---
+{
+  const target3: any = {};
+  const receiver3: any = { y: 10 };
+  const ok = Reflect.set(target3, "y", 99, receiver3);
+  checks.push(ok === true && receiver3.y === 99 && !("y" in target3));
+}
+
+// --- 4. Inherited accessor (setter defined on target's prototype, not
+// target itself) with a distinct receiver: the setter still fires, and
+// `this` inside it is the RECEIVER, not target or the prototype - so the
+// side effect the setter performs (`this._z = v`) lands on the receiver. ---
+{
+  const proto: any = {};
+  Object.defineProperty(proto, "z", {
+    get() {
+      return 2;
+    },
+    set(v: any) {
+      (this as any)._z = v;
+    },
+    configurable: true,
+  });
+  const child: any = Object.create(proto);
+  const rec: any = {};
+  const ok = Reflect.set(child, "z", 42, rec);
+  checks.push(ok === true && rec._z === 42 && (child as any)._z === undefined);
+}
+
+// --- 5. Own accessor, receiver === target (the second bug found while
+// fixing check 1 - not previously covered by any test at all): the
+// setter must actually be invoked, with `this` bound to the object,
+// instead of being silently bypassed. ---
+{
+  const obj: any = {};
+  let calls = 0;
+  let lastValue: any = null;
+  Object.defineProperty(obj, "y", {
+    get() {
+      return 1;
+    },
+    set(v: any) {
+      calls++;
+      lastValue = v;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(obj, "y", 7);
+  checks.push(ok === true && calls === 1 && lastValue === 7 && obj.y === 1);
+}
+
+// --- 6. An accessor with no setter (getter-only) refuses the write and
+// returns false, rather than silently succeeding or throwing. ---
+{
+  const o: any = {};
+  Object.defineProperty(o, "y", {
+    get() {
+      return 1;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(o, "y", 5);
+  checks.push(ok === false);
+}
+
+// --- 7. A non-writable, non-accessor data property on target refuses the
+// write and returns false. ---
+{
+  const o2: any = Object.freeze({ x: 1 });
+  const ok = Reflect.set(o2, "x", 2);
+  checks.push(ok === false && o2.x === 1);
+}
+
+// --- 8. A primitive receiver (not an object) makes the data-write branch
+// fail with false, per 10.1.9.2 step 4.a - not a throw. ---
+{
+  const ok = Reflect.set({}, "y", 5, 42 as any);
+  checks.push(ok === false);
+}
+
+// --- 9. receiver has its own NON-WRITABLE property for the key: the
+// write must be refused (false), and the receiver's value must not
+// change, even though target has no such restriction at all. ---
+{
+  const target4: any = {};
+  const receiver4: any = {};
+  Object.defineProperty(receiver4, "y", { value: 1, writable: false, configurable: true });
+  const ok = Reflect.set(target4, "y", 99, receiver4);
+  checks.push(ok === false && receiver4.y === 1);
+}
+
+// --- 10. receiver has its own ACCESSOR for the key: a plain data write
+// can't overwrite an accessor, so this must be refused (false) and the
+// receiver's setter must NOT be invoked (a data write is not the same
+// operation as calling the accessor). ---
+{
+  const target5: any = {};
+  const receiver5: any = {};
+  Object.defineProperty(receiver5, "y", {
+    get() {
+      return 1;
+    },
+    set(v: any) {
+      (this as any)._y = v;
+    },
+    configurable: true,
+  });
+  const ok = Reflect.set(target5, "y", 99, receiver5);
+  checks.push(ok === false && receiver5._y === undefined);
+}
+
+// --- 11. Array "length" actually resizes (the pre-existing fallback had
+// an explicit "Setting length is complex, skip for now" no-op stub here -
+// verified against Node, which does resize). ---
+{
+  const arr: any = [1, 2, 3, 4, 5];
+  const ok = Reflect.set(arr, "length", 2);
+  checks.push(ok === true && arr.length === 2 && arr[0] === 1 && arr[1] === 2 && arr[2] === undefined);
+}
+
+// --- 12. Array named (non-index) property still works, using a distinct
+// array from check 11 per this session's "distinct target per assertion"
+// convention for shared/mutable state. ---
+{
+  const arr2: any = [1, 2, 3];
+  const ok = Reflect.set(arr2, "customProp", 5);
+  checks.push(ok === true && arr2.customProp === 5);
+}
+
+// --- 13. Array numeric-index set still works. ---
+{
+  const arr3: any = [1, 2, 3];
+  const ok = Reflect.set(arr3, "1", 99);
+  checks.push(ok === true && arr3[1] === 99);
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/symbol_accessor_assign_no_clobber.ts
+++ b/tests/scripts/symbol_accessor_assign_no_clobber.ts
@@ -1,0 +1,247 @@
+// expect: true
+// no-typecheck
+// setOwnCheckedByKey (and, for a string key on RegExp/Map/Set/Promise/
+// BoundFunction/NativeFunction(WithProps), setOwnChecked - that call site
+// never even pre-checked for an accessor the way TypeFunction/TypeClosure's
+// callers in pkg/vm/op_setprop.go did) unconditionally wrote the assigned
+// value through DefineOwnPropertyByKey/PlainObject.SetOwn whenever the
+// target key already existed - including when it named an existing
+// ACCESSOR. Ordinary [[Set]] (obj[key] = v) must instead call the
+// accessor's setter if it has one, or - getter-only - silently no-op in
+// sloppy mode / throw a TypeError in strict mode. It must never convert
+// the accessor into a data property.
+//
+// Fixed by a new shared helper, setOwnAccessorSetter
+// (pkg/vm/properties_table.go), that both setOwnChecked and
+// setOwnCheckedByKey now consult first, mirroring the accessor-setter
+// check pkg/vm/op_setprop.go's TypeObject (plain object) case already had.
+//
+// This file needs `// no-typecheck`: the TypeScript-checked default this
+// repo's tests otherwise run under always compiles as strict mode (see
+// pkg/compiler/compiler.go's "TypeScript mode - always strict"), which
+// would make every assertion below throw instead of exercising the silent
+// sloppy-mode no-op this bug is actually about. The assertions that want
+// strict-mode throwing opt back into it locally via their own
+// "use strict" directive.
+//
+// Getting the strict-mode assertions below to work at all required a
+// second, causally-coupled fix: every OpSetIndex (bracket-notation
+// assignment) dispatch site that calls opSetPropSymbol/opSetProp
+// unconditionally did `if !ok { return status, res }` without checking
+// vm.unwinding first - so a thrown exception (this fix's new strict-mode
+// TypeError included) could never actually be caught by an enclosing
+// try/catch; it just aborted the whole VM run. Fixed by mirroring
+// OpSetProp's dot-notation dispatch (and the one already-correct
+// TypeObject/callable branch of OpSetIndex itself), which check
+// `vm.unwinding` and `goto reloadFrame` instead. See pkg/vm/vm.go's
+// OpSetIndex case.
+
+const checks = [];
+
+function hasAccessorDesc(desc, hasSetter) {
+  return (
+    desc !== undefined &&
+    typeof desc.get === "function" &&
+    (hasSetter ? typeof desc.set === "function" : desc.set === undefined)
+  );
+}
+
+// --- Function: assigning through an existing getter-only accessor must
+// leave the backing state (and the accessor itself) untouched, and must
+// not throw in sloppy mode. ---
+(function () {
+  let backing = 1;
+  function fn() {}
+  const sym = Symbol("k1");
+  Object.defineProperty(fn, sym, {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  fn[sym] = 2; // must not throw, must not touch backing, must not clobber
+  checks.push(backing === 1);
+  const desc = Object.getOwnPropertyDescriptor(fn, sym);
+  checks.push(hasAccessorDesc(desc, false));
+  checks.push(desc.get() === 1);
+})();
+
+// --- Function: assigning through an existing getter+setter accessor must
+// call the setter (whatever it does), not write a data property. ---
+(function () {
+  let backing = 0;
+  function fn() {}
+  const sym = Symbol("k2");
+  Object.defineProperty(fn, sym, {
+    get() {
+      return backing;
+    },
+    set(v) {
+      backing = v * 10;
+    },
+    configurable: true,
+  });
+  fn[sym] = 3;
+  checks.push(backing === 30);
+  const desc = Object.getOwnPropertyDescriptor(fn, sym);
+  checks.push(hasAccessorDesc(desc, true));
+  checks.push(desc.get() === 30);
+})();
+
+// --- Map (an exotic kind whose symbol-set call site, unlike Function's,
+// had no case at all before PR #333): getter-only accessor, sloppy mode. ---
+(function () {
+  let backing = "g";
+  const m = new Map();
+  const sym = Symbol("k3");
+  Object.defineProperty(m, sym, {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  m[sym] = "x";
+  checks.push(backing === "g");
+  checks.push(hasAccessorDesc(Object.getOwnPropertyDescriptor(m, sym), false));
+})();
+
+// --- Map: getter+setter accessor via a symbol key. ---
+(function () {
+  let backing = 0;
+  const m = new Map();
+  const sym = Symbol("k4");
+  Object.defineProperty(m, sym, {
+    get() {
+      return backing;
+    },
+    set(v) {
+      backing = v + 1;
+    },
+    configurable: true,
+  });
+  m[sym] = 5;
+  checks.push(backing === 6);
+  checks.push(hasAccessorDesc(Object.getOwnPropertyDescriptor(m, sym), true));
+})();
+
+// --- Map: the same getter+setter accessor via a STRING key - this call
+// site (setOwnChecked, not setOwnCheckedByKey) never even had a precheck
+// for an existing accessor, string key or symbol, so a setter was never
+// invoked at all here (a distinct, arguably worse instance of the same
+// underlying gap in the shared helper). ---
+(function () {
+  let backing = 0;
+  const m = new Map();
+  Object.defineProperty(m, "custom", {
+    get() {
+      return backing;
+    },
+    set(v) {
+      backing = v + 100;
+    },
+    configurable: true,
+  });
+  m.custom = 7;
+  checks.push(backing === 107);
+  checks.push(hasAccessorDesc(Object.getOwnPropertyDescriptor(m, "custom"), true));
+})();
+
+// --- Strict mode, symbol key: assigning through a getter-only accessor
+// must throw a TypeError instead of silently no-op'ing. Opts back into
+// strict mode locally - the rest of this file is sloppy only because of
+// the `// no-typecheck` directive above. ---
+(function () {
+  "use strict";
+  let backing = 1;
+  let threw = false;
+  function fn() {}
+  const sym = Symbol("k5");
+  Object.defineProperty(fn, sym, {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  try {
+    fn[sym] = 2;
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+  checks.push(backing === 1);
+})();
+
+// --- Strict mode, STRING key: same as above but through opSetProp's
+// TypeFunction case rather than opSetPropSymbol. Before this fix, a
+// getter-only accessor here silently no-op'd in *both* modes (PlainObject
+// SetOwn saw the accessor field's writable:false and returned without
+// ever consulting strict mode) - so this is a genuinely new throw path,
+// not just the symbol-key one becoming stricter. ---
+(function () {
+  "use strict";
+  let backing = 1;
+  let threw = false;
+  function fn() {}
+  Object.defineProperty(fn, "ro", {
+    get() {
+      return backing;
+    },
+    configurable: true,
+  });
+  try {
+    fn.ro = 2;
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  checks.push(threw);
+  checks.push(backing === 1);
+})();
+
+// --- A throwing setter must propagate to an enclosing try/catch in the
+// *same* frame - exercises setOwnAccessorSetter's own exception-wrapping
+// path (the `vm.Call` error branch), which nothing above reaches since
+// every setter there returns normally. ---
+(function () {
+  let caughtMessage = null;
+  function fn() {}
+  const sym = Symbol("k6");
+  Object.defineProperty(fn, sym, {
+    set() {
+      throw new Error("boom");
+    },
+    configurable: true,
+  });
+  try {
+    fn[sym] = 1;
+  } catch (e) {
+    caughtMessage = e.message;
+  }
+  checks.push(caughtMessage === "boom");
+})();
+
+// --- Same throwing setter, but raised from *inside* a native callback
+// (Array.prototype.forEach) with the try/catch outside it. setOwnAccessorSetter
+// re-enters the VM via vm.Call for every one of these nine exotic kinds -
+// this crosses a native boundary on the way back out, the OpSetIndex
+// unwinding fix's riskiest case (see this file's header comment). ---
+(function () {
+  let caughtMessage = null;
+  function fn() {}
+  const sym = Symbol("k7");
+  Object.defineProperty(fn, sym, {
+    set() {
+      throw new Error("boom2");
+    },
+    configurable: true,
+  });
+  try {
+    [1].forEach(function () {
+      fn[sym] = 1;
+    });
+  } catch (e) {
+    caughtMessage = e.message;
+  }
+  checks.push(caughtMessage === "boom2");
+})();
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Recovery merge: brings the full chain-A stack (PRs #330,332-350,352,354,356,360-363) into main directly, since intermediate `gh pr merge` calls landed on feature branches instead of main. See branch history for individual fixes.