### PR TITLE
fix(vm,builtins): instanceof and getPrototypeOf for ArrayBuffer/DataView

### DIFF
--- a/pkg/builtins/function_init.go
+++ b/pkg/builtins/function_init.go
@@ -792,9 +792,21 @@ func getPrototypeOfValue(vmInstance *vm.VM, val vm.Value) (vm.Value, error) {
 	case vm.TypeAsyncGenerator:
 		return vmInstance.AsyncGeneratorPrototype, nil
 	case vm.TypeArrayBuffer:
-		return vmInstance.ObjectPrototype, nil
+		return vmInstance.ArrayBufferPrototype, nil
 	case vm.TypeSharedArrayBuffer:
 		return vmInstance.SharedArrayBufferPrototype, nil
+	case vm.TypeDataView:
+		return vmInstance.DataViewPrototype, nil
+	case vm.TypeTypedArray:
+		return vmInstance.TypedArrayPrototypeForKind(val.AsTypedArray().GetElementType()), nil
+	case vm.TypeWeakMap:
+		return vmInstance.WeakMapPrototype, nil
+	case vm.TypeWeakSet:
+		return vmInstance.WeakSetPrototype, nil
+	case vm.TypeWeakRef:
+		return vmInstance.WeakRefPrototype, nil
+	case vm.TypeFinalizationRegistry:
+		return vmInstance.FinalizationRegistryPrototype, nil
 	case vm.TypeProxy:
 		proxy := val.AsProxy()
 		if proxy.Revoked {

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2395,8 +2395,11 @@ func objectGetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 			return vmInstance.TypedArrayPrototype, nil
 		}
 	case vm.TypeArrayBuffer:
-		// For ArrayBuffers, return Object.prototype (ArrayBuffer doesn't have its own stored prototype)
-		return vmInstance.ObjectPrototype, nil
+		// For ArrayBuffers, return ArrayBuffer.prototype
+		return vmInstance.ArrayBufferPrototype, nil
+	case vm.TypeDataView:
+		// For DataViews, return DataView.prototype
+		return vmInstance.DataViewPrototype, nil
 	case vm.TypeSharedArrayBuffer:
 		// For SharedArrayBuffers, return SharedArrayBuffer.prototype
 		return vmInstance.SharedArrayBufferPrototype, nil

--- a/pkg/vm/proto.go
+++ b/pkg/vm/proto.go
@@ -52,7 +52,7 @@ func (vm *VM) prototypeOf(v Value) Value {
 	case TypeDataView:
 		return vm.DataViewPrototype
 	case TypeTypedArray:
-		return vm.TypedArrayPrototype
+		return vm.TypedArrayPrototypeForKind(v.AsTypedArray().elementType)
 	case TypeArguments:
 		return vm.ObjectPrototype
 	case TypePromise:
@@ -189,4 +189,42 @@ func (vm *VM) getInheritedGeneric(start Value, propName string) (Value, bool) {
 		current = vm.prototypeOf(current)
 	}
 	return Undefined, false
+}
+
+// TypedArrayPrototypeForKind returns the intrinsic per-kind prototype for a
+// typed array element type (%Uint8Array.prototype%, ...). Typed arrays created
+// by a constructor carry the right prototype in their per-instance override,
+// but ones the runtime builds directly (subarray, slice, %TypedArray%.from, ...)
+// leave it Undefined and must be resolved from the element type — falling back
+// to the abstract %TypedArray%.prototype makes `u.subarray(0,2) instanceof
+// Uint8Array` false.
+func (vm *VM) TypedArrayPrototypeForKind(kind TypedArrayKind) Value {
+	switch kind {
+	case TypedArrayInt8:
+		return vm.Int8ArrayPrototype
+	case TypedArrayUint8:
+		return vm.Uint8ArrayPrototype
+	case TypedArrayUint8Clamped:
+		return vm.Uint8ClampedArrayPrototype
+	case TypedArrayInt16:
+		return vm.Int16ArrayPrototype
+	case TypedArrayUint16:
+		return vm.Uint16ArrayPrototype
+	case TypedArrayInt32:
+		return vm.Int32ArrayPrototype
+	case TypedArrayUint32:
+		return vm.Uint32ArrayPrototype
+	case TypedArrayFloat16:
+		return vm.Float16ArrayPrototype
+	case TypedArrayFloat32:
+		return vm.Float32ArrayPrototype
+	case TypedArrayFloat64:
+		return vm.Float64ArrayPrototype
+	case TypedArrayBigInt64:
+		return vm.BigInt64ArrayPrototype
+	case TypedArrayBigUint64:
+		return vm.BigUint64ArrayPrototype
+	default:
+		return vm.TypedArrayPrototype
+	}
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4036,79 +4036,12 @@ startExecution:
 					ip = frame.ip
 					continue
 				}
-				var current Value
-
-				// Get the initial prototype based on type
-				// For built-in types, use the VM's prototype values
-				switch objVal.Type() {
-				case TypeObject:
-					current = objVal.AsPlainObject().GetPrototype()
-				case TypeDictObject:
-					current = objVal.AsDictObject().GetPrototype()
-				case TypeArray:
-					if p := objVal.AsArray().prototype; p.IsObject() {
-						current = p
-					} else {
-						current = vm.ArrayPrototype
-					}
-				case TypeRegExp:
-					current = vm.RegExpPrototype
-				case TypeMap:
-					if p := objVal.AsMap().prototype; p.IsObject() {
-						current = p
-					} else {
-						current = vm.MapPrototype
-					}
-				case TypeSet:
-					if p := objVal.AsSet().prototype; p.IsObject() {
-						current = p
-					} else {
-						current = vm.SetPrototype
-					}
-				case TypeWeakRef:
-					if p := objVal.AsWeakRef().GetPrototype(); p.IsObject() {
-						current = p
-					} else {
-						current = vm.WeakRefPrototype
-					}
-				case TypeFinalizationRegistry:
-					if p := objVal.AsFinalizationRegistry().GetPrototype(); p.IsObject() {
-						current = p
-					} else {
-						current = vm.FinalizationRegistryPrototype
-					}
-				case TypeArguments:
-					current = vm.ObjectPrototype // Arguments objects inherit from Object.prototype
-				case TypePromise:
-					current = vm.PromisePrototype
-				case TypeFunction:
-					current = vm.FunctionPrototype
-				case TypeClosure:
-					current = vm.FunctionPrototype
-				case TypeGenerator:
-					genObj := objVal.AsGenerator()
-					if genObj.Prototype != nil {
-						current = NewValueFromPlainObject(genObj.Prototype)
-					} else {
-						current = vm.GeneratorPrototype
-					}
-				case TypeAsyncGenerator:
-					asyncGenObj := objVal.AsAsyncGenerator()
-					if asyncGenObj.Prototype != nil {
-						current = NewValueFromPlainObject(asyncGenObj.Prototype)
-					} else {
-						current = vm.AsyncGeneratorPrototype
-					}
-				default:
-					current = Undefined
-				}
-
-				// Subclass-of-native instances carry a per-instance [[Prototype]]
-				// override (e.g. `class S extends Int8Array {}`); honor it over the
-				// type-based intrinsic default chosen above.
-				if ov, ok := vm.InstancePrototypeOverride(objVal); ok {
-					current = ov
-				}
+				// [[Prototype]] of the operand, honoring any per-instance override
+				// from subclassing a native constructor. vm.prototypeOf is the single
+				// place that knows every object kind's intrinsic prototype; a local
+				// type switch here previously omitted ArrayBuffer/SharedArrayBuffer/
+				// DataView/TypedArray/WeakMap/WeakSet and answered false for them.
+				current := vm.prototypeOf(objVal)
 
 				// Walk the prototype chain
 				for current.typ != TypeNull && current.typ != TypeUndefined {

--- a/tests/scripts/instanceof_arraybuffer_dataview_test.ts
+++ b/tests/scripts/instanceof_arraybuffer_dataview_test.ts
@@ -1,0 +1,53 @@
+// expect: all true
+
+// Regression test for #377: `instanceof` was always false for ArrayBuffer and
+// DataView values, and Object.getPrototypeOf reported Object.prototype for an
+// ArrayBuffer. Typed arrays built by the runtime rather than by a constructor
+// call (subarray/slice/from) hit the same hole via instanceof.
+
+const ab = new ArrayBuffer(8);
+const dv = new DataView(ab);
+const u8 = new Uint8Array(4);
+
+const checks: boolean[] = [
+  // instanceof on the exotic buffer kinds
+  ab instanceof ArrayBuffer,
+  dv instanceof DataView,
+  u8 instanceof Uint8Array,
+  // a buffer reached through a typed array, i.e. one the runtime handed out
+  // rather than one a `new ArrayBuffer()` call produced
+  u8.buffer instanceof ArrayBuffer,
+  // typed array views the runtime builds internally
+  u8.subarray(0, 2) instanceof Uint8Array,
+  u8.slice() instanceof Uint8Array,
+  Uint8Array.from([1, 2]) instanceof Uint8Array,
+  // everything inherits from Object
+  ab instanceof Object,
+  dv instanceof Object,
+  u8 instanceof Object,
+  // the [[Prototype]] accessors all agree with instanceof
+  Object.getPrototypeOf(ab) === ArrayBuffer.prototype,
+  Object.getPrototypeOf(dv) === DataView.prototype,
+  Object.getPrototypeOf(u8.subarray(0, 2)) === Uint8Array.prototype,
+  Reflect.getPrototypeOf(ab) === ArrayBuffer.prototype,
+  Reflect.getPrototypeOf(dv) === DataView.prototype,
+  ArrayBuffer.prototype.isPrototypeOf(ab),
+  DataView.prototype.isPrototypeOf(dv),
+  Object.prototype.isPrototypeOf(ab),
+  // .constructor already pointed at the real global; keep it pinned
+  ab.constructor === ArrayBuffer,
+  dv.constructor === DataView,
+  // kinds that already worked, guarding against a regression
+  {} instanceof Object,
+  [] instanceof Array,
+  new Map() instanceof Map,
+  (async function () {}) instanceof Function,
+  function* () {} instanceof Function,
+  // and instanceof must still say no when it should
+  !(ab instanceof Uint8Array),
+  !(dv instanceof ArrayBuffer),
+  !(u8 instanceof DataView),
+  !(ab instanceof DataView),
+];
+
+checks.every((c) => c) ? "all true" : "some false: " + checks.indexOf(false);


### PR DESCRIPTION
Fixes #377.

## What was wrong

`(new ArrayBuffer(4)) instanceof ArrayBuffer` and `(new DataView(...)) instanceof DataView` were always `false`, while `.constructor` correctly pointed at the real global. The reason is that this VM has **four** separate hand-rolled `[[Prototype]]` resolvers, and only the one in `op_getprop.go` (which backs `.constructor`) had the right answer:

| resolver | ArrayBuffer | DataView |
|---|---|---|
| `op_getprop.go` (property access) | ✅ `ArrayBuffer.prototype` | ✅ `DataView.prototype` |
| `OpInstanceof`'s local type switch | ❌ no case → `Undefined` | ❌ no case → `Undefined` |
| `getPrototypeOfValue` (`__proto__`, `isPrototypeOf`, `@@hasInstance`) | ❌ `Object.prototype` | ❌ no case → `Null` |
| `objectGetPrototypeOfWithVM` (`Object`/`Reflect.getPrototypeOf`) | ❌ `Object.prototype` | ❌ no case → `Null` |

`OpInstanceof`'s switch was also missing `SharedArrayBuffer`, `TypedArray`, `WeakMap` and `WeakSet`; `getPrototypeOfValue` was missing the weak collections and `FinalizationRegistry`.

A second, related hole turned up while testing: `vm.prototypeOf` resolved *every* typed array to the abstract `%TypedArray%.prototype`. Typed arrays built by a constructor call hide that behind their per-instance subclass override, but ones the runtime builds directly do not — so `new Uint8Array(4).subarray(0, 2) instanceof Uint8Array` was `false` as well (as were `.slice()` and `Uint8Array.from(...)` results).

## What changed

- **`pkg/vm/vm.go`** — `OpInstanceof` now delegates to `vm.prototypeOf` instead of carrying its own partial type switch. `prototypeOf` is the resolver that covers the exotic object kinds, and it applies the subclass per-instance override itself, so the separate override block below it is gone. The chain-walk loop is untouched.
- **`pkg/vm/proto.go`** — new `TypedArrayPrototypeForKind`; `prototypeOf` uses it for `TypeTypedArray`.
- **`pkg/builtins/function_init.go`** — `getPrototypeOfValue`: `ArrayBuffer` fixed, `DataView`/`TypedArray`/`WeakMap`/`WeakSet`/`WeakRef`/`FinalizationRegistry` added. This also fixes `ArrayBuffer.prototype.isPrototypeOf(ab)` and `Function.prototype[Symbol.hasInstance]`.
- **`pkg/builtins/object_init.go`** — `objectGetPrototypeOfWithVM`: `ArrayBuffer` fixed, `DataView` added.

## Verification

- New smoke test `tests/scripts/instanceof_arraybuffer_dataview_test.ts` covers `instanceof`, `Object.getPrototypeOf`, `Reflect.getPrototypeOf` and `isPrototypeOf` for both kinds, the issue's `u.buffer instanceof ArrayBuffer` case, the runtime-built typed array views, and negative cases. It reports `some false: 0` on a pre-fix build.
- `go test ./tests -run TestScripts` green; `go test ./...` green.
- Test262, comparing `-dump` output from a binary built off `main` against this branch (baseline.txt is gitignored, so it can't be trusted for a diff here):
  - `built-ins/**`: 16485 → **16509** passing, **0 regressions** (ArrayBuffer, DataView, TypedArray `subarray`/`map`, TypedArray constructors)
  - `language/**`: 23070 passing, unchanged

## Not fixed here

- The four resolvers are still four. Consolidating them isn't a drop-in: `vm.prototypeOf` has no Proxy-trap case, and `objectGetPrototypeOfWithVM`'s `TypeFunction` branch returns `fn.Prototype` rather than `Function.prototype`. Worth a separate pass.
- `instanceof` still answers `false` for a `Proxy` (`vm.prototypeOf` has no Proxy-trap case) and for a bound function (`TypeBoundFunction` falls outside the `IsObject()` range that gates the whole `OpInstanceof` block). Both were already false before this change — verified against a `main`-built binary — so nothing regressed, but neither is fixed here.
- `ab.__proto__` is still `undefined` (so are `dv.__proto__` and `sab.__proto__`) — the `TypeArrayBuffer`/`TypeSharedArrayBuffer`/`TypeDataView` branches of `opGetProp` read prototype-chain slots with `GetOwn` and never invoke inherited accessors, and `__proto__` is an accessor on `Object.prototype`. Filed as #380.
