### PR TITLE
fix(vm,checker): restore #328/#351/#355 changes dropped by a bad recovery merge

### DIFF
--- a/pkg/checker/call.go
+++ b/pkg/checker/call.go
@@ -249,7 +249,7 @@ func (c *Checker) checkFixedArgumentsWithSpread(arguments []parser.Expression, p
 				if paramIsOptional {
 					paramType = types.NewUnionType(paramType, types.Undefined)
 				}
-				if argType != nil && !c.isAssignableWithExpansion(argType, paramType) {
+				if argType != nil && !c.isArgumentAssignableWithExpansion(argType, paramType) {
 					c.addErrorWithCode(argNode, errors.TS2345, fmt.Sprintf("Argument of type '%s' is not assignable to parameter of type '%s'.", argType.String(), paramType.String()))
 					allOk = false
 				}

--- a/pkg/checker/narrowing.go
+++ b/pkg/checker/narrowing.go
@@ -705,7 +705,43 @@ func (c *Checker) applyPositiveTypeNarrowing(guard *TypeGuard) *Environment {
 	var canNarrow bool
 	var narrowedType types.Type
 
-	if originalType == types.Unknown && guard.NarrowedType != nil {
+	_, originalIsUnion := originalType.(*types.UnionType)
+	if _, isPropMarker := guard.NarrowedType.(*types.PropertyExistenceMarker); isPropMarker && !originalIsUnion {
+		// A PropertyExistenceMarker ("prop" in x, or a symbol-key `in`
+		// check - see detectTypeGuard's Pattern 4) is a filter for UNION
+		// members (consumed by the UnionType branch below via
+		// typeHasProperty/filterUnionByProperty), not a real standalone
+		// type - "x has property p" doesn't by itself refine what x IS
+		// when x isn't already a union of candidates to narrow among.
+		//
+		// Falling through to the generic types.IsAssignable(guard.
+		// NarrowedType, originalType) branch below used to let this marker
+		// get assigned as x's actual narrowed type whenever originalType
+		// was Any or Unknown - IsAssignable trivially succeeds for
+		// "anything is assignable to Any/from Unknown" - silently
+		// replacing a plain `any`/`unknown` variable's real type with the
+		// bare marker for the rest of the enclosing narrowed scope
+		// (notably the remainder of a `&&` chain - see
+		// applyTypeNarrowingFromCondition, which composes each operand's
+		// narrowing into the next). A later index/member access on that
+		// variable then type-checked against the marker's synthetic
+		// "has-property-[[Symbol]]"/"has-property-<name>" pseudo-type
+		// instead of its real one:
+		//
+		//   const arr: any = [1, 2]; const s = Symbol("x");
+		//   true && s in arr && arr[s] === 1;
+		//   // before: PS2001 "cannot apply index operator to type has-property-[[Symbol]]"
+		//   // Node:   type-checks fine (arr stays `any` throughout)
+		//
+		// For a concrete non-union, non-Any/Unknown original type (e.g. an
+		// interface), this was already effectively a no-op - IsAssignable
+		// rejects the marker against anything but Any/Unknown - so this
+		// branch doesn't change observable behavior there, only for the
+		// two universal types where it was silently wrong. canNarrow stays
+		// false, same as the "cannot narrow" fallback below.
+		debugPrintf("// [TypeNarrowing] Property-existence guard on non-union '%s' (%s) - marker has nothing to filter, leaving type unchanged\n",
+			guard.VariableName, originalType.String())
+	} else if originalType == types.Unknown && guard.NarrowedType != nil {
 		// Unknown can be narrowed to any specific type
 		canNarrow = true
 		narrowedType = guard.NarrowedType

--- a/pkg/checker/resolve.go
+++ b/pkg/checker/resolve.go
@@ -2312,6 +2312,22 @@ func (c *Checker) isAssignableWithExpansion(source, target types.Type) bool {
 	return result
 }
 
+// isArgumentAssignableWithExpansion is like isAssignableWithExpansion, but
+// used specifically for checking a value passed as a call argument against
+// its parameter type. It additionally tolerates a `void`-returning function
+// argument wherever the parameter's declared type is itself a function type
+// (see types.IsAssignableForCallArgument for why this is scoped to call
+// arguments rather than general assignability).
+func (c *Checker) isArgumentAssignableWithExpansion(source, target types.Type) bool {
+	source = c.resolveTypeofTypeIfNeeded(source)
+	target = c.resolveTypeofTypeIfNeeded(target)
+
+	expandedTarget := c.expandIfMappedType(target)
+	expandedSource := c.expandIfMappedType(source)
+
+	return types.IsAssignableForCallArgument(expandedSource, expandedTarget)
+}
+
 // expandIfMappedType expands a type if it's a mapped type or contains a mapped type
 func (c *Checker) expandIfMappedType(typ types.Type) types.Type {
 	if typ == nil {

--- a/pkg/types/assignable.go
+++ b/pkg/types/assignable.go
@@ -39,6 +39,69 @@ func IsAssignable(source, target Type) bool {
 	return isAssignable(source, target)
 }
 
+// IsAssignableForCallArgument checks assignability like IsAssignable, but
+// additionally accepts a `void`-returning function argument wherever the
+// parameter's declared type is itself a function type, regardless of the
+// specific return type that function type declares. This matches
+// TypeScript's special-casing of void-returning callbacks (see the TS
+// handbook's discussion of `void`): a callback written without an explicit
+// return (e.g. `(v, i) => { console.log(v, i); }`) is assignable to a
+// callback parameter typed as returning `undefined` or any other type,
+// because the return value is ignored by the caller (e.g.
+// Array.prototype.forEach).
+//
+// This is intentionally narrower than IsAssignable: it only kicks in when
+// both source and target are callable function types, and it is meant to be
+// used specifically when checking values passed as call arguments — not for
+// general variable/property assignability, where a mismatched return type
+// should still be reported.
+func IsAssignableForCallArgument(source, target Type) bool {
+	if isAssignable(source, target) {
+		return true
+	}
+
+	// An optional callback parameter (e.g. `sort(comparefn?: (a, b) => number)`)
+	// is represented as `T | undefined` at the call site. Unwrap the union and
+	// try each member so the void-tolerant check still applies to the
+	// function-typed member.
+	if targetUnion, ok := target.(*UnionType); ok {
+		for _, member := range targetUnion.Types {
+			if IsAssignableForCallArgument(source, member) {
+				return true
+			}
+		}
+		return false
+	}
+
+	sourceObj, sourceOk := source.(*ObjectType)
+	targetObj, targetOk := target.(*ObjectType)
+	if !sourceOk || !targetOk || !sourceObj.IsCallable() || !targetObj.IsCallable() {
+		return false
+	}
+
+	// Only the call-signature return type gets the void-tolerant treatment;
+	// a target that also declares required properties must still have those
+	// checked normally, so don't take the lenient path for it.
+	if len(targetObj.Properties) > 0 {
+		return false
+	}
+
+	sourceSigs := sourceObj.GetCallSignatures()
+	targetSigs := targetObj.GetCallSignatures()
+	if len(sourceSigs) == 0 || len(targetSigs) == 0 {
+		return false
+	}
+
+	for _, targetSig := range targetSigs {
+		for _, sourceSig := range sourceSigs {
+			if isSignatureAssignableForCallbackArgument(sourceSig, targetSig) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func isAssignable(source, target Type) bool {
 	if source == nil || target == nil {
 		return false
@@ -519,6 +582,23 @@ func isAssignable(source, target Type) bool {
 
 // Helper function to check signature assignability
 func isSignatureAssignable(source, target *Signature) bool {
+	return isSignatureAssignableImpl(source, target, false)
+}
+
+// isSignatureAssignableForCallbackArgument is like isSignatureAssignable but
+// additionally tolerates a `void` actual return type on the source signature,
+// matching TypeScript's special-casing of void-returning callbacks: "a
+// void-returning function can have any other return type in its actual
+// implementation... calling it without using the return value is common."
+// (see the TS handbook section on the void type). This is only used when
+// checking a function literal/value used as a call argument (e.g. the
+// callback passed to Array.prototype.forEach), not for general function-type
+// assignability, so it doesn't loosen plain variable/property assignments.
+func isSignatureAssignableForCallbackArgument(source, target *Signature) bool {
+	return isSignatureAssignableImpl(source, target, true)
+}
+
+func isSignatureAssignableImpl(source, target *Signature, tolerateVoidSourceReturn bool) bool {
 	if source == nil || target == nil {
 		return source == target
 	}
@@ -551,6 +631,13 @@ func isSignatureAssignable(source, target *Signature) bool {
 		if !isAssignable(targetParam, sourceParam) && !isAssignable(sourceParam, targetParam) {
 			return false
 		}
+	}
+
+	// A void-returning callback argument is assignable regardless of what
+	// specific return type the parameter's function type declares, since the
+	// caller (e.g. forEach) ignores the return value.
+	if tolerateVoidSourceReturn && source.ReturnType == Void {
+		return true
 	}
 
 	// Check return type (covariant)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -5199,13 +5199,39 @@ startExecution:
 						registers[destReg] = val
 					} else {
 						frame.ip = ip
-						status := vm.runtimeError("%s is not defined", propName)
-						return status, Undefined
+						vm.ThrowReferenceError(fmt.Sprintf("%s is not defined", propName))
+						if vm.handlerFound {
+							vm.handlerFound = false
+							goto reloadFrame
+						}
+						if !vm.unwinding {
+							// Exception was caught by a handler, reload frame and continue
+							frame = &vm.frames[vm.frameCount-1]
+							closure = frame.closure
+							function = closure.Fn
+							registers = frame.registers
+							ip = frame.ip
+							goto reloadFrame
+						}
+						return InterpretRuntimeError, Undefined
 					}
 				} else {
 					frame.ip = ip
-					status := vm.runtimeError("%s is not defined", propName)
-					return status, Undefined
+					vm.ThrowReferenceError(fmt.Sprintf("%s is not defined", propName))
+					if vm.handlerFound {
+						vm.handlerFound = false
+						goto reloadFrame
+					}
+					if !vm.unwinding {
+						// Exception was caught by a handler, reload frame and continue
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						registers = frame.registers
+						ip = frame.ip
+						goto reloadFrame
+					}
+					return InterpretRuntimeError, Undefined
 				}
 			}
 

--- a/tests/scripts/array_callback_void_return.ts
+++ b/tests/scripts/array_callback_void_return.ts
@@ -1,0 +1,65 @@
+// Regression test: a callback argument whose inferred return type is `void`
+// (i.e. it has no return statement) must still be assignable wherever the
+// callback parameter's function type declares a specific return type,
+// matching TypeScript's special-casing of void-returning callbacks. Before
+// this fix, forEach's callback parameter type is `(value, index?, array?) =>
+// undefined`, and a plain arrow function with an implicit void return (no
+// `return` statement) was rejected with:
+//   Argument of type '(any, any) => void' is not assignable to parameter of
+//   type '(any, number?, any[]?) => undefined'.
+// expect: 21
+
+const values: any[] = [1, 2, 3, 4, 5, 6];
+
+let sum = 0;
+
+// forEach's callback parameter type declares an `undefined` return type, but
+// this callback implicitly returns void (no return statement at all).
+values.forEach((v, i) => {
+	sum += v;
+	console.log("forEach", i, v);
+});
+
+// Same, but the callback only uses a subset of the optional parameters.
+values.forEach((v) => {
+	console.log("forEach-one-arg", v);
+});
+
+// Same, with zero parameters.
+values.forEach(() => {
+	console.log("forEach-no-args");
+});
+
+// map/filter/some/every callbacks that DO return a value should keep working
+// (regression coverage for the normal, non-void case).
+const doubled = values.map((v) => v * 2);
+const evens = values.filter((v) => v % 2 === 0);
+const hasBig = values.some((v) => v > 5);
+const allPositive = values.every((v) => v > 0);
+
+if (doubled.length !== values.length) {
+	throw new Error("map result length mismatch");
+}
+if (evens.length !== 3) {
+	throw new Error("filter result mismatch");
+}
+if (!hasBig) {
+	throw new Error("some result mismatch");
+}
+if (!allPositive) {
+	throw new Error("every result mismatch");
+}
+
+// sort's comparefn parameter is optional, so its declared type is a union
+// `((a, b) => number) | undefined` — the void-tolerant check must unwrap
+// that union to reach the callable member.
+let sortCallbackRan = false;
+values.sort((a) => {
+	sortCallbackRan = true;
+	console.log("sort", a);
+});
+if (!sortCallbackRan) {
+	throw new Error("sort comparefn was never called");
+}
+
+sum;

--- a/tests/scripts/array_callback_void_return_still_errors.ts
+++ b/tests/scripts/array_callback_void_return_still_errors.ts
@@ -1,0 +1,12 @@
+// expect_compile_error: not assignable
+
+// The void-returning-callback special case only relaxes the RETURN type of a
+// callback argument; parameter types must still be checked normally, and a
+// non-callback assignment of a void function should still be rejected.
+const values: number[] = [1, 2, 3];
+
+// Wrong parameter type (string instead of number) - must still error even
+// though the callback body has no return statement.
+values.forEach((v: string) => {
+	console.log(v);
+});

--- a/tests/scripts/narrow_in_symbol_any.ts
+++ b/tests/scripts/narrow_in_symbol_any.ts
@@ -1,0 +1,165 @@
+// expect: true
+// The checker's `in`-based control-flow narrowing rejected type-checking a
+// symbol-key `in` check immediately followed by a symbol-key index read on
+// the same `any`-typed variable, inside one logical expression - even
+// though the variable is declared `any` and should permit any index
+// operation regardless of narrowing:
+//
+//   const arr: any = [1, 2];
+//   const s = Symbol("x");
+//   console.log(true && s in arr && arr[s] === 1);
+//   // before: PS2001 "cannot apply index operator to type has-property-[[Symbol]]"
+//   // Node:   type-checks fine, prints false (arr[s] is undefined)
+//
+// Splitting the same checks across separate statements (assigning `s in
+// arr` to a variable first, then indexing `arr[s]` later) avoided the
+// error - so the bug was specifically about narrowing applied INLINE
+// within the same `&&` chain right before a symbol-key index access, not
+// about `in`-narrowing or symbol indexing individually.
+//
+// Root cause: detectTypeGuard's Pattern 4 ("prop" in x, or a symbol-key `in`
+// check) produces a TypeGuard whose NarrowedType is a
+// *types.PropertyExistenceMarker - a synthetic marker meant only to FILTER
+// a union type's members down to the ones that have the property (see
+// applyPositiveTypeNarrowing's UnionType branch, which consumes it via
+// typeHasProperty). Outside a union, that marker isn't a real type at all.
+// But applyPositiveTypeNarrowing's generic non-union fallback branch -
+// `guard.NarrowedType != nil && types.IsAssignable(guard.NarrowedType,
+// originalType)` - fired for it anyway whenever originalType was `any` (or
+// `unknown`, handled by its own even-more-permissive branch just above),
+// since "anything is assignable to Any" trivially includes the marker.
+// That replaced `arr`'s real `any` type with the bare marker for the rest
+// of the narrowed scope (the remainder of the `&&` chain, per
+// applyTypeNarrowingFromCondition's left-to-right composition) - so
+// `arr[s]` then type-checked against the marker's synthetic
+// "has-property-[[Symbol]]" pseudo-type instead of `any`, and failed.
+//
+// Fixed in applyPositiveTypeNarrowing (pkg/checker/narrowing.go) by
+// special-casing a PropertyExistenceMarker guard on a non-union original
+// type: there's nothing for the marker to filter, so it leaves the type
+// unchanged (matches the "cannot narrow" no-op path) instead of assigning
+// the marker itself. Checks below cover both a symbol key and a string
+// key (the same marker type backs both), a missing property/symbol
+// (`false` case, not just `true`), and confirm the pre-existing use of
+// this marker to narrow a real union still works unaffected.
+//
+// Deliberately NOT touched: paserati's `typeof x === "string"` on an
+// `any`-typed x DOES narrow x to `string` (unlike real TypeScript, which
+// keeps `any` as `any` through such a check) - a separate, pre-existing,
+// much broader behavior this fix does not change. Only
+// PropertyExistenceMarker (the `in`-check guard) was special-cased, since
+// unlike a real type such as `string`, it is never itself a valid type to
+// assign to a variable - it exists purely to filter union members.
+
+type UnionA = { kind: "a"; value: number };
+type UnionB = { kind: "b" };
+function describeUnion(x: UnionA | UnionB): number {
+  if ("value" in x) {
+    return x.value;
+  }
+  return -1;
+}
+
+const checks: boolean[] = [];
+
+// --- 1. The exact reported repro: symbol-key `in` immediately followed by
+// a symbol-key index read on the same `any` variable, in one `&&` chain. ---
+{
+  const arr: any = [1, 2];
+  const s = Symbol("x");
+  checks.push((true && s in arr && arr[s] === 1) === false);
+}
+
+// --- 2. Same shape, but the symbol property actually exists - the `in`
+// check is true, and `any` still permits the index read to see the real
+// value (not just "doesn't crash"). Uses a plain object rather than an
+// array: whether an array's OWN symbol-keyed property round-trips through
+// `arr[sym]` at all is unrelated, separately-tracked work (this repo's
+// array-symbol-property support lives in its own PR stack) - this check
+// is only about the checker's narrowing, not that runtime behavior. ---
+{
+  const o2: any = {};
+  const s2 = Symbol("y");
+  o2[s2] = 42;
+  checks.push(true && s2 in o2 && o2[s2] === 42);
+}
+
+// --- 3. String-key `in` on an `any` variable, same inline-chain shape -
+// detectTypeGuard's Pattern 4 produces the identical PropertyExistenceMarker
+// for a string key, so this hit the same bug. ---
+{
+  const o: any = { foo: 1 };
+  checks.push(true && "foo" in o && o.foo === 1);
+  checks.push(true && "foo" in o && o["foo"] === 1);
+}
+
+// --- 4. `in` narrowing negated by a following `||` doesn't crash either -
+// sanity check that the fix didn't just special-case the exact `&&` shape
+// from the repro. ---
+{
+  const o2: any = { bar: 2 };
+  const result = false || ("bar" in o2 && o2.bar === 2);
+  checks.push(result === true);
+}
+
+// --- 5. Sanity: `in` narrowing on a genuine UNION still works (the marker
+// is still meaningful there - this task must not have broken the one case
+// where PropertyExistenceMarker is actually consumed as a filter). ---
+{
+  checks.push(describeUnion({ kind: "a", value: 7 }) === 7);
+  checks.push(describeUnion({ kind: "b" }) === -1);
+}
+
+// --- 6. The INVERTED (else-branch) counterpart of check 1/2, on a plain
+// identifier - applyInvertedTypeNarrowing's non-member-expression path
+// only consumes PropertyExistenceMarker inside its own UnionType branch
+// (gated on `originalType.(*types.UnionType)`), so a non-union `any`
+// already fell through to that function's final "no inverted narrowing
+// applied, return nil" path untouched - unlike the positive side, this
+// direction never had a generic Any/Unknown fallback that could leak the
+// marker in. Verified by inspection AND here: this must keep working
+// exactly as it already did, not because this task changed it. ---
+{
+  const o3: any = { foo: 1 };
+  const s3 = Symbol("z");
+  let sawUndefined = false;
+  if (s3 in o3) {
+    checks.push(false); // s3 was never set - must not reach here
+  } else {
+    sawUndefined = o3[s3] === undefined;
+  }
+  checks.push(sawUndefined);
+
+  let sawFoo = false;
+  if ("bar" in o3) {
+    checks.push(false); // "bar" was never set - must not reach here
+  } else {
+    sawFoo = o3.foo === 1;
+  }
+  checks.push(sawFoo);
+}
+
+// --- 7. A dotted member-expression base ("prop" in holder.inner), also
+// `any` - applyPositiveTypeNarrowing's separate member-expression branch
+// (isMemberExpression=true) routes a PropertyExistenceMarker through
+// filterUnionByProperty instead of the chain this task patched.
+// filterUnionByProperty's own non-union fallback already calls
+// typeHasProperty(originalType, name), which returns false for Any (Any
+// matches none of typeHasProperty's cases) - so `narrowed` comes back
+// false and this path already correctly declines to narrow, leaving
+// holder.inner as `any`. Verified by inspection AND here, both branches,
+// for the same reason as check 6: this task didn't touch it, but it
+// needs to stay covered so a future change to filterUnionByProperty
+// can't silently reintroduce the same class of bug for this call site. ---
+{
+  const holder: { inner: any } = { inner: { foo: 1 } };
+  checks.push(true && "foo" in holder.inner && holder.inner.foo === 1);
+
+  if ("bar" in holder.inner) {
+    checks.push(false); // "bar" was never set - must not reach here
+  } else {
+    checks.push(holder.inner.foo === 1);
+  }
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/with_undefined_property_catchable.ts
+++ b/tests/scripts/with_undefined_property_catchable.ts
@@ -1,0 +1,28 @@
+// expect: ReferenceError:true:after
+// no-typecheck
+// A `with` block reading an identifier that exists neither on the with-object
+// nor at global scope must raise a normal, catchable ReferenceError - not an
+// uncatchable internal error that aborts the whole script. The OpGetWithProperty
+// handler used to call vm.runtimeError(...) directly for this "not found
+// anywhere" fallback case, which appends to vm.errors and returns
+// InterpretRuntimeError without going through vm.throwException/unwindException,
+// so no surrounding try/catch (even one directly wrapping the with block) could
+// ever catch it.
+let caughtName = "no-throw";
+let isReferenceError = false;
+try {
+  with ({}) {
+    undefinedInsideWithXYZ;
+  }
+} catch (e) {
+  caughtName = e.name;
+  isReferenceError =
+    e instanceof ReferenceError &&
+    e.message === "undefinedInsideWithXYZ is not defined";
+}
+
+// Execution must continue normally after the catch.
+let afterMarker = "before";
+afterMarker = "after";
+
+caughtName + ":" + isReferenceError + ":" + afterMarker;


### PR DESCRIPTION
PR #365 (recovery merge for the chain-A Proxy/Reflect stack) was accidentally built against a stale local main instead of the real tip, silently reverting pkg/checker/narrowing.go, pkg/checker/call.go, pkg/checker/resolve.go, pkg/types/assignable.go, part of pkg/vm/vm.go, and 4 test files that only existed on main (added by #328, #351, #355). This restores exactly that content on top of the current main tip. Verified: clean build, TestScripts smoke suite green, no conflict markers.