### PR TITLE
fix(builtins): dispatch AbortSignal abort events and align with spec

### DIFF
--- a/pkg/builtins/abort_controller_init.go
+++ b/pkg/builtins/abort_controller_init.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"sync"
+	"time"
 
 	"github.com/nooga/paserati/pkg/types"
 	"github.com/nooga/paserati/pkg/vm"
@@ -25,9 +26,10 @@ func (a *AbortControllerInitializer) InitTypes(ctx *TypeContext) error {
 	abortSignalType := types.NewObjectType().
 		WithProperty("aborted", types.Boolean).
 		WithProperty("reason", types.Any).
+		WithProperty("onabort", types.Any).
 		WithProperty("throwIfAborted", types.NewSimpleFunction([]types.Type{}, types.Undefined)).
-		WithProperty("addEventListener", types.NewSimpleFunction([]types.Type{types.String, types.Any}, types.Undefined)).
-		WithProperty("removeEventListener", types.NewSimpleFunction([]types.Type{types.String, types.Any}, types.Undefined))
+		WithProperty("addEventListener", types.NewOptionalFunction([]types.Type{types.String, types.Any, types.Any}, types.Undefined, []bool{false, false, true})).
+		WithProperty("removeEventListener", types.NewOptionalFunction([]types.Type{types.String, types.Any, types.Any}, types.Undefined, []bool{false, false, true}))
 
 	// AbortSignal static methods
 	abortSignalConstructorType := types.NewObjectType().
@@ -68,59 +70,89 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if len(args) > 0 && !args[0].IsUndefined() {
 			reason = args[0]
 		} else {
-			// Default reason is DOMException with name "AbortError"
-			reason = vm.NewString("AbortError: signal is aborted without reason")
+			// Default reason is a real Error named "AbortError" (there's no
+			// DOMException in this runtime - see newAbortErrorValue in
+			// fetch_init.go, which this reuses so fetch()'s rejection and a
+			// bare AbortSignal.abort() produce the same shape of reason).
+			reason = newAbortErrorValue(vmInstance, "signal is aborted without reason")
 		}
 		signal := &AbortSignal{
-			aborted:   true,
-			reason:    reason,
-			listeners: make([]vm.Value, 0),
+			aborted: true,
+			reason:  reason,
+			onabort: vm.Null,
 		}
 		return createAbortSignalObject(vmInstance, signal, signalProto), nil
 	}))
 
-	// AbortSignal.timeout(ms) - creates a signal that aborts after timeout
+	// AbortSignal.timeout(ms) - creates a signal that aborts after timeout.
+	//
+	// FIXME: kept as a non-firing stub rather than wired to
+	// rt.ScheduleTimer. The VM's drain loop blocks on AsyncRuntime.
+	// HasPendingTimers()/WaitForIdleProgress() (see pkg/vm/vm.go), and
+	// AsyncRuntime has no "unref" concept - a real timer here would keep
+	// every script alive for the full timeout duration even after
+	// everything else finished, turning `AbortSignal.timeout(30000)` into
+	// an accidental 30s hang. Needs an unref-able timer before this can
+	// actually fire.
 	signalConstructor.SetOwnNonEnumerable("timeout", vm.NewNativeFunction(1, false, "timeout", func(args []vm.Value) (vm.Value, error) {
-		// For now, return a non-aborted signal (timeout would need async runtime support)
-		// This is a simplified implementation
 		signal := &AbortSignal{
-			aborted:   false,
-			reason:    vm.Undefined,
-			listeners: make([]vm.Value, 0),
+			aborted: false,
+			reason:  vm.Undefined,
+			onabort: vm.Null,
 		}
 		return createAbortSignalObject(vmInstance, signal, signalProto), nil
 	}))
 
-	// AbortSignal.any(signals) - creates a signal that aborts when any input signal aborts
+	// AbortSignal.any(signals) - creates a signal that aborts when any input
+	// signal aborts. Per spec this must also react to a source aborting
+	// *later*, not just one that's already aborted at call time: for every
+	// source that isn't aborted yet, we register a listener (through the
+	// source's own addEventListener, exactly as user code would) that
+	// propagates the abort to the composite signal when it fires.
 	signalConstructor.SetOwnNonEnumerable("any", vm.NewNativeFunction(1, false, "any", func(args []vm.Value) (vm.Value, error) {
 		signal := &AbortSignal{
-			aborted:   false,
-			reason:    vm.Undefined,
-			listeners: make([]vm.Value, 0),
+			aborted: false,
+			reason:  vm.Undefined,
+			onabort: vm.Null,
 		}
-		// Check if any input signal is already aborted
-		if len(args) > 0 {
-			if args[0].Type() == vm.TypeArray {
-				arr := args[0].AsArray()
-				for i := 0; i < arr.Length(); i++ {
-					elem := arr.Get(i)
-					if elem.Type() == vm.TypeObject {
-						obj := elem.AsPlainObject()
-						if aborted, exists := obj.GetOwn("aborted"); exists && aborted.IsBoolean() && aborted.AsBoolean() {
-							signal.aborted = true
-							if reason, exists := obj.GetOwn("reason"); exists {
-								signal.reason = reason
-							}
-							break
-						}
-					}
+		signalValue := createAbortSignalObject(vmInstance, signal, signalProto)
+
+		if len(args) > 0 && args[0].Type() == vm.TypeArray {
+			arr := args[0].AsArray()
+			for i := 0; i < arr.Length(); i++ {
+				elem := arr.Get(i)
+				if elem.Type() != vm.TypeObject {
+					continue
 				}
+				srcObj := elem.AsPlainObject()
+
+				if aborted, exists := srcObj.GetOwn("aborted"); exists && aborted.IsBoolean() && aborted.AsBoolean() {
+					if !signal.aborted {
+						reason, _ := srcObj.GetOwn("reason")
+						triggerAbort(vmInstance, signal, reason)
+					}
+					continue
+				}
+
+				addListenerFn, exists := srcObj.GetOwn("addEventListener")
+				if !exists || !addListenerFn.IsCallable() {
+					continue
+				}
+				source := srcObj // per-iteration capture for the closure below
+				propagate := vm.NewNativeFunction(1, false, "", func(_ []vm.Value) (vm.Value, error) {
+					reason, _ := source.GetOwn("reason")
+					triggerAbort(vmInstance, signal, reason)
+					return vm.Undefined, nil
+				})
+				_, _ = vmInstance.Call(addListenerFn, elem, []vm.Value{vm.NewString("abort"), propagate})
 			}
 		}
-		return createAbortSignalObject(vmInstance, signal, signalProto), nil
+
+		return signalValue, nil
 	}))
 
 	signalConstructor.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(signalProto))
+	signalProto.SetOwnNonEnumerable("constructor", vm.NewValueFromPlainObject(signalConstructor))
 
 	if err := ctx.DefineGlobal("AbortSignal", vm.NewValueFromPlainObject(signalConstructor)); err != nil {
 		return err
@@ -132,9 +164,9 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// AbortController constructor
 	controllerConstructorFn := func(args []vm.Value) (vm.Value, error) {
 		signal := &AbortSignal{
-			aborted:   false,
-			reason:    vm.Undefined,
-			listeners: make([]vm.Value, 0),
+			aborted: false,
+			reason:  vm.Undefined,
+			onabort: vm.Null,
 		}
 		controller := &AbortController{
 			signal: signal,
@@ -153,12 +185,45 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 	return ctx.DefineGlobal("AbortController", controllerConstructor)
 }
 
+// abortListener is one addEventListener("abort", ...) registration.
+type abortListener struct {
+	callback vm.Value
+	once     bool
+	// removed guards against a listener firing when it was removed by an
+	// *earlier* listener during the same dispatch - dispatchAbort snapshots
+	// signal.listeners before calling out to JS, and a removeEventListener
+	// call from within one callback mutates this shared struct, which the
+	// snapshot's remaining iterations must see (per DOM event dispatch).
+	removed bool
+}
+
 // AbortSignal represents the signal object
 type AbortSignal struct {
 	mu        sync.Mutex
 	aborted   bool
 	reason    vm.Value
-	listeners []vm.Value
+	listeners []*abortListener
+	onabort   vm.Value // the onabort IDL attribute; vm.Null when unset
+	// jsObj is the exposed JS object for this signal. Its "aborted"/"reason"
+	// own properties are kept in sync with the fields above on every
+	// triggerAbort call (rather than exposed as accessors) because fetch()
+	// polls them with a raw GetOwn from a background goroutine - GetOwn
+	// never invokes getters, and calling into the VM from that goroutine to
+	// resolve one would not be goroutine-safe (see vm.Call's doc comments
+	// in fetch_init.go). Keeping them plain data properties keeps that
+	// poller working unchanged for every kind of signal, including a
+	// composite one from AbortSignal.any().
+	jsObj *vm.PlainObject
+}
+
+// removeListenerLocked removes target from s.listeners. Caller must hold s.mu.
+func (s *AbortSignal) removeListenerLocked(target *abortListener) {
+	for i, l := range s.listeners {
+		if l == target {
+			s.listeners = append(s.listeners[:i], s.listeners[i+1:]...)
+			return
+		}
+	}
 }
 
 // AbortController represents the controller object
@@ -166,78 +231,242 @@ type AbortController struct {
 	signal *AbortSignal
 }
 
-// Abort aborts the signal with an optional reason
-func (s *AbortSignal) Abort(reason vm.Value) {
-	s.mu.Lock()
-	if s.aborted {
-		s.mu.Unlock()
+// triggerAbort marks signal aborted with reason (a no-op if it's already
+// aborted) and synchronously fires the "abort" event to every
+// addEventListener listener (respecting `once`) and then to onabort, per
+// the WHATWG spec's requirement that abort() dispatches synchronously.
+func triggerAbort(vmInstance *vm.VM, signal *AbortSignal, reason vm.Value) {
+	signal.mu.Lock()
+	if signal.aborted {
+		signal.mu.Unlock()
 		return
 	}
-	s.aborted = true
-	s.reason = reason
-	listeners := make([]vm.Value, len(s.listeners))
-	copy(listeners, s.listeners)
-	s.mu.Unlock()
+	signal.aborted = true
+	signal.reason = reason
+	if signal.jsObj != nil {
+		signal.jsObj.SetOwn("aborted", vm.True)
+		signal.jsObj.SetOwn("reason", reason)
+	}
+	listeners := make([]*abortListener, len(signal.listeners))
+	copy(listeners, signal.listeners)
+	onabort := signal.onabort
+	var jsSelf vm.Value
+	if signal.jsObj != nil {
+		jsSelf = vm.NewValueFromPlainObject(signal.jsObj)
+	}
+	signal.mu.Unlock()
 
-	// Note: We don't call listeners here because we don't have access to the VM
-	// The listeners would need to be called from the VM context
+	if jsSelf.Type() == vm.TypeUndefined {
+		return
+	}
+
+	event := createAbortEventValue(vmInstance, jsSelf)
+
+	for _, l := range listeners {
+		signal.mu.Lock()
+		skip := l.removed
+		if l.once && !skip {
+			l.removed = true
+			signal.removeListenerLocked(l)
+		}
+		signal.mu.Unlock()
+		if skip {
+			continue
+		}
+		callEventHandler(vmInstance, l.callback, jsSelf, event)
+	}
+
+	// NOTE: onabort always fires after every addEventListener listener,
+	// regardless of the relative order they were registered/assigned in.
+	// The spec instead fires listeners in registration order (onabort's
+	// "position" is set by its first assignment), so
+	// `addEventListener(A); signal.onabort = B; addEventListener(C)` fires
+	// A, B, C here we fire A, C, B. Documented deviation - accepted to keep
+	// this a single extra field instead of threading onabort through the
+	// same ordered list as real listeners.
+	if onabort.IsCallable() {
+		callEventHandler(vmInstance, onabort, jsSelf, event)
+	}
 }
 
-func createAbortSignalObject(vmInstance *vm.VM, signal *AbortSignal, _ *vm.PlainObject) vm.Value {
-	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+// callEventHandler invokes callback(event) with `this` bound to target, per
+// the EventListener contract: a callable is called directly, an object goes
+// through its handleEvent method.
+func callEventHandler(vmInstance *vm.VM, callback vm.Value, target vm.Value, event vm.Value) {
+	if callback.IsCallable() {
+		_, _ = vmInstance.Call(callback, target, []vm.Value{event})
+		return
+	}
+	if callback.Type() == vm.TypeObject {
+		if he, exists := callback.AsPlainObject().GetOwn("handleEvent"); exists && he.IsCallable() {
+			_, _ = vmInstance.Call(he, callback, []vm.Value{event})
+		}
+	}
+}
+
+// createAbortEventValue builds a minimal Event-like object for dispatch to
+// "abort" listeners: type/target/currentTarget plus the no-op methods
+// libraries commonly call defensively (preventDefault etc. - abort events
+// are neither cancelable nor bubbling, so these are legitimately no-ops).
+func createAbortEventValue(vmInstance *vm.VM, target vm.Value) vm.Value {
+	evt := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	evt.SetOwn("type", vm.NewString("abort"))
+	evt.SetOwn("target", target)
+	evt.SetOwn("currentTarget", target)
+	evt.SetOwn("bubbles", vm.False)
+	evt.SetOwn("cancelable", vm.False)
+	evt.SetOwn("composed", vm.False)
+	evt.SetOwn("defaultPrevented", vm.False)
+	evt.SetOwn("isTrusted", vm.True)
+	evt.SetOwn("timeStamp", vm.NumberValue(float64(time.Now().UnixMilli())))
+
+	noop := func(name string) vm.Value {
+		return vm.NewNativeFunction(0, false, name, func(args []vm.Value) (vm.Value, error) {
+			return vm.Undefined, nil
+		})
+	}
+	evt.SetOwnNonEnumerable("preventDefault", noop("preventDefault"))
+	evt.SetOwnNonEnumerable("stopPropagation", noop("stopPropagation"))
+	evt.SetOwnNonEnumerable("stopImmediatePropagation", noop("stopImmediatePropagation"))
+
+	return vm.NewValueFromPlainObject(evt)
+}
+
+// parseOnceOption reads the `once` flag out of addEventListener's optional
+// third argument. A bare boolean there is the legacy `useCapture` parameter,
+// not `once` (and capture is meaningless for AbortSignal's non-bubbling
+// events), so only an options object's `once` property is honored.
+func parseOnceOption(options vm.Value) bool {
+	if options.Type() == vm.TypeObject {
+		if once, exists := options.AsPlainObject().GetOwn("once"); exists {
+			return once.IsTruthy()
+		}
+	}
+	return false
+}
+
+func createAbortSignalObject(vmInstance *vm.VM, signal *AbortSignal, signalProto *vm.PlainObject) vm.Value {
+	obj := vm.NewObject(vm.NewValueFromPlainObject(signalProto)).AsPlainObject()
 
 	// Store the signal reference for internal use
 	signalRef := signal
 
-	// aborted property (getter-like behavior via direct access)
-	obj.SetOwn("aborted", boolToValue(signal.aborted))
-	obj.SetOwn("reason", signal.reason)
+	signalRef.mu.Lock()
+	signalRef.jsObj = obj
+	aborted := signalRef.aborted
+	reason := signalRef.reason
+	signalRef.mu.Unlock()
 
-	// throwIfAborted() - throws if the signal is aborted
+	// aborted/reason: plain own data properties, kept in sync by
+	// triggerAbort - see the doc comment on AbortSignal.jsObj for why these
+	// aren't accessor properties.
+	obj.SetOwn("aborted", boolToValue(aborted))
+	obj.SetOwn("reason", reason)
+
+	// throwIfAborted() - throws the signal's actual reason (per spec), not
+	// a synthetic wrapper around it.
 	obj.SetOwnNonEnumerable("throwIfAborted", vm.NewNativeFunction(0, false, "throwIfAborted", func(args []vm.Value) (vm.Value, error) {
 		signalRef.mu.Lock()
 		aborted := signalRef.aborted
 		reason := signalRef.reason
 		signalRef.mu.Unlock()
 
-		if aborted {
-			if reason.Type() == vm.TypeUndefined {
-				return vm.Undefined, &AbortError{Message: "signal is aborted without reason"}
-			}
-			return vm.Undefined, &AbortError{Message: reason.ToString()}
+		if !aborted {
+			return vm.Undefined, nil
 		}
-		return vm.Undefined, nil
+		if reason.Type() == vm.TypeUndefined {
+			return vm.Undefined, vmInstance.NewExceptionError(newAbortErrorValue(vmInstance, "signal is aborted without reason"))
+		}
+		return vm.Undefined, vmInstance.NewExceptionError(reason)
 	}))
 
-	// addEventListener(type, listener)
-	obj.SetOwnNonEnumerable("addEventListener", vm.NewNativeFunction(2, false, "addEventListener", func(args []vm.Value) (vm.Value, error) {
+	// addEventListener(type, listener, options?)
+	obj.SetOwnNonEnumerable("addEventListener", vm.NewNativeFunction(2, true, "addEventListener", func(args []vm.Value) (vm.Value, error) {
 		if len(args) < 2 {
 			return vm.Undefined, nil
 		}
-		eventType := args[0].ToString()
-		if eventType == "abort" {
-			signalRef.mu.Lock()
-			signalRef.listeners = append(signalRef.listeners, args[1])
-			signalRef.mu.Unlock()
+		if args[0].ToString() != "abort" {
+			return vm.Undefined, nil
 		}
+		callback := args[1]
+		if !callback.IsCallable() && callback.Type() != vm.TypeObject {
+			return vm.Undefined, nil
+		}
+		once := false
+		if len(args) > 2 {
+			once = parseOnceOption(args[2])
+		}
+
+		signalRef.mu.Lock()
+		for _, l := range signalRef.listeners {
+			if l.callback.StrictlyEquals(callback) {
+				// Adding an identical (type, listener) pair again is a no-op per spec.
+				signalRef.mu.Unlock()
+				return vm.Undefined, nil
+			}
+		}
+		signalRef.listeners = append(signalRef.listeners, &abortListener{callback: callback, once: once})
+		signalRef.mu.Unlock()
+
 		return vm.Undefined, nil
 	}))
 
-	// removeEventListener(type, listener)
-	obj.SetOwnNonEnumerable("removeEventListener", vm.NewNativeFunction(2, false, "removeEventListener", func(args []vm.Value) (vm.Value, error) {
-		// Simplified - just return undefined
+	// removeEventListener(type, listener, options?)
+	obj.SetOwnNonEnumerable("removeEventListener", vm.NewNativeFunction(2, true, "removeEventListener", func(args []vm.Value) (vm.Value, error) {
+		if len(args) < 2 {
+			return vm.Undefined, nil
+		}
+		if args[0].ToString() != "abort" {
+			return vm.Undefined, nil
+		}
+		callback := args[1]
+
+		signalRef.mu.Lock()
+		for i, l := range signalRef.listeners {
+			if l.callback.StrictlyEquals(callback) {
+				l.removed = true
+				signalRef.listeners = append(signalRef.listeners[:i], signalRef.listeners[i+1:]...)
+				break
+			}
+		}
+		signalRef.mu.Unlock()
+
 		return vm.Undefined, nil
 	}))
+
+	// onabort - the event-handler IDL attribute; starts out null. Not
+	// enumerable: real engines put it on the prototype (never own-property
+	// enumerable), which matters because JSON.stringify(signal) must not
+	// start emitting it just because we implement it as an own accessor.
+	accEnumerable, accConfigurable := false, true
+	obj.DefineAccessorProperty("onabort",
+		vm.NewNativeFunction(0, false, "get onabort", func(args []vm.Value) (vm.Value, error) {
+			signalRef.mu.Lock()
+			h := signalRef.onabort
+			signalRef.mu.Unlock()
+			return h, nil
+		}), true,
+		vm.NewNativeFunction(1, false, "set onabort", func(args []vm.Value) (vm.Value, error) {
+			v := vm.Null
+			if len(args) > 0 {
+				v = args[0]
+			}
+			signalRef.mu.Lock()
+			signalRef.onabort = v
+			signalRef.mu.Unlock()
+			return vm.Undefined, nil
+		}), true,
+		&accEnumerable, &accConfigurable,
+	)
 
 	return vm.NewValueFromPlainObject(obj)
 }
 
-func createAbortControllerObject(vmInstance *vm.VM, controller *AbortController, _ *vm.PlainObject, signalProto *vm.PlainObject) vm.Value {
-	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+func createAbortControllerObject(vmInstance *vm.VM, controller *AbortController, controllerProto *vm.PlainObject, signalProto *vm.PlainObject) vm.Value {
+	obj := vm.NewObject(vm.NewValueFromPlainObject(controllerProto)).AsPlainObject()
 
 	// Create the signal object
 	signalObj := createAbortSignalObject(vmInstance, controller.signal, signalProto)
-	signalPlain := signalObj.AsPlainObject()
 
 	// signal property
 	obj.SetOwn("signal", signalObj)
@@ -248,20 +477,10 @@ func createAbortControllerObject(vmInstance *vm.VM, controller *AbortController,
 		if len(args) > 0 && !args[0].IsUndefined() {
 			reason = args[0]
 		} else {
-			reason = vm.NewString("AbortError: signal is aborted without reason")
+			reason = newAbortErrorValue(vmInstance, "signal is aborted without reason")
 		}
 
-		controller.signal.mu.Lock()
-		if !controller.signal.aborted {
-			controller.signal.aborted = true
-			controller.signal.reason = reason
-			// Update the signal object's properties
-			if signalPlain != nil {
-				signalPlain.SetOwn("aborted", vm.True)
-				signalPlain.SetOwn("reason", reason)
-			}
-		}
-		controller.signal.mu.Unlock()
+		triggerAbort(vmInstance, controller.signal, reason)
 
 		return vm.Undefined, nil
 	}))

--- a/tests/scripts/abort_controller_events.ts
+++ b/tests/scripts/abort_controller_events.ts
@@ -1,0 +1,107 @@
+// expect: true
+// Regression test for https://github.com/nooga/paserati/issues/372:
+// AbortController.abort() must synchronously dispatch "abort" to every
+// addEventListener listener (respecting `once`) and to onabort,
+// removeEventListener must actually unregister, and AbortSignal.any() must
+// propagate a signal that aborts *after* any() was called, not just one
+// that was already aborted.
+const checks: boolean[] = [];
+
+// addEventListener listeners fire, with the right Event shape.
+{
+  const c = new AbortController();
+  let seenType = "";
+  let seenTarget: any = null;
+  c.signal.addEventListener("abort", (e: any) => {
+    seenType = e.type;
+    seenTarget = e.target;
+  });
+  c.abort("boom");
+  checks.push(seenType === "abort");
+  checks.push(seenTarget === c.signal);
+  checks.push(c.signal.aborted === true);
+  checks.push(c.signal.reason === "boom");
+}
+
+// `once` listeners run exactly once.
+{
+  const c = new AbortController();
+  let count = 0;
+  c.signal.addEventListener("abort", () => { count++; }, { once: true });
+  c.abort();
+  c.abort(); // second abort() is a no-op - already aborted
+  checks.push(count === 1);
+}
+
+// removeEventListener actually unregisters the listener.
+{
+  const c = new AbortController();
+  let called = false;
+  const handler = () => { called = true; };
+  c.signal.addEventListener("abort", handler);
+  c.signal.removeEventListener("abort", handler);
+  c.abort();
+  checks.push(called === false);
+}
+
+// A listener removed by an earlier listener in the same dispatch doesn't fire.
+{
+  const c = new AbortController();
+  let secondCalled = false;
+  const second = () => { secondCalled = true; };
+  c.signal.addEventListener("abort", () => {
+    c.signal.removeEventListener("abort", second);
+  });
+  c.signal.addEventListener("abort", second);
+  c.abort();
+  checks.push(secondCalled === false);
+}
+
+// onabort fires alongside addEventListener listeners.
+{
+  const c = new AbortController();
+  let fired = false;
+  c.signal.onabort = () => { fired = true; };
+  c.abort();
+  checks.push(fired === true);
+}
+
+// AbortSignal.any() reflects a source that's already aborted.
+{
+  const a = new AbortController();
+  const b = new AbortController();
+  a.abort("first");
+  const combined = AbortSignal.any([a.signal, b.signal]);
+  checks.push(combined.aborted === true);
+  checks.push(combined.reason === "first");
+}
+
+// AbortSignal.any() propagates a source that aborts *later*.
+{
+  const a = new AbortController();
+  const b = new AbortController();
+  const combined = AbortSignal.any([a.signal, b.signal]);
+  let fired = false;
+  combined.addEventListener("abort", () => { fired = true; });
+  checks.push(combined.aborted === false);
+  b.abort("second");
+  checks.push(combined.aborted === true);
+  checks.push(combined.reason === "second");
+  checks.push(fired === true);
+}
+
+// throwIfAborted throws the actual reason value, not a wrapper around it.
+{
+  const c = new AbortController();
+  const reason = { code: 42 };
+  c.abort(reason as any);
+  let thrown: any = null;
+  try {
+    c.signal.throwIfAborted();
+  } catch (e) {
+    thrown = e;
+  }
+  checks.push(thrown === reason);
+}
+
+checks.every((v) => v === true);


### PR DESCRIPTION
## Summary

Fixes #372. `AbortController.abort()` flipped the internal `aborted` flag but never invoked the listeners `addEventListener` had stored, `onabort` didn't exist, and `removeEventListener` was a no-op. `AbortSignal.any()` only checked for an already-aborted source at call time, not one that aborts later. While in there, brought the rest of the implementation closer to the WHATWG spec.

## Changes

- `abort()` now synchronously dispatches an `"abort"` `Event` to every `addEventListener` listener (respecting `{once: true}`) and then to `onabort`.
- `removeEventListener` actually unregisters a listener — including one removed by an earlier listener during the same dispatch (a per-listener `removed` flag makes a live snapshot honor mid-dispatch removal, per the DOM spec).
- `onabort` is now a real accessor property (non-enumerable, so `JSON.stringify`/serialization of a signal is unaffected — matches how real engines keep it off the instance).
- `AbortSignal.any()` wires a listener onto every not-yet-aborted source via the same `addEventListener` path user code would use, so a source that aborts *after* `any()` was called still propagates. Verified this composes when a composite signal is itself passed as a source to another `any()`.
- `throwIfAborted()` now throws the signal's actual `reason` value instead of re-wrapping it into a synthetic `AbortError` string (which used to double-prefix the message and lose the original reason's type/identity).
- `AbortController.abort()` / `AbortSignal.abort()` share the same default-reason construction (a real `Error` named `"AbortError"`, matching what `fetch()` already rejects with).
- Instances now inherit from `AbortSignal.prototype` / `AbortController.prototype` instead of bare `Object.prototype`.
- `addEventListener`/`removeEventListener` TS signatures accept the optional third (`options`) argument.

`AbortSignal.timeout()` is intentionally left as a non-firing stub — see the FIXME comment in the code. The VM's event-loop drain blocks on `AsyncRuntime.HasPendingTimers()`, which has no "unref" concept, so wiring a real timer to it would make any script holding a `timeout()` signal hang for the full duration even after everything else finished. That needs an unref-able timer first, which is out of scope here.

`aborted`/`reason` deliberately stay plain data properties (kept in sync on every abort) rather than becoming accessors, since `fetch()`'s in-flight abort monitoring polls `signal.aborted` via a raw `GetOwn` call from a background goroutine — `GetOwn` never invokes getters, and resolving one from that goroutine wouldn't be safe.

## Testing

- `go test ./tests -run TestScripts` — full smoke suite green
- `go test ./pkg/...` — green
- Added `tests/scripts/abort_controller_events.ts`, a network-free regression test covering: listener dispatch + Event shape, `once`, `removeEventListener`, mid-dispatch removal, `onabort`, `AbortSignal.any()` with a pre-aborted and a later-aborted source, and `throwIfAborted()`'s thrown value.
- Manually verified `JSON.stringify(signal)` doesn't emit `onabort`, `Object.getPrototypeOf(signal) === AbortSignal.prototype`, and that `AbortSignal.any()` composes when nested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)