### PR TITLE
fix(builtins): TypedArray-source constructor, JSON.stringify(typedArray)

### DIFF
--- a/pkg/builtins/json_init.go
+++ b/pkg/builtins/json_init.go
@@ -1267,7 +1267,7 @@ func stringifyValueToJSONWithVisited(vmInstance *vm.VM, value vm.Value, visited 
 
 	// Step 1: Handle toJSON method if present (objects, arrays, proxies, and BigInt)
 	// Per ECMAScript spec: If Type(value) is Object or BigInt, check for toJSON
-	if value.Type() == vm.TypeObject || value.Type() == vm.TypeDictObject || value.Type() == vm.TypeArray || value.Type() == vm.TypeProxy || value.Type() == vm.TypeBigInt {
+	if value.Type() == vm.TypeObject || value.Type() == vm.TypeDictObject || value.Type() == vm.TypeArray || value.Type() == vm.TypeProxy || value.Type() == vm.TypeBigInt || value.Type() == vm.TypeTypedArray {
 		var toJSON vm.Value
 		var err error
 
@@ -1450,6 +1450,83 @@ func stringifyValueToJSONWithVisited(vmInstance *vm.VM, value vm.Value, visited 
 			result += elemJSON
 		}
 		result += "]"
+		return result, nil
+	case vm.TypeTypedArray:
+		// TypedArrays are Integer-Indexed exotic objects: serialize like a
+		// plain object keyed by their indices ({"0":1,"1":2,...}), per spec
+		// SerializeJSONObject over [[OwnPropertyKeys]] (toJSON is handled
+		// above). A replacer's propertyList (if given) picks the key set,
+		// same as for a plain object - it is not limited to valid indices.
+		ta := value.AsTypedArray()
+		if ta == nil {
+			return "null", nil
+		}
+
+		var keys []string
+		if propertyList != nil {
+			keys = propertyList
+		} else {
+			length := ta.GetLength()
+			keys = make([]string, length)
+			for i := 0; i < length; i++ {
+				keys[i] = strconv.Itoa(i)
+			}
+		}
+
+		getElem := func(key string) vm.Value {
+			if vmInstance != nil {
+				v, err := vmInstance.GetProperty(value, key)
+				if err == nil {
+					return v
+				}
+				return vm.Undefined
+			}
+			if idx, err := strconv.Atoi(key); err == nil && idx >= 0 && idx < ta.GetLength() {
+				return ta.GetElement(idx)
+			}
+			return vm.Undefined
+		}
+
+		if gap != "" {
+			stepIndent := indent + gap
+			result := "{"
+			first := true
+			for _, elemKey := range keys {
+				elemJSON, err := stringifyValueToJSONWithVisited(vmInstance, getElem(elemKey), visited, gap, stepIndent, elemKey, value, replacerFunc, propertyList)
+				if err != nil {
+					return "", err
+				}
+				if elemJSON != "" {
+					if !first {
+						result += ","
+					}
+					first = false
+					result += "\n" + stepIndent + "\"" + elemKey + "\": " + elemJSON
+				}
+			}
+			if !first {
+				result += "\n" + indent
+			}
+			result += "}"
+			return result, nil
+		}
+
+		result := "{"
+		first := true
+		for _, elemKey := range keys {
+			elemJSON, err := stringifyValueToJSONWithVisited(vmInstance, getElem(elemKey), visited, gap, indent, elemKey, value, replacerFunc, propertyList)
+			if err != nil {
+				return "", err
+			}
+			if elemJSON != "" {
+				if !first {
+					result += ","
+				}
+				first = false
+				result += "\"" + elemKey + "\":" + elemJSON
+			}
+		}
+		result += "}"
 		return result, nil
 	case vm.TypeRegExp:
 		// RegExp objects serialize as empty objects {}

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -512,6 +512,26 @@ func NumericTypedArrayCtorBody(vmInstance *vm.VM, ek TypedArrayElementKind) func
 			}
 			return applyGPFCPrototype(vm.NewTypedArray(kind, vals, 0, 0), proto), nil
 		}
+		if srcTA := arg.AsTypedArray(); srcTA != nil {
+			// %TypedArray%(typedArray): copy/reinterpret the source's
+			// elements into a freshly allocated typed array of this kind.
+			// Per InitializeTypedArrayFromTypedArray: source and target must
+			// agree on BigInt-ness (Number and BigInt content types never mix).
+			srcIsBigInt := srcTA.GetElementType() == vm.TypedArrayBigInt64 || srcTA.GetElementType() == vm.TypedArrayBigUint64
+			if srcIsBigInt != ek.IsBigInt {
+				return vm.Undefined, vmInstance.NewTypeError("Cannot mix BigInt and other types, use explicit conversions")
+			}
+			proto, err := TypedArrayGPFC(vmInstance, protoName)
+			if err != nil {
+				return vm.Undefined, err
+			}
+			srcLen := srcTA.GetLength()
+			vals := make([]vm.Value, srcLen)
+			for i := 0; i < srcLen; i++ {
+				vals[i] = ek.coerceElement(srcTA.GetElement(i))
+			}
+			return applyGPFCPrototype(vm.NewTypedArray(kind, vals, 0, 0), proto), nil
+		}
 		if arg.IsObject() {
 			proto, err := TypedArrayGPFC(vmInstance, protoName)
 			if err != nil {

--- a/tests/scripts/json_stringify_typed_array.ts
+++ b/tests/scripts/json_stringify_typed_array.ts
@@ -1,0 +1,23 @@
+// Regression test for #387: JSON.stringify(typedArray) must serialize
+// indexed elements (like a plain object) and must call toJSON() when defined,
+// instead of always returning "null".
+
+let plain = JSON.stringify(new Uint8Array([1, 2, 3]));
+let nested = JSON.stringify({ v: new Uint8Array([1, 2, 3]) });
+let empty = JSON.stringify(new Uint8Array([]));
+
+class WithToJSON extends Uint8Array {
+  toJSON() {
+    return { custom: true };
+  }
+}
+let withToJSON = JSON.stringify(new WithToJSON([1, 2, 3]));
+
+let correct =
+  plain === '{"0":1,"1":2,"2":3}' &&
+  nested === '{"v":{"0":1,"1":2,"2":3}}' &&
+  empty === "{}" &&
+  withToJSON === '{"custom":true}';
+
+// expect: true
+correct;

--- a/tests/scripts/typed_array_from_typed_array.ts
+++ b/tests/scripts/typed_array_from_typed_array.ts
@@ -1,0 +1,15 @@
+// expect: 7
+// Regression test for #386: new TypedArray(otherTypedArray) must copy
+// elements, not produce a zero-length array (same-type and cross-type).
+
+const src = new Uint8Array([1, 2, 3]);
+const sameType = new Uint8Array(src);
+const crossType = new Int32Array(src);
+const fromFloat = new Float64Array(new Float64Array([1.5, 2.5]));
+
+let ok = 1;
+if (sameType.length !== 3 || sameType[0] !== 1 || sameType[1] !== 2 || sameType[2] !== 3) ok = 0;
+if (crossType.length !== 3 || crossType[0] !== 1 || crossType[1] !== 2 || crossType[2] !== 3) ok = 0;
+if (fromFloat.length !== 2 || fromFloat[0] !== 1.5 || fromFloat[1] !== 2.5) ok = 0;
+
+src.length + sameType.length + ok;


### PR DESCRIPTION
## Summary

- Fixes #386: `new TypedArray(otherTypedArray)` always produced a zero-length array. `NumericTypedArrayCtorBody` had no dispatch case for a typed-array source argument and fell into the generic object fallback (which allocates length 0). Added the missing branch that copies/reinterprets the source's elements, and — per spec `InitializeTypedArrayFromTypedArray` — throws `TypeError` when Number and BigInt content types are mixed (e.g. `new Uint8Array(bigInt64Array)`), a path this fix newly exposed.

- Fixes #387: `JSON.stringify()` on any `TypedArray` always returned `"null"`, ignoring both `toJSON()` and indexed properties. Added `TypedArray` to the `toJSON()` lookup check and a new serialization case that emits indexed elements as an object (`{"0":1,"1":2,...}`, matching real Node), honoring a replacer's `propertyList` when given.

## Testing

- `go test ./tests -run TestScripts` — full smoke suite green, no regressions.
- Added regression tests `tests/scripts/typed_array_from_typed_array.ts` and `tests/scripts/json_stringify_typed_array.ts`.
- test262 diff against `baseline.txt`:
  - `built-ins/TypedArrayConstructors`: **+7 new passes, 0 regressions**
  - `built-ins/JSON/stringify`: **0 regressions** (no dedicated typed-array cases in that suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)