### PR TITLE
fix(builtins): implement ReadableStream.prototype.tee()

### DIFF
--- a/pkg/builtins/readable_stream_goroutine_test.go
+++ b/pkg/builtins/readable_stream_goroutine_test.go
@@ -152,3 +152,170 @@ func waitForSettled(t *testing.T, rt interface {
 		}
 	}
 }
+
+// drainUntilSettled runs the VM's real event-loop drain (nextTicks,
+// microtasks, timers, external ops - see vm.DrainUntilIdle) until it goes
+// idle, then asserts every given promise has settled. Needed (instead of
+// waitForSettled's plain State-poll) whenever a promise's settlement depends
+// on a *registered reaction* actually running rather than just on
+// trySettle() being called directly - triggerPromiseReactions always
+// defers reaction dispatch via ScheduleMicrotask, so something has to drain
+// the microtask queue for that dispatch to happen at all.
+func drainUntilSettled(t *testing.T, vmInstance *vm.VM, promises ...*vm.PromiseObject) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		vmInstance.DrainUntilIdle()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out draining the event loop")
+	}
+	for i, p := range promises {
+		if p.State == vm.PromisePending {
+			t.Fatalf("promise %d still pending after DrainUntilIdle", i)
+		}
+	}
+}
+
+// TestReadableStreamTeeGoroutineFed exercises tee() (#390) against the exact
+// scenario the issue reports it for: a stream fed from a background
+// goroutine (fetch's own streaming Response.body shape - NewHostFedReadableStream
+// is the same primitive fetch_init.go builds on), not just a synchronous
+// JS start() source. tee()'s own bookkeeping (reading/canceled1/canceled2 in
+// its closure, see readable_stream_init.go) is documented as touched only
+// from the main VM goroutine; this test - run with `-race` - is what backs
+// that claim: enqueue/close happen on a separate goroutine same as
+// TestReadableStreamGoroutineFed above, and both branches' read() calls
+// (which is where tee's pull/reaction closures actually run) happen on this
+// goroutine, same as any real reader.read().
+func TestReadableStreamTeeGoroutineFed(t *testing.T) {
+	vmInstance := vm.NewVM()
+	SymbolAsyncIterator = vm.NewSymbol("Symbol.asyncIterator")
+
+	initializer := &ReadableStreamInitializer{}
+	ctx := &RuntimeContext{
+		VM:           vmInstance,
+		DefineGlobal: func(name string, value vm.Value) error { return nil },
+	}
+	if err := initializer.InitRuntime(ctx); err != nil {
+		t.Fatalf("InitRuntime failed: %v", err)
+	}
+
+	streamVal, controller := NewHostFedReadableStream(vmInstance)
+
+	teeFn, ok := streamVal.AsPlainObject().GetOwn("tee")
+	if !ok || !teeFn.IsCallable() {
+		t.Fatal("stream has no callable tee")
+	}
+	teeResult, err := vmInstance.Call(teeFn, streamVal, nil)
+	if err != nil {
+		t.Fatalf("tee() failed: %v", err)
+	}
+	branches := teeResult.AsArray()
+	if branches == nil || branches.Length() != 2 {
+		t.Fatalf("expected tee() to return a 2-element array, got %+v", teeResult)
+	}
+
+	getReader := func(streamV vm.Value) vm.Value {
+		t.Helper()
+		fn, ok := streamV.AsPlainObject().GetOwn("getReader")
+		if !ok || !fn.IsCallable() {
+			t.Fatal("branch has no callable getReader")
+		}
+		readerVal, err := vmInstance.Call(fn, streamV, nil)
+		if err != nil {
+			t.Fatalf("getReader() failed: %v", err)
+		}
+		return readerVal
+	}
+	readerA := getReader(branches.Get(0))
+	readerB := getReader(branches.Get(1))
+
+	rt := vmInstance.GetAsyncRuntime()
+
+	rt.BeginExternalOp()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		controller.EnqueueBytes([]byte("hello"))
+		controller.Close()
+		rt.EndExternalOp()
+	}()
+
+	readOnce := func(readerVal vm.Value) *vm.PromiseObject {
+		t.Helper()
+		fn, ok := readerVal.AsPlainObject().GetOwn("read")
+		if !ok || !fn.IsCallable() {
+			t.Fatal("reader has no callable read")
+		}
+		promiseVal, err := vmInstance.Call(fn, readerVal, nil)
+		if err != nil {
+			t.Fatalf("read() failed: %v", err)
+		}
+		promise := promiseVal.AsPromise()
+		if promise == nil {
+			t.Fatal("read() did not return a Promise")
+		}
+		return promise
+	}
+
+	promiseA := readOnce(readerA)
+	promiseB := readOnce(readerB)
+
+	// Unlike a plain (non-teed) read(), whose promise trySettle()s directly
+	// inside enqueue() (see TestReadableStreamGoroutineFed's waitForSettled,
+	// which only ever needs to observe that), a tee() branch's read()
+	// promise is only settled once the fulfillment reaction pullAlgorithm
+	// registered on the ORIGINAL stream's own read() actually runs - and
+	// triggerPromiseReactions always dispatches reactions via
+	// ScheduleMicrotask (pkg/vm/promise.go), never synchronously. So this
+	// needs a real event-loop drain (DrainUntilIdle: nextTicks, microtasks,
+	// timers, then wait-for-external-op, repeat) - exactly what a real
+	// script's `await` does - not just a State poll gated on external-op
+	// completion.
+	drainUntilSettled(t, vmInstance, promiseA, promiseB)
+
+	checkChunk := func(label string, promise *vm.PromiseObject) {
+		t.Helper()
+		if promise.State != vm.PromiseFulfilled {
+			t.Fatalf("%s: expected fulfilled, got state=%v result=%v", label, promise.State, promise.Result)
+		}
+		resultObj := promise.Result.AsPlainObject()
+		if resultObj == nil {
+			t.Fatalf("%s: resolved value is not a plain object: %+v", label, promise.Result)
+		}
+		if doneVal, _ := resultObj.GetOwn("done"); doneVal.Type() != vm.TypeBoolean || doneVal.AsBoolean() {
+			t.Fatalf("%s: expected done=false on first chunk, got %v", label, doneVal)
+		}
+		valueVal, _ := resultObj.GetOwn("value")
+		if valueVal.Type() != vm.TypeTypedArray {
+			t.Fatalf("%s: expected a Uint8Array chunk, got type %v", label, valueVal.Type())
+		}
+		ta := valueVal.AsTypedArray()
+		got := make([]byte, ta.GetLength())
+		for i := range got {
+			got[i] = byte(ta.GetElement(i).ToFloat())
+		}
+		if string(got) != "hello" {
+			t.Fatalf("%s: expected chunk %q, got %q", label, "hello", string(got))
+		}
+	}
+	checkChunk("branch A", promiseA)
+	checkChunk("branch B", promiseB)
+
+	// Both branches must independently see the close too.
+	promiseA2 := readOnce(readerA)
+	promiseB2 := readOnce(readerB)
+	drainUntilSettled(t, vmInstance, promiseA2, promiseB2)
+	for label, p := range map[string]*vm.PromiseObject{"branch A": promiseA2, "branch B": promiseB2} {
+		if p.State != vm.PromiseFulfilled {
+			t.Fatalf("%s: expected fulfilled after close, got state=%v", label, p.State)
+		}
+		resultObj := p.Result.AsPlainObject()
+		if doneVal, _ := resultObj.GetOwn("done"); doneVal.Type() != vm.TypeBoolean || !doneVal.AsBoolean() {
+			t.Fatalf("%s: expected done=true after close, got %v", label, doneVal)
+		}
+	}
+}

--- a/pkg/builtins/readable_stream_init.go
+++ b/pkg/builtins/readable_stream_init.go
@@ -46,6 +46,9 @@ func (r *ReadableStreamInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("locked", types.Boolean).
 		WithProperty("getReader", types.NewSimpleFunction([]types.Type{}, readerType)).
 		WithProperty("cancel", types.NewOptionalFunction([]types.Type{types.Any}, types.Any, []bool{true}))
+	streamType.WithProperty("tee", types.NewSimpleFunction([]types.Type{}, &types.TupleType{
+		ElementTypes: []types.Type{streamType, streamType},
+	}))
 
 	streamCtorType := types.NewObjectType().
 		WithSimpleCallSignature([]types.Type{}, streamType).             // new ReadableStream()
@@ -129,6 +132,15 @@ type readableStreamState struct {
 	locked bool
 
 	underlyingSource vm.Value // Undefined if none was given
+
+	// goPull/goCancel let a Go-authored producer (currently just tee(), below)
+	// hook read()/cancel() without going through a JS underlyingSource object.
+	// Both are only ever invoked from the main VM goroutine - read() and
+	// cancel() are themselves main-goroutine-only (see their doc comments) -
+	// so, like the rest of this file's teeing logic, they need no locking of
+	// their own beyond s.mu guarding this struct's fields.
+	goPull   func()
+	goCancel func(reason vm.Value) vm.Value
 }
 
 func newReadableStreamState(vmInstance *vm.VM) *readableStreamState {
@@ -244,6 +256,7 @@ func (s *readableStreamState) read() vm.Value {
 	promiseVal := s.vmInstance.NewPendingPromise()
 	s.pendingReads = append(s.pendingReads, &pendingStreamRead{promise: promiseVal.AsPromise()})
 	source := s.underlyingSource
+	goPull := s.goPull
 	s.mu.Unlock()
 
 	// Best-effort backpressure signal: ask a JS-authored underlying source
@@ -255,6 +268,12 @@ func (s *readableStreamState) read() vm.Value {
 			controllerVal := createReadableStreamControllerObject(s.vmInstance, s)
 			_, _ = s.vmInstance.Call(pullFn, source, []vm.Value{controllerVal})
 		}
+	}
+
+	// Same signal, for a Go-authored producer (tee()'s branches) instead of a
+	// JS underlyingSource.
+	if goPull != nil {
+		goPull()
 	}
 
 	return promiseVal
@@ -276,10 +295,18 @@ func (s *readableStreamState) cancel(reason vm.Value) vm.Value {
 	pending := s.pendingReads
 	s.pendingReads = nil
 	source := s.underlyingSource
+	goCancel := s.goCancel
 	s.mu.Unlock()
 
 	for _, pr := range pending {
 		s.vmInstance.ResolvePromise(pr.promise, iterResultValue(s.vmInstance, vm.Undefined, true))
+	}
+
+	// A tee() branch has no JS underlyingSource to forward to - instead it
+	// tells the teeing coordinator it was cancelled, which cancels the
+	// shared original stream once both branches have been.
+	if goCancel != nil {
+		return goCancel(reason)
 	}
 
 	if source.Type() == vm.TypeObject || source.Type() == vm.TypeDictObject {
@@ -306,6 +333,101 @@ func (s *readableStreamState) release() {
 	}
 }
 
+// tee implements ReadableStream.prototype.tee(): like getReader(), it errors
+// if the stream is already locked; otherwise it locks the original stream
+// and returns two independent branch states, each fed its own copy of every
+// chunk a single shared read loop pulls from the original. Cancelling one
+// branch only closes that branch; the original is only cancelled once both
+// branches have been (per spec), via goCancel.
+//
+// Simplifications vs. the full spec: no byte-stream chunk cloning (both
+// branches share the same chunk value/reference, fine as long as consumers
+// don't mutate what they read) and no backpressure/highWaterMark
+// bookkeeping - matching the rest of this file's read()/pull scope note.
+func (s *readableStreamState) tee() (*readableStreamState, *readableStreamState, error) {
+	s.mu.Lock()
+	if s.locked {
+		s.mu.Unlock()
+		return nil, nil, s.vmInstance.NewTypeError("ReadableStream is already locked to a reader")
+	}
+	s.locked = true
+	obj := s.streamObj
+	s.mu.Unlock()
+	if obj != nil {
+		obj.SetOwn("locked", vm.True)
+	}
+
+	branch1 := newReadableStreamState(s.vmInstance)
+	branch2 := newReadableStreamState(s.vmInstance)
+
+	// All of this closure's state is only ever touched from the main VM
+	// goroutine (read()/cancel() are main-goroutine-only), so it needs no
+	// locking of its own.
+	var reading, canceled1, canceled2 bool
+	reason1, reason2 := vm.Undefined, vm.Undefined
+
+	pullAlgorithm := func() {
+		if reading {
+			return
+		}
+		reading = true
+		promiseVal := s.read()
+		s.vmInstance.AddPromiseReaction(promiseVal, true, func(result vm.Value) {
+			reading = false
+			resultObj := result.AsPlainObject()
+			if resultObj == nil {
+				return
+			}
+			doneVal, _ := resultObj.GetOwn("done")
+			chunkVal, _ := resultObj.GetOwn("value")
+			if doneVal.AsBoolean() {
+				if !canceled1 {
+					branch1.close()
+				}
+				if !canceled2 {
+					branch2.close()
+				}
+				return
+			}
+			if !canceled1 {
+				branch1.enqueue(chunkVal)
+			}
+			if !canceled2 {
+				branch2.enqueue(chunkVal)
+			}
+		})
+		s.vmInstance.AddPromiseReaction(promiseVal, false, func(reason vm.Value) {
+			reading = false
+			if !canceled1 {
+				branch1.errorOut(reason)
+			}
+			if !canceled2 {
+				branch2.errorOut(reason)
+			}
+		})
+	}
+
+	branch1.goPull = pullAlgorithm
+	branch2.goPull = pullAlgorithm
+
+	branch1.goCancel = func(reason vm.Value) vm.Value {
+		canceled1, reason1 = true, reason
+		if canceled2 {
+			return s.cancel(vm.NewArrayWithArgs([]vm.Value{reason1, reason2}))
+		}
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	branch2.goCancel = func(reason vm.Value) vm.Value {
+		canceled2, reason2 = true, reason
+		if canceled1 {
+			return s.cancel(vm.NewArrayWithArgs([]vm.Value{reason1, reason2}))
+		}
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+
+	return branch1, branch2, nil
+}
+
 func createReadableStreamObject(vmInstance *vm.VM, state *readableStreamState, streamProto, readerProto *vm.PlainObject) vm.Value {
 	obj := vm.NewObject(vm.NewValueFromPlainObject(streamProto)).AsPlainObject()
 	state.streamObj = obj
@@ -329,6 +451,16 @@ func createReadableStreamObject(vmInstance *vm.VM, state *readableStreamState, s
 			reason = args[0]
 		}
 		return state.cancel(reason), nil
+	}))
+
+	obj.SetOwnNonEnumerable("tee", vm.NewNativeFunction(0, false, "tee", func(args []vm.Value) (vm.Value, error) {
+		branch1State, branch2State, err := state.tee()
+		if err != nil {
+			return vm.Undefined, err
+		}
+		branch1Val := createReadableStreamObject(vmInstance, branch1State, streamProto, readerProto)
+		branch2Val := createReadableStreamObject(vmInstance, branch2State, streamProto, readerProto)
+		return vm.NewArrayWithArgs([]vm.Value{branch1Val, branch2Val}), nil
 	}))
 
 	// [Symbol.asyncIterator] - the surface every real SDK's own

--- a/tests/scripts/readable_stream_tee.ts
+++ b/tests/scripts/readable_stream_tee.ts
@@ -1,0 +1,114 @@
+// expect: true
+// #390: ReadableStream.prototype.tee() - two independent branches fed from
+// one shared underlying source, each getting every chunk.
+const results: unknown[] = [];
+
+async function main(): Promise<boolean> {
+  // Basic fan-out: both branches see every chunk, in order, then close.
+  const rs = new ReadableStream({
+    start(controller: any) {
+      controller.enqueue(1);
+      controller.enqueue(2);
+      controller.close();
+    },
+  });
+  results.push(typeof rs.tee === "function");
+  results.push(rs.locked === false);
+
+  const [a, b] = rs.tee();
+  results.push(rs.locked === true);
+
+  const ra = a.getReader();
+  const rb = b.getReader();
+
+  const outA: unknown[] = [];
+  const outB: unknown[] = [];
+  while (true) {
+    const { value, done } = await ra.read();
+    if (done) break;
+    outA.push(value);
+  }
+  while (true) {
+    const { value, done } = await rb.read();
+    if (done) break;
+    outB.push(value);
+  }
+  results.push(outA.length === 2 && outA[0] === 1 && outA[1] === 2);
+  results.push(outB.length === 2 && outB[0] === 1 && outB[1] === 2);
+
+  // Cancelling one branch doesn't cancel the shared original; cancelling
+  // both does, with a composite [reason1, reason2] reason.
+  let cancelledWith: unknown = null;
+  const rs2 = new ReadableStream({
+    start(controller: any) {
+      controller.enqueue("x");
+    },
+    cancel(reason: any) {
+      cancelledWith = reason;
+    },
+  });
+  const [c, d] = rs2.tee();
+  const rc = c.getReader();
+  const rd = d.getReader();
+  await rc.cancel("reasonC");
+  results.push(cancelledWith === null);
+  const stillReadable = await rd.read();
+  results.push(stillReadable.value === "x" && stillReadable.done === false);
+  await rd.cancel("reasonD");
+  const composite = cancelledWith as unknown[];
+  results.push(Array.isArray(composite) && composite[0] === "reasonC" && composite[1] === "reasonD");
+
+  // controller.error() rejects reads on both branches.
+  const rs3 = new ReadableStream({
+    start(controller: any) {
+      controller.enqueue("first");
+      controller.error(new Error("boom"));
+    },
+  });
+  const [e, f] = rs3.tee();
+  const re = e.getReader();
+  const rf = f.getReader();
+  results.push((await re.read()).value === "first");
+  let eRejected = false;
+  let fRejected = false;
+  try {
+    await re.read();
+  } catch (err) {
+    eRejected = (err as any).message === "boom";
+  }
+  try {
+    await rf.read();
+    await rf.read();
+  } catch (err) {
+    fRejected = (err as any).message === "boom";
+  }
+  results.push(eRejected);
+  results.push(fRejected);
+
+  // tee() rejects an already-locked stream, same as getReader() does; and
+  // a stream teed once cannot be teed again.
+  const rs4 = new ReadableStream({ start(c: any) { c.enqueue("y"); } });
+  const lockedReader = rs4.getReader();
+  let teeThrewOnLocked = false;
+  try {
+    rs4.tee();
+  } catch {
+    teeThrewOnLocked = true;
+  }
+  results.push(teeThrewOnLocked);
+  lockedReader.releaseLock();
+
+  const rs5 = new ReadableStream({ start(c: any) { c.enqueue("z"); } });
+  rs5.tee();
+  let teeThrewOnRetee = false;
+  try {
+    rs5.tee();
+  } catch {
+    teeThrewOnRetee = true;
+  }
+  results.push(teeThrewOnRetee);
+
+  return results.every((v) => v === true);
+}
+
+await main();


### PR DESCRIPTION
## Summary

Implements `ReadableStream.prototype.tee()`, which was entirely unimplemented (`rs.tee` was `undefined` on any `ReadableStream` instance). Fixes #390.

Per the issue, this blocked undici's `fetch()` body-cloning path: `lib/web/fetch/body.js#cloneBody` does `const [out1, out2] = body.stream.tee()` as part of `cloneRequest`, which `httpNetworkOrCacheFetch` calls on every real `fetch()` with a request body.

## Implementation

- Added a Go-level `goPull`/`goCancel` hook on `readableStreamState` (`pkg/builtins/readable_stream_init.go`), so a Go-authored producer (not just a JS `underlyingSource` object) can drive `read()`/`cancel()`.
- Implemented `tee()` on top of it: locks the original stream (erroring if already locked, mirroring `getReader()`), spins up two branch states fed by one shared pull loop reading the original, and forwards `cancel()` per spec — cancelling one branch only closes that branch; cancelling both cancels the shared original with a composite `[reason1, reason2]` reason.
- Added `tee` to the type surface as `() => [ReadableStream, ReadableStream]`.

Simplifications vs. the full spec (consistent with the rest of this file's scope note): no byte-stream chunk cloning (both branches share the same chunk reference — fine unless a consumer mutates what it reads) and no backpressure/`highWaterMark` bookkeeping.

## Testing

- `tests/scripts/readable_stream_tee.ts`: new smoke test covering fan-out, single/double cancel semantics, error propagation, and the already-locked guard.
- `pkg/builtins/readable_stream_goroutine_test.go`: new `TestReadableStreamTeeGoroutineFed`, mirroring the existing `TestReadableStreamGoroutineFed` but through `tee()`'s two branches — this is what the issue's actual scenario looks like (a stream fed from a background goroutine, e.g. incremental fetch(), not just a synchronous JS `start()` source). Run under `-race` to validate that tee's internal bookkeeping is only ever touched from the main VM goroutine.
- Verified the issue's exact repro (including `type: "bytes"`) now works.
- `go test ./tests -run TestScripts` and `go test -race ./pkg/builtins/... ./tests/...` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)