### PR TITLE
fix(vm): async function [[Prototype]], spread-call exception routing

### DIFF
--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -106,16 +106,6 @@ func (vm *VM) handleCallableProperty(objVal Value, propName string) (Value, bool
 		}
 	}
 
-	// An async function's `constructor` is %AsyncFunction%. This VM does not
-	// give async functions the %AsyncFunction.prototype% intrinsic - their
-	// [[Prototype]] is plain Function.prototype - so the chain walk below,
-	// which now continues into built-in constructors, would answer Function.
-	// Resolved here, ahead of the walk, to keep the answer it had when the
-	// walk stopped at the first NativeFunctionWithProps.
-	if propName == "constructor" && fn != nil && fn.IsAsync && !fn.IsGenerator && vm.AsyncFunctionConstructor.IsCallable() {
-		return vm.AsyncFunctionConstructor, true
-	}
-
 	// Walk the closure's [[Prototype]] chain for inherited static properties (class inheritance)
 	// This handles `class C extends B { }` where C.staticMethod should find B.staticMethod
 	// Only walk user-defined class constructors (Closure/Function), stop at built-in prototypes

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6225,9 +6225,38 @@ startExecution:
 				return InterpretRuntimeError, Undefined
 			}
 			if err != nil {
+				// Same class of bug as #384 (OpSpreadCall/OpSpreadCallMethod): a
+				// native callee resolved from a with object (e.g. `with (obj) {
+				// fn.call(...) }`) may recursively throw from JS, returning a Go
+				// error here instead of going through vm.throwException. Route it
+				// through the exception table rather than escaping past any
+				// enclosing try/catch.
 				frame.ip = ip
-				vm.runtimeError("%s", err.Error())
-				return InterpretRuntimeError, Undefined
+				var excVal Value
+				if exceptionErr, ok := err.(ExceptionError); ok {
+					excVal = exceptionErr.GetExceptionValue()
+				} else {
+					if errCtor, ok := vm.GetGlobal("Error"); ok {
+						if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+							excVal = res
+						} else {
+							errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+							errObj.SetOwn("name", NewString("Error"))
+							errObj.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(errObj)
+						}
+					} else {
+						errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+						errObj.SetOwn("name", NewString("Error"))
+						errObj.SetOwn("message", NewString(err.Error()))
+						excVal = NewValueFromPlainObject(errObj)
+					}
+				}
+				vm.throwException(excVal)
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				goto reloadFrame
 			}
 
 			if shouldSwitch {
@@ -6915,6 +6944,7 @@ startExecution:
 
 				// Generator functions have GeneratorFunction.prototype as their [[Prototype]]
 				// Async generator functions have AsyncGeneratorFunction.prototype
+				// Async functions have AsyncFunction.prototype
 				// Regular functions have Function.prototype
 				if cl.Fn.IsGenerator && cl.Fn.IsAsync {
 					if !vm.AsyncGeneratorFunctionPrototype.IsUndefined() {
@@ -6925,6 +6955,12 @@ startExecution:
 				} else if cl.Fn.IsGenerator {
 					if !vm.GeneratorFunctionPrototype.IsUndefined() {
 						cl.Fn.Prototype = vm.GeneratorFunctionPrototype
+					} else {
+						cl.Fn.Prototype = vm.FunctionPrototype
+					}
+				} else if cl.Fn.IsAsync {
+					if !vm.AsyncFunctionPrototype.IsUndefined() {
+						cl.Fn.Prototype = vm.AsyncFunctionPrototype
 					} else {
 						cl.Fn.Prototype = vm.FunctionPrototype
 					}
@@ -7073,6 +7109,7 @@ startExecution:
 
 				// Generator functions have GeneratorFunction.prototype as their [[Prototype]]
 				// Async generator functions have AsyncGeneratorFunction.prototype
+				// Async functions have AsyncFunction.prototype
 				// Regular functions have Function.prototype
 				if cl.Fn.IsGenerator && cl.Fn.IsAsync {
 					if !vm.AsyncGeneratorFunctionPrototype.IsUndefined() {
@@ -7083,6 +7120,12 @@ startExecution:
 				} else if cl.Fn.IsGenerator {
 					if !vm.GeneratorFunctionPrototype.IsUndefined() {
 						cl.Fn.Prototype = vm.GeneratorFunctionPrototype
+					} else {
+						cl.Fn.Prototype = vm.FunctionPrototype
+					}
+				} else if cl.Fn.IsAsync {
+					if !vm.AsyncFunctionPrototype.IsUndefined() {
+						cl.Fn.Prototype = vm.AsyncFunctionPrototype
 					} else {
 						cl.Fn.Prototype = vm.FunctionPrototype
 					}
@@ -14807,8 +14850,44 @@ startExecution:
 
 			shouldSwitch, err := vm.prepareCall(calleeVal, Undefined, spreadArgs, destReg, callerRegisters, callerIP)
 			if err != nil {
-				status := vm.runtimeError("%s", err.Error())
-				return status, Undefined
+				// A native callee (e.g. Function.prototype.call/apply invoked via
+				// spread) may recursively invoke a JS closure that throws; that
+				// throw comes back here as a Go error rather than being routed
+				// through vm.throwException by the nested call. Without this,
+				// the error escaped straight out of vm.run() past any enclosing
+				// try/catch (#384). Mirrors OpCallMethod's err handling below.
+				var excVal Value
+				if exceptionErr, ok := err.(ExceptionError); ok {
+					excVal = exceptionErr.GetExceptionValue()
+				} else {
+					if errCtor, ok := vm.GetGlobal("Error"); ok {
+						if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+							excVal = res
+						} else {
+							errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+							errObj.SetOwn("name", NewString("Error"))
+							errObj.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(errObj)
+						}
+					} else {
+						errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+						errObj.SetOwn("name", NewString("Error"))
+						errObj.SetOwn("message", NewString(err.Error()))
+						excVal = NewValueFromPlainObject(errObj)
+					}
+				}
+				vm.throwException(excVal)
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				frame = &vm.frames[vm.frameCount-1]
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
+				continue
 			}
 
 			if shouldSwitch {
@@ -14874,8 +14953,43 @@ startExecution:
 
 			shouldSwitch, err := vm.prepareMethodCall(calleeVal, thisVal, spreadArgs, destReg, callerRegisters, callerIP)
 			if err != nil {
-				status := vm.runtimeError("%s", err.Error())
-				return status, Undefined
+				// See the matching comment in OpSpreadCall above (#384): a native
+				// callee reached via spread (e.g. fn.call(recv, ...args)) may
+				// recursively throw from JS; route that through the exception
+				// table the same way OpCallMethod does instead of escaping past
+				// every enclosing try/catch.
+				var excVal Value
+				if exceptionErr, ok := err.(ExceptionError); ok {
+					excVal = exceptionErr.GetExceptionValue()
+				} else {
+					if errCtor, ok := vm.GetGlobal("Error"); ok {
+						if res, callErr := vm.Call(errCtor, Undefined, []Value{NewString(err.Error())}); callErr == nil {
+							excVal = res
+						} else {
+							errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+							errObj.SetOwn("name", NewString("Error"))
+							errObj.SetOwn("message", NewString(err.Error()))
+							excVal = NewValueFromPlainObject(errObj)
+						}
+					} else {
+						errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+						errObj.SetOwn("name", NewString("Error"))
+						errObj.SetOwn("message", NewString(err.Error()))
+						excVal = NewValueFromPlainObject(errObj)
+					}
+				}
+				vm.throwException(excVal)
+				if vm.frameCount == 0 || vm.unwindingCrossedNative {
+					return InterpretRuntimeError, vm.currentException
+				}
+				frame = &vm.frames[vm.frameCount-1]
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
+				continue
 			}
 
 			if shouldSwitch {


### PR DESCRIPTION
## Summary

- Closes #382 (async-function half only — see note below)
- Closes #384

### #382 — async function `[[Prototype]]`

`OpClosure`/`OpClosure16` set a closure's `[[Prototype]]` by switching on `IsGenerator`/`IsAsync`, but the switch only had cases for generator and async-generator — plain async functions fell into the default `Function.prototype` branch instead of `AsyncFunction.prototype`. That's exactly what the "async function constructor answers Function" compensation in `handleCallableProperty` was papering over (added alongside the static-inheritance walk in 79bcb5fc). Giving async closures the real `[[Prototype]]` lets `af.constructor` and `Object.prototype.toString.call(af)` resolve through the ordinary prototype-chain walk, so the compensation is now dead code and removed.

test262: **+2 built-ins, +1 language, 0 regressions**.

The `caller`/`arguments` half of #382 is intentionally left alone. I tried a receiver-aware `Function.prototype` accessor returning V8's `null`, but reverted it — it moved zero test262 tests (this VM tracks no real caller chain, and test262's own `language/arguments-object/10.6-13-a-2.js` explicitly prefers `undefined` — its "extension not supported" branch — over a non-function sentinel it would try to call), and it broke the file's documented "single `%ThrowTypeError%` for get+set" identity invariant for no benefit. The existing compensation is correct behavior here, not a mask, so it stays as-is.

### #384 — spread-call exceptions bypassing try/catch

`OpSpreadCall`, `OpSpreadCallMethod`, and `OpCallFromWithContext` converted a callee's returned Go error straight into `vm.runtimeError()` + a hard return, bypassing `vm.throwException()` and the exception table entirely — unlike `OpCall`/`OpCallMethod`/`OpTailCall*`, which unwrap `ExceptionError` and route it through normal handler dispatch.

This is exactly what `fn.call(receiver, ...args)` compiles to: a spread call into the native `Function.prototype.call`, which recursively invokes the JS closure and propagates its throw back as a Go error. That error skipped every enclosing `try/catch` instead of being caught — matching the issue's minimal repro, all 6 bisection cases, and the `for-of` + spread `.call()` shape from the reported undici crash.

Same fix applied to all three opcodes: unwrap `ExceptionError` (or wrap a plain Go error into a real `Error` instance) and route through `vm.throwException`/frame-reload the same way the other call opcodes already do.

### #380 — no code change needed

Already fixed by 79bcb5fc, which replaced the hand-rolled `ArrayBuffer`/`SharedArrayBuffer`/`DataView` prototype walks with the accessor-aware `finishProtoChainGet`. Verified `__proto__` resolves correctly for all three. Closing separately (not via this PR, since there's no diff for it).

## Testing

- `go test ./tests -run TestScripts` — green
- test262 scoped diffs (`built-ins`, `language`) — net positive, 0 regressions
- Manual repros for all three issues, including the bisection table and the `for-of`/`with` variants from #384