### PR TITLE
fix(compiler): object/class methods must not self-bind their name

### DIFF
--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -1272,7 +1272,12 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 	// If node.Name differs from nameHint or nameHint is empty, it's a named expression
 	var funcNameForInnerBinding string
 	var needsInnerNameBinding bool
-	if node.Name != nil {
+	// Methods (isMethod=true) never get an inner self-binding: node.Name for a method
+	// is a display name synthesized from its PropertyName for the function's own .name
+	// property, not a real BindingIdentifier (#204, #389). Only genuine named function
+	// expressions create the "the name refers to the function itself inside its body"
+	// binding.
+	if node.Name != nil && !isMethod {
 		// Check if this is a named function expression (not a declaration)
 		if nameHint == "" || nameHint != node.Name.Value {
 			// This is a named function expression - create inner binding

--- a/tests/scripts/shorthand_method_no_self_bind.ts
+++ b/tests/scripts/shorthand_method_no_self_bind.ts
@@ -1,0 +1,34 @@
+// expect: true
+// Regression test for #389: an ES6 object-literal shorthand method (and a
+// class method) must NOT bind its own name inside its body, unlike a
+// genuine named function expression, which legitimately does.
+
+function foo(x: number): string {
+  return "outer foo called with " + x;
+}
+
+// Object-literal shorthand method: bare `foo` inside must resolve to the
+// OUTER `foo`, not recurse into itself.
+const obj = {
+  foo(x: number): string {
+    return foo(x);
+  },
+};
+const objResult = obj.foo(42) === "outer foo called with 42";
+
+// Class method: same rule applies.
+class C {
+  foo(x: number): string {
+    return foo(x);
+  }
+}
+const classResult = new C().foo(1) === "outer foo called with 1";
+
+// Sanity check: a genuine named function expression DOES self-bind - the
+// fix must not over-fire and break this legitimate case.
+const rec = function fact(n: number): number {
+  return n <= 1 ? 1 : n * fact(n - 1);
+};
+const namedFnExprResult = rec(5) === 120;
+
+objResult && classResult && namedFnExprResult;


### PR DESCRIPTION
## Summary

An ES6 object-literal shorthand method (`{ name(...) { ... } }`) incorrectly bound its own name inside its body, so a bare reference to that name resolved to the method itself instead of the enclosing scope — causing silent infinite recursion whenever a method's name matched an outer function/variable it meant to call (e.g. undici's `lib/util/timers.js`: `{ clearTimeout(t) { ... clearTimeout(t) ... } }`).

## Root cause

In `compileFunctionLiteralWithOptions`, the decision to create an inner self-reference binding (for genuine named function expressions like `let f = function g() { g() }`) only checked `node.Name != nil` and `nameHint` — it ignored the `isMethod` flag. A method's `Name` field is a display name synthesized from its PropertyName purely for the function's own `.name` property (see the `#204` comment already in the code), not a real `BindingIdentifier`, so it should never trigger self-binding.

## Fix

Gate the inner-binding logic on `!isMethod` in `pkg/compiler/compile_literal.go`. Class methods were never affected (the parser always sets `Name: nil` for them), but the same code path is shared, so the fix is scoped there defensively.

## Testing

- Exact repro from the issue, the undici `clearTimeout` pattern, getters/setters, async/generator shorthand methods, `.name` correctness, and legitimate named-function-expression self-binding all verified manually.
- `go test ./tests -run TestScripts` — full smoke suite passes.
- Test262 dumps for `language/expressions/object` and `language/statements/class` are byte-identical before/after this change — zero regressions.
- Added `tests/scripts/shorthand_method_no_self_bind.ts` covering object-method, class-method, and named-function-expression cases.

Fixes #389