### PR TITLE
fix(vm): module namespace [[Delete]] must throw via computed bracket access too

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17460,6 +17460,43 @@ startExecution:
 						}
 					} else {
 						propName := key.ToString()
+						// Module Namespace Exotic Object [[Delete]] behavior (ECMAScript
+						// 10.4.6.8), string-key path. Mirrors OpDeleteProp's dot-notation
+						// dispatch (which had this check) - OpDeleteIndex's computed
+						// `delete ns[key]` lacked it entirely, so a non-configurable
+						// exported binding's delete silently "succeeded" instead of
+						// throwing TypeError (namespaces only exist in module context,
+						// which is always strict).
+						if po.IsModuleNamespace() {
+							if _, exists := po.GetOwn(propName); exists {
+								frame.ip = ip
+								vm.ThrowTypeError("Cannot delete property '" + propName + "' of [object Module]")
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									code = function.Chunk.Code
+									constants = function.Chunk.Constants
+									registers = frame.registers
+									ip = frame.ip
+									continue
+								}
+								if vm.unwindingCrossedNative || vm.frameCount == 0 {
+									return InterpretRuntimeError, vm.currentException
+								}
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							// Property doesn't exist in exports - delete succeeds
+							registers[destReg] = BooleanValue(true)
+							continue
+						}
 						// For GlobalObject, check the heap's configurable flag first
 						// Global var declarations are non-configurable (DontDelete) per ECMAScript
 						if po == vm.GlobalObject {
@@ -17496,6 +17533,37 @@ startExecution:
 									registers[destReg] = BooleanValue(false)
 									continue
 								}
+							}
+						}
+						// In strict mode, throw TypeError for non-configurable properties
+						// on regular objects. Mirrors OpDeleteProp's dot-notation dispatch,
+						// which already had this check for the computed-index path.
+						if function.Chunk.IsStrict {
+							exists, nonConfig := po.IsOwnPropertyNonConfigurable(propName)
+							if exists && nonConfig {
+								frame.ip = ip
+								vm.ThrowTypeError("Cannot delete property '" + propName + "' of #<Object>")
+								if !vm.unwinding {
+									frame = &vm.frames[vm.frameCount-1]
+									closure = frame.closure
+									function = closure.Fn
+									code = function.Chunk.Code
+									constants = function.Chunk.Constants
+									registers = frame.registers
+									ip = frame.ip
+									continue
+								}
+								if vm.unwindingCrossedNative || vm.frameCount == 0 {
+									return InterpretRuntimeError, vm.currentException
+								}
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
 							}
 						}
 						success = po.DeleteOwn(propName)

--- a/tests/scripts/module_namespace_delete_index_strict.ts
+++ b/tests/scripts/module_namespace_delete_index_strict.ts
@@ -1,0 +1,29 @@
+// expect: 0,set-threw-typeerror,delete-threw-typeerror
+// Regression test for #369: Module Namespace Exotic Object [[Set]]/[[Delete]]
+// via *computed* bracket access (`ns[0] = v`, `delete ns[0]`) must throw
+// TypeError for an existing exported binding, same as the dot-notation path
+// already did. OpSetIndex's TypeObject dispatch had the module-namespace
+// [[Set]] check, but OpDeleteIndex's string-key branch was missing the
+// equivalent [[Delete]] check entirely, so `delete ns[key]` silently
+// "succeeded" instead of throwing in module (always-strict) code.
+import * as ns from "./module_namespace_delete_index_strict_helper.ts";
+
+let results: string[] = [];
+
+results.push(String(ns[0]));
+
+try {
+  (ns as any)[0] = 1;
+  results.push("no-throw-set");
+} catch (e) {
+  results.push(e instanceof TypeError ? "set-threw-typeerror" : "set-threw-other");
+}
+
+try {
+  delete (ns as any)[0];
+  results.push("no-throw-delete");
+} catch (e) {
+  results.push(e instanceof TypeError ? "delete-threw-typeerror" : "delete-threw-other");
+}
+
+results.join(",");

--- a/tests/scripts/module_namespace_delete_index_strict_helper.ts
+++ b/tests/scripts/module_namespace_delete_index_strict_helper.ts
@@ -1,0 +1,3 @@
+export var a = 0;
+export var b = 1;
+export { a as "0", b as "1" };


### PR DESCRIPTION
Fixes #369.

## Summary

`delete ns[key]` (computed bracket access, `OpDeleteIndex`) on a module namespace exotic object never threw `TypeError` for an existing exported binding — it silently "succeeded" instead. The dot-notation path (`OpDeleteProp`, `delete ns.key`) already had the module-namespace `[[Delete]]` check (ECMAScript 10.4.6.8); `OpDeleteIndex`'s string-key branch for `TypeObject` was missing it entirely, along with the general strict-mode non-configurable-property throw that `OpDeleteProp`'s dot-notation dispatch also already had.

## Root cause correction

The linked issue's bisect pointed at `efa675f0` ("ordinary `[[Set]]` on a side-table accessor calls the setter instead of clobbering it"). That commit is **not actually the source of this bug** — both hunks of this fix are byte-identical between `main` and `bf46d1fe` (the commit immediately before `efa675f0`'s content landed), so the `OpDeleteIndex` gap is pre-existing.

What actually happened: `efa675f0`'s second half fixed 13 `OpSetIndex` dispatch sites that returned past a caught exception instead of checking `vm.unwinding`, which made a thrown `TypeError` uncatchable — it just silently aborted the whole VM run with exit 0, no error printed. At `bf46d1fe`, `ns[0] = 1`'s `TypeError` hit exactly that bug and aborted the script before ever reaching the `delete ns[0]` assertion, so the test scored a false pass. Once `efa675f0` made that throw catchable, execution proceeded far enough to actually hit the pre-existing delete bug. The bisect's first-bad commit was mechanically correct, but the change it points to unmasked a bug rather than introducing one.

## Fix

`pkg/vm/vm.go`'s `OpDeleteIndex` `TypeObject`/string-key branch now mirrors `OpDeleteProp`'s dispatch:
1. Check `IsModuleNamespace()` first — throw `TypeError` if the key names an export, otherwise delete succeeds.
2. In strict mode, throw `TypeError` for any other non-configurable own property before falling through to `DeleteOwn`.

## Verification

- Isolated the two hunks: with only the module-namespace check (no strict-mode non-configurable hunk), `built-ins/Object` diffs +0/-0 against the combined-fix baseline, and the target test already passes — the strict-mode hunk is a no-op there.
- Diffed clean (+0/-0) against `built-ins/Reflect/deleteProperty`, `built-ins/Object/defineProperty`, `built-ins/Proxy/deleteProperty`, `language/statements/class`, and `language/expressions/delete`.
- Added `tests/scripts/module_namespace_delete_index_strict.ts` (+ module helper): confirmed it fails with `no-throw-delete` without this fix and passes with it.
- `go test ./tests -run TestScripts`: ok
- `go test ./...`: ok
- `./paserati-test262 -path ./test262 -subpath "language/module-code" -pattern "export-expname-binding-index.js"`: now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)