### PR TITLE
fix(builtins): fetch(request) must read url/method/headers/body from Request

### DIFF
--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -475,10 +475,60 @@ func (f *FetchInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("fetch requires at least 1 argument")
 		}
 
-		url := args[0].ToString()
-		var init vm.Value = vm.Undefined
+		var explicitInit vm.Value = vm.Undefined
 		if len(args) > 1 {
-			init = args[1]
+			explicitInit = args[1]
+		}
+
+		// fetch(input, init) is spec'd as effectively `new Request(input,
+		// init)` followed by sending that request - so when input is itself
+		// a Request instance (recovered via the internal slot
+		// createRequestObject stashes on it, the same pattern
+		// mergeHeadersFrom uses for Headers), pull url/method/headers/body/
+		// signal/redirect off of it as defaults, then let an explicit init
+		// argument's own properties override them. Without this, args[0]
+		// was stringified unconditionally below (ToString() on a Request
+		// object produces "[object Object]", which then fails as an
+		// unsupported protocol) and any options carried on the Request
+		// (method, body, signal, ...) were silently dropped.
+		url := args[0].ToString()
+		init := explicitInit
+		if args[0].Type() == vm.TypeObject {
+			if req, ok := args[0].AsPlainObject().InternalSlots().(*FetchRequest); ok && req != nil {
+				url = req.URL
+
+				merged := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+				merged.SetOwn("method", vm.NewString(req.Method))
+				merged.SetOwn("headers", createHeadersObject(vmInstance, &FetchHeaders{headers: req.Headers.headers.Clone()}))
+				if req.body != nil {
+					merged.SetOwn("body", vm.NewString(string(req.body)))
+				}
+				merged.SetOwn("redirect", vm.NewString(req.Redirect))
+				if req.Signal.Type() != vm.TypeUndefined {
+					merged.SetOwn("signal", req.Signal)
+				}
+
+				// Let an explicit init argument override any of the above,
+				// per fetch(request, init) / new Request(request, init)
+				// semantics.
+				if explicitInit.Type() == vm.TypeObject {
+					explicitObj := explicitInit.AsPlainObject()
+					for _, key := range explicitObj.OwnKeys() {
+						if val, exists := explicitObj.GetOwn(key); exists {
+							merged.SetOwn(key, val)
+						}
+					}
+				} else if explicitInit.Type() == vm.TypeDictObject {
+					explicitObj := explicitInit.AsDictObject()
+					for _, key := range explicitObj.OwnKeys() {
+						if val, exists := explicitObj.GetOwn(key); exists {
+							merged.SetOwn(key, val)
+						}
+					}
+				}
+
+				init = vm.NewValueFromPlainObject(merged)
+			}
 		}
 
 		// Check for pre-aborted signal synchronously before spawning goroutine
@@ -1557,6 +1607,16 @@ func parseRequestInitDict(req *FetchRequest, initObj *vm.DictObject) {
 // createRequestObject creates a Request object for the VM
 func createRequestObject(vmInstance *vm.VM, req *FetchRequest, _ *vm.PlainObject) vm.Value {
 	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	// Stash the underlying *FetchRequest behind an internal slot (same
+	// pattern createHeadersObject uses for *FetchHeaders) so fetch() can
+	// recover the full request - including its body bytes and Signal,
+	// neither of which round-trip through the JS-visible properties below
+	// ("body" is always exposed as null; "signal" here is whatever value
+	// was passed in, but reading it back this way is more direct and
+	// matches how mergeHeadersFrom already prefers internal state) -
+	// instead of stringifying the Request object itself into a URL.
+	obj.SetInternalSlots(req)
 
 	// Read-only properties
 	obj.SetOwn("method", vm.NewString(req.Method))

--- a/tests/scripts/fetch_request_object_test.ts
+++ b/tests/scripts/fetch_request_object_test.ts
@@ -1,0 +1,73 @@
+// skip: network
+// fetch(request) must pull url/method/headers/body/signal from a Request
+// instance instead of stringifying it into the URL (which used to produce
+// "[object Object]" and silently drop every option on the Request).
+
+async function runTests() {
+    let passed = 0;
+    let failed = 0;
+
+    // Test 1: fetch(request) with no init - options come entirely from the Request.
+    console.log("1. Testing fetch(request) with no init...");
+    try {
+        const req = new Request("https://httpbin.org/anything/one", {
+            method: "POST",
+            headers: { "X-Test": "hello" },
+            body: "abc123",
+        });
+        const response = await fetch(req);
+        const json = await response.json();
+        console.log("method:", json.method);
+        console.log("body:", json.data);
+        console.log("header:", json.headers["X-Test"]);
+
+        if (json.method === "POST" && json.data === "abc123" && json.headers["X-Test"] === "hello") {
+            console.log("fetch(request) test passed");
+            passed++;
+        } else {
+            console.log("fetch(request) test failed");
+            failed++;
+        }
+    } catch (error) {
+        console.log("fetch(request) test error:", error);
+        failed++;
+    }
+
+    // Test 2: fetch(request, init) - explicit init overrides the Request's own fields.
+    console.log("\n2. Testing fetch(request, init) override...");
+    try {
+        const req = new Request("https://httpbin.org/anything/two", {
+            method: "GET",
+            headers: { "X-Test": "original" },
+        });
+        const response = await fetch(req, {
+            method: "PUT",
+            headers: { "X-Test": "overridden" },
+            body: "newbody",
+        });
+        const json = await response.json();
+        console.log("method:", json.method);
+        console.log("body:", json.data);
+        console.log("header:", json.headers["X-Test"]);
+
+        if (json.method === "PUT" && json.data === "newbody" && json.headers["X-Test"] === "overridden") {
+            console.log("fetch(request, init) override test passed");
+            passed++;
+        } else {
+            console.log("fetch(request, init) override test failed");
+            failed++;
+        }
+    } catch (error) {
+        console.log("fetch(request, init) override test error:", error);
+        failed++;
+    }
+
+    console.log("\n=== Fetch Request Object Tests Complete ===");
+    console.log("Passed:", passed, "Failed:", failed);
+
+    return passed === 2 ? "fetch_request_object_tests_passed" : "fetch_request_object_tests_failed";
+}
+
+await runTests();
+
+// expect: fetch_request_object_tests_passed


### PR DESCRIPTION
## Summary

`fetch()`'s native implementation unconditionally did `args[0].ToString()` for the URL, never checking whether `args[0]` was a `Request` instance created via `new Request(...)`. Calling `fetch(new Request(url, { ... }))` therefore stringified the Request object itself into the URL (producing `"[object Object]"`, which then failed as `"unsupported protocol scheme"`), and any options stored on the Request (`method`, `headers`, `body`, `signal`, etc.) were silently ignored.

Found while verifying #372/#373/#374 (AbortController event dispatch / `AbortSignal.timeout()`) didn't regress the Request+signal path — it's a separate, pre-existing gap.

## Fix

- `createRequestObject` now stashes the underlying `*FetchRequest` behind an internal slot (`obj.SetInternalSlots(req)`), the same pattern already used for `Headers` (`*FetchHeaders`), so `fetch()` can recover the full request rather than relying on JS-visible properties (`body` is always exposed as `null`).
- `fetch()`'s native implementation now checks for that internal slot on `args[0]`. When present:
  - `url` is taken from the Request's own URL instead of `ToString()`-ing the object.
  - A merged init is built from the Request's `method`/`headers`/`body`/`redirect`/`signal`.
  - An explicit second `init` argument's own properties override the Request's defaults — matching `fetch(request, init)` / `new Request(request, init)` merge semantics per the Fetch spec.

`doFetchRequestWithContext` (which already knows how to read `method`/`headers`/`body`/`redirect`/`signal` from a generic init object) is untouched, keeping the change additive and low-risk.

## Tests

Added `tests/scripts/fetch_request_object_test.ts` (tagged `// skip: network`, matching the convention for the other `httpbin.org`-based fetch tests), covering:
1. `fetch(request)` with no init — method/headers/body all come from the Request.
2. `fetch(request, init)` — explicit init overrides the Request's own method/headers/body.

## Verification

- `go build ./...` — clean.
- `go test ./tests -run TestScripts` — all pass, no regressions (network tests excluded by default as usual).
- `PASERATI_TEST_TAGS=network go test ./tests -run "TestScripts/fetch" -v` — all 6 fetch-related tests pass against real `httpbin.org`, including the new one, in both `--no-typecheck` and type-checked modes.
- Manually verified against a local echo server for both the no-init and overriding-init cases before switching to the real network test.