### PR TITLE
fix(vm,builtins): Symbol.species, subclass prototypes, and Promise resolution

### DIFF
--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -3091,6 +3091,8 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Set Array prototype in VM
 	vmInstance.ArrayPrototype = vm.NewValueFromPlainObject(arrayProto)
 
+	defineSpeciesAccessor(vmInstance, arrayCtor.AsNativeFunctionWithProps().Properties)
+
 	// Register Array constructor as global
 	return ctx.DefineGlobal("Array", arrayCtor)
 }

--- a/pkg/builtins/arraybuffer_init.go
+++ b/pkg/builtins/arraybuffer_init.go
@@ -220,17 +220,15 @@ func (a *ArrayBufferInitializer) InitRuntime(ctx *RuntimeContext) error {
 			return vm.Undefined, vmInstance.NewTypeError("ArrayBuffer.prototype.slice: constructor property is not an object")
 		}
 
-		// Step 6: Get [Symbol.species] from constructor
-		var species vm.Value
-		if ctor.IsObject() {
-			if ctor.Type() == vm.TypeObject {
-				po := ctor.AsPlainObject()
-				species, _ = po.GetOwnByKey(vm.NewSymbolKey(vmInstance.SymbolSpecies))
-			}
-		}
-		if species.Type() == 0 || species.IsUndefined() {
-			// Try to get Symbol.species via GetProperty which handles symbol lookup
-			species, _ = vmInstance.GetProperty(ctor, string(vmInstance.SymbolSpecies.AsSymbol()))
+		// Step 6: Get [Symbol.species] from constructor. This used to check
+		// only an own data property and then fall back to GetProperty with the
+		// symbol's description stringized into a string key - which looked up a
+		// property literally named "Symbol.species" and so never found
+		// anything. The species property is an accessor, so it needs the
+		// symbol-aware getter path.
+		species, _, err := vmInstance.GetSymbolPropertyWithGetter(ctor, vmInstance.SymbolSpecies)
+		if err != nil {
+			return vm.Undefined, err
 		}
 
 		// Step 7: If species is null or undefined, use default constructor
@@ -397,6 +395,8 @@ func (a *ArrayBufferInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Set ArrayBuffer prototype in VM for proper prototype chain lookups
 	vmInstance.ArrayBufferPrototype = vm.NewValueFromPlainObject(arrayBufferProto)
+
+	defineSpeciesAccessor(vmInstance, ctorWithProps.AsNativeFunctionWithProps().Properties)
 
 	// Register ArrayBuffer constructor as global
 	return ctx.DefineGlobal("ArrayBuffer", ctorWithProps)

--- a/pkg/builtins/map_init.go
+++ b/pkg/builtins/map_init.go
@@ -564,5 +564,7 @@ func (m *MapInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}))
 
 	// Define Map constructor in global scope
+	defineSpeciesAccessor(vmInstance, mapConstructor.AsNativeFunctionWithProps().Properties)
+
 	return ctx.DefineGlobal("Map", mapConstructor)
 }

--- a/pkg/builtins/promise_init.go
+++ b/pkg/builtins/promise_init.go
@@ -132,6 +132,31 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Create Promise.prototype inheriting from Object.prototype
 	promiseProto := vm.NewObject(objectProto).AsPlainObject()
 
+	// The intrinsic %Promise% constructor, needed by the prototype methods'
+	// SpeciesConstructor step below but only built further down; the closures
+	// capture the variable, which is assigned as soon as it exists.
+	var intrinsicPromise vm.Value
+
+	// speciesThen is PerformPromiseThen with the result promise built by
+	// SpeciesConstructor(promise, %Promise%) per ES 27.2.5.4 step 3 - which is
+	// what makes `class P extends Promise {}` have p.then(...) return a P.
+	// Only the prototype methods do this; the static combinators build their
+	// capability from `this` directly (see Promise.all).
+	speciesThen := func(thisVal vm.Value, onFulfilled, onRejected vm.Value) (vm.Value, error) {
+		ctor, err := promiseSpeciesConstructor(vmInstance, thisVal, intrinsicPromise)
+		if err != nil {
+			return vm.Undefined, err
+		}
+		if ctor.Type() == vm.TypeUndefined || ctor.Is(intrinsicPromise) {
+			// Intrinsic %Promise%: keep the direct path, which skips the
+			// executor round-trip through Construct.
+			return vmInstance.PromiseThen(thisVal, onFulfilled, onRejected)
+		}
+		return vmInstance.PromiseThenWith(thisVal, onFulfilled, onRejected, func(executor vm.Value) (vm.Value, error) {
+			return vmInstance.Construct(ctor, []vm.Value{executor})
+		})
+	}
+
 	// Promise.prototype.then(onFulfilled, onRejected)
 	promiseProto.SetOwnNonEnumerable("then", vm.NewNativeFunction(2, false, "then", func(args []vm.Value) (vm.Value, error) {
 		thisVal := vmInstance.GetThis()
@@ -145,7 +170,7 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			onRejected = args[1]
 		}
 
-		return vmInstance.PromiseThen(thisVal, onFulfilled, onRejected)
+		return speciesThen(thisVal, onFulfilled, onRejected)
 	}))
 
 	// Promise.prototype.catch(onRejected)
@@ -157,30 +182,72 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		}
 
 		// catch(onRejected) is equivalent to then(undefined, onRejected)
-		return vmInstance.PromiseThen(thisVal, vm.Undefined, onRejected)
+		return speciesThen(thisVal, vm.Undefined, onRejected)
 	}))
 
-	// Promise.prototype.finally(onFinally)
+	// Promise.prototype.finally(onFinally) - ES 27.2.5.3.
+	//
+	// The previous implementation registered ONE wrapper for both the fulfill
+	// and the reject reaction and returned its argument, which turned every
+	// rejection into a fulfillment carrying the reason, and it discarded
+	// onFinally's return value entirely instead of awaiting it. Per spec the
+	// two reactions are distinct: each calls onFinally, wraps its result with
+	// PromiseResolve(C, result) - so a thenable is awaited - and only then
+	// replays the original outcome, re-throwing in the reject case.
 	promiseProto.SetOwnNonEnumerable("finally", vm.NewNativeFunction(1, false, "finally", func(args []vm.Value) (vm.Value, error) {
+		// Step 2: If promise is not an Object, throw a TypeError.
 		thisVal := vmInstance.GetThis()
+		if !thisVal.IsObject() && !thisVal.IsCallable() && thisVal.Type() != vm.TypePromise {
+			return vm.Undefined, vmInstance.NewTypeError("Promise.prototype.finally called on a non-object")
+		}
 		onFinally := vm.Undefined
 		if len(args) > 0 {
 			onFinally = args[0]
 		}
 
-		// finally wraps both fulfill and reject handlers
-		wrapper := vm.NewNativeFunction(1, false, "finallyWrapper", func(wrapperArgs []vm.Value) (vm.Value, error) {
-			if onFinally.IsCallable() {
-				_, _ = vmInstance.Call(onFinally, vm.Undefined, []vm.Value{})
-			}
-			// Pass through the original value
-			if len(wrapperArgs) > 0 {
-				return wrapperArgs[0], nil
-			}
-			return vm.Undefined, nil
-		})
+		// Step 3: C = SpeciesConstructor(promise, %Promise%).
+		ctor, err := promiseSpeciesConstructor(vmInstance, thisVal, intrinsicPromise)
+		if err != nil {
+			return vm.Undefined, err
+		}
 
-		return vmInstance.PromiseThen(thisVal, wrapper, wrapper)
+		// Step 5: a non-callable onFinally is installed as both handlers
+		// unchanged, so `then` applies its own "not callable" pass-through.
+		if !onFinally.IsCallable() {
+			return invokeThen(vmInstance, thisVal, onFinally, onFinally)
+		}
+
+		// Step 6: thenFinally / catchFinally. replay is what runs after
+		// PromiseResolve(C, onFinally()) settles: return the original value,
+		// or re-throw the original reason.
+		// Both handlers are anonymous per spec (built-ins/Promise/prototype/
+		// finally/invokes-then-with-function.js asserts name === "").
+		makeHandler := func(rethrow bool) vm.Value {
+			return vm.NewNativeFunction(1, false, "", func(handlerArgs []vm.Value) (vm.Value, error) {
+				outcome := vm.Undefined
+				if len(handlerArgs) > 0 {
+					outcome = handlerArgs[0]
+				}
+				result, callErr := vmInstance.Call(onFinally, vm.Undefined, nil)
+				if callErr != nil {
+					return vm.Undefined, callErr
+				}
+				wrapped, resolveErr := promiseResolveWith(vmInstance, ctor, result)
+				if resolveErr != nil {
+					return vm.Undefined, resolveErr
+				}
+				replay := vm.NewNativeFunction(0, false, "", func([]vm.Value) (vm.Value, error) {
+					if rethrow {
+						return vm.Undefined, vmInstance.NewExceptionError(outcome)
+					}
+					return outcome, nil
+				})
+				return invokeThen(vmInstance, wrapped, replay, vm.Undefined)
+			})
+		}
+
+		// Step 7: Invoke(promise, "then", thenFinally, catchFinally).
+		return invokeThen(vmInstance, thisVal, makeHandler(false), makeHandler(true))
 	}))
 
 	// Add Promise.prototype[@@toStringTag] = "Promise" (writable: false, enumerable: false, configurable: true)
@@ -218,6 +285,10 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vmInstance.NewPromiseFromExecutor(executor)
 	})
 
+	// Publish the intrinsic to the prototype methods' SpeciesConstructor step
+	// (declared above, before Promise.prototype's methods were installed).
+	intrinsicPromise = promiseCtor
+
 	// Add static methods to Promise constructor
 	props := promiseCtor.AsNativeFunctionWithProps().Properties
 
@@ -237,12 +308,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 			value = args[0]
 		}
 
-		// If value is already a promise, return it
-		if value.Type() == vm.TypePromise {
-			return value, nil
-		}
-
-		return vmInstance.NewResolvedPromise(value), nil
+		// Step 3: PromiseResolve(C, value). This used to return an
+		// already-fulfilled intrinsic promise, which got two things wrong: it
+		// ignored `this`, so Promise.resolve.call(SubPromise, v) produced a
+		// plain Promise, and it fulfilled WITH a thenable instead of
+		// assimilating it, because it never went through a resolve function.
+		return promiseResolveWith(vmInstance, thisVal, value)
 	}))
 
 	// Promise.reject(reason)
@@ -261,33 +332,11 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		return vmInstance.NewRejectedPromise(reason), nil
 	}))
 
-	// Promise[Symbol.species] - should be a getter that returns 'this'
-	// For now, just set it to Promise itself (simpler, covers most cases)
-	props.DefineOwnPropertyByKey(vm.NewSymbolKey(SymbolSpecies), promiseCtor, nil, nil, nil)
-
-	// Helper: Get the species constructor from 'this' or fall back to Promise
-	getSpeciesConstructor := func(thisVal vm.Value) vm.Value {
-		// Try to get this[Symbol.species]
-		if thisVal.IsObject() || thisVal.Type() == vm.TypeNativeFunctionWithProps {
-			var speciesVal vm.Value
-
-			// Try to get Symbol.species property
-			if thisVal.Type() == vm.TypeNativeFunctionWithProps {
-				nfp := thisVal.AsNativeFunctionWithProps()
-				if species, exists := nfp.Properties.GetOwnByKey(vm.NewSymbolKey(SymbolSpecies)); exists {
-					speciesVal = species
-				}
-			}
-
-			// If species is defined and not null/undefined, use it
-			if speciesVal.Type() != vm.TypeUndefined && speciesVal.Type() != vm.TypeNull {
-				return speciesVal
-			}
-		}
-
-		// Fall back to 'this' value (the constructor itself)
-		return thisVal
-	}
+	// Promise[Symbol.species] - an accessor whose getter returns 'this', so a
+	// subclass inherits it and answers itself. This used to be a plain data
+	// property holding Promise, which made `class P extends Promise {}` report
+	// Promise rather than P.
+	defineSpeciesAccessor(vmInstance, props)
 
 	// getPromiseResolve implements GetPromiseResolve(C) per ECMAScript spec.
 	// Returns C.resolve if it's callable, otherwise returns an error.
@@ -341,7 +390,12 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if !vmInstance.IsConstructor(thisVal) {
 			return vm.Undefined, vmInstance.NewTypeError("Promise.all called on non-constructor")
 		}
-		constructor := getSpeciesConstructor(thisVal)
+		// Per spec the static combinators do NewPromiseCapability(C) on the
+		// `this` value directly - they must NOT read C[Symbol.species]
+		// (built-ins/Promise/{all,allSettled,any,race}/species-get-error.js all
+		// install a throwing species getter and require it never runs). Only
+		// Promise.prototype.then/finally use SpeciesConstructor.
+		constructor := thisVal
 
 		// Convert iterable to array (before promise creation per spec)
 		arr, err := vmInstance.IterableToArray(iterable)
@@ -507,7 +561,9 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if !vmInstance.IsConstructor(thisVal) {
 			return vm.Undefined, vmInstance.NewTypeError("Promise.race called on non-constructor")
 		}
-		constructor := getSpeciesConstructor(thisVal)
+		// NewPromiseCapability(C) on `this` directly, no species read - see
+		// Promise.all above.
+		constructor := thisVal
 
 		// Convert iterable to array
 		arr, err := vmInstance.IterableToArray(iterable)
@@ -639,7 +695,9 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if !vmInstance.IsConstructor(thisVal) {
 			return vm.Undefined, vmInstance.NewTypeError("Promise.any called on non-constructor")
 		}
-		constructor := getSpeciesConstructor(thisVal)
+		// NewPromiseCapability(C) on `this` directly, no species read - see
+		// Promise.all above.
+		constructor := thisVal
 
 		// Convert iterable to array
 		arr, err := vmInstance.IterableToArray(iterable)
@@ -795,7 +853,9 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if !vmInstance.IsConstructor(thisVal) {
 			return vm.Undefined, vmInstance.NewTypeError("Promise.allSettled called on non-constructor")
 		}
-		constructor := getSpeciesConstructor(thisVal)
+		// NewPromiseCapability(C) on `this` directly, no species read - see
+		// Promise.all above.
+		constructor := thisVal
 
 		// Convert iterable to array
 		arr, err := vmInstance.IterableToArray(iterable)
@@ -1002,7 +1062,9 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Use the species constructor to create the result promise
 		thisVal := vmInstance.GetThis()
-		constructor := getSpeciesConstructor(thisVal)
+		// NewPromiseCapability(C) on `this` directly, no species read - see
+		// Promise.all above.
+		constructor := thisVal
 		if constructor.IsCallable() {
 			return vmInstance.Construct(constructor, []vm.Value{executor})
 		}
@@ -1014,4 +1076,96 @@ func (p *PromiseInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 	// Register Promise constructor as global
 	return ctx.DefineGlobal("Promise", promiseCtor)
+}
+
+// promiseSpeciesConstructor implements SpeciesConstructor(O, %Promise%) for
+// Promise.prototype.then/catch/finally (ES 27.2.5.4 step 3 via 7.3.23).
+//
+//  1. C = O.constructor; if undefined, use the default.
+//  2. If C is not an Object, throw a TypeError.
+//  3. S = C[Symbol.species]; if undefined or null, use the default.
+//  4. If S is a constructor, return it; otherwise throw a TypeError.
+//
+// Returns the default (the intrinsic %Promise%) for every case the spec routes
+// there, so callers can compare against it to take the fast path.
+func promiseSpeciesConstructor(vmInstance *vm.VM, promise vm.Value, defaultCtor vm.Value) (vm.Value, error) {
+	ctor, err := vmInstance.GetProperty(promise, "constructor")
+	if err != nil {
+		return vm.Undefined, err
+	}
+	if ctor.Type() == vm.TypeUndefined {
+		return defaultCtor, nil
+	}
+	if !ctor.IsObject() && !ctor.IsCallable() {
+		return vm.Undefined, vmInstance.NewTypeError("Promise.prototype.then: constructor property is not an object")
+	}
+	species, found, err := vmInstance.GetSymbolPropertyWithGetter(ctor, vmInstance.SymbolSpecies)
+	if err != nil {
+		return vm.Undefined, err
+	}
+	if !found || species.Type() == vm.TypeUndefined || species.Type() == vm.TypeNull {
+		return defaultCtor, nil
+	}
+	if !vmInstance.IsConstructor(species) {
+		return vm.Undefined, vmInstance.NewTypeError("Promise.prototype.then: @@species is not a constructor")
+	}
+	return species, nil
+}
+
+// invokeThen implements Invoke(promise, "then", args) - it reads the actual
+// `then` property off the value rather than calling the intrinsic directly, so
+// a subclass's (or a thenable's) own override is honored, which is what
+// Promise.prototype.finally's spec steps require.
+func invokeThen(vmInstance *vm.VM, promise vm.Value, onFulfilled, onRejected vm.Value) (vm.Value, error) {
+	then, err := vmInstance.GetProperty(promise, "then")
+	if err != nil {
+		return vm.Undefined, err
+	}
+	if !then.IsCallable() {
+		return vm.Undefined, vmInstance.NewTypeError("Promise.prototype.finally: `then` is not callable")
+	}
+	return vmInstance.Call(then, promise, []vm.Value{onFulfilled, onRejected})
+}
+
+// promiseResolveWith implements PromiseResolve(C, x) (ES 27.2.4.7.1): a promise
+// whose own constructor is already C passes through untouched; anything else -
+// a plain value, a foreign promise, or a thenable - is fed through a fresh
+// NewPromiseCapability(C)'s resolve function, which is what assimilates a
+// thenable rather than fulfilling with it.
+//
+// Note this deliberately does NOT go through C.resolve: the spec operation
+// builds the capability directly, and routing through C.resolve would recurse
+// forever when C is %Promise% (whose resolve is this function's only caller).
+func promiseResolveWith(vmInstance *vm.VM, ctor vm.Value, x vm.Value) (vm.Value, error) {
+	if x.Type() == vm.TypePromise {
+		xCtor, err := vmInstance.GetProperty(x, "constructor")
+		if err != nil {
+			return vm.Undefined, err
+		}
+		if xCtor.Is(ctor) {
+			return x, nil
+		}
+	}
+
+	capResolve := vm.Undefined
+	guard := promiseCapabilityGuard(vmInstance)
+	executor := vm.NewNativeFunction(2, false, "", func(execArgs []vm.Value) (vm.Value, error) {
+		resolve, _, guardErr := guard(execArgs)
+		if guardErr != nil {
+			return vm.Undefined, guardErr
+		}
+		capResolve = resolve
+		return vm.Undefined, nil
+	})
+	promise, err := vmInstance.Construct(ctor, []vm.Value{executor})
+	if err != nil {
+		return vm.Undefined, err
+	}
+	if !capResolve.IsCallable() {
+		return vm.Undefined, vmInstance.NewTypeError("PromiseResolve: capability's resolve function is not callable")
+	}
+	if _, err := vmInstance.Call(capResolve, vm.Undefined, []vm.Value{x}); err != nil {
+		return vm.Undefined, err
+	}
+	return promise, nil
 }

--- a/pkg/builtins/set_init.go
+++ b/pkg/builtins/set_init.go
@@ -826,5 +826,7 @@ func (s *SetInitializer) InitRuntime(ctx *RuntimeContext) error {
 	}
 
 	// Define Set constructor in global scope
+	defineSpeciesAccessor(vmInstance, setConstructor.AsNativeFunctionWithProps().Properties)
+
 	return ctx.DefineGlobal("Set", setConstructor)
 }

--- a/pkg/builtins/sharedarraybuffer_init.go
+++ b/pkg/builtins/sharedarraybuffer_init.go
@@ -222,6 +222,8 @@ func (s *SharedArrayBufferInitializer) InitRuntime(ctx *RuntimeContext) error {
 	// Set SharedArrayBuffer prototype in VM for proper prototype chain lookups
 	vmInstance.SharedArrayBufferPrototype = vm.NewValueFromPlainObject(sharedArrayBufferProto)
 
+	defineSpeciesAccessor(vmInstance, ctorWithProps.AsNativeFunctionWithProps().Properties)
+
 	// Register SharedArrayBuffer constructor as global
 	return ctx.DefineGlobal("SharedArrayBuffer", ctorWithProps)
 }

--- a/pkg/builtins/species.go
+++ b/pkg/builtins/species.go
@@ -1,0 +1,33 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// defineSpeciesAccessor installs the well-known `get [Symbol.species]`
+// accessor on a constructor's property table.
+//
+// Per spec (e.g. ES2025 23.1.2.5 for Array, 23.2.2.4 for %TypedArray%) every
+// species-aware constructor carries an accessor whose getter simply returns
+// its `this`, with { set: undefined, enumerable: false, configurable: true }.
+// Returning `this` rather than a captured constructor is what makes the
+// property inherit correctly: `Uint8Array[Symbol.species]` finds the getter on
+// %TypedArray% but answers Uint8Array, and `class Foo extends Uint8Array {}`
+// answers Foo. For that reason the accessor belongs on the intrinsic only -
+// installing a copy on each TypedArray subclass would both break the subclass
+// case and wrongly show up in Object.getOwnPropertySymbols(Uint8Array).
+func defineSpeciesAccessor(vmInstance *vm.VM, props *vm.PlainObject) {
+	if props == nil || vmInstance.SymbolSpecies.Type() != vm.TypeSymbol {
+		return
+	}
+	getter := vm.NewNativeFunction(0, false, "get [Symbol.species]", func(args []vm.Value) (vm.Value, error) {
+		return vmInstance.GetThis(), nil
+	})
+	enumerable, configurable := false, true
+	props.DefineAccessorPropertyByKey(
+		vm.NewSymbolKey(vmInstance.SymbolSpecies),
+		getter, true,
+		vm.Undefined, false,
+		&enumerable, &configurable,
+	)
+}

--- a/pkg/builtins/typedarray_base_init.go
+++ b/pkg/builtins/typedarray_base_init.go
@@ -156,6 +156,8 @@ func (i *TypedArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 	vmInstance.TypedArrayConstructor = typedArrayCtor
 
 	// Register TypedArray constructor as global
+	defineSpeciesAccessor(vmInstance, typedArrayCtor.AsNativeFunctionWithProps().Properties)
+
 	return ctx.DefineGlobal("TypedArray", typedArrayCtor)
 }
 

--- a/pkg/vm/async_runtime.go
+++ b/pkg/vm/async_runtime.go
@@ -1,14 +1,32 @@
 package vm
 
-import "github.com/nooga/paserati/pkg/runtime"
+import (
+	"sync"
+
+	"github.com/nooga/paserati/pkg/runtime"
+)
+
+// asyncRuntimeMu guards the lazy initialization in GetAsyncRuntime.
+//
+// GetAsyncRuntime is reached from host goroutines - anything that settles a
+// Promise off the VM's own goroutine ends up scheduling a microtask through it
+// (fetch's HTTP goroutine, ReadableStream's pump, and now ResolvePromise's
+// thenable branch). Its "create one if nil" write raced against the VM
+// goroutine's own first call, which -race reports as a plain unsynchronized
+// read/write on vm.asyncRuntime.
+var asyncRuntimeMu sync.Mutex
 
 // SetAsyncRuntime sets the async execution runtime
 func (vm *VM) SetAsyncRuntime(rt runtime.AsyncRuntime) {
+	asyncRuntimeMu.Lock()
+	defer asyncRuntimeMu.Unlock()
 	vm.asyncRuntime = rt
 }
 
 // GetAsyncRuntime returns the current async runtime (or default)
 func (vm *VM) GetAsyncRuntime() runtime.AsyncRuntime {
+	asyncRuntimeMu.Lock()
+	defer asyncRuntimeMu.Unlock()
 	if vm.asyncRuntime == nil {
 		vm.asyncRuntime = runtime.NewDefaultAsyncRuntime()
 	}

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -825,58 +825,22 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 
 	// 10a. WeakMap objects - consult WeakMap.prototype chain for properties like get, set, has, delete
 	if objVal.Type() == TypeWeakMap {
-		proto := vm.WeakMapPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// The instance's own [[Prototype]] (a subclass's, when one was
+		// installed) rather than the hardcoded intrinsic, and a walk that
+		// invokes accessors - see finishProtoChainGet. The hand-rolled walk
+		// this replaces did neither, so `class S extends WeakMap {}` could reach
+		// none of S.prototype's methods or getters.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10b. WeakSet objects - consult WeakSet.prototype chain for properties like add, has, delete
 	if objVal.Type() == TypeWeakSet {
-		proto := vm.WeakSetPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// The instance's own [[Prototype]] (a subclass's, when one was
+		// installed) rather than the hardcoded intrinsic, and a walk that
+		// invokes accessors - see finishProtoChainGet. The hand-rolled walk
+		// this replaces did neither, so `class S extends WeakSet {}` could reach
+		// none of S.prototype's methods or getters.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10b'. WeakRef objects - consult the instance's stored prototype (set by
@@ -956,30 +920,12 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			}
 		}
 		// Then check prototype chain
-		proto := vm.SharedArrayBufferPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// The instance's own [[Prototype]] (a subclass's, when one was
+		// installed) rather than the hardcoded intrinsic, and a walk that
+		// invokes accessors - see finishProtoChainGet. The hand-rolled walk
+		// this replaces did neither, so `class S extends SharedArrayBuffer {}` could reach
+		// none of S.prototype's methods or getters.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10d. ArrayBuffer objects - check own properties first, then prototype chain
@@ -993,59 +939,23 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			}
 		}
 		// Then check prototype chain
-		proto := vm.ArrayBufferPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// The instance's own [[Prototype]] (a subclass's, when one was
+		// installed) rather than the hardcoded intrinsic, and a walk that
+		// invokes accessors - see finishProtoChainGet. The hand-rolled walk
+		// this replaces did neither, so `class S extends ArrayBuffer {}` could reach
+		// none of S.prototype's methods or getters.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10e. DataView objects - check own properties first, then prototype chain
 	if objVal.Type() == TypeDataView {
 		// Then check prototype chain
-		proto := vm.DataViewPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// The instance's own [[Prototype]] (a subclass's, when one was
+		// installed) rather than the hardcoded intrinsic, and a walk that
+		// invokes accessors - see finishProtoChainGet. The hand-rolled walk
+		// this replaces did neither, so `class S extends DataView {}` could reach
+		// none of S.prototype's methods or getters.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 11. Generator objects
@@ -1129,34 +1039,13 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 				return true, InterpretOK, *dest
 			}
 		}
-		// Check RegExp.prototype for inherited methods
-		if vm.RegExpPrototype.Type() == TypeObject {
-			proto := vm.RegExpPrototype.AsPlainObject()
-			if v, ok := proto.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk prototype chain to Object.prototype
-			current := proto.GetPrototype()
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					if current.Type() == TypeObject {
-						p := current.AsPlainObject()
-						if v, ok := p.GetOwn(propName); ok {
-							*dest = v
-							return true, InterpretOK, *dest
-						}
-						current = p.GetPrototype()
-					} else {
-						break
-					}
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// The instance's own [[Prototype]] rather than the hardcoded
+		// RegExp.prototype, and a walk that invokes accessors - see
+		// finishProtoChainGet. This is what makes `class S extends RegExp {}`
+		// reach S.prototype's methods, and (per spec) lets
+		// String.prototype.replace/match/split dispatch through a subclass's
+		// own `exec` override.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 13. Proxy objects - delegate to handler
@@ -1508,38 +1397,15 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		*dest = Undefined
 		return true, InterpretOK, *dest
 	case TypeTypedArray:
-		// TypedArrays: consult appropriate TypedArray.prototype chain for symbol properties
-		var proto Value
-		ta := base.AsTypedArray()
-		switch ta.GetElementType() {
-		case TypedArrayInt8:
-			proto = vm.Int8ArrayPrototype
-		case TypedArrayUint8:
-			proto = vm.Uint8ArrayPrototype
-		case TypedArrayUint8Clamped:
-			proto = vm.Uint8ClampedArrayPrototype
-		case TypedArrayInt16:
-			proto = vm.Int16ArrayPrototype
-		case TypedArrayUint16:
-			proto = vm.Uint16ArrayPrototype
-		case TypedArrayInt32:
-			proto = vm.Int32ArrayPrototype
-		case TypedArrayUint32:
-			proto = vm.Uint32ArrayPrototype
-		case TypedArrayFloat16:
-			proto = vm.Float16ArrayPrototype
-		case TypedArrayFloat32:
-			proto = vm.Float32ArrayPrototype
-		case TypedArrayFloat64:
-			proto = vm.Float64ArrayPrototype
-		case TypedArrayBigInt64:
-			proto = vm.BigInt64ArrayPrototype
-		case TypedArrayBigUint64:
-			proto = vm.BigUint64ArrayPrototype
-		default:
-			proto = vm.TypedArrayPrototype // fallback to base TypedArray prototype
-		}
-		if proto.IsObject() {
+		// TypedArrays: consult the TypedArray.prototype chain for symbol
+		// properties. vm.PrototypeOf rather than a local element-type switch so
+		// a subclass instance's per-instance [[Prototype]] override wins - see
+		// getPropertyWithReceiver's TypeTypedArray case (pkg/vm/vm_init.go).
+		proto := vm.PrototypeOf(base)
+		// Type() == TypeObject, not IsObject(): the latter admits Proxy and
+		// DictObject, which AsPlainObject cannot represent - see
+		// getPropertyWithReceiver's TypePromise case (pkg/vm/vm_init.go).
+		if proto.Type() == TypeObject {
 			po := proto.AsPlainObject()
 			symKeyVal := NewSymbolKey(symKey)
 			// Check for accessor property first
@@ -2164,206 +2030,24 @@ func (vm *VM) opGetPropSymbol(frame *CallFrame, ip int, objVal *Value, symKey Va
 		return true, InterpretOK, *dest
 	}
 
-	// Function objects: check own symbol properties, then Function.prototype chain
-	if base.Type() == TypeFunction {
-		funcObj := base.AsFunction()
-		key := NewSymbolKey(symKey)
-		// Check own properties first
-		if funcObj.Properties != nil {
-			if v, ok := funcObj.Properties.GetOwnByKey(key); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-		}
-		// Walk Function.prototype chain
-		// Function.prototype is TypeNativeFunctionWithProps, so handle that type too
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			*dest = v
-			return true, InterpretOK, *dest
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
-	}
-
-	// Closure objects: check own symbol properties, then Function.prototype chain
-	if base.Type() == TypeClosure {
-		closure := base.AsClosure()
-		key := NewSymbolKey(symKey)
-		// Check own properties first
-		if closure.Properties != nil {
-			if v, ok := closure.Properties.GetOwnByKey(key); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-		}
-		// Walk Function.prototype chain
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			*dest = v
-			return true, InterpretOK, *dest
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
-	}
-
-	// NativeFunctionWithProps: check own symbol properties, then prototype chain
-	if base.Type() == TypeNativeFunctionWithProps {
-		nfp := base.AsNativeFunctionWithProps()
-		key := NewSymbolKey(symKey)
-		if nfp.Properties != nil {
-			if v, ok := nfp.Properties.GetOwnByKey(key); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk prototype chain from Properties
-			if found, v := vm.lookupSymbolOnProtoChain(nfp.Properties.GetPrototype(), key); found {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
-	}
-
-	// NativeFunction: check own symbol properties (accessor first, mirroring
-	// TypeObject's GetOwnAccessorByKey-then-GetOwnByKey pattern above and
-	// this same TypeNativeFunction kind's string-key equivalent in
-	// opGetProp's block 3b), then Function.prototype chain.
+	// Callable objects (plain functions, closures, native functions, bound
+	// functions and the property-carrying built-in constructors) all resolve a
+	// symbol key the same way: own properties first, then the real
+	// [[Prototype]] chain, invoking any accessor's getter with this = base.
 	//
-	// This case didn't exist at all before this fix, so a symbol-keyed own
-	// property - even a plain data one - set via bracket-notation
-	// assignment or Object.defineProperty always fell through to the
-	// DictObject default below and read back as undefined, even though
-	// Object.getOwnPropertyDescriptor already showed it existed correctly.
-	//
-	// The accessor check specifically was added after review flagged an
-	// asymmetry a first pass introduced: opGetProp's block 3b (string keys,
-	// same TypeNativeFunction kind) invokes an own accessor's getter, so
-	// leaving this symbol-key sibling without one would have made
-	// `nf.custom` call the getter while `nf[sym]` did not, on the very
-	// same value in the same commit - worse than the pre-fix state of
-	// "symbol keys don't work at all". TypeFunction/TypeClosure/
-	// TypeBoundFunction/TypeNativeFunctionWithProps above still lack this
-	// (none of those four invoke a symbol-key accessor's getter; TypeObject,
-	// separately, already does - see its own case earlier in this
-	// function), so that remains a real, separate, still-open gap.
-	if base.Type() == TypeNativeFunction {
-		nf := base.AsNativeFunction()
-		key := NewSymbolKey(symKey)
-		if nf.Properties != nil {
-			if g, _, _, _, ok := nf.Properties.GetOwnAccessorByKey(key); ok {
-				if g.Type() != TypeUndefined {
-					res, err := vm.Call(g, base, nil)
-					if err != nil {
-						if ee, ok := err.(ExceptionError); ok {
-							if frame != nil && !frameWasNil {
-								frame.ip = ip - 4
-							}
-							vm.throwException(ee.GetExceptionValue())
-							if !vm.unwinding {
-								return false, InterpretOK, Undefined
-							}
-							return false, InterpretRuntimeError, Undefined
-						}
-						var excVal Value
-						if errCtor, ok := vm.GetGlobal("Error"); ok {
-							if res2, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
-								excVal = res2
-							} else {
-								eo := NewObject(vm.ErrorPrototype).AsPlainObject()
-								eo.SetOwn("name", NewString("Error"))
-								eo.SetOwn("message", NewString(err.Error()))
-								excVal = NewValueFromPlainObject(eo)
-							}
-						} else {
-							eo := NewObject(vm.ErrorPrototype).AsPlainObject()
-							eo.SetOwn("name", NewString("Error"))
-							eo.SetOwn("message", NewString(err.Error()))
-							excVal = NewValueFromPlainObject(eo)
-						}
-						if frame != nil && !frameWasNil {
-							frame.ip = ip - 4
-						}
-						vm.throwException(excVal)
-						if !vm.unwinding {
-							return false, InterpretOK, Undefined
-						}
-						return false, InterpretRuntimeError, Undefined
-					}
-					*dest = res
-					return true, InterpretOK, *dest
-				}
-				// Setter-only accessor (no getter): reads as undefined per spec.
-				*dest = Undefined
-				return true, InterpretOK, *dest
-			}
-			if v, ok := nf.Properties.GetOwnByKey(key); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			*dest = v
-			return true, InterpretOK, *dest
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
-	}
-
-	// BoundFunction: check own properties, then Function.prototype chain
-	if base.Type() == TypeBoundFunction {
-		bf := base.AsBoundFunction()
-		key := NewSymbolKey(symKey)
-		if bf.Properties != nil {
-			if v, ok := bf.Properties.GetOwnByKey(key); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			*dest = v
-			return true, InterpretOK, *dest
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+	// Before this was unified, each flavour had its own copy of the walk and
+	// only TypeNativeFunction invoked a getter - and even that only for an OWN
+	// accessor. Inherited accessors were unreachable because the shared
+	// lookupSymbolOnProtoChain took no receiver, and TypeFunction/TypeClosure
+	// hardcoded Function.prototype as the parent instead of the constructor's
+	// actual [[Prototype]], so `class Foo extends Uint8Array {}` could never
+	// see anything Uint8Array or %TypedArray% defined.
+	switch base.Type() {
+	case TypeFunction, TypeClosure, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction:
+		return vm.resolveSymbolSlot(frame, ip, frameWasNil, base, NewSymbolKey(symKey), dest)
 	}
 
 	// DictObject: no symbol identity support yet
 	*dest = Undefined
 	return true, InterpretOK, *dest
-}
-
-// lookupSymbolOnProtoChain walks a prototype chain starting from proto,
-// looking for a symbol-keyed property. Handles PlainObject, NativeFunctionWithProps,
-// and DictObject prototype types.
-func (vm *VM) lookupSymbolOnProtoChain(proto Value, key PropertyKey) (bool, Value) {
-	current := proto
-	for i := 0; i < 100; i++ { // safety limit
-		switch current.Type() {
-		case TypeObject:
-			po := current.AsPlainObject()
-			if v, ok := po.GetOwnByKey(key); ok {
-				return true, v
-			}
-			current = po.prototype
-		case TypeNativeFunctionWithProps:
-			nfp := current.AsNativeFunctionWithProps()
-			if nfp.Properties != nil {
-				if v, ok := nfp.Properties.GetOwnByKey(key); ok {
-					return true, v
-				}
-				current = nfp.Properties.GetPrototype()
-			} else {
-				return false, Undefined
-			}
-		case TypeDictObject:
-			dict := current.AsDictObject()
-			current = dict.GetPrototype()
-		default:
-			return false, Undefined
-		}
-		if current.typ == TypeNull || current.typ == TypeUndefined {
-			break
-		}
-	}
-	return false, Undefined
 }

--- a/pkg/vm/op_setprop.go
+++ b/pkg/vm/op_setprop.go
@@ -959,6 +959,16 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 				regex.SetLastIndex(int(valueToSet.ToFloat()))
 				return true, InterpretOK, *valueToSet
 			}
+			// An inherited accessor on the [[Prototype]] chain wins over
+			// creating an own property: without this, `re.global = x` (whose
+			// accessor on RegExp.prototype is getter-only) silently stored a
+			// shadowing own data property, which test262's
+			// verifyNotWritable checks reject. TypeObject's set path has
+			// always done this walk; the side-table kinds went straight to
+			// setOwnChecked, whose only accessor awareness is the OWN table's.
+			if handled, ok, status, val := vm.checkCustomProtoChainAccessorSetter(vm.PrototypeOf(*objVal), propName, objVal, valueToSet); handled {
+				return ok, status, val
+			}
 			if regex.Properties == nil {
 				regex.Properties = newPropertiesTable()
 			}
@@ -969,6 +979,10 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		// Map objects can have user-defined properties
 		mapObj := objVal.AsMap()
 		if mapObj != nil {
+			// Same inherited-accessor precedence as the RegExp case above.
+			if handled, ok, status, val := vm.checkCustomProtoChainAccessorSetter(vm.PrototypeOf(*objVal), propName, objVal, valueToSet); handled {
+				return ok, status, val
+			}
 			if mapObj.Properties == nil {
 				mapObj.Properties = newPropertiesTable()
 			}
@@ -979,6 +993,10 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		// Set objects can have user-defined properties
 		setObj := objVal.AsSet()
 		if setObj != nil {
+			// Same inherited-accessor precedence as the RegExp case above.
+			if handled, ok, status, val := vm.checkCustomProtoChainAccessorSetter(vm.PrototypeOf(*objVal), propName, objVal, valueToSet); handled {
+				return ok, status, val
+			}
 			if setObj.Properties == nil {
 				setObj.Properties = newPropertiesTable()
 			}
@@ -990,6 +1008,10 @@ func (vm *VM) opSetProp(ip int, objVal *Value, propName string, valueToSet *Valu
 		// constructor doing `this.foo = 1` after super()).
 		promiseObj := objVal.AsPromise()
 		if promiseObj != nil {
+			// Same inherited-accessor precedence as the RegExp case above.
+			if handled, ok, status, val := vm.checkCustomProtoChainAccessorSetter(vm.PrototypeOf(*objVal), propName, objVal, valueToSet); handled {
+				return ok, status, val
+			}
 			if promiseObj.Properties == nil {
 				promiseObj.Properties = newPropertiesTable()
 			}

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -274,9 +274,23 @@ func (vm *VM) NewRejectedPromise(reason Value) Value {
 	return Value{typ: TypePromise, obj: promiseToUnsafe(promise)}
 }
 
-// resolvePromise fulfills a promise with a value. Safe to call from any
-// goroutine (see PromiseObject's mu doc comment).
+// resolvePromise implements the resolve half of CreateResolvingFunctions
+// (ES 27.2.1.3.2). It must run on the VM's own execution goroutine: the
+// thenable branch below reads and calls JS. Host goroutines go through the
+// exported ResolvePromise, which queues the whole thing as a microtask.
 func (vm *VM) resolvePromise(promise *PromiseObject, value Value) {
+	// Step 1: resolving a promise with itself is a chaining cycle.
+	if value.Type() == TypePromise && value.AsPromise() == promise {
+		cycleErr := vm.NewTypeError("Chaining cycle detected for promise")
+		reason := NewString(cycleErr.Error())
+		if ee, ok := cycleErr.(ExceptionError); ok {
+			reason = ee.GetExceptionValue()
+		}
+		vm.ClearUnwindingState()
+		vm.rejectPromise(promise, reason)
+		return
+	}
+
 	// Handle promise resolution with thenable chaining
 	if value.Type() == TypePromise {
 		otherPromise := value.AsPromise()
@@ -306,9 +320,66 @@ func (vm *VM) resolvePromise(promise *PromiseObject, value Value) {
 		return
 	}
 
+	// Steps 8-12: an object (functions included) with a callable `then` is a
+	// thenable and must be assimilated, not used as the fulfillment value.
+	// Reading `then` happens here, synchronously, so a plain object with no
+	// `then` still fulfills on this tick; only the CALL is deferred to a
+	// microtask, which is NewPromiseResolveThenableJob.
+	if value.IsObject() || value.IsFunction() {
+		then, err := vm.GetProperty(value, "then")
+		if err != nil {
+			// A throwing `then` getter rejects the promise rather than
+			// escaping to whoever called resolve.
+			reason := NewString(err.Error())
+			if ee, ok := err.(ExceptionError); ok {
+				reason = ee.GetExceptionValue()
+			}
+			vm.ClearUnwindingState()
+			vm.rejectPromise(promise, reason)
+			return
+		}
+		if then.IsCallable() {
+			vm.scheduleThenableJob(promise, value, then)
+			return
+		}
+	}
+
 	if promise.trySettle(PromiseFulfilled, value) {
 		vm.triggerPromiseReactions(promise, true)
 	}
+}
+
+// scheduleThenableJob is NewPromiseResolveThenableJob (ES 27.2.2.2): it calls
+// thenable.then(resolvingFunctions) on a later tick. Whichever of resolve or
+// reject runs first wins - that is what trySettle already enforces - and a
+// throw from `then` rejects, but only if nothing has settled the promise yet.
+func (vm *VM) scheduleThenableJob(promise *PromiseObject, thenable Value, then Value) {
+	vm.GetAsyncRuntime().ScheduleMicrotask(func() {
+		resolve := NewNativeFunction(1, false, "", func(args []Value) (Value, error) {
+			v := Undefined
+			if len(args) > 0 {
+				v = args[0]
+			}
+			vm.resolvePromise(promise, v)
+			return Undefined, nil
+		})
+		reject := NewNativeFunction(1, false, "", func(args []Value) (Value, error) {
+			r := Undefined
+			if len(args) > 0 {
+				r = args[0]
+			}
+			vm.rejectPromise(promise, r)
+			return Undefined, nil
+		})
+		if _, err := vm.Call(then, thenable, []Value{resolve, reject}); err != nil {
+			reason := NewString(err.Error())
+			if ee, ok := err.(ExceptionError); ok {
+				reason = ee.GetExceptionValue()
+			}
+			vm.ClearUnwindingState()
+			vm.rejectPromise(promise, reason)
+		}
+	})
 }
 
 // rejectPromise rejects a promise with a reason. Safe to call from any
@@ -417,8 +488,22 @@ func (vm *VM) addPromiseReaction(promiseVal Value, isFulfilled bool, callback fu
 	}
 }
 
-// PromiseThen implements Promise.prototype.then()
+// PromiseThen implements Promise.prototype.then() with the intrinsic %Promise%
+// as the result promise's constructor.
 func (vm *VM) PromiseThen(thisPromise Value, onFulfilled, onRejected Value) (Value, error) {
+	return vm.PromiseThenWith(thisPromise, onFulfilled, onRejected, vm.NewPromiseFromExecutor)
+}
+
+// PromiseThenWith is PromiseThen with an explicit result-promise factory.
+//
+// Per spec Promise.prototype.then does NewPromiseCapability(C) where C is
+// SpeciesConstructor(promise, %Promise%), so the chained promise is built by
+// the species constructor - that is what makes `subclassPromise.then(...)`
+// return an instance of the subclass. newPromise receives the executor the
+// reactions are wired through and must return the promise built from it;
+// pkg/builtins/promise_init.go passes a Construct(C, executor) closure when C
+// is not the intrinsic.
+func (vm *VM) PromiseThenWith(thisPromise Value, onFulfilled, onRejected Value, newPromise func(executor Value) (Value, error)) (Value, error) {
 	promise := thisPromise.AsPromise()
 	if promise == nil {
 		return Undefined, fmt.Errorf("TypeError: Promise.prototype.then called on non-Promise")
@@ -477,7 +562,7 @@ func (vm *VM) PromiseThen(thisPromise Value, onFulfilled, onRejected Value) (Val
 		return Undefined, nil
 	})
 
-	return vm.NewPromiseFromExecutor(executor)
+	return newPromise(executor)
 }
 
 // maxIterableToArrayIterations bounds how many elements IterableToArray pulls
@@ -651,8 +736,19 @@ func (vm *VM) NewPendingPromise() Value {
 	return Value{typ: TypePromise, obj: promiseToUnsafe(promise)}
 }
 
-// ResolvePromise fulfills a promise with a value (exported wrapper)
+// ResolvePromise fulfills a promise with a value. This is the entry point for
+// host goroutines (fetch, ReadableStream, timers), which must never execute JS
+// themselves - so when the value might be a thenable, the whole resolution is
+// queued as a microtask and runs on the VM's goroutine instead. Queuing still
+// happens-before the caller returns, so the runtime sees pending work and stays
+// awake (#238). Everything else settles synchronously, as it always has.
 func (vm *VM) ResolvePromise(promise *PromiseObject, value Value) {
+	if vm.hasPotentialThen(value) {
+		vm.GetAsyncRuntime().ScheduleMicrotask(func() {
+			vm.resolvePromise(promise, value)
+		})
+		return
+	}
 	vm.resolvePromise(promise, value)
 }
 
@@ -664,4 +760,56 @@ func (vm *VM) RejectPromise(promise *PromiseObject, reason Value) {
 // AddPromiseReaction adds a reaction to a promise (exported wrapper)
 func (vm *VM) AddPromiseReaction(promiseVal Value, isFulfilled bool, callback func(Value)) {
 	vm.addPromiseReaction(promiseVal, isFulfilled, callback)
+}
+
+// hasPotentialThen reports whether v could be a thenable, WITHOUT running any
+// JS: it looks for a `then` slot - data property or accessor - on v's own
+// storage and along its [[Prototype]] chain, but never invokes a getter.
+//
+// This exists for ResolvePromise, the entry point host goroutines use (fetch's
+// HTTP goroutine, ReadableStream's pump). Those must not execute JS, so they
+// cannot do the spec's Get(resolution, "then") inline; but they also must not
+// unconditionally defer, because a settle that happens after the caller's
+// EndExternalOp loses the happen-before that keeps the runtime awake (#238).
+// A conservative "no `then` anywhere" answer lets the overwhelmingly common
+// case - resolving with a Response, an iterator result, an array - settle
+// synchronously exactly as before.
+func (vm *VM) hasPotentialThen(v Value) bool {
+	if !v.IsObject() && !v.IsFunction() {
+		return false
+	}
+	current := v
+	for i := 0; i < 100; i++ {
+		if props := OwnPropertiesTable(current); props != nil {
+			if _, _, _, _, isAccessor := props.GetOwnAccessor("then"); isAccessor {
+				return true
+			}
+			if _, ok := props.GetOwn("then"); ok {
+				return true
+			}
+		}
+		switch current.Type() {
+		case TypeObject:
+			po := current.AsPlainObject()
+			if _, _, _, _, isAccessor := po.GetOwnAccessor("then"); isAccessor {
+				return true
+			}
+			if _, ok := po.GetOwn("then"); ok {
+				return true
+			}
+		case TypeDictObject:
+			if _, ok := current.AsDictObject().GetOwn("then"); ok {
+				return true
+			}
+		case TypeProxy:
+			// A proxy's get trap is arbitrary JS; assume it may produce one.
+			return true
+		}
+		next := vm.prototypeOf(current)
+		if next.Type() == TypeNull || next.Type() == TypeUndefined || next.Equals(current) {
+			return false
+		}
+		current = next
+	}
+	return false
 }

--- a/pkg/vm/promise_goroutine_race_test.go
+++ b/pkg/vm/promise_goroutine_race_test.go
@@ -136,3 +136,49 @@ func TestAddAwaitReactionsDoesNotLeakOnSettledPromise(t *testing.T) {
 		}
 	})
 }
+
+// TestPromiseGoroutineResolveThenableRace covers ResolvePromise's thenable
+// branch, which is the one path where a host-goroutine resolution cannot settle
+// inline: assimilating a thenable means reading and calling JS, so the whole
+// resolution is queued as a microtask and runs on the VM's goroutine. The race
+// this guards is the queueing itself happening concurrently with the VM
+// draining that queue.
+func TestPromiseGoroutineResolveThenableRace(t *testing.T) {
+	vmInstance := NewVM()
+	p := vmInstance.NewPendingPromise()
+	promise := p.AsPromise()
+
+	// A thenable whose `then` immediately fulfills, built as a plain object so
+	// hasPotentialThen finds the slot without running anything.
+	thenable := NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	thenable.SetOwn("then", NewNativeFunction(2, false, "then", func(args []Value) (Value, error) {
+		if len(args) > 0 && args[0].IsCallable() {
+			_, _ = vmInstance.Call(args[0], Undefined, []Value{NumberValue(42)})
+		}
+		return Undefined, nil
+	}))
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		vmInstance.ResolvePromise(promise, NewValueFromPlainObject(thenable))
+	}()
+
+	// Drain microtasks from this goroutine, the way the VM's own loop does,
+	// while the goroutine above is enqueueing into the same runtime.
+	rt := vmInstance.GetAsyncRuntime()
+	deadline := time.Now().Add(2 * time.Second)
+	for promise.GetState() == PromisePending {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for goroutine to resolve promise with a thenable")
+		}
+		rt.RunUntilIdle()
+		time.Sleep(time.Millisecond)
+	}
+
+	if state := promise.GetState(); state != PromiseFulfilled {
+		t.Fatalf("expected PromiseFulfilled, got %v", state)
+	}
+	if result := promise.GetResult(); result.ToFloat() != 42 {
+		t.Fatalf("expected the thenable's resolution value 42, got %v", result.Inspect())
+	}
+}

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -106,6 +106,16 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 		}
 	}
 
+	// An async function's `constructor` is %AsyncFunction%. This VM does not
+	// give async functions the %AsyncFunction.prototype% intrinsic - their
+	// [[Prototype]] is plain Function.prototype - so the chain walk below,
+	// which now continues into built-in constructors, would answer Function.
+	// Resolved here, ahead of the walk, to keep the answer it had when the
+	// walk stopped at the first NativeFunctionWithProps.
+	if propName == "constructor" && fn != nil && fn.IsAsync && !fn.IsGenerator && vm.AsyncFunctionConstructor.IsCallable() {
+		return vm.AsyncFunctionConstructor, true
+	}
+
 	// Walk the closure's [[Prototype]] chain for inherited static properties (class inheritance)
 	// This handles `class C extends B { }` where C.staticMethod should find B.staticMethod
 	// Only walk user-defined class constructors (Closure/Function), stop at built-in prototypes
@@ -196,9 +206,54 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 					return prop, true
 				}
 				proto = po.GetPrototype()
+			case TypeNativeFunctionWithProps, TypeNativeFunction:
+				// `caller` and `arguments` are modelled only as
+				// Function.prototype's %ThrowTypeError% poison-pill accessors
+				// here; ordinary non-strict functions carry no own legacy
+				// versions to shadow them. Reaching the pill through this new
+				// link would turn every legacy `f.caller` read into a throw,
+				// where both this VM (undefined) and V8 (null) answer with a
+				// value - so leave those two to the handling further down.
+				if propName == "caller" || propName == "arguments" {
+					proto = Null
+					break
+				}
+				// A built-in constructor standing in the chain, i.e.
+				// `class P extends Promise {}`. This used to hit the default
+				// below and stop dead, so a class extending a native
+				// constructor inherited none of its statics - Promise.resolve,
+				// Uint8Array.from, Map.groupBy and friends were all undefined
+				// on the subclass. Function.prototype is itself one of these
+				// and is reached the same way, which is what the old comment
+				// meant by "handled by the FunctionPrototype lookup below";
+				// finding call/apply/bind here instead gives the same answer.
+				props := OwnPropertiesTable(proto)
+				if props == nil {
+					proto = Null
+					break
+				}
+				if getter, _, _, _, exists := props.GetOwnAccessor(propName); exists {
+					if getter.Type() != TypeUndefined {
+						res, err := vm.Call(getter, objVal, nil)
+						if err != nil {
+							if ee, ok := err.(ExceptionError); ok {
+								vm.throwException(ee.GetExceptionValue())
+							} else {
+								vm.throwException(NewString(err.Error()))
+							}
+							return Undefined, false
+						}
+						return res, true
+					}
+					return Undefined, true
+				}
+				if prop, exists := props.GetOwn(propName); exists {
+					return prop, true
+				}
+				proto = props.GetPrototype()
 			default:
-				// Stop at built-in prototypes (NativeFunctionWithProps like Function.prototype)
-				// These are handled by the FunctionPrototype lookup below
+				// Any other kind can't carry static properties in this VM's
+				// model; stop rather than spin.
 				proto = Null
 			}
 		}
@@ -836,6 +891,18 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 		}
 	default:
 		return Undefined, false
+	}
+
+	// [[Get]] checks the object's own properties before its prototype's. Only
+	// the TypeTypedArray case above did that; every other exotic kind walked
+	// straight to the prototype, so a property the instance genuinely owned was
+	// shadowed whenever the prototype happened to have one of the same name -
+	// most visibly `constructor`, which made
+	// `p.constructor = C; p.constructor` answer the intrinsic (and left
+	// test262's built-ins/Promise/prototype/then/ctor-custom.js unreachable
+	// even with correct SpeciesConstructor support).
+	if v, ok := vm.getOwnInstanceProperty(objVal, propName); ok {
+		return v, true
 	}
 
 	if prototype != nil {

--- a/pkg/vm/proto.go
+++ b/pkg/vm/proto.go
@@ -78,9 +78,18 @@ func (vm *VM) prototypeOf(v Value) Value {
 		}
 		return vm.FunctionPrototype
 	case TypeNativeFunctionWithProps:
+		// A built-in function's [[Prototype]] is Function.prototype unless one
+		// was explicitly installed (the TypedArray constructors, whose is
+		// %TypedArray%). An untouched Properties table reports the default
+		// object prototype, which is not the answer here - leaving it made
+		// `Map instanceof Function` false. Mirrors getPrototypeOfValue's
+		// TypeNativeFunctionWithProps case (pkg/builtins/object_init.go).
 		nfp := v.AsNativeFunctionWithProps()
 		if nfp.Properties != nil {
-			return nfp.Properties.GetPrototype()
+			proto := nfp.Properties.GetPrototype()
+			if proto.Type() != TypeUndefined && proto.Type() != TypeNull && proto != DefaultObjectPrototype {
+				return proto
+			}
 		}
 		return vm.FunctionPrototype
 	case TypeNativeFunction, TypeBoundFunction, TypeAsyncNativeFunction:
@@ -227,4 +236,136 @@ func (vm *VM) TypedArrayPrototypeForKind(kind TypedArrayKind) Value {
 	default:
 		return vm.TypedArrayPrototype
 	}
+}
+
+// plainPrototypeOf resolves v's [[Prototype]] for the property-read paths,
+// returning nil when it is not a PlainObject.
+//
+// The read paths walk chains with AsPlainObject, whose pointer reinterpretation
+// is only valid for TypeObject. Value.IsObject() is NOT a sufficient guard: it
+// is the contiguous [TypeObject, TypeProxy] range check (see the comment on
+// getPropertyWithReceiver's TypeObject case), so a Proxy or DictObject standing
+// in as a [[Prototype]] - reachable from ordinary code via
+// `Reflect.construct(C, args, F)` with an exotic `F.prototype` - passes it and
+// then panics the VM. Callers that get nil should treat the chain as exhausted.
+func (vm *VM) plainPrototypeOf(v Value) *PlainObject {
+	proto := vm.PrototypeOf(v)
+	if proto.Type() != TypeObject {
+		return nil
+	}
+	return proto.AsPlainObject()
+}
+
+// lookupOnPrototypeChain walks a PlainObject [[Prototype]] chain for a
+// string-keyed property, invoking an accessor's getter with this = receiver.
+//
+// This is the shared form of the walk that the per-kind blocks in opGetProp
+// (WeakMap, WeakSet, ArrayBuffer, SharedArrayBuffer, DataView, RegExp) each
+// used to hand-roll. Those copies had two defects this fixes: they started from
+// the hardcoded intrinsic prototype rather than the instance's own, so a
+// subclass's methods were unreachable, and they only ever did GetOwn, so a
+// subclass's getter read as undefined.
+func (vm *VM) lookupOnPrototypeChain(start *PlainObject, propName string, receiver Value) (Value, bool, error) {
+	for current := start; current != nil; {
+		if getter, _, _, _, isAccessor := current.GetOwnAccessor(propName); isAccessor {
+			if getter.Type() == TypeUndefined {
+				// Setter-only accessor reads as undefined per spec.
+				return Undefined, true, nil
+			}
+			res, err := vm.Call(getter, receiver, nil)
+			if err != nil {
+				return Undefined, false, err
+			}
+			return res, true, nil
+		}
+		if v, exists := current.GetOwn(propName); exists {
+			return v, true, nil
+		}
+		protoVal := current.GetPrototype()
+		if protoVal.Type() != TypeObject {
+			break
+		}
+		current = protoVal.AsPlainObject()
+	}
+	return Undefined, false, nil
+}
+
+// finishProtoChainGet resolves propName on receiver's own [[Prototype]] chain
+// and writes the result - Undefined when absent, per spec - into dest, in
+// opGetProp's (ok, status, value) shape. A getter that throws is converted into
+// a VM exception the same way opGetPropSymbol's accessor branches do.
+func (vm *VM) finishProtoChainGet(frame *CallFrame, ip int, frameWasNil bool, propName string, receiver Value, dest *Value) (bool, InterpretResult, Value) {
+	v, found, err := vm.lookupOnPrototypeChain(vm.plainPrototypeOf(receiver), propName, receiver)
+	if err != nil {
+		var excVal Value
+		if ee, ok := err.(ExceptionError); ok {
+			excVal = ee.GetExceptionValue()
+		} else {
+			excVal = vm.errorValueFromGoError(err)
+		}
+		if frame != nil && !frameWasNil {
+			frame.ip = ip - 4
+		}
+		vm.throwException(excVal)
+		if !vm.unwinding {
+			return false, InterpretOK, Undefined
+		}
+		return false, InterpretRuntimeError, Undefined
+	}
+	if found {
+		*dest = v
+		return true, InterpretOK, *dest
+	}
+	*dest = Undefined
+	return true, InterpretOK, *dest
+}
+
+// getOwnInstanceProperty returns an own, non-index property stored directly on
+// an exotic instance - the lazily-created side table that a plain
+// `promise.foo = 1` / Object.defineProperty writes into for RegExp/Map/Set/
+// Promise (and functions), plus the per-kind own storage Array, TypedArray,
+// ArrayBuffer and SharedArrayBuffer keep. An own accessor's getter is invoked
+// with `this` = objVal.
+//
+// This exists so a prototype lookup can be preceded by the own-property check
+// [[Get]] requires. Without it `p.constructor = C` on a Promise (or Map, Set,
+// RegExp, Array) read back as the intrinsic constructor: the own value was
+// stored and Object.getOwnPropertyDescriptor could see it, but the read path
+// reached the prototype's `constructor` first and stopped there.
+func (vm *VM) getOwnInstanceProperty(objVal Value, propName string) (Value, bool) {
+	if props := OwnPropertiesTable(objVal); props != nil {
+		if g, _, _, _, isAccessor := props.GetOwnAccessor(propName); isAccessor {
+			if g.Type() == TypeUndefined {
+				return Undefined, true
+			}
+			res, err := vm.Call(g, objVal, nil)
+			if err != nil {
+				return Undefined, false
+			}
+			return res, true
+		}
+		if v, ok := props.GetOwn(propName); ok {
+			return v, true
+		}
+		return Undefined, false
+	}
+	switch objVal.Type() {
+	case TypeArray:
+		if arr := objVal.AsArray(); arr != nil {
+			return arr.GetOwn(propName)
+		}
+	case TypeTypedArray:
+		if ta := objVal.AsTypedArray(); ta != nil {
+			return ta.GetOwnProperty(propName)
+		}
+	case TypeArrayBuffer:
+		if ab := objVal.AsArrayBuffer(); ab != nil {
+			return ab.GetOwnProperty(propName)
+		}
+	case TypeSharedArrayBuffer:
+		if sab := objVal.AsSharedArrayBuffer(); sab != nil {
+			return sab.GetOwnProperty(propName)
+		}
+	}
+	return Undefined, false
 }

--- a/pkg/vm/symbol_lookup.go
+++ b/pkg/vm/symbol_lookup.go
@@ -1,0 +1,253 @@
+package vm
+
+// Symbol-keyed property lookup across the callable object flavours.
+//
+// Historically every branch of opGetPropSymbol re-implemented its own walk,
+// and only TypeObject/TypeNativeFunction ever invoked an accessor's getter.
+// That made a symbol-keyed accessor on a constructor (the shape every
+// well-known-symbol accessor takes, e.g. `get [Symbol.species]`) unreadable:
+// `RegExp[Symbol.species]` returned undefined even though the accessor was
+// correctly defined and `descriptor.get.call(RegExp)` worked. Inherited
+// accessors were worse off still - lookupSymbolOnProtoChain took no receiver,
+// so it structurally could not call a getter with the right `this`, which is
+// exactly what `Uint8Array[Symbol.species]` (inherited from %TypedArray%) and
+// `class Foo extends Uint8Array {}` -> `Foo[Symbol.species]` need.
+//
+// The helpers here centralise both halves: resolving the slot along the real
+// [[Prototype]] chain, and invoking a found getter with the original receiver.
+
+// symbolSlot is the result of resolving a symbol-keyed property along a
+// prototype chain. When found is true exactly one of the accessor/data halves
+// is meaningful: isAccessor selects which.
+type symbolSlot struct {
+	found      bool
+	isAccessor bool
+	getter     Value // meaningful when isAccessor; Undefined for a setter-only accessor
+	value      Value // meaningful when !isAccessor
+}
+
+// symbolPropsAndProto returns the own property table(s) backing v - empty when
+// it has none yet, and two for a closure, whose lazily-created per-closure
+// table sits in front of its shared FunctionObject's - along with v's
+// [[Prototype]]. It mirrors getPrototypeOfValue's function
+// cases in pkg/builtins/object_init.go: a class constructor's [[Prototype]] is
+// its FunctionObject.Prototype (set to the superclass by `extends`), and a
+// built-in constructor's is its Properties table's prototype - which is how
+// Uint8Array reaches %TypedArray%. Returning FunctionPrototype as the fallback
+// keeps plain functions terminating on Function.prototype as before.
+func (vm *VM) symbolPropsAndProto(v Value) ([]*PlainObject, Value, bool) {
+	switch v.Type() {
+	case TypeObject:
+		po := v.AsPlainObject()
+		if po == nil {
+			return nil, Undefined, false
+		}
+		return []*PlainObject{po}, po.GetPrototype(), true
+	case TypeDictObject:
+		// DictObject has no symbol-key storage; only its prototype matters.
+		d := v.AsDictObject()
+		if d == nil {
+			return nil, Undefined, false
+		}
+		return nil, d.GetPrototype(), true
+	case TypeFunction:
+		fn := v.AsFunction()
+		if fn == nil {
+			return nil, Undefined, false
+		}
+		return []*PlainObject{fn.Properties}, vm.functionProtoOrDefault(fn.Prototype), true
+	case TypeClosure:
+		cl := v.AsClosure()
+		if cl == nil {
+			return nil, Undefined, false
+		}
+		proto := Undefined
+		if cl.Fn != nil {
+			proto = cl.Fn.Prototype
+		}
+		// A closure's own Properties shadow its FunctionObject's, but both are
+		// consulted: the per-closure table is created lazily, so a property
+		// installed on the shared FunctionObject still has to be visible once
+		// the closure grows a table of its own.
+		var tables []*PlainObject
+		if cl.Properties != nil {
+			tables = append(tables, cl.Properties)
+		}
+		if cl.Fn != nil && cl.Fn.Properties != nil {
+			tables = append(tables, cl.Fn.Properties)
+		}
+		return tables, vm.functionProtoOrDefault(proto), true
+	case TypeNativeFunction:
+		nf := v.AsNativeFunction()
+		if nf == nil {
+			return nil, Undefined, false
+		}
+		return []*PlainObject{nf.Properties}, vm.FunctionPrototype, true
+	case TypeNativeFunctionWithProps:
+		nfp := v.AsNativeFunctionWithProps()
+		if nfp == nil {
+			return nil, Undefined, false
+		}
+		if nfp.Properties == nil {
+			return nil, vm.FunctionPrototype, true
+		}
+		proto := nfp.Properties.GetPrototype()
+		if proto.Type() == TypeUndefined || proto.Type() == TypeNull || proto == DefaultObjectPrototype {
+			// Built-ins default to Function.prototype unless a custom
+			// [[Prototype]] was installed (e.g. the TypedArray constructors,
+			// whose Properties prototype is %TypedArray%).
+			proto = vm.FunctionPrototype
+		}
+		return []*PlainObject{nfp.Properties}, proto, true
+	case TypeBoundFunction:
+		bf := v.AsBoundFunction()
+		if bf == nil {
+			return nil, Undefined, false
+		}
+		return []*PlainObject{bf.Properties}, vm.FunctionPrototype, true
+	}
+	return nil, Undefined, false
+}
+
+// functionProtoOrDefault normalises an unset function [[Prototype]] to
+// Function.prototype so the walk still reaches the intrinsics.
+func (vm *VM) functionProtoOrDefault(proto Value) Value {
+	if proto.Type() == TypeUndefined || proto.Type() == TypeNull {
+		return vm.FunctionPrototype
+	}
+	return proto
+}
+
+// findSymbolSlot resolves key starting at start (inclusive) and walking the
+// [[Prototype]] chain, reporting an accessor without invoking it so the caller
+// can supply the correct receiver.
+func (vm *VM) findSymbolSlot(start Value, key PropertyKey) symbolSlot {
+	current := start
+	// The depth cap matches the one the per-flavour walks this replaced used:
+	// real chains are a handful of links, and a cycle installed via
+	// Object.setPrototypeOf (which the proto == current check below only
+	// catches when it is a self-loop) should cost as little as possible on a
+	// path that now runs for every symbol read on every constructor.
+	for i := 0; i < 100; i++ {
+		tables, proto, ok := vm.symbolPropsAndProto(current)
+		if !ok {
+			break
+		}
+		for _, props := range tables {
+			if props == nil {
+				continue
+			}
+			if g, _, _, _, isAcc := props.GetOwnAccessorByKey(key); isAcc {
+				return symbolSlot{found: true, isAccessor: true, getter: g}
+			}
+			if v, exists := props.GetOwnByKey(key); exists {
+				return symbolSlot{found: true, value: v}
+			}
+		}
+		if proto.Type() == TypeUndefined || proto.Type() == TypeNull {
+			break
+		}
+		// Self-referential prototype: stop rather than spin.
+		if proto == current {
+			break
+		}
+		current = proto
+	}
+	return symbolSlot{}
+}
+
+// resolveSymbolSlot is findSymbolSlot plus getter invocation, returning the
+// value in the same (ok, status, value) shape opGetPropSymbol's branches use.
+func (vm *VM) resolveSymbolSlot(frame *CallFrame, ip int, frameWasNil bool, base Value, key PropertyKey, dest *Value) (bool, InterpretResult, Value) {
+	slot := vm.findSymbolSlot(base, key)
+	if !slot.found {
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+	if !slot.isAccessor {
+		*dest = slot.value
+		return true, InterpretOK, *dest
+	}
+	return vm.invokeSymbolGetter(frame, ip, frameWasNil, slot.getter, base, dest)
+}
+
+// invokeSymbolGetter calls getter with `this` = receiver, translating a Go
+// error into a thrown VM exception. The frame.ip = ip - 4 rewind matches what
+// opGetPropSymbol's existing accessor branches do so a getter that throws
+// still reports the property-access site.
+func (vm *VM) invokeSymbolGetter(frame *CallFrame, ip int, frameWasNil bool, getter Value, receiver Value, dest *Value) (bool, InterpretResult, Value) {
+	if getter.Type() == TypeUndefined {
+		// Setter-only accessor: reads as undefined per spec.
+		*dest = Undefined
+		return true, InterpretOK, *dest
+	}
+	res, err := vm.Call(getter, receiver, nil)
+	if err == nil {
+		*dest = res
+		return true, InterpretOK, *dest
+	}
+
+	var excVal Value
+	if ee, ok := err.(ExceptionError); ok {
+		excVal = ee.GetExceptionValue()
+	} else {
+		excVal = vm.errorValueFromGoError(err)
+	}
+	if frame != nil && !frameWasNil {
+		frame.ip = ip - 4
+	}
+	vm.throwException(excVal)
+	if !vm.unwinding {
+		return false, InterpretOK, Undefined
+	}
+	return false, InterpretRuntimeError, Undefined
+}
+
+// errorValueFromGoError wraps a non-exception Go error as a JS Error value.
+func (vm *VM) errorValueFromGoError(err error) Value {
+	if errCtor, ok := vm.GetGlobal("Error"); ok {
+		if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+			return res
+		}
+	}
+	eo := NewObject(vm.ErrorPrototype).AsPlainObject()
+	eo.SetOwn("name", NewString("Error"))
+	eo.SetOwn("message", NewString(err.Error()))
+	return NewValueFromPlainObject(eo)
+}
+
+// symbolProtoOf returns v's [[Prototype]] as used by the symbol-key walk, or
+// Undefined for kinds this walk doesn't model.
+func (vm *VM) symbolProtoOf(v Value) Value {
+	_, proto, ok := vm.symbolPropsAndProto(v)
+	if !ok {
+		return Undefined
+	}
+	return proto
+}
+
+// lookupSymbolWithReceiver resolves key starting at start (inclusive), walking
+// the [[Prototype]] chain and invoking any accessor's getter with `this` =
+// receiver. Unlike resolveSymbolSlot it returns a Go error instead of throwing
+// into the interpreter loop, for the native-facing callers (Proxy targets,
+// GetSymbolPropertyWithGetter) that need to propagate one.
+func (vm *VM) lookupSymbolWithReceiver(start Value, key PropertyKey, receiver Value) (Value, bool, error) {
+	slot := vm.findSymbolSlot(start, key)
+	if !slot.found {
+		return Undefined, false, nil
+	}
+	if !slot.isAccessor {
+		return slot.value, true, nil
+	}
+	if slot.getter.Type() == TypeUndefined {
+		return Undefined, true, nil
+	}
+	res, err := vm.Call(slot.getter, receiver, nil)
+	if err != nil {
+		if ee, ok := err.(ExceptionError); ok {
+			vm.throwException(ee.GetExceptionValue())
+		}
+		return Undefined, false, err
+	}
+	return res, true, nil
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4014,9 +4014,17 @@ startExecution:
 			// Check if objVal has a prototype chain to walk (is an object)
 			// Per ECMAScript 7.3.21 OrdinaryHasInstance step 3:
 			// If Type(O) is not Object, return false.
-			if objVal.IsObject() || objVal.Type() == TypeArray || objVal.Type() == TypeRegExp ||
-				objVal.Type() == TypeMap || objVal.Type() == TypeSet || objVal.Type() == TypeArguments ||
-				objVal.Type() == TypeFunction || objVal.Type() == TypeClosure || objVal.Type() == TypePromise {
+			//
+			// IsObject() is the contiguous [TypeObject, TypeProxy] range check,
+			// so the Array/RegExp/Map/Set/Arguments/Promise arms this replaces
+			// were already redundant; what the enumeration actually left out
+			// were four of the six callable kinds - TypeNativeFunction,
+			// TypeNativeFunctionWithProps, TypeAsyncNativeFunction and
+			// TypeBoundFunction. Functions are objects, so
+			// `Map.prototype.get instanceof Function` and `Map instanceof
+			// Function` answered false purely because the operand never
+			// reached the walk below. IsFunction() covers exactly those six.
+			if objVal.IsObject() || objVal.IsFunction() {
 				// Per ECMAScript 7.3.21 OrdinaryHasInstance step 5:
 				// If Type(P) is not Object, throw a TypeError exception
 				// (This only applies when O is an object)
@@ -4043,27 +4051,26 @@ startExecution:
 				// DataView/TypedArray/WeakMap/WeakSet and answered false for them.
 				current := vm.prototypeOf(objVal)
 
-				// Walk the prototype chain
-				for current.typ != TypeNull && current.typ != TypeUndefined {
+				// Walk the prototype chain. Each step goes through
+				// vm.prototypeOf, the same helper that produced the first
+				// link, rather than a local per-kind switch: the switch this
+				// replaces stepped a NativeFunctionWithProps via
+				// nfp.Properties.GetPrototype() directly, which reports the
+				// default object prototype for a built-in that never had one
+				// installed and so lost the chain - `Uint8Array instanceof
+				// Function` (Uint8Array -> %TypedArray% -> Function.prototype)
+				// answered false. The bound also guards against a prototype
+				// cycle installed via Object.setPrototypeOf.
+				for i := 0; i < 1000 && current.typ != TypeNull && current.typ != TypeUndefined; i++ {
 					if current.Equals(constructorPrototype) {
 						result = true
 						break
 					}
-					if current.IsObject() {
-						if current.Type() == TypeObject {
-							current = current.AsPlainObject().GetPrototype()
-						} else if current.Type() == TypeDictObject {
-							current = current.AsDictObject().GetPrototype()
-						} else {
-							break
-						}
-					} else if current.Type() == TypeNativeFunctionWithProps {
-						// Handle callable Function.prototype
-						nfp := current.AsNativeFunctionWithProps()
-						current = nfp.Properties.GetPrototype()
-					} else {
+					next := vm.prototypeOf(current)
+					if next.Equals(current) {
 						break
 					}
+					current = next
 				}
 			}
 

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -490,12 +490,12 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 			if v, ok := arr.GetOwn(propName); ok {
 				return v, nil
 			}
-			// Check array prototype
-			if vm.ArrayPrototype.IsObject() {
-				proto := vm.ArrayPrototype.AsPlainObject()
-				if v, ok := proto.Get(propName); ok {
-					return v, nil
-				}
+			// vm.plainPrototypeOf(obj) rather than the hardcoded
+			// Array.prototype: a `class S extends Array {}` instance carries
+			// its own [[Prototype]], and starting from the intrinsic made
+			// every override on S.prototype unreachable from native code.
+			if v, found, err := vm.lookupOnPrototypeChain(vm.plainPrototypeOf(obj), propName, receiver); found || err != nil {
+				return v, err
 			}
 		}
 		return Undefined, nil
@@ -574,9 +574,21 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 				return v, nil
 			}
 		}
-		if vm.PromisePrototype.IsObject() {
-			proto := vm.PromisePrototype.AsPlainObject()
-			if v, ok := proto.Get(propName); ok {
+		// vm.PrototypeOf, not vm.PromisePrototype: a promise built by a
+		// subclass constructor carries a per-instance [[Prototype]] override,
+		// and hardcoding the intrinsic made every native read on such a
+		// promise - `constructor` above all, which is step 1 of
+		// SpeciesConstructor - answer as though it were a plain Promise. The
+		// bytecode read path (pkg/vm/property_helpers.go's TypePromise case)
+		// has honored the override since paserati#198.
+		// Type() == TypeObject, not IsObject(): IsObject is the contiguous
+		// [TypeObject, TypeProxy] range check, so a [[Prototype]] that is a
+		// Proxy/DictObject/Array (reachable via Reflect.construct with a
+		// newTarget whose .prototype is one) would pass it and then have its
+		// pointer reinterpreted by AsPlainObject. Same guard as
+		// property_helpers.go's per-kind cases.
+		if proto := vm.PrototypeOf(obj); proto.Type() == TypeObject {
+			if v, ok := proto.AsPlainObject().Get(propName); ok {
 				return v, nil
 			}
 		}
@@ -596,48 +608,13 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 					return v, nil
 				}
 			}
-			// Check RegExp.prototype (with accessor invocation)
-			if vm.RegExpPrototype.IsObject() {
-				proto := vm.RegExpPrototype.AsPlainObject()
-				if proto != nil {
-					// Check for accessor property (getter) on prototype
-					if g, _, _, _, ok := proto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-						// Call the getter with this=original RegExp object
-						result, err := vm.Call(g, receiver, nil)
-						if err != nil {
-							return Undefined, err
-						}
-						return result, nil
-					}
-					// Check for data property on prototype
-					if v, ok := proto.GetOwn(propName); ok {
-						return v, nil
-					}
-					// Walk prototype chain (Object.prototype)
-					current := proto.GetPrototype()
-					for current.typ != TypeNull && current.typ != TypeUndefined {
-						if current.IsObject() {
-							if current.Type() == TypeObject {
-								grandProto := current.AsPlainObject()
-								if g, _, _, _, ok := grandProto.GetOwnAccessor(propName); ok && g.Type() != TypeUndefined {
-									result, err := vm.Call(g, receiver, nil)
-									if err != nil {
-										return Undefined, err
-									}
-									return result, nil
-								}
-								if v, ok := grandProto.GetOwn(propName); ok {
-									return v, nil
-								}
-								current = grandProto.GetPrototype()
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					}
-				}
+			// vm.plainPrototypeOf(obj) rather than the hardcoded
+			// RegExp.prototype: a `class S extends RegExp {}` instance carries
+			// its own [[Prototype]], and starting from the intrinsic meant
+			// Symbol.replace/match/split - which read `exec` off the regexp
+			// natively - could never see a subclass's override.
+			if v, found, err := vm.lookupOnPrototypeChain(vm.plainPrototypeOf(obj), propName, receiver); found || err != nil {
+				return v, err
 			}
 		}
 		return Undefined, nil
@@ -670,38 +647,21 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 			if idx, err := strconv.Atoi(propName); err == nil && idx >= 0 && idx < ta.GetLength() {
 				return ta.GetElement(idx), nil
 			}
-			// Get the specific TypedArray prototype based on element type
-			var proto Value
-			switch ta.GetElementType() {
-			case TypedArrayInt8:
-				proto = vm.Int8ArrayPrototype
-			case TypedArrayUint8:
-				proto = vm.Uint8ArrayPrototype
-			case TypedArrayUint8Clamped:
-				proto = vm.Uint8ClampedArrayPrototype
-			case TypedArrayInt16:
-				proto = vm.Int16ArrayPrototype
-			case TypedArrayUint16:
-				proto = vm.Uint16ArrayPrototype
-			case TypedArrayInt32:
-				proto = vm.Int32ArrayPrototype
-			case TypedArrayUint32:
-				proto = vm.Uint32ArrayPrototype
-			case TypedArrayFloat16:
-				proto = vm.Float16ArrayPrototype
-			case TypedArrayFloat32:
-				proto = vm.Float32ArrayPrototype
-			case TypedArrayFloat64:
-				proto = vm.Float64ArrayPrototype
-			case TypedArrayBigInt64:
-				proto = vm.BigInt64ArrayPrototype
-			case TypedArrayBigUint64:
-				proto = vm.BigUint64ArrayPrototype
-			default:
-				proto = vm.TypedArrayPrototype
-			}
-			// Check prototype chain - need to check for accessors (getters) first
-			if proto.IsObject() {
+			// vm.PrototypeOf, not a local element-type switch: a typed array
+			// built by a subclass constructor (`class Foo extends Uint8Array {}`)
+			// or by Reflect.construct with a custom newTarget carries a
+			// per-instance [[Prototype]] override, and only PrototypeOf consults
+			// it before falling back to the intrinsic for the element type. The
+			// bytecode read path (pkg/vm/property_helpers.go's TypeTypedArray
+			// case) has always honored the override; these native ones silently
+			// resolved every subclass instance to the intrinsic prototype, which
+			// is why TypedArraySpeciesCreate read `constructor` as Uint8Array and
+			// filter/map/subarray never produced subclass results.
+			proto := vm.PrototypeOf(obj)
+			// Check prototype chain - need to check for accessors (getters) first.
+			// Type() == TypeObject rather than IsObject() - see the TypePromise
+			// case above for why the range check is not safe before AsPlainObject.
+			if proto.Type() == TypeObject {
 				cur := proto.AsPlainObject()
 				for cur != nil {
 					// Check for accessor (getter) first
@@ -757,24 +717,13 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 				return v, nil
 			}
 		}
-		if vm.SetPrototype.IsObject() {
-			proto := vm.SetPrototype.AsPlainObject()
-			// Check for accessor (getter) first
-			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
-				if getter.Type() != TypeUndefined {
-					// Call the getter with this=receiver (the Set)
-					result, err := vm.Call(getter, receiver, nil)
-					if err != nil {
-						return Undefined, err
-					}
-					return result, nil
-				}
-				return Undefined, nil
-			}
-			// Check for regular property
-			if v, ok := proto.Get(propName); ok {
-				return v, nil
-			}
+		// vm.plainPrototypeOf(obj) rather than the hardcoded intrinsic:
+		// a subclass instance carries its own [[Prototype]], and starting
+		// from Set.prototype made every override on it unreachable
+		// from native code. lookupOnPrototypeChain (pkg/vm/proto.go) walks
+		// that chain invoking accessors with this = receiver.
+		if v, found, err := vm.lookupOnPrototypeChain(vm.plainPrototypeOf(obj), propName, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -796,24 +745,13 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 				return v, nil
 			}
 		}
-		if vm.MapPrototype.IsObject() {
-			proto := vm.MapPrototype.AsPlainObject()
-			// Check for accessor (getter) first
-			if getter, _, _, _, ok := proto.GetOwnAccessor(propName); ok {
-				if getter.Type() != TypeUndefined {
-					// Call the getter with this=receiver (the Map)
-					result, err := vm.Call(getter, receiver, nil)
-					if err != nil {
-						return Undefined, err
-					}
-					return result, nil
-				}
-				return Undefined, nil
-			}
-			// Check for regular property
-			if v, ok := proto.Get(propName); ok {
-				return v, nil
-			}
+		// vm.plainPrototypeOf(obj) rather than the hardcoded intrinsic:
+		// a subclass instance carries its own [[Prototype]], and starting
+		// from Map.prototype made every override on it unreachable
+		// from native code. lookupOnPrototypeChain (pkg/vm/proto.go) walks
+		// that chain invoking accessors with this = receiver.
+		if v, found, err := vm.lookupOnPrototypeChain(vm.plainPrototypeOf(obj), propName, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -1091,6 +1029,25 @@ func (vm *VM) getPropertyWithReceiver(obj Value, propName string, receiver Value
 		}
 		return Undefined, nil
 
+	case TypeArrayBuffer, TypeSharedArrayBuffer, TypeDataView,
+		TypeWeakMap, TypeWeakSet, TypeWeakRef, TypeFinalizationRegistry:
+		// These kinds had no case at all and fell through to the primitive
+		// default at the bottom of this switch, which leaves proto unset - so
+		// every native read on them answered undefined, including the
+		// `constructor` that ArrayBuffer.prototype.slice's SpeciesConstructor
+		// step depends on. Own side-table property first (the same table a
+		// plain `ab.foo = 1` writes into), then the instance's own
+		// [[Prototype]] chain so a subclass's overrides are reachable.
+		if props := OwnPropertiesTable(obj); props != nil {
+			if v, found, err := vm.getOwnFromTableByKey(props, keyFromString(propName), receiver); found || err != nil {
+				return v, err
+			}
+		}
+		if v, found, err := vm.lookupOnPrototypeChain(vm.plainPrototypeOf(obj), propName, receiver); found || err != nil {
+			return v, err
+		}
+		return Undefined, nil
+
 	case TypeArguments:
 		// Arguments objects: check length, numeric indices, and named properties
 		args := obj.AsArguments()
@@ -1308,18 +1265,18 @@ func (vm *VM) ReflectGetSymbolPropertyWithReceiver(obj Value, sym Value, receive
 // exactly as it was, not retrofitted onto the same helpers, to avoid
 // risking a regression there for this task's sake.
 //
-// The FunctionPrototype fallback used by every callable kind
+// The prototype-chain fallback used by every callable kind
 // (TypeFunction/TypeClosure/TypeNativeFunction/TypeNativeFunctionWithProps/
-// TypeBoundFunction) reuses the existing lookupSymbolOnProtoChain
-// (pkg/vm/op_getprop.go) rather than walkPlainObjectChainForKey, since
-// Function.prototype itself can be a TypeNativeFunctionWithProps at
-// runtime (see that function's own doc comment) - walkPlainObjectChainForKey
-// only handles a TypeObject chain. Matching lookupSymbolOnProtoChain's
-// existing behavior, this does NOT invoke an accessor's getter found on
-// the FunctionPrototype chain - a real, separate, still-open gap already
-// documented where it was first found (pkg/vm/op_getprop.go's
-// opGetPropSymbol, TypeNativeFunction case), not introduced or widened
-// here.
+// TypeBoundFunction) goes through lookupSymbolWithReceiver
+// (pkg/vm/symbol_lookup.go) rather than walkPlainObjectChainForKey, since a
+// callable's chain can pass through Function.prototype - itself a
+// TypeNativeFunctionWithProps at runtime - and through other constructors,
+// neither of which walkPlainObjectChainForKey's TypeObject-only walk
+// handles. That helper invokes an accessor's getter found anywhere on the
+// chain with this = receiver; an earlier version used
+// lookupSymbolOnProtoChain against a hardcoded Function.prototype and did
+// neither, which is what made an inherited `get [Symbol.species]`
+// unreadable.
 func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value) (Value, error) {
 	key := NewSymbolKey(sym)
 
@@ -1475,40 +1432,13 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 	case TypeTypedArray:
 		// TypedArrays don't expose own symbol-keyed properties (only
 		// indices and the fixed set of string built-ins) - straight to
-		// the element-type-specific prototype, same selection as
-		// getPropertyWithReceiver's TypeTypedArray case.
+		// the prototype, resolved the same way as
+		// getPropertyWithReceiver's TypeTypedArray case: vm.PrototypeOf so a
+		// subclass instance's per-instance override wins over the intrinsic.
 		ta := obj.AsTypedArray()
 		if ta != nil {
-			var proto Value
-			switch ta.GetElementType() {
-			case TypedArrayInt8:
-				proto = vm.Int8ArrayPrototype
-			case TypedArrayUint8:
-				proto = vm.Uint8ArrayPrototype
-			case TypedArrayUint8Clamped:
-				proto = vm.Uint8ClampedArrayPrototype
-			case TypedArrayInt16:
-				proto = vm.Int16ArrayPrototype
-			case TypedArrayUint16:
-				proto = vm.Uint16ArrayPrototype
-			case TypedArrayInt32:
-				proto = vm.Int32ArrayPrototype
-			case TypedArrayUint32:
-				proto = vm.Uint32ArrayPrototype
-			case TypedArrayFloat16:
-				proto = vm.Float16ArrayPrototype
-			case TypedArrayFloat32:
-				proto = vm.Float32ArrayPrototype
-			case TypedArrayFloat64:
-				proto = vm.Float64ArrayPrototype
-			case TypedArrayBigInt64:
-				proto = vm.BigInt64ArrayPrototype
-			case TypedArrayBigUint64:
-				proto = vm.BigUint64ArrayPrototype
-			default:
-				proto = vm.TypedArrayPrototype
-			}
-			if proto.IsObject() {
+			proto := vm.PrototypeOf(obj)
+			if proto.Type() == TypeObject {
 				v, _, err := vm.walkPlainObjectChainForKey(proto, key, receiver)
 				return v, err
 			}
@@ -1546,8 +1476,13 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 				return v, err
 			}
 		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			return v, nil
+		// Walk obj's real [[Prototype]] chain, not a hardcoded
+		// Function.prototype: a class constructor's parent is its superclass
+		// (`class Foo extends Uint8Array {}`), and a built-in constructor's is
+		// whatever its Properties table carries (Uint8Array -> %TypedArray%).
+		// Accessors found along the way are invoked with this = receiver.
+		if v, found, err := vm.lookupSymbolWithReceiver(vm.symbolProtoOf(obj), key, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -1565,8 +1500,10 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 				}
 			}
 		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			return v, nil
+		// obj's real [[Prototype]] chain, accessors invoked with this = receiver
+		// (see this function's doc comment).
+		if v, found, err := vm.lookupSymbolWithReceiver(vm.symbolProtoOf(obj), key, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -1577,8 +1514,10 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 				return v, err
 			}
 		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			return v, nil
+		// obj's real [[Prototype]] chain, accessors invoked with this = receiver
+		// (see this function's doc comment).
+		if v, found, err := vm.lookupSymbolWithReceiver(vm.symbolProtoOf(obj), key, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -1589,8 +1528,10 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 				return v, err
 			}
 		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			return v, nil
+		// obj's real [[Prototype]] chain, accessors invoked with this = receiver
+		// (see this function's doc comment).
+		if v, found, err := vm.lookupSymbolWithReceiver(vm.symbolProtoOf(obj), key, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -1601,8 +1542,10 @@ func (vm *VM) getSymbolPropertyWithReceiver(obj Value, sym Value, receiver Value
 				return v, err
 			}
 		}
-		if found, v := vm.lookupSymbolOnProtoChain(vm.FunctionPrototype, key); found {
-			return v, nil
+		// obj's real [[Prototype]] chain, accessors invoked with this = receiver
+		// (see this function's doc comment).
+		if v, found, err := vm.lookupSymbolWithReceiver(vm.symbolProtoOf(obj), key, receiver); found || err != nil {
+			return v, err
 		}
 		return Undefined, nil
 
@@ -1908,6 +1851,19 @@ func (vm *VM) GetSymbolPropertyWithGetter(obj Value, symbol Value) (Value, bool,
 			cur = protoVal.AsPlainObject()
 		}
 		return Undefined, false, nil
+	}
+
+	// Callables (constructors above all) resolve through the shared
+	// symbol-key walk: own properties, then the real [[Prototype]] chain,
+	// invoking any accessor's getter with this = obj. Without this case the
+	// function kinds fell straight through to the "non-objects" return below,
+	// so native callers such as TypedArraySpeciesCreate read every
+	// constructor's [[Symbol.species]] as absent and silently used the default
+	// constructor - invisible from the bytecode read path, which has its own
+	// implementation in opGetPropSymbol.
+	switch obj.Type() {
+	case TypeFunction, TypeClosure, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction:
+		return vm.lookupSymbolWithReceiver(obj, symKey, obj)
 	}
 
 	// For non-objects, just return undefined

--- a/tests/scripts/promise_resolve_and_instanceof.ts
+++ b/tests/scripts/promise_resolve_and_instanceof.ts
@@ -1,0 +1,57 @@
+// expect: 0
+// Promise.resolve per spec (PromiseResolve(C, x)): honors `this`, and feeds the
+// value through a promise capability's resolve function so a thenable is
+// assimilated instead of becoming the fulfillment value. Plus `instanceof
+// Function` for the callable kinds that never reached the prototype walk.
+
+let fails = 0;
+function chk(name: string, cond: boolean): void {
+  if (!cond) {
+    fails++;
+    console.log("FAIL", name);
+  }
+}
+
+// Functions are objects: every callable kind must walk its prototype chain.
+chk("native method", (Map.prototype.get as any) instanceof Function);
+chk("builtin constructor", (Map as any) instanceof Function);
+chk("bound function", (function () {}).bind(null) instanceof Function);
+chk("user function", function () {} instanceof Function);
+chk("arrow function", (() => {}) instanceof Function);
+// Uint8Array reaches Function.prototype only through %TypedArray%.
+chk("typed array constructor", (Uint8Array as any) instanceof Function);
+chk("function is an Object too", (function () {} as any) instanceof Object);
+// ...and primitives still are not.
+chk("number is not an Object", !((5 as any) instanceof Object));
+chk("string is not an Object", !(("s" as any) instanceof Object));
+
+// Promise.resolve uses `this` as the constructor.
+class SubPromise extends Promise {}
+chk("subclass resolve", (SubPromise as any).resolve(1) instanceof SubPromise);
+chk("subclass statics reachable", typeof (SubPromise as any).resolve === "function");
+
+// A promise already constructed by C passes through identically; one built by a
+// different constructor does not.
+const p: any = Promise.resolve(5);
+chk("identity for same constructor", Promise.resolve(p) === p);
+chk("no identity across constructors", (SubPromise as any).resolve(p) !== p);
+
+// Thenable assimilation is inherently asynchronous - the `then` CALL is a
+// microtask - and this harness compares the last statement's value before the
+// microtask queue drains, so the outcome of an assimilated thenable cannot be
+// asserted here. test262 covers it (built-ins/Promise/resolve/*,
+// built-ins/Promise/prototype/finally/*). What IS synchronously observable is
+// that resolving reads `then` on this tick, which is the step that decides
+// between assimilating and fulfilling with the object.
+let thenWasRead = false;
+const probe: any = {};
+Object.defineProperty(probe, "then", {
+  get() {
+    thenWasRead = true;
+    return undefined;
+  },
+});
+Promise.resolve(probe);
+chk("resolving reads `then` synchronously", thenWasRead);
+
+fails;

--- a/tests/scripts/subclass_builtins.ts
+++ b/tests/scripts/subclass_builtins.ts
@@ -1,0 +1,98 @@
+// expect: 0
+// Subclassing the built-in exotic kinds: a subclass instance carries its own
+// [[Prototype]], and the read paths must consult it rather than the intrinsic.
+// Several kinds had per-kind read blocks that walked straight to the intrinsic
+// prototype, so none of the subclass's methods or getters were reachable.
+
+let fails = 0;
+function chk(name: string, cond: boolean): void {
+  if (!cond) {
+    fails++;
+    console.log("FAIL", name);
+  }
+}
+
+class MyRegExp extends RegExp {
+  tag(): string {
+    return "re";
+  }
+  get marker(): string {
+    return "re-getter";
+  }
+}
+const re: any = new MyRegExp("a");
+chk("regexp method", re.tag() === "re");
+chk("regexp getter", re.marker === "re-getter");
+
+class MyBuffer extends ArrayBuffer {
+  tag(): string {
+    return "ab";
+  }
+}
+const ab: any = new MyBuffer(8);
+chk("arraybuffer method", ab.tag() === "ab");
+chk("arraybuffer slice species", ab.slice(0, 4) instanceof MyBuffer);
+
+class MyShared extends SharedArrayBuffer {
+  tag(): string {
+    return "sab";
+  }
+}
+chk("sharedarraybuffer method", (new MyShared(8) as any).tag() === "sab");
+
+class MyView extends DataView {
+  tag(): string {
+    return "dv";
+  }
+}
+chk("dataview method", (new MyView(new ArrayBuffer(8)) as any).tag() === "dv");
+
+class MyWeakMap extends WeakMap {
+  tag(): string {
+    return "wm";
+  }
+}
+chk("weakmap method", (new MyWeakMap() as any).tag() === "wm");
+
+class MyWeakSet extends WeakSet {
+  tag(): string {
+    return "ws";
+  }
+}
+chk("weakset method", (new MyWeakSet() as any).tag() === "ws");
+
+// Statics are inherited from a native parent constructor.
+class SubPromise extends Promise {}
+class SubBytes extends Uint8Array {}
+class SubMap extends Map {}
+chk("Promise statics", typeof (SubPromise as any).resolve === "function" && typeof (SubPromise as any).all === "function");
+chk("TypedArray statics", typeof (SubBytes as any).from === "function" && typeof (SubBytes as any).of === "function");
+chk("Map statics", typeof (SubMap as any).groupBy === "function");
+chk("BYTES_PER_ELEMENT inherited", (SubBytes as any).BYTES_PER_ELEMENT === 1);
+
+// An own property shadows the prototype's - [[Get]] checks own first. These
+// kinds keep their own properties in a side table that the read path skipped.
+const shadowed: any[] = [new Map(), new Set(), new Promise(() => {}), [], /a/];
+for (const target of shadowed) {
+  target.constructor = "OWN";
+  chk("own constructor shadows prototype", target.constructor === "OWN");
+}
+
+// ...but an inherited getter-only accessor still wins over creating one:
+// assigning through it is a silent no-op, not a new own data property.
+const plainRe: any = /a/;
+plainRe.global = "shifted";
+chk("getter-only accessor rejects assignment", plainRe.global === false);
+chk("no own property was created", Object.getOwnPropertyDescriptor(plainRe, "global") === undefined);
+
+// Async function `constructor` is %AsyncFunction%, not %Function%. This is the
+// regression guard for the hoist in handleCallableProperty: this VM gives async
+// functions plain Function.prototype as their [[Prototype]] instead of
+// %AsyncFunction.prototype%, so the static-inheritance chain walk would
+// otherwise answer Function here.
+const anAsyncFn: any = async function () {};
+const AsyncFunction: any = anAsyncFn.constructor;
+chk("async function constructor", AsyncFunction !== Function && AsyncFunction.name === "AsyncFunction");
+
+
+fails;

--- a/tests/scripts/symbol_species.ts
+++ b/tests/scripts/symbol_species.ts
@@ -1,0 +1,130 @@
+// expect: 0
+// Symbol.species accessors on the built-in constructors (issue #381).
+// Each species-aware constructor carries a `get [Symbol.species]` whose getter
+// returns `this`, so the property is both directly readable and correctly
+// inherited by subclasses.
+
+let fails = 0;
+function chk(name: string, cond: boolean): void {
+  if (!cond) {
+    fails++;
+    console.log("FAIL", name);
+  }
+}
+
+const ctors: any[] = [Array, ArrayBuffer, SharedArrayBuffer, Map, Set, Promise, RegExp];
+for (const C of ctors) {
+  chk(C.name + " returns itself", C[Symbol.species] === C);
+  const d: any = Object.getOwnPropertyDescriptor(C, Symbol.species);
+  chk(C.name + " is an accessor", typeof d.get === "function");
+  chk(C.name + " has no setter", d.set === undefined);
+  chk(C.name + " non-enumerable", d.enumerable === false);
+  chk(C.name + " configurable", d.configurable === true);
+  chk(C.name + " getter name", d.get.name === "get [Symbol.species]");
+  chk(C.name + " getter length", d.get.length === 0);
+}
+
+// The TypedArray constructors inherit the accessor from %TypedArray%: it must
+// answer the subclass, and must NOT appear as an own property of each of them.
+chk("Uint8Array", Uint8Array[Symbol.species] === Uint8Array);
+chk("Int32Array", Int32Array[Symbol.species] === Int32Array);
+chk("Float64Array", Float64Array[Symbol.species] === Float64Array);
+chk("no own species on Uint8Array", Object.getOwnPropertyDescriptor(Uint8Array, Symbol.species) === undefined);
+
+// DataView is not species-aware per spec.
+chk("DataView has none", (DataView as any)[Symbol.species] === undefined);
+
+// User subclasses inherit the getter and answer themselves.
+class MyBytes extends Uint8Array {}
+class MyList extends Array {}
+class MyPromise extends Promise {}
+chk("subclass of Uint8Array", (MyBytes as any)[Symbol.species] === MyBytes);
+chk("subclass of Array", (MyList as any)[Symbol.species] === MyList);
+chk("subclass of Promise", (MyPromise as any)[Symbol.species] === MyPromise);
+
+// ...until it is overridden.
+class Overridden extends Uint8Array {
+  static get [Symbol.species]() {
+    return Uint8Array;
+  }
+}
+chk("override wins", (Overridden as any)[Symbol.species] === Uint8Array);
+
+// The undici pattern from the issue: read the species off a TypedArray
+// constructor and use it to build a view.
+const FastBuffer: any = Uint8Array[Symbol.species];
+const view = new FastBuffer(new ArrayBuffer(8), 0, 4);
+chk("species-constructed view", view.length === 4 && view instanceof Uint8Array);
+
+// Species-aware methods must build their result through the species
+// constructor, which means the native read path has to resolve a subclass
+// instance's own [[Prototype]] rather than the intrinsic one.
+class Bytes extends Uint8Array {}
+const b: any = new Bytes([1, 2, 3, 4]);
+chk("typed array filter", b.filter((v: number) => v > 1) instanceof Bytes);
+chk("typed array map", b.map((v: number) => v) instanceof Bytes);
+chk("typed array slice", b.slice(0, 2) instanceof Bytes);
+chk("typed array subarray", b.subarray(0, 2) instanceof Bytes);
+
+class PlainBytes extends Uint8Array {
+  static get [Symbol.species]() {
+    return Uint8Array;
+  }
+}
+const pb: any = new PlainBytes([1, 2, 3, 4]);
+chk("species override wins over subclass", pb.slice(0, 2).constructor === Uint8Array);
+
+// Promise.prototype.then/catch/finally do SpeciesConstructor(promise, %Promise%).
+class Chained extends Promise {}
+const cp: any = new Chained((resolve: any) => resolve(1));
+chk("promise then", cp.then((x: number) => x) instanceof Chained);
+chk("promise catch", cp.catch(() => {}) instanceof Chained);
+chk("promise finally", cp.finally(() => {}) instanceof Chained);
+chk("plain promise then", Promise.resolve(1).then((x) => x) instanceof Promise);
+
+class PlainChained extends Promise {
+  static get [Symbol.species]() {
+    return Promise;
+  }
+}
+const pc: any = new PlainChained((resolve: any) => resolve(1));
+chk("promise species override", pc.then((x: number) => x).constructor === Promise);
+
+// A user-defined (bytecode) species getter reached from a native method must
+// see the right `this`: %TypedArray%.prototype.filter resolves species through
+// the VM's native symbol-get path, not the bytecode one.
+let seenThis: any = "getter not called";
+class Reporting extends Uint8Array {
+  static get [Symbol.species]() {
+    seenThis = this;
+    return Uint8Array;
+  }
+}
+const plain: any = new Uint8Array([1, 2, 3, 4]);
+plain.constructor = Reporting;
+chk("native path reaches species", plain.filter((v: number) => v > 1).length === 3);
+chk("native path passes the right this", seenThis === Reporting);
+
+// Honoring a per-instance [[Prototype]] on the native read path must not assume
+// that prototype is a plain object: Reflect.construct with a newTarget whose
+// .prototype is a Proxy (or a dictionary-mode object) puts an exotic value in
+// that slot, and reading through it used to crash the VM.
+function ProxyProto(): void {}
+(ProxyProto as any).prototype = new Proxy({}, {});
+const exotic: any = Reflect.construct(Uint8Array, [4], ProxyProto as any);
+chk("exotic prototype survives a native read", (Uint8Array.prototype as any).filter.call(exotic, () => true).length === 4);
+
+// Symbol-keyed accessors on ordinary functions must work the same way, own and
+// inherited - that read path is what made the built-in accessors observable.
+const marker = Symbol("marker");
+class Base {}
+Object.defineProperty(Base, marker, {
+  get() {
+    return this;
+  },
+});
+class Derived extends Base {}
+chk("own symbol accessor on a constructor", (Base as any)[marker] === Base);
+chk("inherited symbol accessor on a subclass", (Derived as any)[marker] === Derived);
+
+fails;


### PR DESCRIPTION
Closes #381.

**test262: `built-ins` +188 / −0, `language` +2 / −0.** `TestScripts`, `go test ./...` and `go test -race` on `pkg/vm`, `pkg/builtins`, `pkg/driver` all green.

No built-in constructor defined a `[Symbol.species]` accessor, which is what broke real undici (`Buffer[Symbol.species]` → `TypeError: undefined is not a constructor`). Adding the accessors alone would have been dead code — RegExp already had a correct one and still read back `undefined` — so this starts with the read path, and fixing that uncovered a chain of adjacent gaps with the same shape: a per-kind read block walking to a hardcoded intrinsic prototype and skipping the instance's own.

Each part below was diffed against `main` separately before the next one started, so the numbers are attributable.

### 1. Symbol-keyed reads on callables — `pkg/vm/symbol_lookup.go` (new)

Every callable flavour had its own copy of the symbol-key walk, and only `TypeNativeFunction` ever invoked an accessor's getter — for an **own** accessor only. Inherited accessors were structurally unreachable: `lookupSymbolOnProtoChain` took no receiver, so it could not call a getter with the right `this`, and `TypeFunction`/`TypeClosure` hardcoded `Function.prototype` as the parent instead of the constructor's real `[[Prototype]]`.

One shared walk replaces the five copies in `opGetPropSymbol` (−210 lines there) and the five in `getSymbolPropertyWithReceiver`. `GetSymbolPropertyWithGetter` — which `TypedArraySpeciesCreate` calls — had no callable case at all, so it read every constructor's species as absent.

### 2. The accessors — `pkg/builtins/species.go` (new)

Getter returns `this`, `{set: undefined, enumerable: false, configurable: true}`, on `Array`, `ArrayBuffer`, `SharedArrayBuffer`, `Map`, `Set`, `Promise` and `%TypedArray%` — the intrinsic only, never the per-type TypedArray constructors, so subclasses inherit correctly and `getOwnPropertySymbols(Uint8Array)` stays clean. Not `DataView`, per spec.

Promise's was a *data* property holding `Promise` (so `class P extends Promise {}` reported `Promise`). Replacing it surfaced a real spec bug: `all`/`allSettled`/`any`/`race`/`try` were consulting species, which the spec forbids — they do `NewPromiseCapability(C)` on `this` directly. Four test262 tests had only been passing because the getter was previously unreachable.

### 3. Subclass `[[Prototype]]` on the read paths

Eight kinds could not reach their own subclass's methods or getters: **RegExp, ArrayBuffer, SharedArrayBuffer, DataView, WeakMap, WeakSet** on the bytecode path, plus **TypedArray and Promise** on the native path — where seven kinds had no case at all and fell through to the primitive default, answering `undefined` for everything including the `constructor` that `ArrayBuffer.prototype.slice`'s SpeciesConstructor step depends on.

Replaced with three shared helpers in `proto.go`. `plainPrototypeOf` guards the `AsPlainObject` cast with `Type() == TypeObject` rather than `IsObject()`, whose `[TypeObject, TypeProxy]` range admits values that cast cannot represent — reachable from ordinary code via `Reflect.construct(C, args, F)` with an exotic `F.prototype`, and a VM panic. (I hit exactly that while writing this; it's covered by a smoke test now.)

### 4. Own properties shadow the prototype

`[[Get]]` checks own properties before inherited ones; only the TypedArray case did. `p.constructor = C` on a Promise (or Map, Set, RegExp, Array) stored the value — `getOwnPropertyDescriptor` could see it — but reads reached the prototype's `constructor` first.

Fixing that exposed a set-path bug it had been masking: assigning through an inherited **getter-only** accessor (`re.global = x`) wrongly created a shadowing own property instead of being rejected. The side-table set paths now do the prototype-chain accessor walk `TypeObject` always did.

### 5. Class statics from a native parent

The static-inheritance walk stopped at the first `NativeFunctionWithProps`, so `class P extends Promise {}` inherited nothing — `P.resolve`, `U.from`, `M.groupBy` all `undefined`. This is where most of the +188 came from.

⚠️ This initially caused **24 regressions**, both from the correct walk overriding compensations elsewhere. Both are fixed, but the fixes are themselves compensations that mask real gaps — filed as #382:
- an async function's `constructor` (this VM gives async functions plain `Function.prototype`, not `%AsyncFunction.prototype%`)
- `f.caller` / `f.arguments` (non-strict functions have no own legacy versions, so the chain reaches `Function.prototype`'s `%ThrowTypeError%` pill)

### 6. `instanceof Function`

Two defects: the operand gate enumerated kinds by hand and omitted four of the six callables, so `Map.prototype.get instanceof Function` was false purely because the operand never reached the walk; and the walk stepped a `NativeFunctionWithProps` through its `Properties` table directly, which reports the default object prototype for a built-in that never had one installed — losing `Uint8Array` → `%TypedArray%` → `Function.prototype`.

### 7. Promise resolution

Thenables were never assimilated anywhere — `Promise.resolve`, the executor's `resolve`, and handler return values all fulfilled **with** the object. Implemented the resolve half of `CreateResolvingFunctions`: self-resolution rejects with a TypeError, `Get(resolution, "then")` runs synchronously so a plain object still fulfills on the same tick, a throwing getter rejects, and only the *call* defers to a microtask as `NewPromiseResolveThenableJob`.

`Promise.resolve` now does spec `PromiseResolve(C, x)` — capability-based, honoring `this`, identity shortcut gated on `SameValue(x.constructor, C)`. `Promise.prototype.finally` registered **one** handler for both reactions and returned its argument, turning every rejection into a fulfillment carrying the reason; it now follows the spec's `thenFinally`/`catchFinally` shape and awaits `onFinally`'s result. All 28 `finally` tests pass.

Two things worth a reviewer's eye:

- **`hasPotentialThen` is a heuristic, not a spec operation.** `ResolvePromise` is the host-goroutine entry point (fetch, ReadableStream, timers) and must never run JS, but must also not defer unconditionally — a settle after the caller's `EndExternalOp` loses the happen-before that keeps the runtime awake (#238). So it does a JS-free walk for a `then` slot, answering conservatively for Proxy. It is **not** a complete `then` lookup: an object whose `then` lives in per-kind storage the walk doesn't model would settle without assimilating. Values with no `then` keep settling synchronously exactly as before.
- **The race test for that branch found a real race it introduced.** `GetAsyncRuntime`'s lazy `if nil { create }` is now reached from host goroutines and raced the VM goroutine's first call; it's guarded. Worth noting that a narrower `-race` run had passed — no existing test resolves a thenable off-goroutine.

### Tests

Three new smoke tests (`symbol_species.ts`, `subclass_builtins.ts`, `promise_resolve_and_instanceof.ts`) and a `-race` regression test for the thenable branch.

I also found that async assertions in a smoke test are **silently not observed** — the harness compares the last statement's value before microtasks drain, so a deliberately broken async `chk` still passes. The new tests assert only synchronously-observable behaviour, and I verified each file fails when an assertion is inverted. Async Promise behaviour is left to test262, which covers it thoroughly.

### Still open

The two compensations in part 5 and the gaps they mask — #382. Everything else I flagged along the way — `slice` species, `then`/`finally` species, `instanceof Function`, `Promise.resolve` ignoring `this`, thenable assimilation — landed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
