### PR TITLE
fix(runtime,builtins): wire up AbortSignal.timeout() via unref'd timers

### DIFF
--- a/pkg/builtins/abort_controller_init.go
+++ b/pkg/builtins/abort_controller_init.go
@@ -86,21 +86,38 @@ func (a *AbortControllerInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// AbortSignal.timeout(ms) - creates a signal that aborts after timeout.
 	//
-	// FIXME: kept as a non-firing stub rather than wired to
-	// rt.ScheduleTimer. The VM's drain loop blocks on AsyncRuntime.
-	// HasPendingTimers()/WaitForIdleProgress() (see pkg/vm/vm.go), and
-	// AsyncRuntime has no "unref" concept - a real timer here would keep
-	// every script alive for the full timeout duration even after
-	// everything else finished, turning `AbortSignal.timeout(30000)` into
-	// an accidental 30s hang. Needs an unref-able timer before this can
-	// actually fire.
+	// Scheduled via ScheduleUnrefTimer (#374), not ScheduleTimer: the VM's
+	// drain loop blocks on AsyncRuntime.HasPendingTimers()/
+	// WaitForIdleProgress() (see pkg/vm/vm.go), so a plain timer here would
+	// keep every script alive for the full timeout duration even after
+	// everything else finished - turning `AbortSignal.timeout(30000)` into
+	// an accidental 30s hang. An unref'd timer doesn't by itself justify
+	// waiting, but still fires normally once due if something else (e.g.
+	// the fetch() it's guarding) is keeping the loop alive anyway - which
+	// is the only situation in which anything is listening for it.
 	signalConstructor.SetOwnNonEnumerable("timeout", vm.NewNativeFunction(1, false, "timeout", func(args []vm.Value) (vm.Value, error) {
+		ms := 0.0
+		if len(args) > 0 {
+			ms = args[0].ToFloat()
+		}
+		if ms < 0 {
+			ms = 0
+		}
+
 		signal := &AbortSignal{
 			aborted: false,
 			reason:  vm.Undefined,
 			onabort: vm.Null,
 		}
-		return createAbortSignalObject(vmInstance, signal, signalProto), nil
+		signalValue := createAbortSignalObject(vmInstance, signal, signalProto)
+
+		rt := vmInstance.GetAsyncRuntime()
+		rt.ScheduleUnrefTimer(time.Duration(ms)*time.Millisecond, func() {
+			reason := newErrorValueWithPrototype(vmInstance.ErrorPrototype, "TimeoutError", "signal timed out")
+			triggerAbort(vmInstance, signal, reason)
+		})
+
+		return signalValue, nil
 	}))
 
 	// AbortSignal.any(signals) - creates a signal that aborts when any input

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -500,7 +500,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 							// Signal is already aborted - reject immediately without async
 							reason := "signal is aborted without reason"
 							if r, exists := signalObj.GetOwn("reason"); exists && r.Type() != vm.TypeUndefined {
-								reason = r.ToString()
+								reason = reasonToMessage(r)
 							}
 							promise := vmInstance.NewPendingPromise()
 							promiseObj := promise.AsPromise()
@@ -527,6 +527,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Extract signal for abort monitoring
 		var signalObj *vm.PlainObject
+		var signalValue vm.Value
 		if init.Type() != vm.TypeUndefined && init.Type() != vm.TypeNull {
 			var initObj interface {
 				GetOwn(string) (vm.Value, bool)
@@ -539,35 +540,37 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 			if initObj != nil {
 				if s, exists := initObj.GetOwn("signal"); exists && s.Type() == vm.TypeObject {
 					signalObj = s.AsPlainObject()
+					signalValue = s
 				}
 			}
 		}
 
-		// If we have a signal, set up abort monitoring
-		var abortOnce sync.Once
+		// If we have a signal, cancel the request's context the moment it
+		// fires "abort" - registered through the signal's own
+		// addEventListener, the same path user code would use, right here
+		// on this native call's own goroutine (fetch() itself always runs
+		// on the VM's goroutine; only the request below is backgrounded).
+		// abort() dispatches synchronously and always from that same VM
+		// goroutine too - directly from a script's controller.abort() call,
+		// or from a due timer's RunDueTimers callback (AbortSignal.timeout(),
+		// #374) - so this callback firing, and the SetOwn writes it
+		// triggers, never race this function's own background request
+		// goroutine. That's why this isn't a 10ms-poll of signalObj's
+		// properties from that goroutine like it used to be: GetOwn/SetOwn
+		// aren't synchronized for concurrent access, and polling from a
+		// second goroutine while abort() writes from this one was a real
+		// (if narrow) data race - `go test -race` catches it as soon as an
+		// abort can happen without user code on the VM goroutine ever
+		// observing it first, which is exactly what an async timer fire
+		// looks like.
 		if signalObj != nil {
-			// Start a goroutine to poll for abort
-			// This is a simple polling approach - a more sophisticated approach
-			// would use event listeners on the signal
-			go func() {
-				ticker := time.NewTicker(10 * time.Millisecond)
-				defer ticker.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-ticker.C:
-						if aborted, exists := signalObj.GetOwn("aborted"); exists {
-							if aborted.IsBoolean() && aborted.AsBoolean() {
-								abortOnce.Do(func() {
-									cancel()
-								})
-								return
-							}
-						}
-					}
-				}
-			}()
+			if addListenerFn, exists := signalObj.GetOwn("addEventListener"); exists && addListenerFn.IsCallable() {
+				onAbort := vm.NewNativeFunction(1, false, "", func(_ []vm.Value) (vm.Value, error) {
+					cancel() // context.CancelFunc is idempotent; abort() itself only ever fires once anyway.
+					return vm.Undefined, nil
+				})
+				_, _ = vmInstance.Call(addListenerFn, signalValue, []vm.Value{vm.NewString("abort"), onAbort})
+			}
 		}
 
 		// Perform HTTP request asynchronously in a goroutine. On a response
@@ -599,7 +602,7 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 					reason := "The operation was aborted"
 					if signalObj != nil {
 						if r, exists := signalObj.GetOwn("reason"); exists && r.Type() != vm.TypeUndefined {
-							reason = r.ToString()
+							reason = reasonToMessage(r)
 						}
 					}
 					vmInstance.RejectPromise(promiseObj, newAbortErrorValue(vmInstance, reason))
@@ -1092,6 +1095,38 @@ func newErrorValueWithPrototype(proto vm.Value, name, message string) vm.Value {
 	return errVal
 }
 
+// reasonToMessage renders an AbortSignal's `reason` as a message string for
+// fetch()'s own synthesized AbortError. Every call site here runs off the
+// main VM goroutine (see newErrorValueWithPrototype above for why), which
+// rules out invoking a JS-level toString() to stringify an arbitrary
+// object reason - so an Error-shaped reason (an own "name"/"message" pair
+// of *data* properties, exactly what newErrorValueWithPrototype itself
+// builds - AbortController's default reason, AbortSignal.timeout()'s
+// TimeoutError, etc.) is rendered the way Error.prototype.toString would
+// ("name: message"), read directly via GetOwn rather than a getter call.
+// A string reason is used as-is; anything else falls back to
+// Value.ToString(), which degrades to "[object Object]" for an arbitrary
+// non-Error object reason - the same unhelpful-but-harmless default a bare
+// Error()'s toString would give for a message that isn't a string.
+func reasonToMessage(reason vm.Value) string {
+	if reason.Type() == vm.TypeObject {
+		obj := reason.AsPlainObject()
+		nameVal, hasName := obj.GetOwn("name")
+		msgVal, hasMsg := obj.GetOwn("message")
+		if hasName || hasMsg {
+			name := "Error"
+			if hasName && nameVal.Type() == vm.TypeString {
+				name = nameVal.ToString()
+			}
+			if hasMsg && msgVal.Type() == vm.TypeString && msgVal.ToString() != "" {
+				return name + ": " + msgVal.ToString()
+			}
+			return name
+		}
+	}
+	return reason.ToString()
+}
+
 // newAbortErrorValue builds a real Error instance (name "AbortError") so a
 // fetch() abort rejects with an actual Error object rather than a bare
 // string (#214) - there is no DOMException in this runtime to construct
@@ -1159,7 +1194,6 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 	method := "GET"
 	headers := &FetchHeaders{headers: make(http.Header)}
 	var body io.Reader
-	var abortSignal *AbortSignal
 	redirectMode := "follow" // "follow", "error", "manual"
 
 	// Parse init options if provided
@@ -1213,23 +1247,19 @@ func doFetchRequestWithContext(ctx context.Context, cancel context.CancelFunc, r
 				}
 			}
 
-			// Signal (AbortSignal)
-			if s, exists := initObj.GetOwn("signal"); exists && s.Type() == vm.TypeObject {
-				signalObj := s.AsPlainObject()
-				// Check if signal is already aborted
-				if aborted, exists := signalObj.GetOwn("aborted"); exists {
-					if aborted.IsBoolean() && aborted.AsBoolean() {
-						reason := vm.NewString("AbortError: signal is aborted without reason")
-						if r, exists := signalObj.GetOwn("reason"); exists && r.Type() != vm.TypeUndefined {
-							reason = r
-						}
-						return &AbortError{Message: reason.ToString()}
-					}
-				}
-				// Store reference for potential future abort (would need more infrastructure)
-				abortSignal = &AbortSignal{aborted: false}
-				_ = abortSignal // Avoid unused variable warning
-			}
+			// Signal (AbortSignal): deliberately *not* re-checked here. This
+			// function runs on its own background goroutine (see the call
+			// site's doc comment), and "signal" is one of the exposed
+			// AbortSignal JS properties fetchFn's own addEventListener
+			// registration (in InitRuntime, before this goroutine was even
+			// started) already races safely - re-reading signalObj.GetOwn
+			// here instead, unsynchronized against a concurrent abort()'s
+			// SetOwn, used to be a real (if narrow) data race (#374).
+			// Both cases are already handled correctly elsewhere: an
+			// already-aborted signal is caught synchronously before this
+			// goroutine is ever spawned, and a concurrent/later abort
+			// cancels ctx (via that addEventListener registration), which
+			// client.Do below turns into an AbortError through ctx.Err().
 
 			// Redirect mode
 			if r, exists := initObj.GetOwn("redirect"); exists && r.Type() == vm.TypeString {

--- a/pkg/driver/abort_signal_timeout_test.go
+++ b/pkg/driver/abort_signal_timeout_test.go
@@ -1,0 +1,80 @@
+package driver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestFetchAbortSignalTimeoutFires is the end-to-end regression test for
+// #374: AbortSignal.timeout(ms) used to be a stub that never actually
+// aborted anything. It's now wired to an *unref'd* timer
+// (runtime.AsyncRuntime.ScheduleUnrefTimer) rather than a plain one,
+// specifically so it doesn't by itself keep a script's event loop alive -
+// but paired with an in-flight fetch() (which does keep the loop alive via
+// BeginExternalOp/EndExternalOp), it must still fire and cancel the
+// request once the deadline passes.
+//
+// The server never responds (blocks on `unblock`), so the only way this
+// fetch() can settle within the test is via the timeout firing.
+func TestFetchAbortSignalTimeoutFires(t *testing.T) {
+	unblock := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-unblock
+	}))
+	defer func() {
+		close(unblock)
+		server.Close()
+	}()
+
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	script := `
+		async function run() {
+			try {
+				await fetch("` + server.URL + `", { signal: AbortSignal.timeout(20) });
+				return { ok: true };
+			} catch (e) {
+				return {
+					ok: false,
+					name: e.name,
+					isError: e instanceof Error,
+					message: e.message,
+				};
+			}
+		}
+		await run();
+	`
+
+	resultVal, errs := p.RunCode(script, RunOptions{})
+	if len(errs) > 0 {
+		t.Fatalf("script failed: %v", errs[0])
+	}
+	if !resultVal.IsObject() {
+		t.Fatalf("script result is not an object: %#v", resultVal)
+	}
+	result := resultVal.AsPlainObject()
+
+	okVal, _ := result.GetOwn("ok")
+	if okVal.AsBoolean() {
+		t.Fatal("fetch() unexpectedly resolved; AbortSignal.timeout(20) should have cancelled it")
+	}
+
+	isErrorVal, _ := result.GetOwn("isError")
+	if !isErrorVal.AsBoolean() {
+		t.Fatal("rejection is not `instanceof Error`")
+	}
+
+	// fetch()'s own abort-classification always names its rejection
+	// "AbortError" regardless of the triggering signal's actual reason
+	// (pre-existing behavior, unrelated to #374) - so the reason's own
+	// name ("TimeoutError") only survives in the message text. Checking
+	// for it here confirms the *right* reason actually made it through
+	// AbortSignal.timeout(), not just that abort() fired at all.
+	messageVal, _ := result.GetOwn("message")
+	if msg := messageVal.ToString(); !strings.Contains(msg, "TimeoutError") {
+		t.Fatalf("rejection message = %q, want it to mention TimeoutError", msg)
+	}
+}

--- a/pkg/runtime/async.go
+++ b/pkg/runtime/async.go
@@ -55,6 +55,16 @@ type AsyncRuntime interface {
 	// Timer expiry goroutines only mark the timer due; callbacks run on the drain thread.
 	ScheduleTimer(delay time.Duration, callback func()) (id uint64)
 
+	// ScheduleUnrefTimer is ScheduleTimer's "doesn't keep the process alive"
+	// counterpart (mirrors Node's timer.unref()). While it's pending (not
+	// yet due), HasPendingTimers/HasPendingWork ignore it, so a drain loop
+	// with nothing else outstanding exits without waiting out its delay.
+	// If something else IS keeping the loop running when it becomes due
+	// (a pending external op, another ref'd timer, ...), it still fires
+	// normally - the exclusion only affects whether it can, by itself,
+	// justify waiting.
+	ScheduleUnrefTimer(delay time.Duration, callback func()) (id uint64)
+
 	// CancelTimer cancels a scheduled timer before it fires.
 	CancelTimer(id uint64)
 
@@ -78,6 +88,10 @@ type timerEntry struct {
 	id       uint64
 	deadline time.Time
 	callback func()
+	// unref: see ScheduleUnrefTimer. Only affects whether this entry counts
+	// toward hasPendingWorkLocked/HasPendingTimers while still pending -
+	// once it's due, it runs like any other timer regardless of this flag.
+	unref bool
 }
 
 // DefaultAsyncRuntime is a simple Go-based runtime with a microtask queue
@@ -243,6 +257,16 @@ func (rt *DefaultAsyncRuntime) RunMacrotasks() bool {
 
 // ScheduleTimer schedules a timer callback after delay.
 func (rt *DefaultAsyncRuntime) ScheduleTimer(delay time.Duration, callback func()) uint64 {
+	return rt.scheduleTimer(delay, callback, false)
+}
+
+// ScheduleUnrefTimer schedules a timer callback after delay that doesn't by
+// itself count as pending work. See the interface doc comment.
+func (rt *DefaultAsyncRuntime) ScheduleUnrefTimer(delay time.Duration, callback func()) uint64 {
+	return rt.scheduleTimer(delay, callback, true)
+}
+
+func (rt *DefaultAsyncRuntime) scheduleTimer(delay time.Duration, callback func(), unref bool) uint64 {
 	if delay < 0 {
 		delay = 0
 	}
@@ -255,6 +279,7 @@ func (rt *DefaultAsyncRuntime) ScheduleTimer(delay time.Duration, callback func(
 		id:       id,
 		deadline: deadline,
 		callback: callback,
+		unref:    unref,
 	}
 	rt.signalWaitersLocked()
 	rt.mu.Unlock()
@@ -316,11 +341,28 @@ func (rt *DefaultAsyncRuntime) RunDueTimers() bool {
 	return true
 }
 
-// HasPendingTimers returns true if timers are scheduled or due but not yet run.
+// HasPendingTimers returns true if a ref'd timer is scheduled or due but
+// not yet run. A still-pending unref'd timer (see ScheduleUnrefTimer) does
+// not count - once due, it's in dueTimers either way and counts there.
 func (rt *DefaultAsyncRuntime) HasPendingTimers() bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	return len(rt.timers) > 0 || len(rt.dueTimers) > 0
+	return rt.hasPendingRefTimersLocked()
+}
+
+// hasPendingRefTimersLocked reports whether there's a timer worth waiting
+// for: any due timer (ref'd or unref'd - it's ready now, no more waiting
+// needed to run it), or a not-yet-due timer that isn't unref'd.
+func (rt *DefaultAsyncRuntime) hasPendingRefTimersLocked() bool {
+	if len(rt.dueTimers) > 0 {
+		return true
+	}
+	for _, e := range rt.timers {
+		if !e.unref {
+			return true
+		}
+	}
+	return false
 }
 
 // HasPendingWork returns true if any async work remains.
@@ -334,8 +376,7 @@ func (rt *DefaultAsyncRuntime) hasPendingWorkLocked() bool {
 	return len(rt.nextTicks) > 0 ||
 		len(rt.microtasks) > 0 ||
 		len(rt.macrotasks) > 0 ||
-		len(rt.timers) > 0 ||
-		len(rt.dueTimers) > 0 ||
+		rt.hasPendingRefTimersLocked() ||
 		rt.pendingExternal > 0
 }
 

--- a/pkg/runtime/async_test.go
+++ b/pkg/runtime/async_test.go
@@ -145,3 +145,83 @@ func TestResetClearsPendingTimer(t *testing.T) {
 		t.Fatal("expected no pending timers after Reset")
 	}
 }
+
+// TestUnrefTimerAloneDoesNotBlockDrain is the regression test for #374: an
+// unref'd timer must not, by itself, keep the drain loop waiting out its
+// delay - HasPendingTimers/HasPendingWork must ignore it while it's still
+// pending, exactly like Node's timer.unref().
+func TestUnrefTimerAloneDoesNotBlockDrain(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var ran atomic.Bool
+
+	rt.ScheduleUnrefTimer(2*time.Second, func() {
+		ran.Store(true)
+	})
+
+	if rt.HasPendingTimers() {
+		t.Fatal("a pending unref'd timer should not count as a pending (ref'd) timer")
+	}
+	if rt.HasPendingWork() {
+		t.Fatal("a pending unref'd timer alone should not count as pending work")
+	}
+
+	start := time.Now()
+	drainUntilIdle(rt)
+	elapsed := time.Since(start)
+
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("drain loop should return immediately with only an unref'd timer pending, took %v", elapsed)
+	}
+	if ran.Load() {
+		t.Fatal("unref'd timer should not have run before the drain loop gave up waiting on it")
+	}
+}
+
+// TestUnrefTimerStillFiresAlongsideOtherWork is the flip side: an unref'd
+// timer must still run normally once it's due, as long as something else
+// (here, a pending external op) is keeping the loop alive for it to be
+// picked up - unref only means "doesn't justify waiting by itself".
+func TestUnrefTimerStillFiresAlongsideOtherWork(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var ran atomic.Bool
+
+	rt.ScheduleUnrefTimer(20*time.Millisecond, func() {
+		ran.Store(true)
+	})
+
+	rt.BeginExternalOp()
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		rt.EndExternalOp()
+	}()
+
+	drainUntilIdle(rt)
+
+	if !ran.Load() {
+		t.Fatal("unref'd timer should have fired while another op kept the loop alive")
+	}
+}
+
+// TestCancelUnrefTimerPreventsCallback confirms CancelTimer works the same
+// way for unref'd timers as it does for ordinary ones.
+func TestCancelUnrefTimerPreventsCallback(t *testing.T) {
+	rt := NewDefaultAsyncRuntime()
+	var ran atomic.Bool
+
+	id := rt.ScheduleUnrefTimer(10*time.Millisecond, func() {
+		ran.Store(true)
+	})
+	rt.CancelTimer(id)
+
+	rt.BeginExternalOp()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		rt.EndExternalOp()
+	}()
+
+	drainUntilIdle(rt)
+
+	if ran.Load() {
+		t.Fatal("cancelled unref'd timer callback should not run")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #374. `AbortSignal.timeout(ms)` was a stub — it created a signal that never actually aborted, because a plain `rt.ScheduleTimer` would have kept the VM's drain loop (`DrainUntilIdle`, and the top-level-await loop in `vm.go`) alive for the full timeout duration even after everything else finished (`AsyncRuntime` had no "unref" concept, so `HasPendingTimers()`/`WaitForIdleProgress()` treated any pending timer as a reason to keep waiting).

## Changes

- `runtime.AsyncRuntime` gains `ScheduleUnrefTimer` alongside `ScheduleTimer`: schedules the same way, but while pending it's excluded from `HasPendingTimers()`/`HasPendingWork()`, so a drain loop with nothing else outstanding exits without waiting out its delay — mirrors Node's `timer.unref()`. Once due, or as long as something else is keeping the loop alive (a pending external op, another ref'd timer), it still fires normally; the exclusion only affects whether it can, by itself, justify waiting.
- `AbortSignal.timeout(ms)` now schedules via `ScheduleUnrefTimer` and aborts with an `Error` named `"TimeoutError"` (there's no `DOMException` in this runtime — same rationale as `fetch()`'s existing `AbortError` construction).

### Two more things this surfaced, fixed alongside it

- **`reasonToMessage` (`pkg/builtins/fetch_init.go`)**: #373 changed `AbortController`'s default abort reason to a real `Error` object (previously a plain string). `fetch()`'s abort-rejection paths stringify that reason via `Value.ToString()`, which gives `"[object Object]"` for any object — so a plain `new AbortController().abort()` used with `fetch()` and no explicit reason silently regressed fetch's rejection message. Those call sites run off the main VM goroutine and can't safely invoke a JS-level `toString()`, so `reasonToMessage` instead renders an Error-shaped reason (its own `name`/`message` *data* properties) the way `Error.prototype.toString` would, read via a plain `GetOwn`.
- **A real (if narrow) data race in fetch's in-flight abort monitoring**: it used to poll `signal.GetOwn("aborted")` from a background goroutine every 10ms with no synchronization against `abort()`'s `SetOwn` — never caught by `go test -race` before because the one test that exercised a concurrent in-flight abort was network-skipped. `AbortSignal.timeout()` makes an async, only-observable-after-the-fact abort trivial to hit, so my new end-to-end test surfaced it immediately. Fixed by registering an actual `"abort"` listener on the signal (through its own `addEventListener`, now that `abort()` actually dispatches — #373) that calls the request's `context.CancelFunc` directly instead of polling. This also let me delete a second, separately racy, and already entirely redundant early-abort recheck inside `doFetchRequestWithContext` (fully covered by the synchronous pre-flight check before the goroutine starts, and by the new listener + `ctx.Err()` classification for anything after).

## Testing

- `pkg/runtime/async_test.go`: `ScheduleUnrefTimer` coverage — doesn't block a drain with nothing else pending, still fires alongside other pending work, `CancelTimer` still works on it.
- `pkg/driver/abort_signal_timeout_test.go`: end-to-end test using a local `httptest` server that never responds, confirming `AbortSignal.timeout(20)` actually cancels an in-flight `fetch()` and carries the right `TimeoutError` reason through — this is what caught the data race above.
- `go test ./tests -run TestScripts` and `go test ./pkg/...` — green.
- `go test -race ./pkg/runtime/... ./pkg/driver/... ./pkg/builtins/... ./pkg/vm/...` — clean.
- Manually confirmed a standalone `AbortSignal.timeout(ms)` with nothing else pending no longer blocks process exit.

## Out of scope

While verifying this didn't regress `fetch(new Request(...))`'s abort handling, found that `fetch()` never actually supported a `Request` object as its argument at all (pre-existing, unrelated to abort handling — `fetchFn` does `args[0].ToString()` unconditionally rather than checking for a `Request` instance). Filed separately, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)