### PR TITLE
chore(merge): integrate chain-B/D array-symbol-property stack (#353,358,359) into main

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1815,6 +1815,103 @@ func arraySparseIndexValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Val
 	return vm.Undefined, nil
 }
 
+// arrayDenseIndexValue reads the value at a dense-range array index (i <
+// DenseLength()), calling its getter if Object.defineProperty installed
+// an accessor there instead of blindly trusting arrObj.Get(i), which reads
+// `elements` directly with no accessor check at all. An index accessor is
+// never written into elements in the first place - see
+// ArrayDefineOwnProperty's own doc comment ("Every read path that knows
+// about per-index accessors ... checks GetOwnAccessor before ever
+// consulting the elements slice, so nothing needs to be written there") -
+// this is exactly one of those read paths, previously missed:
+//
+//	const arr = [1, 2, 3];
+//	Object.defineProperty(arr, "1", { get() { return 99; }, enumerable: true });
+//	arr[1];                    // 99 - the index-access path already checks
+//	Object.assign({}, arr)[1]; // before: 2 (stale element) - Node: 99
+//
+// The sparse half of this same read (arraySparseIndexValue, above) already
+// gets it right; this is its dense-range counterpart.
+func arrayDenseIndexValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Value, i int) (vm.Value, error) {
+	key := strconv.Itoa(i)
+	if getter, _, _, _, isAccessor := a.GetOwnAccessor(key); isAccessor {
+		if getter.Type() == vm.TypeUndefined {
+			return vm.Undefined, nil
+		}
+		return vmInstance.Call(getter, receiver, nil)
+	}
+	return a.Get(i), nil
+}
+
+// arrayNamedKeys returns an array's own named (non-index) property keys:
+// AccessorKeys() (an accessor installed via Object.defineProperty lives in
+// getters/setters, never in `properties` - see ArrayObject.
+// DefineAccessorProperty's own doc comment, which explicitly deletes the
+// properties entry when converting a plain property to an accessor, so a
+// given name lives in at most one of the two stores at a time) followed by
+// NamedPropertyKeys() (plain data). Both are filtered with
+// vm.ParseArrayIndex - not vm.LooksLikeArrayIndex, which has no upper
+// bound and would let an out-of-range numeric key like "4294967295" slip
+// past both this filter and arraySparseIndices' own vm.ParseArrayIndex
+// filter, vanishing from enumeration entirely - to exclude a sparse index
+// sharing either map, which arraySparseIndices already covers.
+//
+// Before this, a named ACCESSOR property was invisible to every array
+// enumeration/collection operation that walked NamedPropertyKeys() alone:
+//
+//	const arr = [1, 2];
+//	Object.defineProperty(arr, "foo", { get() { return 5; }, enumerable: true });
+//	Object.keys(arr); // before: ["0","1"] - Node: ["0","1","foo"]
+//
+// enumerableOnly mirrors arraySparseIndices' own parameter: true for
+// for-in/Object.keys/values/entries/Object.assign (own-ENUMERABLE-
+// properties only, per CopyDataProperties/EnumerableOwnPropertyNames),
+// false for Object.getOwnPropertyNames/Reflect.ownKeys (every own key
+// regardless of enumerability).
+func arrayNamedKeys(a *vm.ArrayObject, enumerableOnly bool) []string {
+	var keys []string
+	for _, name := range a.AccessorKeys() {
+		if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+			continue
+		}
+		if enumerableOnly {
+			if _, _, enumerable, _, isAccessor := a.GetOwnAccessor(name); !isAccessor || !enumerable {
+				continue
+			}
+		}
+		keys = append(keys, name)
+	}
+	for _, name := range a.NamedPropertyKeys() {
+		if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+			continue
+		}
+		if enumerableOnly {
+			if _, enumerable, ok := a.GetNamedPropertyDescriptor(name); !ok || !enumerable {
+				continue
+			}
+		}
+		keys = append(keys, name)
+	}
+	return keys
+}
+
+// arrayNamedKeyValue reads the value of a named (non-index) own property
+// arrayNamedKeys already found, calling its getter if it's an accessor -
+// the named-key counterpart to arrayDenseIndexValue/arraySparseIndexValue,
+// for Object.values/entries.
+func arrayNamedKeyValue(vmInstance *vm.VM, a *vm.ArrayObject, receiver vm.Value, name string) (vm.Value, error) {
+	if getter, _, _, _, isAccessor := a.GetOwnAccessor(name); isAccessor {
+		if getter.Type() == vm.TypeUndefined {
+			return vm.Undefined, nil
+		}
+		return vmInstance.Call(getter, receiver, nil)
+	}
+	if v, _, ok := a.GetNamedPropertyDescriptor(name); ok {
+		return v, nil
+	}
+	return vm.Undefined, nil
+}
+
 func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined to object")
@@ -2041,14 +2138,11 @@ func objectKeysWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			keysArray.Append(vm.NewString(strconv.Itoa(idx)))
 		}
 		// Named own properties (an exec result's index/input/groups/indices,
-		// or anything stored on the array) follow the indices.
-		for _, key := range arrObj.NamedPropertyKeys() {
-			if vm.LooksLikeArrayIndex(key) {
-				continue
-			}
-			if _, enumerable, ok := arrObj.GetNamedPropertyDescriptor(key); ok && enumerable {
-				keysArray.Append(vm.NewString(key))
-			}
+		// or anything stored on the array, accessor or plain) follow the
+		// indices - see arrayNamedKeys' own doc comment for why this can't
+		// be NamedPropertyKeys() alone.
+		for _, key := range arrayNamedKeys(arrObj, true) {
+			keysArray.Append(vm.NewString(key))
 		}
 	case vm.TypeArguments:
 		argsObj := obj.AsArguments()
@@ -2483,7 +2577,14 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
-			valuesArray.Append(arrObj.Get(i))
+			// arrayDenseIndexValue, not arrObj.Get(i) - see that function's
+			// own doc comment for why a plain element read misses an index
+			// accessor installed via Object.defineProperty.
+			value, err := arrayDenseIndexValue(vmInstance, arrObj, obj, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			valuesArray.Append(value)
 		}
 		// A sparse index beyond the dense range (paserati#176/#178 - see
 		// arraySparseIndices) lives in the properties map (or, for an
@@ -2493,6 +2594,17 @@ func objectValuesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 		// calling the getter for an accessor index.
 		for _, idx := range arraySparseIndices(arrObj, true) {
 			value, err := arraySparseIndexValue(vmInstance, arrObj, obj, idx)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			valuesArray.Append(value)
+		}
+		// Named (non-index) own properties, accessor or plain - see
+		// arrayNamedKeys' own doc comment. Before this, Object.values(arr)
+		// never returned a value for `arr.foo = ...` at all, regardless of
+		// whether foo was a plain property or an accessor.
+		for _, key := range arrayNamedKeys(arrObj, true) {
+			value, err := arrayNamedKeyValue(vmInstance, arrObj, obj, key)
 			if err != nil {
 				return vm.Undefined, err
 			}
@@ -2618,9 +2730,16 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			if !arrObj.HasOwnIndexProperty(key, i) {
 				continue // hole - not an own property at all (paserati#300)
 			}
+			// arrayDenseIndexValue, not arrObj.Get(i) - see that function's
+			// own doc comment for why a plain element read misses an index
+			// accessor installed via Object.defineProperty.
+			value, err := arrayDenseIndexValue(vmInstance, arrObj, obj, i)
+			if err != nil {
+				return vm.Undefined, err
+			}
 			entry := vm.NewArray()
 			entry.AsArray().Append(vm.NewString(key))
-			entry.AsArray().Append(arrObj.Get(i))
+			entry.AsArray().Append(value)
 			entriesArray.Append(entry)
 		}
 		// A sparse index beyond the dense range (paserati#176/#178 - see
@@ -2636,6 +2755,20 @@ func objectEntriesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			}
 			entry := vm.NewArray()
 			entry.AsArray().Append(vm.NewString(strconv.Itoa(idx)))
+			entry.AsArray().Append(value)
+			entriesArray.Append(entry)
+		}
+		// Named (non-index) own properties, accessor or plain - see
+		// arrayNamedKeys' own doc comment. Before this, Object.entries(arr)
+		// never produced an entry for `arr.foo = ...` at all, regardless of
+		// whether foo was a plain property or an accessor.
+		for _, key := range arrayNamedKeys(arrObj, true) {
+			value, err := arrayNamedKeyValue(vmInstance, arrObj, obj, key)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			entry := vm.NewArray()
+			entry.AsArray().Append(vm.NewString(key))
 			entry.AsArray().Append(value)
 			entriesArray.Append(entry)
 		}
@@ -2768,10 +2901,13 @@ func objectGetOwnPropertyNamesWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Val
 			arrObj.Append(vm.NewString(strconv.Itoa(idx)))
 		}
 		arrObj.Append(vm.NewString("length"))
-		for _, key := range a.NamedPropertyKeys() {
-			if !vm.LooksLikeArrayIndex(key) {
-				arrObj.Append(vm.NewString(key))
-			}
+		// Named own properties (accessor or plain) - see arrayNamedKeys'
+		// own doc comment for why NamedPropertyKeys() alone missed a named
+		// accessor property here. enumerableOnly=false: getOwnPropertyNames
+		// wants every own key regardless of enumerability, same as the
+		// sparse-index loop above.
+		for _, key := range arrayNamedKeys(a, false) {
+			arrObj.Append(vm.NewString(key))
 		}
 	case vm.TypeFunction:
 		fn := obj.AsFunction()
@@ -3375,6 +3511,64 @@ func setObjectAssignTargetProperty(vmInstance *vm.VM, target vm.Value, key strin
 	return nil
 }
 
+// setObjectAssignTargetPropertyByKey is setObjectAssignTargetProperty for a
+// symbol key - backing Object.assign's own symbol-key copy loops below
+// (previously nonexistent: no source branch ever walked a symbol key at
+// all, so there was nothing to write here either - see objectAssignWithVM's
+// doc comment). Mirrors the string-key version's exact per-target-kind
+// scope: an accessor is only checked for a TypeObject target (the
+// string-key version doesn't check one for TypeArray or the callable
+// side-table kinds either - a separate, narrower, pre-existing limitation
+// this function deliberately doesn't widen).
+//
+// There is no PlainObject.SetOwnByKey (only the string-keyed SetOwn, which
+// itself implements "preserve existing writable/enumerable/configurable,
+// default a brand-new key to true/true/true"), so the TypeObject and
+// callable-side-table branches reproduce that same rule explicitly via
+// HasOwnByKey + DefineOwnPropertyByKey, matching vm.setOwnCheckedByKey's
+// identical pattern (pkg/vm/properties_table.go) for the same "ordinary
+// [[Set]], not Object.defineProperty" distinction that function's own doc
+// comment explains - and the identical pattern this session's Reflect.set
+// symbol-key fix (reflectCreateOrUpdateDataPropertyByKey) already used for
+// the same reason.
+func setObjectAssignTargetPropertyByKey(vmInstance *vm.VM, target vm.Value, sym vm.Value, value vm.Value) error {
+	key := vm.NewSymbolKey(sym)
+	switch target.Type() {
+	case vm.TypeObject:
+		plainTarget := target.AsPlainObject()
+		if _, setter, _, _, isAccessor := plainTarget.GetOwnAccessorByKey(key); isAccessor {
+			if setter.Type() == vm.TypeUndefined {
+				return nil // accessor with no setter: [[Set]] silently no-ops (non-strict)
+			}
+			_, err := vmInstance.Call(setter, target, []vm.Value{value})
+			return err
+		}
+		if plainTarget.HasOwnByKey(key) {
+			plainTarget.DefineOwnPropertyByKey(key, value, nil, nil, nil)
+		} else {
+			w, e, c := true, true, true
+			plainTarget.DefineOwnPropertyByKey(key, value, &w, &e, &c)
+		}
+	case vm.TypeDictObject:
+		// DictObjects have no symbol-keyed storage at all - matches every
+		// other DictObject-and-symbols case in this codebase.
+	case vm.TypeArray:
+		if symObj := sym.AsSymbolObject(); symObj != nil {
+			target.AsArray().SetSymbolProp(symObj, value)
+		}
+	case vm.TypeFunction, vm.TypeClosure, vm.TypeNativeFunction, vm.TypeNativeFunctionWithProps, vm.TypeBoundFunction:
+		if props := vm.EnsureOwnPropertiesTable(target); props != nil {
+			if props.HasOwnByKey(key) {
+				props.DefineOwnPropertyByKey(key, value, nil, nil, nil)
+			} else {
+				w, e, c := true, true, true
+				props.DefineOwnPropertyByKey(key, value, &w, &e, &c)
+			}
+		}
+	}
+	return nil
+}
+
 func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) == 0 {
 		return vm.Undefined, vmInstance.NewTypeError("Cannot convert undefined or null to object")
@@ -3446,6 +3640,49 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 					return vm.Undefined, err
 				}
 			}
+			// Symbol-keyed own properties - this loop never existed at all,
+			// so Object.assign silently dropped every symbol property a
+			// TypeObject source had, plain or accessor, regardless of
+			// enumerability (verified against Node, which copies an
+			// enumerable one and skips a non-enumerable one, exactly like
+			// the string-key loop just above):
+			//
+			//   const o = {}; const s = Symbol("x"); o[s] = "v";
+			//   Object.assign({}, o)[s]; // before: undefined - Node: "v"
+			//
+			// Same accessor-invokes-getter rule as the string-key loop
+			// (paserati#274) - OwnSymbolKeys() (unlike OwnKeys()) isn't
+			// pre-filtered to enumerable-only, since a symbol key can only
+			// become non-enumerable via an explicit Object.defineProperty,
+			// which is comparatively rare - so this filters explicitly per
+			// key instead.
+			for _, symVal := range plainObj.OwnSymbolKeys() {
+				symKey := vm.NewSymbolKey(symVal)
+				var value vm.Value
+				if getter, _, enumerable, _, isAccessor := plainObj.GetOwnAccessorByKey(symKey); isAccessor {
+					if !enumerable {
+						continue
+					}
+					if getter.Type() == vm.TypeUndefined {
+						value = vm.Undefined
+					} else {
+						var err error
+						value, err = vmInstance.Call(getter, source, nil)
+						if err != nil {
+							return vm.Undefined, err
+						}
+					}
+				} else {
+					v, _, enumerable, _, ok := plainObj.GetOwnDescriptorByKey(symKey)
+					if !ok || !enumerable {
+						continue
+					}
+					value = v
+				}
+				if err := setObjectAssignTargetPropertyByKey(vmInstance, target, symVal, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
 		} else if source.Type() == vm.TypeDictObject {
 			dictObj := source.AsDictObject()
 			for _, key := range dictObj.OwnKeys() {
@@ -3456,13 +3693,22 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 			}
 		} else if source.Type() == vm.TypeArray {
 			arrObj := source.AsArray()
-			// For arrays, copy indexed properties
+			// For arrays, copy indexed properties. arrayDenseIndexValue, not
+			// arrObj.Get(i): HasOwnIndexProperty above correctly treats an
+			// index accessor (installed via Object.defineProperty) as
+			// existing, but a bare arrObj.Get(i) reads `elements` directly
+			// with no accessor check, so it would copy the stale
+			// underlying element instead of calling the getter - see
+			// arrayDenseIndexValue's own doc comment.
 			for i := 0; i < arrObj.DenseLength(); i++ {
 				key := strconv.Itoa(i)
 				if !arrObj.HasOwnIndexProperty(key, i) {
 					continue // hole - not an own property at all, nothing to copy (paserati#300)
 				}
-				value := arrObj.Get(i)
+				value, err := arrayDenseIndexValue(vmInstance, arrObj, source, i)
+				if err != nil {
+					return vm.Undefined, err
+				}
 				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
 					return vm.Undefined, err
 				}
@@ -3485,6 +3731,113 @@ func objectAssignWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 				}
 				key := strconv.Itoa(idx)
 				if err := setObjectAssignTargetProperty(vmInstance, target, key, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// Named (non-index) accessor properties, e.g.
+			// Object.defineProperty(arr, "foo", {get, set, enumerable}) -
+			// stored in getters/setters, never in `properties` (see
+			// ArrayObject.DefineAccessorProperty's own doc comment), so the
+			// named-data loop just below can't see these at all. This whole
+			// branch - named string properties on an array source, accessor
+			// or plain - never existed prior to this fix: Object.assign(
+			// {}, arr) only ever copied indexed elements, silently dropping
+			// anything set via `arr.foo = ...` or Object.defineProperty:
+			//
+			//   const arr = [1, 2]; arr.foo = "bar";
+			//   Object.assign({}, arr).foo; // before: undefined - Node: "bar"
+			//
+			// AccessorKeys() can also report a numeric-index key (an
+			// accessor installed AT an array index via Object.defineProperty
+			// - ParseArrayIndex skips those here since the dense/sparse
+			// index loops above already own that key space (though neither
+			// of those loops actually invokes an index accessor's getter
+			// today - a separate, narrower, pre-existing gap not touched by
+			// this fix; see arraySparseIndexValue's own accessor handling
+			// for the sparse-index case, which DOES get this right - the
+			// gap is specific to the DENSE-range loop above, whose
+			// arrObj.Get(i) reads straight from `elements` with no accessor
+			// check at all). Deliberately vm.ParseArrayIndex, NOT
+			// vm.LooksLikeArrayIndex: the latter has no upper bound, so a key
+			// like "4294967295" (past the 2^32-2 array-index ceiling) would
+			// look like an index here and get skipped, while arraySparseIndices'
+			// own vm.ParseArrayIndex-based filter (used below) also rejects it
+			// as too big - the two filters must use the SAME predicate or a
+			// key can fall in the gap between them and vanish entirely.
+			for _, name := range arrObj.AccessorKeys() {
+				if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+					continue
+				}
+				getter, _, enumerable, _, isAccessor := arrObj.GetOwnAccessor(name)
+				if !isAccessor || !enumerable {
+					continue
+				}
+				var value vm.Value
+				if getter.Type() == vm.TypeUndefined {
+					value = vm.Undefined
+				} else {
+					var err error
+					value, err = vmInstance.Call(getter, source, nil)
+					if err != nil {
+						return vm.Undefined, err
+					}
+				}
+				if err := setObjectAssignTargetProperty(vmInstance, target, name, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// Named (non-index) plain data properties, e.g. `arr.foo = "bar"`.
+			// NamedPropertyKeys() (despite its doc comment) also returns any
+			// sparse-index key sharing the same `properties` map - already
+			// handled above via arraySparseIndices - so vm.ParseArrayIndex
+			// filters those back out here, the exact same predicate
+			// arraySparseIndices itself uses to find only the ones that ARE
+			// indices (not vm.LooksLikeArrayIndex, which has no upper bound
+			// and would leave an out-of-range numeric key like
+			// "4294967295" matched by neither filter - see the AccessorKeys
+			// loop above for the full explanation).
+			for _, name := range arrObj.NamedPropertyKeys() {
+				if _, isIndex := vm.ParseArrayIndex(name); isIndex {
+					continue
+				}
+				value, enumerable, ok := arrObj.GetNamedPropertyDescriptor(name)
+				if !ok || !enumerable {
+					continue
+				}
+				if err := setObjectAssignTargetProperty(vmInstance, target, name, value); err != nil {
+					return vm.Undefined, err
+				}
+			}
+			// Symbol-keyed properties, plain or accessor (see
+			// ArrayDefineOwnSymbolProperty, pkg/vm/array_props.go) - same
+			// gap and same fix shape as the TypeObject source branch's own
+			// symbol loop above, just against ArrayObject's own symbol
+			// storage (GetOwnSymbolAccessor/GetSymbolPropertyDescriptor)
+			// instead of PlainObject's.
+			for _, symVal := range arrObj.OwnSymbolKeys() {
+				symObj := symVal.AsSymbolObject()
+				var value vm.Value
+				if getter, _, enumerable, _, isAccessor := arrObj.GetOwnSymbolAccessor(symObj); isAccessor {
+					if !enumerable {
+						continue
+					}
+					if getter.Type() == vm.TypeUndefined {
+						value = vm.Undefined
+					} else {
+						var err error
+						value, err = vmInstance.Call(getter, source, nil)
+						if err != nil {
+							return vm.Undefined, err
+						}
+					}
+				} else {
+					v, desc, ok := arrObj.GetSymbolPropertyDescriptor(symObj)
+					if !ok || !desc.Enumerable {
+						continue
+					}
+					value = v
+				}
+				if err := setObjectAssignTargetPropertyByKey(vmInstance, target, symVal, value); err != nil {
 					return vm.Undefined, err
 				}
 			}
@@ -4206,6 +4559,26 @@ func objectDefinePropertyWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		}
 	}
 
+	// Array objects, symbol key: ES 10.4.2.1 Array exotic [[DefineOwnProperty]]
+	// defers to OrdinaryDefineOwnProperty for any key that "length" doesn't
+	// intercept - true for every symbol key, since a symbol can never equal
+	// the string "length". This used to have no branch at all: a symbol key
+	// on an array fell through every propName-gated check above (all of them
+	// meaningless for a symbol, since propName is "" here) and reached the
+	// `obj.Type() == vm.TypeObject` block below, which a TypeArray value
+	// never satisfies - so Object.defineProperty(arr, sym, {...}) silently
+	// did nothing: it neither stored anything nor threw, for both data and
+	// accessor descriptors alike.
+	if obj.Type() == vm.TypeArray && keyIsSymbol {
+		arr := obj.AsArray()
+		if arr != nil && propSym.AsSymbolObject() != nil {
+			if err := vmInstance.ArrayDefineOwnSymbolProperty(arr, propSym.AsSymbolObject(), hasValue, value, writablePtr, enumerablePtr, configurablePtr, hasGetter, getter, hasSetter, setter); err != nil {
+				return vm.Undefined, err
+			}
+			return obj, nil
+		}
+	}
+
 	// Define the property with attributes (on plain objects only for now)
 	if obj.Type() == vm.TypeObject {
 		if obj.Type() == vm.TypeObject {
@@ -4865,46 +5238,40 @@ func objectGetOwnPropertyDescriptorWithVM(vmInstance *vm.VM, args []vm.Value) (v
 	// Check arrays first before plainObj (arrays can also be AsPlainObject but their indices are stored separately)
 	if obj.Type() == vm.TypeArray {
 		arrObj := obj.AsArray()
-		// Symbol-keyed own properties (arr[sym] = v) live in ArrayObject's
-		// own symbolProps map (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp,
-		// pkg/vm/value.go) - completely separate from the propName-based
-		// index/"length"/named-property checks below, all of which are
-		// meaningless for a symbol key (propName is "" here). This function
-		// never had a symbol-key branch for TypeArray at all, so it fell
-		// through the propName checks (none matched an empty propName) and
-		// then the switch below (which also has no TypeArray case), landing
-		// on the final default and reporting undefined even for a symbol
-		// property that demonstrably exists - Object.getOwnPropertySymbols
-		// lists it (task_778749f8) and `arr[sym]`/Reflect.get both read it
-		// back correctly, but Object.getOwnPropertyDescriptor claimed no
-		// such property existed:
+		// Symbol-keyed own properties (arr[sym] = v, or an explicit
+		// Object.defineProperty(arr, sym, {...})) live in ArrayObject's own
+		// symbol-keyed storage (GetSymbolProp/SetSymbolProp/HasOwnSymbolProp
+		// for a plain value; symbolPropertyDesc/symbolGetters/symbolSetters
+		// for an explicit descriptor - see ArrayDefineOwnSymbolProperty,
+		// pkg/vm/array_props.go) - completely separate from the
+		// propName-based index/"length"/named-property checks below, all of
+		// which are meaningless for a symbol key (propName is "" here). This
+		// function used to have no symbol-key branch for TypeArray at all
+		// (task_778749f8's fix here only handled the plain-value case, since
+		// Object.defineProperty on a symbol key was itself still a no-op at
+		// the time - see ArrayDefineOwnSymbolProperty's doc comment):
 		//
-		//   const arr = [1, 2, 3]; const s = Symbol("x"); arr[s] = 42;
+		//   const arr = [1, 2]; const s = Symbol("d");
+		//   Object.defineProperty(arr, s, {value: 7, writable: false, enumerable: false, configurable: false});
 		//   Object.getOwnPropertyDescriptor(arr, s);
-		//   // before: undefined
-		//   // Node:   {value: 42, writable: true, enumerable: true, configurable: true}
-		//
-		// Symbol properties on arrays have no separate attribute-override
-		// tracking (unlike named string properties' propertyDesc map), so -
-		// verified against Node - the descriptor is always the plain
-		// ordinary-property default: writable/enumerable/configurable all
-		// true. This is only safe because Object.defineProperty(arr, sym,
-		// {...}) is ITSELF currently a no-op for arrays (verified: it
-		// neither stores into symbolProps nor throws, so no non-default
-		// attribute combination or accessor can exist to misreport here) -
-		// a separate, pre-existing gap, not fixed by this branch. If a
-		// future fix adds symbol-keyed defineProperty support for arrays,
-		// this hardcoded true/true/true (and the early `return
-		// vm.Undefined, nil` for an absent key just below) will need to
-		// consult whatever attribute storage that fix introduces instead.
+		//   // before: {value: 7, writable: true, enumerable: true, configurable: true} (hardcoded default)
+		//   // Node:   {value: 7, writable: false, enumerable: false, configurable: false}
 		if keyIsSymbol {
 			if sym := propSym.AsSymbolObject(); sym != nil {
-				if v, ok := arrObj.GetSymbolProp(sym); ok {
+				if g, s, e, c, ok := arrObj.GetOwnSymbolAccessor(sym); ok {
+					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+					descriptor.SetOwn("get", g)
+					descriptor.SetOwn("set", s)
+					descriptor.SetOwn("enumerable", vm.BooleanValue(e))
+					descriptor.SetOwn("configurable", vm.BooleanValue(c))
+					return vm.NewValueFromPlainObject(descriptor), nil
+				}
+				if v, desc, ok := arrObj.GetSymbolPropertyDescriptor(sym); ok {
 					descriptor := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
 					descriptor.SetOwn("value", v)
-					descriptor.SetOwn("writable", vm.BooleanValue(true))
-					descriptor.SetOwn("enumerable", vm.BooleanValue(true))
-					descriptor.SetOwn("configurable", vm.BooleanValue(true))
+					descriptor.SetOwn("writable", vm.BooleanValue(desc.Writable))
+					descriptor.SetOwn("enumerable", vm.BooleanValue(desc.Enumerable))
+					descriptor.SetOwn("configurable", vm.BooleanValue(desc.Configurable))
 					return vm.NewValueFromPlainObject(descriptor), nil
 				}
 			}
@@ -5499,10 +5866,44 @@ func objectGetOwnPropertyDescriptorsWithVM(vmInstance *vm.VM, args []vm.Value) (
 		}
 	case vm.TypeArray:
 		arr := obj.AsArray()
-		for i := 0; i < arr.Length(); i++ {
-			stringKeys = append(stringKeys, strconv.Itoa(i))
+		// This used to loop `i := 0; i < arr.Length()` - arr.Length() is
+		// the array's .length property, which a huge sparse index (one
+		// defined past maxDenseArrayDefineIndex via Object.defineProperty,
+		// see ArrayDefineOwnProperty) extends without growing `elements`
+		// at all, making this a multi-billion-iteration hang for an array
+		// that otherwise holds a handful of elements - the exact
+		// paserati#176/#178 shape every other array-key-collecting
+		// operation in this file already guards against by bounding the
+		// per-index scan to DenseLength() and walking arraySparseIndices
+		// separately (O(number of sparse entries), not O(index value)).
+		// It also never collected any NAMED (non-index) key at all -
+		// plain or accessor - so `arr.foo = "bar"` and an
+		// Object.defineProperty(arr, "foo", {get, ...}) accessor were
+		// both silently dropped, on top of the loop's own hang risk.
+		for i := 0; i < arr.DenseLength(); i++ {
+			key := strconv.Itoa(i)
+			if !arr.HasOwnIndexProperty(key, i) {
+				continue // hole - not an own property at all (paserati#300)
+			}
+			stringKeys = append(stringKeys, key)
+		}
+		// getOwnPropertyDescriptors wants every own key regardless of
+		// enumerability, hence enumerableOnly=false for both helpers below
+		// - matching Object.getOwnPropertyNames' own TypeArray case.
+		for _, idx := range arraySparseIndices(arr, false) {
+			stringKeys = append(stringKeys, strconv.Itoa(idx))
 		}
 		stringKeys = append(stringKeys, "length")
+		stringKeys = append(stringKeys, arrayNamedKeys(arr, false)...)
+		// This case never collected symbol keys at all, so
+		// Object.getOwnPropertyDescriptors(arr) silently dropped a symbol
+		// property entirely (whether a plain `arr[sym] = v` or one defined
+		// via Object.defineProperty - see ArrayDefineOwnSymbolProperty,
+		// pkg/vm/array_props.go) despite the single-key
+		// Object.getOwnPropertyDescriptor already answering correctly for
+		// the exact same property - same gap this switch's other
+		// branches' doc comments describe fixing for their own kinds.
+		symbolKeys = append(symbolKeys, arr.OwnSymbolKeys()...)
 	case vm.TypeFunction:
 		fn := obj.AsFunction()
 		// Function intrinsics: length, name, prototype

--- a/pkg/builtins/reflect_delete.go
+++ b/pkg/builtins/reflect_delete.go
@@ -79,8 +79,12 @@ func reflectDeleteProperty(vmInstance *vm.VM, target vm.Value, key vm.Value) (bo
 	case vm.TypeArray:
 		arr := target.AsArray()
 		if isSym {
-			arr.DeleteSymbolProp(key.AsSymbolObject())
-			return true, nil
+			// A symbol property can now be explicitly non-configurable via
+			// Object.defineProperty (see ArrayDefineOwnSymbolProperty,
+			// pkg/vm/array_props.go) - propagate DeleteSymbolProp's actual
+			// result instead of hardcoding success, matching every other
+			// case in this function.
+			return arr.DeleteSymbolProp(key.AsSymbolObject()), nil
 		}
 		if idx, isIndex := vm.ParseArrayIndex(name); isIndex {
 			return arr.DeleteIndex(idx), nil

--- a/pkg/vm/array_props.go
+++ b/pkg/vm/array_props.go
@@ -282,6 +282,105 @@ func (vm *VM) ArrayDefineOwnProperty(
 	return nil
 }
 
+// ArrayDefineOwnSymbolProperty implements the Array exotic object's
+// [[DefineOwnProperty]] (ECMA-262 10.4.2.1 -> OrdinaryDefineOwnProperty
+// 10.1.6.3) for a symbol-keyed property. This is the symbol-keyed
+// counterpart of ArrayDefineOwnProperty above, backing
+// Object.defineProperty(arr, sym, {...}) - previously a silent no-op for
+// arrays: a symbol key never matched any of ArrayDefineOwnProperty's
+// callers' branches (all gated on a non-symbol propName), and there was no
+// storage to hold a non-default attribute combination or an accessor even if
+// one had been dispatched here. A symbol key never aliases a numeric index
+// or "length" the way a named key can, so none of ArrayDefineOwnProperty's
+// index/length-specific machinery (dense-element growth, sparse-index
+// tracking, tryParseArrayIndex) applies - this mirrors only that function's
+// plain named-property tail (the non-index path).
+func (vm *VM) ArrayDefineOwnSymbolProperty(
+	a *ArrayObject, sym *SymbolObject,
+	hasValue bool, value Value,
+	writablePtr, enumerablePtr, configurablePtr *bool,
+	hasGetter bool, getter Value,
+	hasSetter bool, setter Value,
+) error {
+	becomingAccessor := hasGetter || hasSetter
+
+	var exists, isAccessor, curWritable, curEnumerable, curConfigurable bool
+	if _, _, e, c, ok := a.GetOwnSymbolAccessor(sym); ok {
+		exists, isAccessor, curEnumerable, curConfigurable = true, true, e, c
+	} else if _, desc, ok := a.GetSymbolPropertyDescriptor(sym); ok {
+		exists, curWritable, curEnumerable, curConfigurable = true, desc.Writable, desc.Enumerable, desc.Configurable
+	}
+
+	// OrdinaryDefineOwnProperty 10.1.6.3 steps 3-4: reject on a
+	// non-configurable existing property whose descriptor the caller is
+	// trying to widen or whose kind/writability it's trying to narrow.
+	if exists && !curConfigurable {
+		if configurablePtr != nil && *configurablePtr {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if enumerablePtr != nil && *enumerablePtr != curEnumerable {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if isAccessor && (hasValue || writablePtr != nil) {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if !isAccessor && becomingAccessor {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		if !isAccessor && !becomingAccessor && !curWritable && writablePtr != nil && *writablePtr {
+			return vm.NewTypeError("Cannot redefine property: Symbol()")
+		}
+		// NOT checked here, matching ArrayDefineOwnProperty's identical
+		// pre-existing gap for named keys (10.1.6.3 step 4e-ii): redefining
+		// a non-configurable, non-writable data property with a *different*
+		// [[Value]] should also throw, but doesn't - it's silently accepted
+		// as a no-op-that-isn't since the write below still updates the
+		// value if hasValue is true. Left this way for parity with the
+		// named-key path rather than fixing only the symbol-key side.
+	} else if !exists && !a.IsExtensible() {
+		return vm.NewTypeError("Cannot define property Symbol(), object is not extensible")
+	}
+
+	enumerable := curEnumerable
+	if !exists {
+		enumerable = false
+	}
+	if enumerablePtr != nil {
+		enumerable = *enumerablePtr
+	}
+	configurable := curConfigurable
+	if !exists {
+		configurable = false
+	}
+	if configurablePtr != nil {
+		configurable = *configurablePtr
+	}
+
+	if becomingAccessor {
+		a.DefineSymbolAccessorProperty(sym, getter, hasGetter, setter, hasSetter, &enumerable, &configurable)
+		return nil
+	}
+
+	writable := curWritable
+	if !exists {
+		writable = false
+	}
+	if writablePtr != nil {
+		writable = *writablePtr
+	}
+	newValue := value
+	if !hasValue {
+		if v, ok := a.GetSymbolProp(sym); ok {
+			newValue = v
+		} else {
+			newValue = Undefined
+		}
+	}
+
+	a.DefineSymbolProperty(sym, newValue, writable, enumerable, configurable)
+	return nil
+}
+
 // DeleteIndex implements [[Delete]] (ECMA-262 10.4.2.1 -> OrdinaryDelete
 // 10.1.7) for a numeric array index, clearing the slot (and any tracked
 // accessor/descriptor state for it) and reporting success. A plain element

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -1433,6 +1433,31 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		// case can see it) - this case just never called it.
 		arrObj := base.AsArray()
 		if sym := symKey.AsSymbolObject(); sym != nil {
+			// A symbol-keyed accessor defined via Object.defineProperty(arr,
+			// sym, {get, set}) takes priority over the plain symbolProps
+			// value, mirroring the named-property read path (GetOwnAccessor
+			// consulted before a plain element/property) - see
+			// ArrayObject.GetOwnSymbolAccessor and
+			// ArrayDefineOwnSymbolProperty (array_props.go).
+			if arrObj.HasSymbolAccessors() {
+				if getter, _, _, _, ok := arrObj.GetOwnSymbolAccessor(sym); ok {
+					if getter.Type() == TypeUndefined {
+						*dest = Undefined
+						return true, InterpretOK, *dest
+					}
+					res, err := vm.Call(getter, base, nil)
+					if err != nil {
+						if ee, ok := err.(ExceptionError); ok {
+							vm.throwException(ee.GetExceptionValue())
+							return false, InterpretRuntimeError, Undefined
+						}
+						vm.ThrowTypeError(err.Error())
+						return false, InterpretRuntimeError, Undefined
+					}
+					*dest = res
+					return true, InterpretOK, *dest
+				}
+			}
 			if v, ok := arrObj.GetSymbolProp(sym); ok {
 				*dest = v
 				return true, InterpretOK, *dest

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -1214,12 +1214,36 @@ func (vm *VM) opSetPropSymbol(ip int, objVal *Value, symKey Value, valueToSet *V
 		return vm.setOwnCheckedByKey(closure.Properties, NewSymbolKey(symKey), *objVal, *valueToSet)
 	}
 
-	// Array objects: store symbol properties directly on the array
+	// Array objects: store symbol properties directly on the array. A
+	// symbol-keyed accessor defined via Object.defineProperty(arr, sym,
+	// {get, set}) takes priority over the plain symbolProps slot, mirroring
+	// the named-property write path and this function's own RegExp/Proxy
+	// branches above - see ArrayObject.GetOwnSymbolAccessor and
+	// ArrayDefineOwnSymbolProperty (array_props.go).
 	if objVal.Type() == TypeArray {
 		arr := objVal.AsArray()
 		if arr != nil {
 			sym := symKey.AsSymbolObject()
 			if sym != nil {
+				if arr.HasSymbolAccessors() {
+					if _, setter, _, _, ok := arr.GetOwnSymbolAccessor(sym); ok {
+						if setter.Type() != TypeUndefined {
+							_, err := vm.Call(setter, *objVal, []Value{*valueToSet})
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+									return false, InterpretRuntimeError, Undefined
+								}
+								vm.ThrowTypeError(err.Error())
+								return false, InterpretRuntimeError, Undefined
+							}
+						}
+						// A getter-only accessor silently swallows the write in
+						// sloppy mode, matching ArrayPrototypeSetterFor's
+						// identical rule for a named-property accessor.
+						return true, InterpretOK, *valueToSet
+					}
+				}
 				arr.SetSymbolProp(sym, *valueToSet)
 			}
 		}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -227,10 +227,23 @@ type ArrayObject struct {
 	// Reflect.ownKeys, and stay after every string key regardless of when
 	// each was added relative to the symbols). See OwnSymbolKeys.
 	symbolPropOrder []*SymbolObject
-	getters         map[string]Value // Accessor getters for named properties
-	setters         map[string]Value // Accessor setters for named properties
-	extensible      bool             // When false, no new properties can be added (for Object.freeze/seal)
-	frozen          bool             // When true, elements are also non-writable and non-configurable
+	// symbolPropertyDesc/symbolGetters/symbolSetters are the symbol-keyed
+	// counterparts of propertyDesc/getters/setters above, backing
+	// Object.defineProperty(arr, sym, {...}) - previously a silent no-op for
+	// arrays (paserati task_778749f8 follow-up): symbolProps only ever held a
+	// bare value with no attribute tracking and no accessor storage at all, so
+	// a non-default writable/enumerable/configurable combination, or a
+	// get/set pair, defined via Object.defineProperty on a symbol key
+	// couldn't be represented and defineProperty quietly dropped it. See
+	// DefineSymbolProperty/DefineSymbolAccessorProperty/GetOwnSymbolAccessor
+	// and ArrayDefineOwnSymbolProperty (array_props.go).
+	symbolPropertyDesc map[*SymbolObject]PropertyDesc
+	symbolGetters      map[*SymbolObject]Value
+	symbolSetters      map[*SymbolObject]Value
+	getters            map[string]Value // Accessor getters for named properties
+	setters            map[string]Value // Accessor setters for named properties
+	extensible         bool             // When false, no new properties can be added (for Object.freeze/seal)
+	frozen             bool             // When true, elements are also non-writable and non-configurable
 	// lengthNonWritable tracks Object.defineProperty(arr, "length",
 	// {writable: false}) - stored inverted (zero value = writable, the ES
 	// default) so every existing ArrayObject construction site, which
@@ -2847,27 +2860,46 @@ func (a *ArrayObject) GetSymbolProp(sym *SymbolObject) (Value, bool) {
 	return v, ok
 }
 
-// SetSymbolProp sets a symbol-keyed property on the array object
+// SetSymbolProp sets a symbol-keyed property on the array object. Uses
+// noteSymbolPropOrder (which checks all of symbolProps/symbolGetters/
+// symbolSetters via HasOwnSymbolProp) rather than a bare `_, existed :=
+// a.symbolProps[sym]` check: since DefineSymbolAccessorProperty added a
+// second place a symbol key can already "exist" without an entry in
+// symbolProps (an accessor-only symbol has its data entry deleted - see
+// that method), the bare check alone would have missed that case and
+// appended a second symbolPropOrder entry for the same symbol, making
+// Object.getOwnPropertySymbols list it twice.
 func (a *ArrayObject) SetSymbolProp(sym *SymbolObject, val Value) {
 	if a.symbolProps == nil {
 		a.symbolProps = make(map[*SymbolObject]Value)
 	}
-	if _, existed := a.symbolProps[sym]; !existed {
-		// New key - record its creation-order position. An overwrite of an
-		// already-present key keeps its original position, matching
-		// ordinary property semantics (redefining a value doesn't move it).
-		a.symbolPropOrder = append(a.symbolPropOrder, sym)
-	}
+	a.noteSymbolPropOrder(sym)
 	a.symbolProps[sym] = val
 }
 
-// HasOwnSymbolProp checks if the array object has an own symbol property
+// HasOwnSymbolProp checks if the array object has an own symbol property -
+// either a plain data value (symbolProps) or an accessor defined via
+// Object.defineProperty (symbolGetters/symbolSetters). Callers like `in`,
+// Reflect.has, and hasOwnProperty must see an accessor-only symbol (one
+// whose value was replaced entirely by DefineSymbolAccessorProperty, which
+// deletes the symbolProps entry) as present too.
 func (a *ArrayObject) HasOwnSymbolProp(sym *SymbolObject) bool {
-	if a.symbolProps == nil {
-		return false
+	if a.symbolProps != nil {
+		if _, ok := a.symbolProps[sym]; ok {
+			return true
+		}
 	}
-	_, ok := a.symbolProps[sym]
-	return ok
+	if a.symbolGetters != nil {
+		if _, ok := a.symbolGetters[sym]; ok {
+			return true
+		}
+	}
+	if a.symbolSetters != nil {
+		if _, ok := a.symbolSetters[sym]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // OwnSymbolKeys returns every symbol this array has an own property for, in
@@ -2883,6 +2915,157 @@ func (a *ArrayObject) OwnSymbolKeys() []Value {
 		symbols = append(symbols, Value{typ: TypeSymbol, obj: unsafe.Pointer(sym)})
 	}
 	return symbols
+}
+
+// noteSymbolPropOrder records sym's creation-order position the first time
+// it becomes an own property by any means (plain value, attributed data
+// property, or accessor) - shared by SetSymbolProp and
+// DefineSymbolAccessorProperty so a symbol that starts as one kind and is
+// later redefined as the other (Object.defineProperty converting a data
+// property to an accessor or back) keeps its original position instead of
+// moving to the end, matching ordinary property semantics (redefining a key
+// doesn't move it) - the same rule ArrayDefineOwnProperty's named-property
+// path already follows.
+func (a *ArrayObject) noteSymbolPropOrder(sym *SymbolObject) {
+	if a.HasOwnSymbolProp(sym) {
+		return
+	}
+	a.symbolPropOrder = append(a.symbolPropOrder, sym)
+}
+
+// DefineSymbolProperty sets a symbol-keyed data property with an explicit
+// writable/enumerable/configurable combination - the symbol-keyed
+// counterpart of DefineOwnProperty, backing
+// Object.defineProperty(arr, sym, {value, writable, enumerable, configurable}).
+// Converts an existing accessor at this key back into a data property,
+// mirroring DefineOwnProperty's/ArrayDefineOwnProperty's handling of the
+// same conversion for named keys.
+func (a *ArrayObject) DefineSymbolProperty(sym *SymbolObject, value Value, writable, enumerable, configurable bool) {
+	if a.symbolGetters != nil {
+		delete(a.symbolGetters, sym)
+	}
+	if a.symbolSetters != nil {
+		delete(a.symbolSetters, sym)
+	}
+	a.noteSymbolPropOrder(sym)
+	if a.symbolProps == nil {
+		a.symbolProps = make(map[*SymbolObject]Value)
+	}
+	a.symbolProps[sym] = value
+	if a.symbolPropertyDesc == nil {
+		a.symbolPropertyDesc = make(map[*SymbolObject]PropertyDesc)
+	}
+	a.symbolPropertyDesc[sym] = PropertyDesc{
+		Writable:     writable,
+		Enumerable:   enumerable,
+		Configurable: configurable,
+	}
+}
+
+// GetSymbolPropertyDescriptor returns the descriptor for a symbol-keyed data
+// property - the symbol-keyed counterpart of GetOwnPropertyDescriptor. A
+// symbol whose value was set via the plain SetSymbolProp path (`arr[sym] =
+// v`, never touched by Object.defineProperty) has no entry in
+// symbolPropertyDesc and reports the ES ordinary-property default
+// (writable/enumerable/configurable all true), same as GetOwnPropertyDescriptor
+// does for a plain named property.
+func (a *ArrayObject) GetSymbolPropertyDescriptor(sym *SymbolObject) (Value, PropertyDesc, bool) {
+	v, ok := a.GetSymbolProp(sym)
+	if !ok {
+		return Undefined, PropertyDesc{}, false
+	}
+	if a.symbolPropertyDesc != nil {
+		if desc, hasDesc := a.symbolPropertyDesc[sym]; hasDesc {
+			return v, desc, true
+		}
+	}
+	return v, PropertyDesc{Writable: true, Enumerable: true, Configurable: true}, true
+}
+
+// DefineSymbolAccessorProperty defines a symbol-keyed accessor property - the
+// symbol-keyed counterpart of DefineAccessorProperty, backing
+// Object.defineProperty(arr, sym, {get, set, ...}).
+func (a *ArrayObject) DefineSymbolAccessorProperty(sym *SymbolObject, getter Value, hasGetter bool, setter Value, hasSetter bool, enumerable *bool, configurable *bool) {
+	a.noteSymbolPropOrder(sym)
+	if a.symbolGetters == nil {
+		a.symbolGetters = make(map[*SymbolObject]Value)
+	}
+	if a.symbolSetters == nil {
+		a.symbolSetters = make(map[*SymbolObject]Value)
+	}
+	if hasGetter {
+		a.symbolGetters[sym] = getter
+	}
+	if hasSetter {
+		a.symbolSetters[sym] = setter
+	}
+
+	desc := PropertyDesc{
+		Writable:     false, // accessors don't have writable
+		Enumerable:   false,
+		Configurable: true,
+	}
+	if enumerable != nil {
+		desc.Enumerable = *enumerable
+	}
+	if configurable != nil {
+		desc.Configurable = *configurable
+	}
+	if a.symbolPropertyDesc == nil {
+		a.symbolPropertyDesc = make(map[*SymbolObject]PropertyDesc)
+	}
+	a.symbolPropertyDesc[sym] = desc
+
+	// Converting a data property into an accessor: drop the plain value,
+	// mirroring DefineAccessorProperty's delete(a.properties, name).
+	if a.symbolProps != nil {
+		delete(a.symbolProps, sym)
+	}
+}
+
+// HasSymbolAccessors reports whether this array has ever had a symbol-keyed
+// accessor property defined on it - the symbol-keyed counterpart of
+// HasAccessors, letting hot per-symbol paths (opGetPropSymbol/opSetPropSymbol)
+// skip the GetOwnSymbolAccessor map probe on the overwhelmingly common array
+// that has never had one.
+func (a *ArrayObject) HasSymbolAccessors() bool {
+	return a.symbolGetters != nil || a.symbolSetters != nil
+}
+
+// GetOwnSymbolAccessor returns the getter and setter for a symbol-keyed
+// accessor property - the symbol-keyed counterpart of GetOwnAccessor.
+// Returns (getter, setter, enumerable, configurable, isAccessor).
+func (a *ArrayObject) GetOwnSymbolAccessor(sym *SymbolObject) (Value, Value, bool, bool, bool) {
+	hasGetter := a.symbolGetters != nil && a.symbolGetters[sym].Type() != 0
+	hasSetter := a.symbolSetters != nil && a.symbolSetters[sym].Type() != 0
+
+	if !hasGetter && !hasSetter {
+		return Undefined, Undefined, false, false, false
+	}
+
+	getter := Undefined
+	setter := Undefined
+	if a.symbolGetters != nil {
+		if g, ok := a.symbolGetters[sym]; ok {
+			getter = g
+		}
+	}
+	if a.symbolSetters != nil {
+		if s, ok := a.symbolSetters[sym]; ok {
+			setter = s
+		}
+	}
+
+	enumerable := false
+	configurable := true
+	if a.symbolPropertyDesc != nil {
+		if desc, ok := a.symbolPropertyDesc[sym]; ok {
+			enumerable = desc.Enumerable
+			configurable = desc.Configurable
+		}
+	}
+
+	return getter, setter, enumerable, configurable, true
 }
 
 // DefineAccessorProperty defines an accessor property on the array object
@@ -3683,26 +3866,47 @@ func formatDateTimestamp(timestamp float64) string {
 	return t.Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
 }
 
-// DeleteSymbolProp removes a symbol-keyed own property from the array object
-// and reports whether it was present. Symbol-keyed array properties are
-// ordinary configurable properties, so removal always succeeds.
+// DeleteSymbolProp removes a symbol-keyed own property from the array
+// object and reports whether the delete succeeded. A symbol with no own
+// property at all trivially succeeds (OrdinaryDelete 10.1.7 step 2: nothing
+// to reject). A symbol-keyed property with no tracked descriptor (a plain
+// `arr[sym] = v` assignment, never touched by Object.defineProperty) is an
+// ordinary configurable property and always comes off; one explicitly
+// defined non-configurable via Object.defineProperty(arr, sym,
+// {configurable: false, ...}) - now representable via symbolPropertyDesc,
+// see ArrayDefineOwnSymbolProperty (array_props.go) - must be left alone and
+// report failure instead, matching OrdinaryDelete's [[Configurable]] check
+// the same way DeleteOwn already does for named properties.
 func (a *ArrayObject) DeleteSymbolProp(sym *SymbolObject) bool {
-	if a.symbolProps == nil {
-		return false
+	if !a.HasOwnSymbolProp(sym) {
+		return true
 	}
-	_, existed := a.symbolProps[sym]
-	delete(a.symbolProps, sym)
-	if existed {
-		// Keep symbolPropOrder in sync - a re-added key after deletion
-		// gets a fresh, later creation-order position via SetSymbolProp's
-		// own "not already present" check, matching how deleting then
-		// redefining an ordinary property moves it to the end too.
-		for i, s := range a.symbolPropOrder {
-			if s == sym {
-				a.symbolPropOrder = append(a.symbolPropOrder[:i], a.symbolPropOrder[i+1:]...)
-				break
-			}
+	if a.symbolPropertyDesc != nil {
+		if desc, ok := a.symbolPropertyDesc[sym]; ok && !desc.Configurable {
+			return false
 		}
 	}
-	return existed
+	if a.symbolProps != nil {
+		delete(a.symbolProps, sym)
+	}
+	if a.symbolGetters != nil {
+		delete(a.symbolGetters, sym)
+	}
+	if a.symbolSetters != nil {
+		delete(a.symbolSetters, sym)
+	}
+	if a.symbolPropertyDesc != nil {
+		delete(a.symbolPropertyDesc, sym)
+	}
+	// Keep symbolPropOrder in sync - a re-added key after deletion gets a
+	// fresh, later creation-order position via noteSymbolPropOrder's own
+	// "not already present" check, matching how deleting then redefining an
+	// ordinary property moves it to the end too.
+	for i, s := range a.symbolPropOrder {
+		if s == sym {
+			a.symbolPropOrder = append(a.symbolPropOrder[:i], a.symbolPropOrder[i+1:]...)
+			break
+		}
+	}
+	return true
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -9733,8 +9733,10 @@ startExecution:
 				continue
 			}
 
-			// Only process actual objects (non-Proxy)
-			if sourceVal.Type() != TypeObject && sourceVal.Type() != TypeDictObject {
+			// Only process actual objects (non-Proxy). TypeArray used to be
+			// excluded here too - see the TypeArray case in the switch
+			// below for what that silently dropped.
+			if sourceVal.Type() != TypeObject && sourceVal.Type() != TypeDictObject && sourceVal.Type() != TypeArray {
 				// For other primitive types, they should be converted to objects first
 				// But for now, skip them as they typically have no enumerable properties
 				continue
@@ -9870,6 +9872,231 @@ startExecution:
 									destObj.DefineOwnPropertyByKey(key, value, &w, &e, &c)
 								}
 							}
+						}
+					}
+					// DictObject doesn't support symbol keys, so skip for DictObject destination
+				}
+			case TypeArray:
+				// A TypeArray source used to fall straight into the
+				// `sourceVal.Type() != TypeObject && sourceVal.Type() !=
+				// TypeDictObject` skip above and contribute NOTHING to the
+				// destination - not just missing named/symbol properties
+				// (the gap this case exists to close), but missing even the
+				// array's own indexed elements:
+				//
+				//   const arr = [1, 2, 3]; arr.foo = "bar";
+				//   const s = Symbol("s"); arr[s] = "v";
+				//   ({...arr});
+				//   // before: {} (nothing copied at all)
+				//   // Node:   {0: 1, 1: 2, 2: 3, foo: "bar"} (plus the
+				//   //         symbol, invisible to a plain {} print but
+				//   //         present - see this file's Object.assign
+				//   //         equivalent, pkg/builtins/object_init.go,
+				//   //         which this case is built to match: object
+				//   //         spread and Object.assign both implement
+				//   //         ECMAScript's CopyDataProperties abstract
+				//   //         operation, so they must copy the same set of
+				//   //         properties).
+				//
+				// Mirrors the TypeObject case just above: dense indices,
+				// then sparse indices beyond DenseLength() (paserati#176/
+				// #178 - see arraySparseIndices's own doc comment for why a
+				// naive 0..Length() loop would hang), then named (non-index)
+				// properties - accessor first since DefineAccessorProperty
+				// removes a converted key from `properties` entirely, then
+				// plain data - then symbol-keyed properties, accessor or
+				// plain, via ArrayObject's own symbol storage (see
+				// ArrayDefineOwnSymbolProperty, array_props.go).
+				arr := AsArray(sourceVal)
+				denseLen := arr.DenseLength()
+				for i := 0; i < denseLen; i++ {
+					key := strconv.Itoa(i)
+					if getter, _, enumerable, _, isAccessor := arr.GetOwnAccessor(key); isAccessor {
+						if !enumerable {
+							continue
+						}
+						var value Value
+						if getter.Type() != TypeUndefined {
+							frame.ip = ip
+							res, err := vm.Call(getter, sourceVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("Error calling getter for index '%s': %v", key, err)
+								}
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									registers = frame.registers
+									ip = frame.ip
+									goto reloadFrame
+								}
+								return InterpretRuntimeError, Undefined
+							}
+							value = res
+						} else {
+							value = Undefined
+						}
+						if destVal.Type() == TypeDictObject {
+							AsDictObject(destVal).SetOwn(key, value)
+						} else {
+							AsPlainObject(destVal).SetOwn(key, value)
+						}
+						continue
+					}
+					if !arr.HasIndex(i) {
+						continue // hole - not an own property at all (paserati#300)
+					}
+					value := arr.Get(i)
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(key, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(key, value)
+					}
+				}
+				for _, idx := range arraySparseIndices(arr, true) {
+					key := strconv.Itoa(idx)
+					var value Value
+					if getter, _, _, _, isAccessor := arr.GetOwnAccessor(key); isAccessor {
+						if getter.Type() != TypeUndefined {
+							frame.ip = ip
+							res, err := vm.Call(getter, sourceVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("Error calling getter for index '%s': %v", key, err)
+								}
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									registers = frame.registers
+									ip = frame.ip
+									goto reloadFrame
+								}
+								return InterpretRuntimeError, Undefined
+							}
+							value = res
+						} else {
+							value = Undefined
+						}
+					} else if v, ok := arr.GetOwn(key); ok {
+						value = v
+					}
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(key, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(key, value)
+					}
+				}
+				for _, name := range arr.AccessorKeys() {
+					// tryParseArrayIndex, not LooksLikeArrayIndex: the latter has
+					// no upper bound, so an out-of-range numeric key like
+					// "4294967295" would look like an index here and get
+					// skipped, while the dense/sparse loops above (which use
+					// tryParseArrayIndex, via arraySparseIndices) would also
+					// reject it as too big to be an index - leaving it matched
+					// by neither loop and silently dropped. Both filters must
+					// use the same predicate so they partition the key space
+					// exactly.
+					if _, isIndex := tryParseArrayIndex(name); isIndex {
+						continue // an index accessor - already handled above
+					}
+					getter, _, enumerable, _, isAccessor := arr.GetOwnAccessor(name)
+					if !isAccessor || !enumerable {
+						continue
+					}
+					var value Value
+					if getter.Type() != TypeUndefined {
+						frame.ip = ip
+						res, err := vm.Call(getter, sourceVal, nil)
+						if err != nil {
+							if ee, ok := err.(ExceptionError); ok {
+								vm.throwException(ee.GetExceptionValue())
+							} else {
+								vm.runtimeError("Error calling getter for property '%s': %v", name, err)
+							}
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								registers = frame.registers
+								ip = frame.ip
+								goto reloadFrame
+							}
+							return InterpretRuntimeError, Undefined
+						}
+						value = res
+					} else {
+						value = Undefined
+					}
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(name, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(name, value)
+					}
+				}
+				for _, name := range arr.NamedPropertyKeys() {
+					// tryParseArrayIndex - see the matching comment on the
+					// AccessorKeys loop above for why this can't be
+					// LooksLikeArrayIndex.
+					if _, isIndex := tryParseArrayIndex(name); isIndex {
+						continue // a sparse index sharing this map - already handled above
+					}
+					value, enumerable, ok := arr.GetNamedPropertyDescriptor(name)
+					if !ok || !enumerable {
+						continue
+					}
+					if destVal.Type() == TypeDictObject {
+						AsDictObject(destVal).SetOwn(name, value)
+					} else {
+						AsPlainObject(destVal).SetOwn(name, value)
+					}
+				}
+				for _, sym := range arr.OwnSymbolKeys() {
+					symKey := NewSymbolKey(sym)
+					symObj := sym.AsSymbolObject()
+					if getter, _, enumerable, _, isAccessor := arr.GetOwnSymbolAccessor(symObj); isAccessor {
+						if !enumerable {
+							continue
+						}
+						var value Value
+						if getter.Type() != TypeUndefined {
+							frame.ip = ip
+							res, err := vm.Call(getter, sourceVal, nil)
+							if err != nil {
+								if ee, ok := err.(ExceptionError); ok {
+									vm.throwException(ee.GetExceptionValue())
+								} else {
+									vm.runtimeError("Error calling getter for symbol property: %v", err)
+								}
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									registers = frame.registers
+									ip = frame.ip
+									goto reloadFrame
+								}
+								return InterpretRuntimeError, Undefined
+							}
+							value = res
+						} else {
+							value = Undefined
+						}
+						if destVal.Type() == TypeObject {
+							destObj := AsPlainObject(destVal)
+							w, e, c := true, true, true
+							destObj.DefineOwnPropertyByKey(symKey, value, &w, &e, &c)
+						}
+					} else if value, desc, ok := arr.GetSymbolPropertyDescriptor(symObj); ok && desc.Enumerable {
+						if destVal.Type() == TypeObject {
+							destObj := AsPlainObject(destVal)
+							w, e, c := true, true, true
+							destObj.DefineOwnPropertyByKey(symKey, value, &w, &e, &c)
 						}
 					}
 					// DictObject doesn't support symbol keys, so skip for DictObject destination
@@ -14840,10 +15067,29 @@ startExecution:
 				}
 				// Then the named (non-index) own properties: an exec result's
 				// index/input/groups/indices, or anything a program stored on
-				// the array. Sparse indices living in the named/accessor
-				// stores were already handled above.
+				// the array - accessor properties (AccessorKeys(), e.g. an
+				// Object.defineProperty(arr, "foo", {get, enumerable}) -
+				// stored in getters/setters, never in `properties`, so
+				// NamedPropertyKeys() alone can't see it) first, then plain
+				// data properties. Sparse indices living in either store were
+				// already handled above via arraySparseIndices, so both loops
+				// filter them out with tryParseArrayIndex - not
+				// LooksLikeArrayIndex, which has no upper bound and would let
+				// an out-of-range numeric key like "4294967295" slip past
+				// both this filter and arraySparseIndices' own filter,
+				// vanishing from enumeration entirely (see the matching
+				// object-spread TypeArray case above for the full
+				// explanation of that predicate mismatch).
+				for _, key := range arr.AccessorKeys() {
+					if _, isIndex := tryParseArrayIndex(key); isIndex {
+						continue
+					}
+					if _, _, enumerable, _, isAccessor := arr.GetOwnAccessor(key); isAccessor && enumerable {
+						keys = append(keys, key)
+					}
+				}
 				for _, key := range arr.NamedPropertyKeys() {
-					if LooksLikeArrayIndex(key) {
+					if _, isIndex := tryParseArrayIndex(key); isIndex {
 						continue
 					}
 					if _, enumerable, ok := arr.GetNamedPropertyDescriptor(key); ok && enumerable {
@@ -17282,13 +17528,24 @@ startExecution:
 				// numeric index's configurability comes from the array-wide
 				// `frozen` flag rather than a per-element bit.
 				arr := obj.AsArray()
-				keyStr := key.ToString()
-				if idx, isNumeric := tryParseArrayIndex(keyStr); isNumeric {
-					success = arr.DeleteIndex(idx)
-				} else if key.Type() != TypeSymbol {
-					success = arr.DeleteOwn(keyStr)
+				if key.Type() == TypeSymbol {
+					// Symbol-keyed properties can now be explicitly defined
+					// non-configurable via Object.defineProperty (see
+					// ArrayDefineOwnSymbolProperty, array_props.go) - route
+					// through DeleteSymbolProp so a `delete arr[sym]` both
+					// respects that and actually removes the entry (data,
+					// accessor, and descriptor alike) rather than
+					// unconditionally reporting success while leaving the
+					// property in place, which used to be safe only because
+					// every symbol property was implicitly configurable.
+					success = arr.DeleteSymbolProp(key.AsSymbolObject())
 				} else {
-					success = true
+					keyStr := key.ToString()
+					if idx, isNumeric := tryParseArrayIndex(keyStr); isNumeric {
+						success = arr.DeleteIndex(idx)
+					} else {
+						success = arr.DeleteOwn(keyStr)
+					}
 				}
 			} else if obj.Type() == TypeString {
 				// String primitives: indices within length are non-configurable

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1373,7 +1373,25 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 	case TypeArray:
 		arr := obj.AsArray()
 		if arr != nil {
-			if v, ok := arr.GetSymbolProp(sym.AsSymbolObject()); ok {
+			symObj := sym.AsSymbolObject()
+			// A symbol-keyed accessor defined via Object.defineProperty(arr,
+			// sym, {get, set}) takes priority over the plain symbolProps
+			// value - mirrors getOwnFromTableByKey's accessor-then-data
+			// order just above, and opGetPropSymbol's own TypeArray case
+			// (pkg/vm/op_getprop.go), which this function must agree with
+			// per PR #350's own invariant (arr[sym] === Reflect.get(arr,
+			// sym)) - Object.defineProperty on a symbol key was itself
+			// still a no-op when that invariant was written, so this
+			// couldn't yet be tested there. See ArrayObject.GetOwnSymbolAccessor.
+			if arr.HasSymbolAccessors() {
+				if g, _, _, _, ok := arr.GetOwnSymbolAccessor(symObj); ok {
+					if g.Type() == TypeUndefined {
+						return Undefined, nil
+					}
+					return vm.Call(g, receiver, nil)
+				}
+			}
+			if v, ok := arr.GetSymbolProp(symObj); ok {
 				return v, nil
 			}
 			if vm.ArrayPrototype.IsObject() {

--- a/tests/scripts/array_defineproperty_symbol.ts
+++ b/tests/scripts/array_defineproperty_symbol.ts
@@ -1,0 +1,297 @@
+// expect: true
+// Object.defineProperty(arr, sym, {...}) was a silent no-op for arrays: it
+// neither threw nor stored anything, for both data and accessor
+// descriptors, on any array-typed target:
+//
+//   const arr = [1, 2]; const s = Symbol("d");
+//   Object.defineProperty(arr, s, {value: 7, writable: false, enumerable: false, configurable: false});
+//   arr[s];                                    // before: undefined - Node: 7
+//   Object.getOwnPropertyDescriptor(arr, s);    // before: undefined - Node: {value:7,writable:false,enumerable:false,configurable:false}
+//   Object.getOwnPropertySymbols(arr).length;   // before: 0 - Node: 1
+//
+//   const a2 = [1, 2]; const s2 = Symbol("g");
+//   Object.defineProperty(a2, s2, { get() { return 99; } });
+//   a2[s2];                                     // before: undefined - Node: 99
+//
+// Root cause: ArrayObject's existing accessor/attribute-override storage
+// (getters/setters/propertyDesc, pkg/vm/value.go) is keyed by string only -
+// unlike symbolProps (map[*SymbolObject]Value), which stores a bare value
+// with no attribute tracking at all. objectDefinePropertyWithVM
+// (pkg/builtins/object_init.go) never had a symbol-key branch for TypeArray
+// either - a symbol key fell through every propName-gated check (all
+// meaningless for a symbol, since propName is "" for one) and landed on the
+// TypeObject-only block below, which a TypeArray value never satisfies.
+//
+// Fixed by adding symbol-keyed counterparts of the existing string-keyed
+// storage - symbolPropertyDesc/symbolGetters/symbolSetters on ArrayObject -
+// plus ArrayDefineOwnSymbolProperty (pkg/vm/array_props.go, mirroring
+// ArrayDefineOwnProperty's non-index tail) to implement
+// [[DefineOwnProperty]] for a symbol key, and wiring it into
+// objectDefinePropertyWithVM, Object.getOwnPropertyDescriptor's TypeArray
+// branch, and the read (opGetPropSymbol) / write (opSetPropSymbol) bytecode
+// paths so an accessor's getter/setter actually fires.
+//
+// This also surfaced (and fixes) a second, independent gap: `delete
+// arr[sym]` (OpDeleteIndex's TypeArray case, pkg/vm/vm.go) unconditionally
+// reported success without ever calling ArrayObject.DeleteSymbolProp,
+// relying on the old invariant that every symbol property was implicitly
+// configurable (true before this fix, since Object.defineProperty could
+// never make one otherwise). Now that a symbol property can be
+// non-configurable, or an accessor, `delete` is routed through
+// DeleteSymbolProp so it both respects configurability and actually clears
+// accessor/descriptor state on success - see checks 5-6 below. Same gap,
+// same fix, for Reflect.deleteProperty (pkg/builtins/reflect_delete.go).
+//
+// Every check below (including exact attribute values, TypeError on an
+// illegal redefinition, and delete's success/failure split) was verified
+// against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Data descriptor, all attributes false: round-trips through
+// arr[sym], Object.getOwnPropertyDescriptor, and Object.getOwnPropertySymbols. ---
+{
+  const arr: any = [1, 2];
+  const s = Symbol("d");
+  Object.defineProperty(arr, s, {
+    value: 7,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  const desc = Object.getOwnPropertyDescriptor(arr, s) as any;
+  const syms = Object.getOwnPropertySymbols(arr);
+  checks.push(
+    arr[s] === 7 &&
+      desc !== undefined &&
+      desc.value === 7 &&
+      desc.writable === false &&
+      desc.enumerable === false &&
+      desc.configurable === false &&
+      syms.length === 1 &&
+      syms[0] === s
+  );
+}
+
+// --- 2. Data descriptor, all attributes true (the ordinary-property
+// default) - distinguishes "attributes are tracked at all" from "tracked
+// attributes happen to read back as their zero value". ---
+{
+  const arr2: any = [1, 2];
+  const s2 = Symbol("all-true");
+  Object.defineProperty(arr2, s2, {
+    value: "v",
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  const desc2 = Object.getOwnPropertyDescriptor(arr2, s2) as any;
+  checks.push(
+    arr2[s2] === "v" &&
+      desc2.writable === true &&
+      desc2.enumerable === true &&
+      desc2.configurable === true
+  );
+}
+
+// --- 3. Data descriptor, a mixed combination (writable, non-enumerable,
+// configurable) - the two attributes above aren't just being ORed/ANDed
+// together into one bit. ---
+{
+  const arr3: any = [1, 2];
+  const s3 = Symbol("mixed");
+  Object.defineProperty(arr3, s3, {
+    value: 1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  const desc3 = Object.getOwnPropertyDescriptor(arr3, s3) as any;
+  checks.push(
+    desc3.writable === true &&
+      desc3.enumerable === false &&
+      desc3.configurable === true
+  );
+}
+
+// --- 4. Accessor property: `arr[sym]` invokes the getter (not a stored
+// value), and the getter is called freshly on every read. ---
+{
+  const arr4: any = [1, 2];
+  const s4 = Symbol("g");
+  let calls = 0;
+  Object.defineProperty(arr4, s4, {
+    get() {
+      calls++;
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const first = arr4[s4];
+  const second = arr4[s4];
+  const desc4 = Object.getOwnPropertyDescriptor(arr4, s4) as any;
+  checks.push(
+    first === 99 &&
+      second === 99 &&
+      calls === 2 &&
+      typeof desc4.get === "function" &&
+      desc4.set === undefined &&
+      desc4.enumerable === true &&
+      desc4.configurable === true &&
+      !("value" in desc4) &&
+      !("writable" in desc4)
+  );
+}
+
+// --- 5. Accessor property with both get and set: assignment invokes the
+// setter (not overwriting a plain data slot), and the getter reflects
+// whatever the setter stored. ---
+{
+  const arr5: any = [1, 2];
+  const s5 = Symbol("gs");
+  let backing = 0;
+  Object.defineProperty(arr5, s5, {
+    get() {
+      return backing;
+    },
+    set(v: number) {
+      backing = v * 2;
+    },
+    configurable: true,
+  });
+  arr5[s5] = 21;
+  checks.push(arr5[s5] === 42 && backing === 42);
+}
+
+// --- 6. Object.getOwnPropertySymbols / Reflect.ownKeys include a symbol
+// defined via Object.defineProperty (not just via a plain `arr[sym] = v`
+// assignment - the array_getownpropertysymbols.ts test already covers that
+// path; this one exercises the descriptor-based path added by this fix). ---
+{
+  const arr6: any = [1, 2, 3];
+  const s6 = Symbol("via-define");
+  Object.defineProperty(arr6, s6, { value: "x", enumerable: true });
+  const syms6 = Object.getOwnPropertySymbols(arr6);
+  const keys6 = Reflect.ownKeys(arr6);
+  checks.push(
+    syms6.length === 1 &&
+      syms6[0] === s6 &&
+      keys6[keys6.length - 1] === s6
+  );
+}
+
+// --- 7. A non-configurable symbol property rejects a defineProperty call
+// that tries to widen configurable/enumerable or change writable - and
+// `delete arr[sym]` reports failure and leaves the property in place
+// (exercises the OpDeleteIndex fix: it used to unconditionally report
+// success without even checking, back when every symbol property was
+// implicitly configurable). ---
+{
+  const arr7: any = [1, 2];
+  const s7 = Symbol("locked");
+  Object.defineProperty(arr7, s7, {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  let threw = false;
+  try {
+    Object.defineProperty(arr7, s7, { configurable: true });
+  } catch (e) {
+    threw = e instanceof TypeError;
+  }
+  const deleteResult = delete arr7[s7];
+  const stillHasIt = s7 in arr7;
+  const stillReadsAsOne = arr7[s7] === 1;
+  checks.push(threw && deleteResult === false && stillHasIt && stillReadsAsOne);
+}
+
+// --- 8. A configurable accessor property CAN be deleted, and deleting it
+// actually removes the property (not just reporting success while leaving
+// the getter/setter behind) - `sym in arr` and getOwnPropertyDescriptor
+// both agree it's gone afterward. ---
+{
+  const arr8: any = [1, 2];
+  const s8 = Symbol("removable");
+  Object.defineProperty(arr8, s8, {
+    get() {
+      return 5;
+    },
+    configurable: true,
+  });
+  const deleteResult = delete arr8[s8];
+  checks.push(
+    deleteResult === true &&
+      !(s8 in arr8) &&
+      Object.getOwnPropertyDescriptor(arr8, s8) === undefined &&
+      Object.getOwnPropertySymbols(arr8).length === 0
+  );
+}
+
+// --- 9. Reflect.deleteProperty agrees with the `delete` operator for a
+// non-configurable symbol property on an array (same underlying
+// DeleteSymbolProp fix, different call site - pkg/builtins/reflect_delete.go). ---
+{
+  const arr9: any = [1, 2];
+  const s9 = Symbol("reflect-locked");
+  Object.defineProperty(arr9, s9, { value: 1, configurable: false });
+  const result9 = Reflect.deleteProperty(arr9, s9);
+  checks.push(result9 === false && s9 in arr9);
+}
+
+// --- 10. Reflect.get(arr, sym) agrees with `arr[sym]` for a symbol
+// accessor - the accessor's getter must fire either way, and both with a
+// default receiver and an explicit one (called as `this`). A sibling read
+// path (getSymbolPropertyWithReceiver, pkg/vm/vm_init.go) backs
+// Reflect.get and had its own, independent no-accessor-check gap - the
+// same class of bug array_getownpropertysymbols.ts's header describes
+// (opGetPropSymbol vs. Reflect.get drifting apart), just for the
+// accessor case this fix newly makes possible. ---
+{
+  const arr10: any = [1, 2];
+  const s10 = Symbol("g10");
+  const receiverProbe = { tag: "probe" };
+  Object.defineProperty(arr10, s10, {
+    get() {
+      return (this as any) === receiverProbe ? "receiver" : "self";
+    },
+    configurable: true,
+  });
+  checks.push(
+    arr10[s10] === "self" &&
+      Reflect.get(arr10, s10) === "self" &&
+      Reflect.get(arr10, s10, receiverProbe) === "receiver"
+  );
+}
+
+// --- 11. Object.getOwnPropertyDescriptors (plural) includes a symbol
+// property on an array, agreeing with the singular
+// Object.getOwnPropertyDescriptor for the same key - the plural function
+// collects its own key list per source kind and had no symbol-key
+// collection for TypeArray at all, so it silently dropped every array
+// symbol property regardless of how it was defined. ---
+{
+  const arr11: any = [1, 2];
+  const s11 = Symbol("plural");
+  Object.defineProperty(arr11, s11, {
+    value: 3,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  const all = Object.getOwnPropertyDescriptors(arr11) as any;
+  const single = Object.getOwnPropertyDescriptor(arr11, s11) as any;
+  checks.push(
+    all[s11] !== undefined &&
+      all[s11].value === 3 &&
+      all[s11].writable === false &&
+      all[s11].enumerable === false &&
+      all[s11].configurable === false &&
+      all[s11].value === single.value &&
+      all[s11].writable === single.writable
+  );
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/array_named_accessor_enum_and_index_accessor_read.ts
+++ b/tests/scripts/array_named_accessor_enum_and_index_accessor_read.ts
@@ -1,0 +1,395 @@
+// expect: true
+// Two related gaps in how arrays' own properties get enumerated/copied,
+// both stemming from the same root causes as this session's earlier
+// array-property fixes:
+//
+// Gap 1 - a named ENUMERABLE ACCESSOR property (installed via
+// Object.defineProperty(arr, "foo", {get, enumerable: true})) was
+// invisible to every operation that collects an array's named keys by
+// walking ArrayObject.NamedPropertyKeys() alone - a plain-data-only
+// store (see DefineAccessorProperty's own doc comment: converting a
+// name to an accessor deletes its NamedPropertyKeys()/`properties`
+// entry entirely, moving it to getters/setters instead, visible only
+// via AccessorKeys()). Confirmed missing from Object.keys,
+// Object.values, Object.entries, Object.getOwnPropertyNames,
+// Reflect.ownKeys, and for-in:
+//
+//   const arr = [1, 2];
+//   Object.defineProperty(arr, "foo", { get() { return 5; }, enumerable: true });
+//   Object.keys(arr);
+//   // before: ["0", "1"]           - missing "foo"
+//   // Node:   ["0", "1", "foo"]
+//
+// Object.values/Object.entries had a broader version of the same gap:
+// they never walked ANY named property at all, accessor or plain, so
+// even a plain `arr.foo = "bar"` (no accessor involved) was dropped.
+//
+// Fixed by adding a shared arrayNamedKeys(a, enumerableOnly) helper
+// (pkg/builtins/object_init.go, mirroring the existing arraySparseIndices
+// helper's shape/doc-comment) that walks AccessorKeys() then
+// NamedPropertyKeys(), and a matching helper in pkg/vm/vm.go's own
+// for-in case (package vm has its own, separate hand-rolled duplicate of
+// this same array-property-collection logic, same as arraySparseIndices
+// does - see that function's own comment in both files).
+//
+// Gap 2 - Object.assign didn't invoke a numeric-INDEX accessor (one
+// installed AT an existing element, e.g.
+// Object.defineProperty(arr, "1", {get, enumerable: true})) at all -
+// its dense-range copy loop checked HasOwnIndexProperty (which does
+// consult accessors) to decide whether the index exists, then read the
+// VALUE via arrObj.Get(i), which returns the stale `elements` slot
+// directly with no accessor check:
+//
+//   const arr = [1, 2, 3];
+//   Object.defineProperty(arr, "1", { get() { return 99; }, enumerable: true });
+//   arr[1];                    // 99 - ordinary index access already gets this right
+//   Object.assign({}, arr)[1]; // before: 2 (stale element) - Node: 99
+//
+// Object.values/Object.entries had the identical dense-range gap.
+// Object-literal spread's TypeArray case (this session's earlier fix)
+// already got this right from the start - locked in below as a sanity
+// check, not a fix.
+//
+// Fixed with a new arrayDenseIndexValue helper (the dense-range sibling
+// of the pre-existing arraySparseIndexValue), used by Object.assign's
+// dense-index copy loop and Object.values/entries' own dense-index
+// loops.
+//
+// Object.getOwnPropertyDescriptors' TypeArray case had an even bigger
+// version of gap 1 (it collected NO named key at all, plain or
+// accessor) plus its own separate bug: it looped `i := 0; i <
+// arr.Length()` instead of bounding the per-index scan to
+// DenseLength() and walking arraySparseIndices for anything beyond it -
+// the exact paserati#176/#178 multi-billion-iteration hang shape every
+// other array-key-collecting function in this file already guards
+// against, since a sparse index far past DenseLength() extends
+// arr.Length() without growing `elements`. Fixed the same way as the
+// others: DenseLength() bound + arraySparseIndices(enumerableOnly:
+// false) + arrayNamedKeys(enumerableOnly: false).
+//
+// Every check below was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. Object.keys omits a named enumerable accessor property. ---
+{
+  const arr: any = [1, 2];
+  Object.defineProperty(arr, "foo", {
+    get() {
+      return 5;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(JSON.stringify(Object.keys(arr)) === '["0","1","foo"]');
+}
+
+// --- 2. Object.values omits a plain named property entirely (not an
+// accessor at all - the broader half of the gap: this loop didn't walk
+// ANY named property before the fix, not just accessor ones). Kept as
+// its own array (rather than combined with an accessor property) since
+// paserati doesn't track true creation order across the separate
+// plain-data/accessor stores a named property can live in - Node
+// orders "plain" before "acc" here because that's insertion order, a
+// property this fix deliberately doesn't take on; see check 3 below for
+// a same-array combination that only depends on membership, not order. ---
+{
+  const arr2: any = [1, 2];
+  arr2.plain = "p";
+  checks.push(JSON.stringify(Object.values(arr2)) === "[1,2,\"p\"]");
+}
+
+// --- 3. Object.entries omits a named accessor property entirely, and
+// the getter must actually be invoked (not a stale/absent slot). ---
+{
+  const arr3: any = [1, 2];
+  let calls3 = 0;
+  Object.defineProperty(arr3, "acc", {
+    get() {
+      calls3++;
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Object.entries(arr3)) ===
+      '[["0",1],["1",2],["acc","a"]]' && calls3 === 1
+  );
+}
+
+// --- 4. Object.getOwnPropertyNames omits a named enumerable accessor
+// property (getOwnPropertyNames wants every own key regardless of
+// enumerability, so this must include a NON-enumerable one too). ---
+{
+  // Two separate arrays, not one array carrying both accessor names:
+  // AccessorKeys() (pkg/vm/value.go) walks Go maps (getters/setters),
+  // whose iteration order is randomized per run - two accessor names on
+  // the same array would make an exact-order assertion here flaky
+  // (paserati doesn't track a named property's true creation order
+  // across separate stores at all - see check 2's comment - so this
+  // isn't a fixable ordering gap, just something a test must avoid
+  // depending on when a single array holds more than one same-store
+  // named key).
+  const arr4a: any = [1, 2];
+  Object.defineProperty(arr4a, "acc", {
+    get() {
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const arr4b: any = [1, 2];
+  Object.defineProperty(arr4b, "hiddenAcc", {
+    get() {
+      return "h";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Object.getOwnPropertyNames(arr4a)) ===
+      '["0","1","length","acc"]' &&
+      JSON.stringify(Object.getOwnPropertyNames(arr4b)) ===
+        '["0","1","length","hiddenAcc"]'
+  );
+}
+
+// --- 5. Reflect.ownKeys omits a named enumerable accessor property
+// (delegates to the same collection logic as getOwnPropertyNames, so
+// this locks in that the delegation actually picked up the fix). ---
+{
+  const arr5: any = [1, 2];
+  Object.defineProperty(arr5, "acc", {
+    get() {
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Reflect.ownKeys(arr5)) === '["0","1","length","acc"]'
+  );
+}
+
+// --- 6. for-in omits a named enumerable accessor property, and skips a
+// named NON-enumerable one (for-in only visits enumerable keys). ---
+{
+  const arr6: any = [1, 2];
+  Object.defineProperty(arr6, "acc", {
+    get() {
+      return "a";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(arr6, "hiddenAcc", {
+    get() {
+      return "h";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const seen: string[] = [];
+  for (const k in arr6) {
+    seen.push(k);
+  }
+  checks.push(JSON.stringify(seen) === '["0","1","acc"]');
+}
+
+// --- 7. Object.assign doesn't invoke a numeric-index accessor - copies
+// the stale underlying element instead of calling the getter. ---
+{
+  const arr7: any = [1, 2, 3];
+  let calls7 = 0;
+  Object.defineProperty(arr7, "1", {
+    get() {
+      calls7++;
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const copy7 = Object.assign({}, arr7);
+  checks.push(copy7[1] === 99 && calls7 === 1);
+}
+
+// --- 8. Object.values/Object.entries also miss an index accessor's
+// real value (same dense-range gap as Object.assign). ---
+{
+  const arr8: any = [1, 2, 3];
+  Object.defineProperty(arr8, "0", {
+    get() {
+      return "zero";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  checks.push(
+    JSON.stringify(Object.values(arr8)) === '["zero",2,3]' &&
+      JSON.stringify(Object.entries(arr8)) ===
+        '[["0","zero"],["1",2],["2",3]]'
+  );
+}
+
+// --- 9. Sanity: object-literal spread already invoked a dense-index
+// accessor correctly before this fix (this session's earlier
+// Object.assign/spread PR) - must still work, unchanged. ---
+{
+  const arr9: any = [1, 2, 3];
+  let calls9 = 0;
+  Object.defineProperty(arr9, "1", {
+    get() {
+      calls9++;
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const spread9: any = { ...arr9 };
+  checks.push(spread9[1] === 99 && calls9 === 1);
+}
+
+// --- 10. Sanity: a NON-enumerable named accessor is still excluded from
+// Object.keys/values/entries/Object.assign/spread (only
+// getOwnPropertyNames/Reflect.ownKeys/getOwnPropertyDescriptors want
+// non-enumerable own keys) - the enumerableOnly gate on the new
+// arrayNamedKeys helper must still work in both directions. ---
+{
+  const arr10: any = [1, 2];
+  let calls10 = 0;
+  Object.defineProperty(arr10, "hidden", {
+    get() {
+      calls10++;
+      return "h";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const keys10 = Object.keys(arr10);
+  const values10 = Object.values(arr10);
+  const assign10 = Object.assign({}, arr10);
+  const spread10: any = { ...arr10 };
+  checks.push(
+    !keys10.includes("hidden") &&
+      values10.length === 2 &&
+      !("hidden" in assign10) &&
+      !("hidden" in spread10) &&
+      calls10 === 0
+  );
+}
+
+// --- 11. Combined: an array carrying all four property shapes at once
+// (dense-index accessor, sparse-index accessor, named accessor, named
+// plain) must agree with Node across every operation in one shot - a
+// single-shape probe can pass while a combination still double-counts
+// or drops a key two different loops both claim (or both skip). ---
+{
+  const arr11: any = [1, 2, 3];
+  Object.defineProperty(arr11, "1", {
+    get() {
+      return 99;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(arr11, "1000", {
+    get() {
+      return "sparse";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(arr11, "namedAcc", {
+    get() {
+      return "na";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  arr11.namedPlain = "np";
+
+  const expectedKeys = '["0","1","2","1000","namedAcc","namedPlain"]';
+  const expectedValues = '[1,99,3,"sparse","na","np"]';
+  const expectedEntries =
+    '[["0",1],["1",99],["2",3],["1000","sparse"],["namedAcc","na"],["namedPlain","np"]]';
+  const expectedGopn =
+    '["0","1","2","1000","length","namedAcc","namedPlain"]';
+  const expectedAssignSpread =
+    '{"0":1,"1":99,"2":3,"1000":"sparse","namedAcc":"na","namedPlain":"np"}';
+
+  const forin: string[] = [];
+  for (const k in arr11) {
+    forin.push(k);
+  }
+
+  checks.push(
+    JSON.stringify(Object.keys(arr11)) === expectedKeys &&
+      JSON.stringify(Object.values(arr11)) === expectedValues &&
+      JSON.stringify(Object.entries(arr11)) === expectedEntries &&
+      JSON.stringify(Object.getOwnPropertyNames(arr11)) === expectedGopn &&
+      JSON.stringify(Reflect.ownKeys(arr11)) === expectedGopn &&
+      JSON.stringify(forin) === expectedKeys &&
+      JSON.stringify(Object.assign({}, arr11)) === expectedAssignSpread &&
+      JSON.stringify({ ...arr11 }) === expectedAssignSpread
+  );
+}
+
+// --- 12. Object.getOwnPropertyDescriptors omitted every named key
+// entirely (plain or accessor) - checked individually (not via a
+// whole-object JSON.stringify) so this doesn't depend on the same
+// cross-store/map-iteration ordering check 4 had to avoid. ---
+{
+  const arr12: any = [1, 2];
+  arr12.plain = "p";
+  Object.defineProperty(arr12, "acc", {
+    get() {
+      return "a";
+    },
+    set(_v: any) {},
+    enumerable: true,
+    configurable: true,
+  });
+  const descs12 = Object.getOwnPropertyDescriptors(arr12);
+  const has0 = "0" in descs12;
+  const has1 = "1" in descs12;
+  const hasLength = "length" in descs12;
+  checks.push(
+    descs12.plain.value === "p" &&
+      descs12.plain.enumerable === true &&
+      descs12.plain.writable === true &&
+      typeof descs12.acc.get === "function" &&
+      typeof descs12.acc.set === "function" &&
+      descs12.acc.value === undefined &&
+      descs12.acc.enumerable === true &&
+      has0 &&
+      has1 &&
+      hasLength
+  );
+}
+
+// --- 13. Object.getOwnPropertyDescriptors must not hang on a huge
+// sparse index (the same paserati#176/#178 shape every other
+// array-key-collecting operation in this file already guards against -
+// this function's own array-key loop used to scan 0..arr.Length()
+// directly instead of bounding to DenseLength() + arraySparseIndices).
+// No wall-clock assertion here - a hardware-dependent timing check is
+// its own kind of flaky. If the scan were still unbounded, this would
+// hang and fail the whole suite at the timeout level, which is signal
+// enough; this just asserts the result is still correct. ---
+{
+  const arr13: any = [1, 2];
+  Object.defineProperty(arr13, "1000000000", {
+    value: "far",
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  const descs13 = Object.getOwnPropertyDescriptors(arr13);
+  checks.push(
+    descs13["1000000000"].value === "far" &&
+      descs13.length.value === 1000000001
+  );
+}
+
+checks.every((c) => c === true);

--- a/tests/scripts/object_assign_spread_array_named_symbol_props.ts
+++ b/tests/scripts/object_assign_spread_array_named_symbol_props.ts
@@ -1,0 +1,225 @@
+// expect: true
+// Object.assign(target, arr) only ever copied an array's indexed elements
+// (dense + sparse, paserati#176/#178) plus (for an object/dict target)
+// "length" - it never copied a named string property (`arr.foo = ...`,
+// plain or an accessor via Object.defineProperty) or ANY symbol-keyed
+// property at all (plain or accessor), regardless of enumerability.
+// Object-literal spread (`{...arr}`) had an even broader version of the
+// same gap: a TypeArray source was excluded entirely, before the
+// string-key/symbol-key copying loops even started, so it contributed
+// NOTHING - not even the indexed elements:
+//
+//   const arr = [1, 2, 3]; arr.foo = "bar";
+//   const sym = Symbol("s"); arr[sym] = "sym-val";
+//
+//   Object.assign({}, arr);
+//   // before: {0: 1, 1: 2, 2: 3}                      - missing foo AND the symbol
+//   // Node:   {0: 1, 1: 2, 2: 3, foo: "bar"} plus the symbol (verified below)
+//
+//   ({...arr});
+//   // before: {}                                       - missing everything, even the indices
+//   // Node:   {0: 1, 1: 2, 2: 3, foo: "bar"} plus the symbol
+//
+// Fixed by adding named-property (accessor-then-plain, mirroring how
+// DefineAccessorProperty removes a converted key from the plain-data
+// store entirely) and symbol-property (via ArrayObject's own symbol
+// storage - ArrayDefineOwnSymbolProperty, pkg/vm/array_props.go) copy
+// loops to Object.assign's TypeArray source branch
+// (pkg/builtins/object_init.go), and a whole new TypeArray case to
+// object-literal spread's bytecode handler (pkg/vm/vm.go) covering the
+// same set of properties - the two must stay in sync, since ECMAScript
+// defines both operations in terms of the same CopyDataProperties
+// abstract operation.
+//
+// Both fixes call an accessor's getter (never copy the bare data slot
+// underneath it - paserati#274's rule, already applied elsewhere) and
+// skip a non-enumerable property entirely (own-enumerable-properties is
+// CopyDataProperties' own filter, not a data/accessor distinction).
+//
+// Every check below was verified against real Node.js output.
+
+const checks: boolean[] = [];
+
+// --- 1. A plain enumerable named string property (`arr.foo = ...`) is
+// copied by both operations. ---
+{
+  const arr: any = [1, 2];
+  arr.foo = "bar";
+  const viaAssign = Object.assign({}, arr);
+  const viaSpread: any = { ...arr };
+  checks.push(viaAssign.foo === "bar" && viaSpread.foo === "bar");
+}
+
+// --- 2. A non-enumerable named string property (defined via
+// Object.defineProperty) is NOT copied by either operation. ---
+{
+  const arr2: any = [1, 2];
+  Object.defineProperty(arr2, "hidden", {
+    value: "h",
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign2 = Object.assign({}, arr2);
+  const viaSpread2: any = { ...arr2 };
+  checks.push(
+    !("hidden" in viaAssign2) &&
+      !("hidden" in viaSpread2) &&
+      viaAssign2.hidden === undefined &&
+      viaSpread2.hidden === undefined
+  );
+}
+
+// --- 3. A named ENUMERABLE ACCESSOR property invokes its getter exactly
+// once per operation - the value copied is what the getter returns, not
+// a stale/absent data slot (accessors are stored separately from plain
+// data - see DefineAccessorProperty's own doc comment). ---
+{
+  const arr3: any = [1, 2];
+  let calls = 0;
+  Object.defineProperty(arr3, "computed", {
+    get() {
+      calls++;
+      return 42;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const viaAssign3 = Object.assign({}, arr3);
+  const viaSpread3: any = { ...arr3 };
+  checks.push(
+    viaAssign3.computed === 42 && viaSpread3.computed === 42 && calls === 2
+  );
+}
+
+// --- 4. A named NON-enumerable accessor property is not copied, and its
+// getter is never invoked (no observable side effect from skipping it). ---
+{
+  const arr4: any = [1, 2];
+  let calls4 = 0;
+  Object.defineProperty(arr4, "hiddenAcc", {
+    get() {
+      calls4++;
+      return 99;
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign4 = Object.assign({}, arr4);
+  const viaSpread4: any = { ...arr4 };
+  checks.push(
+    !("hiddenAcc" in viaAssign4) && !("hiddenAcc" in viaSpread4) && calls4 === 0
+  );
+}
+
+// --- 5. A plain enumerable symbol-keyed property (`arr[sym] = v`) is
+// copied by both operations - the exact shape of the originally reported
+// bug. ---
+{
+  const arr5: any = [1, 2, 3];
+  const sym5 = Symbol("plain");
+  arr5[sym5] = "sym-val";
+  const viaAssign5 = Object.assign({}, arr5);
+  const viaSpread5: any = { ...arr5 };
+  checks.push(viaAssign5[sym5] === "sym-val" && viaSpread5[sym5] === "sym-val");
+}
+
+// --- 6. A non-enumerable symbol-keyed data property (defined via
+// Object.defineProperty) is NOT copied by either operation. ---
+{
+  const arr6: any = [1, 2];
+  const sym6 = Symbol("hidden");
+  Object.defineProperty(arr6, sym6, {
+    value: "hv",
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign6 = Object.assign({}, arr6);
+  const viaSpread6: any = { ...arr6 };
+  checks.push(
+    !(sym6 in viaAssign6) &&
+      !(sym6 in viaSpread6) &&
+      viaAssign6[sym6] === undefined &&
+      viaSpread6[sym6] === undefined
+  );
+}
+
+// --- 7. A symbol-keyed ENUMERABLE ACCESSOR property (get/set via
+// Object.defineProperty) invokes its getter, exactly once per operation. ---
+{
+  const arr7: any = [1, 2];
+  const sym7 = Symbol("symacc");
+  let calls7 = 0;
+  Object.defineProperty(arr7, sym7, {
+    get() {
+      calls7++;
+      return "sav";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  const viaAssign7 = Object.assign({}, arr7);
+  const viaSpread7: any = { ...arr7 };
+  checks.push(
+    viaAssign7[sym7] === "sav" && viaSpread7[sym7] === "sav" && calls7 === 2
+  );
+}
+
+// --- 8. A symbol-keyed NON-enumerable accessor property is not copied,
+// and its getter is never invoked. ---
+{
+  const arr8: any = [1, 2];
+  const sym8 = Symbol("hiddensymacc");
+  let calls8 = 0;
+  Object.defineProperty(arr8, sym8, {
+    get() {
+      calls8++;
+      return "nope";
+    },
+    enumerable: false,
+    configurable: true,
+  });
+  const viaAssign8 = Object.assign({}, arr8);
+  const viaSpread8: any = { ...arr8 };
+  checks.push(!(sym8 in viaAssign8) && !(sym8 in viaSpread8) && calls8 === 0);
+}
+
+// --- 9. Sanity: the array's own indexed elements are still copied
+// alongside its named/symbol properties (spread's TypeArray case is
+// brand new - it must not have dropped the basic indexed-copy behavior
+// while adding named/symbol coverage). ---
+{
+  const arr9: any = [10, 20, 30];
+  arr9.tag = "meta";
+  const viaAssign9 = Object.assign({}, arr9);
+  const viaSpread9: any = { ...arr9 };
+  checks.push(
+    viaAssign9[0] === 10 &&
+      viaAssign9[1] === 20 &&
+      viaAssign9[2] === 30 &&
+      viaAssign9.tag === "meta" &&
+      viaSpread9[0] === 10 &&
+      viaSpread9[1] === 20 &&
+      viaSpread9[2] === 30 &&
+      viaSpread9.tag === "meta"
+  );
+}
+
+// --- 10. A named string key that LOOKS numeric but is beyond the
+// canonical array-index bound (2^32 - 2, ECMA-262 6.1.7's definition of
+// an array index) is an ordinary named property, not an index - and must
+// land in the named-property copy loop, not the sparse-index loop, which
+// rejects it as too big. Both loops filter with the same "is this a
+// canonical array index" predicate the sparse-index loop itself uses, so
+// a key like this can't fall in the gap between the two and vanish. ---
+{
+  const arr10: any = [1, 2];
+  arr10["4294967295"] = "past-bound";
+  const viaAssign10 = Object.assign({}, arr10);
+  const viaSpread10: any = { ...arr10 };
+  checks.push(
+    viaAssign10["4294967295"] === "past-bound" &&
+      viaSpread10["4294967295"] === "past-bound"
+  );
+}
+
+checks.every((c) => c === true);


### PR DESCRIPTION
Recovery for the objectassign-spread-array-props branch, repackaged as a single linear commit on the current main tip (same pattern as #365). Resolved 9 real conflict hunks against the already-merged chain-A stack in array symbol-property handling; details in the commit message. Verified: clean build, TestScripts green, plus targeted tests from both stacks.

Brings in: #353, #358, #359.