### PR TITLE
fix(vm): remove ineffectual proto assignment flagged by lint

### DIFF
--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -1461,8 +1461,7 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 					return v, err
 				}
 			}
-			proto := Undefined
-			proto = regexObj.GetPrototype()
+			proto := regexObj.GetPrototype()
 			if !proto.IsObject() {
 				proto = vm.RegExpPrototype
 			}


### PR DESCRIPTION
CI's lint job has been failing on main since the recovery merge landed: golangci-lint's ineffassign check flags `pkg/vm/vm_init.go:1464` (`proto := Undefined` immediately overwritten). One-line fix. Verified: clean build, `golangci-lint run` clean locally, TestScripts smoke suite green.