### PR TITLE
fix(builtins,vm): TextEncoder.encode() byteLength + top-level await microtask ordering

### DIFF
--- a/pkg/builtins/globals_init.go
+++ b/pkg/builtins/globals_init.go
@@ -78,6 +78,17 @@ func (g *GlobalsInitializer) InitTypes(ctx *TypeContext) error {
 		return err
 	}
 
+	// Add queueMicrotask(callback) - queues callback as a microtask (#393:
+	// real-world host code, e.g. undici's ReadableStream sources, routinely
+	// closes a controller via `queueMicrotask(() => controller.close())`).
+	queueMicrotaskFunctionType := types.NewSimpleFunction(
+		[]types.Type{types.NewSimpleFunction([]types.Type{}, types.Void)},
+		types.Void,
+	)
+	if err := ctx.DefineGlobal("queueMicrotask", queueMicrotaskFunctionType); err != nil {
+		return err
+	}
+
 	// Add parseFloat function
 	parseFloatFunctionType := types.NewSimpleFunction([]types.Type{types.String}, types.Number)
 	if err := ctx.DefineGlobal("parseFloat", parseFloatFunctionType); err != nil {
@@ -136,6 +147,29 @@ func (g *GlobalsInitializer) InitRuntime(ctx *RuntimeContext) error {
 	})
 
 	if err := ctx.DefineGlobal("clock", clockFunc); err != nil {
+		return err
+	}
+
+	// Add queueMicrotask(callback): per spec it throws synchronously if
+	// callback isn't callable, otherwise queues it to run as a microtask on
+	// a later tick. An exception the callback itself throws is reported the
+	// same way an unhandled event-listener exception is elsewhere in this
+	// codebase (e.g. abort_controller_init.go's dispatchEvent) - swallowed
+	// rather than propagated, since there is no promise or caller left to
+	// deliver it to by the time the microtask runs.
+	queueMicrotaskFunc := vm.NewNativeFunction(1, false, "queueMicrotask", func(args []vm.Value) (vm.Value, error) {
+		if len(args) == 0 || !args[0].IsCallable() {
+			return vm.Undefined, vmInstance.NewTypeError("The callback provided as parameter 1 is not a function.")
+		}
+		callback := args[0]
+		rt := vmInstance.GetAsyncRuntime()
+		rt.ScheduleMicrotask(func() {
+			_, _ = vmInstance.Call(callback, vm.Undefined, nil)
+		})
+		return vm.Undefined, nil
+	})
+
+	if err := ctx.DefineGlobal("queueMicrotask", queueMicrotaskFunc); err != nil {
 		return err
 	}
 

--- a/pkg/builtins/text_codec_init.go
+++ b/pkg/builtins/text_codec_init.go
@@ -52,12 +52,15 @@ func (t *TextEncoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 			input = args[0].ToString()
 		}
 		data := []byte(input)
-		arr := vm.NewArray()
-		arrObj := arr.AsArray()
-		for _, b := range data {
-			arrObj.Append(vm.NumberValue(float64(b)))
-		}
-		return arr, nil
+		// Per spec, TextEncoder.prototype.encode() returns a real Uint8Array,
+		// not a plain array of byte values - callers routinely branch on
+		// .byteLength (e.g. undici's extractBody guards enqueue() with
+		// `if (buffer.byteLength)`), which is undefined (falsy) on a plain
+		// Array and silently drops/hangs every such stream (#393).
+		bufVal := vm.NewArrayBuffer(len(data))
+		backing := bufVal.AsArrayBuffer()
+		copy(backing.GetData(), data)
+		return vm.NewTypedArray(vm.TypedArrayUint8, backing, 0, -1), nil
 	}))
 
 	ctor := vm.NewNativeFunction(0, true, "TextEncoder", func(args []vm.Value) (vm.Value, error) {
@@ -152,8 +155,10 @@ func (t *TextDecoderInitializer) InitRuntime(ctx *RuntimeContext) error {
 			ab := input.AsArrayBuffer()
 			return vm.NewString(string(ab.GetData())), nil
 		case vm.TypeArray:
-			// Not a real BufferSource, but TextEncoder.encode() here still
-			// returns a plain array of byte values - keep decoding those.
+			// Not a real BufferSource. TextEncoder.encode() no longer returns
+			// one of these (#393 - it returns a real Uint8Array now), but
+			// decode() stays lenient for any other plain array of byte values
+			// a caller might hand it.
 			arrObj := input.AsArray()
 			bytes := make([]byte, arrObj.Length())
 			for i := 0; i < arrObj.Length(); i++ {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -16607,24 +16607,67 @@ startExecution:
 
 			// Check if we're in top-level await (no async function context)
 			if frame.promiseObj == nil {
-				// Top-level await - drain microtasks until settled for pending
-				// promises. Every check of the promise's disposition below
-				// goes through snapshot() rather than direct field access:
-				// awaitedPromise may be settled from a goroutine other than
-				// this one (e.g. fetch()'s own request goroutine calling
-				// vm.ResolvePromise once its HTTP round-trip completes), and
-				// a raw `awaitedPromise.State` read here is exactly the
-				// unsynchronized access `go test -race` catches racing
-				// against that goroutine's write.
-				tlaState, tlaResult := awaitedPromise.snapshot()
-				if tlaState == PromisePending {
+				// Top-level await must resume only via a proper microtask
+				// hop, even when awaitedPromise is ALREADY settled - the
+				// comment above ("await ALWAYS suspends and schedules
+				// resumption as microtask even when the promise is already
+				// settled") is exactly what this used to violate: it used
+				// to read snapshot() directly and, if not Pending, resume
+				// immediately inline. That let an earlier-queued microtask
+				// (e.g. a ReadableStream pull() that defers
+				// controller.close() via queueMicrotask(), scheduled just
+				// before this await runs) get skipped over entirely,
+				// because nothing here ever drained the microtask queue for
+				// the "already settled" case - so this await's own
+				// resumption jumped the FIFO line ahead of jobs queued
+				// before it (#393: a ReadableStream source deferring its
+				// close() this way saw pull() invoked again before that
+				// close() had a chance to run).
+				//
+				// addAwaitReactions+triggerPromiseReactions is exactly the
+				// mechanism the async-function branch below already uses to
+				// get this right (registering interest and dispatching
+				// through rt.ScheduleMicrotask even for an already-settled
+				// promise) - reused here instead of resuming from a direct
+				// snapshot() read. resumed/tlaState/tlaResult are plain
+				// closures with no lock of their own: the reactions that
+				// write them only ever run inside a scheduled microtask,
+				// which - like every microtask - executes exclusively on
+				// this same goroutine as the drain loop below that reads
+				// them, never concurrently with it (see PromiseObject's own
+				// mu doc comment for why settling itself, from another
+				// goroutine, stays safe regardless).
+				resumed := false
+				var tlaState PromiseState
+				var tlaResult Value
+				awaitDisposition := awaitedPromise.addAwaitReactions(
+					PromiseReaction{
+						Handler: Undefined,
+						Resolve: func(value Value) {
+							tlaState, tlaResult = PromiseFulfilled, value
+							resumed = true
+						},
+						Reject: func(Value) {},
+					},
+					PromiseReaction{
+						Handler: Undefined,
+						Resolve: func(Value) {},
+						Reject: func(reason Value) {
+							tlaState, tlaResult = PromiseRejected, reason
+							resumed = true
+						},
+					},
+				)
+				switch awaitDisposition {
+				case PromiseFulfilled:
+					vm.triggerPromiseReactions(awaitedPromise, true)
+				case PromiseRejected:
+					vm.triggerPromiseReactions(awaitedPromise, false)
+				}
+				if !resumed {
 					rt := vm.GetAsyncRuntime()
 					deadlockRetries := 0
-					for {
-						tlaState, tlaResult = awaitedPromise.snapshot()
-						if tlaState != PromisePending {
-							break
-						}
+					for !resumed {
 						progress := false
 						if rt.RunNextTicks() {
 							progress = true

--- a/tests/scripts/issue_393_text_encoder_bytelength.ts
+++ b/tests/scripts/issue_393_text_encoder_bytelength.ts
@@ -1,0 +1,58 @@
+// expect: true
+// #393: TextEncoder.prototype.encode() must return a real Uint8Array, not a
+// plain Array. A plain Array's .byteLength is undefined (falsy), so any
+// ReadableStream pull() that guards enqueue() on the encoded chunk's own
+// .byteLength - e.g. undici's extractBody:
+//   if (buffer.byteLength) { controller.enqueue(buffer); }
+// - would silently drop the chunk (sync pull) or hang forever (async pull),
+// even though every other equivalent guard (.length, a literal, a
+// different object's .byteLength, or no guard at all) worked fine.
+const results: unknown[] = [];
+
+const encoded = new TextEncoder().encode("hi");
+results.push(encoded instanceof Uint8Array);
+results.push(encoded.byteLength === 2);
+results.push(encoded.length === 2);
+
+// The other branch of undici's guard: an empty body must produce a real,
+// zero-length Uint8Array (falsy .byteLength), not a truthy plain object.
+const empty = new TextEncoder().encode("");
+results.push(empty instanceof Uint8Array);
+results.push(empty.byteLength === 0);
+results.push(!empty.byteLength);
+
+async function readOne(
+  rs: ReadableStream
+): Promise<{ done: boolean; length: number }> {
+  const { done, value } = await rs.getReader().read();
+  return { done, length: value ? value.length : -1 };
+}
+
+// Sync pull: used to silently drop the chunk (done: true, value: undefined).
+const syncStream = new ReadableStream({
+  pull(controller: any) {
+    const buffer = new TextEncoder().encode("hi");
+    if (buffer.byteLength) {
+      controller.enqueue(buffer);
+    }
+    controller.close();
+  },
+});
+const syncResult = await readOne(syncStream);
+results.push(syncResult.done === false && syncResult.length === 2);
+
+// Async pull: used to hang forever (read() promise never settled).
+const buffer = new TextEncoder().encode("hi");
+const asyncStream = new ReadableStream({
+  async pull(controller: any) {
+    if (buffer.byteLength) {
+      controller.enqueue(buffer);
+    }
+    await Promise.resolve(undefined);
+    controller.close();
+  },
+});
+const asyncResult = await readOne(asyncStream);
+results.push(asyncResult.done === false && asyncResult.length === 2);
+
+results.every((r) => r === true);

--- a/tests/scripts/queue_microtask.ts
+++ b/tests/scripts/queue_microtask.ts
@@ -1,0 +1,41 @@
+// expect: true
+// #393: queueMicrotask() didn't exist as a global at all, which meant the
+// very common pattern `queueMicrotask(() => controller.close())` inside a
+// ReadableStream pull() threw "queueMicrotask is not defined" - undici's
+// extractBody() uses exactly this to close its request-body stream.
+const results: unknown[] = [];
+
+results.push(typeof queueMicrotask === "function");
+
+async function main(): Promise<void> {
+  const order: string[] = [];
+  order.push("sync-start");
+  queueMicrotask(() => {
+    order.push("micro-1");
+  });
+  Promise.resolve(undefined).then(() => {
+    order.push("then");
+  });
+  queueMicrotask(() => {
+    order.push("micro-2");
+  });
+  order.push("sync-end");
+
+  await Promise.resolve(undefined);
+  await Promise.resolve(undefined);
+
+  // Both queued microtasks (and the promise reaction) must run after the
+  // synchronous code, and queueMicrotask callbacks must run in FIFO order.
+  results.push(order.join(",") === "sync-start,sync-end,micro-1,then,micro-2");
+}
+await main();
+
+// A non-callable argument throws synchronously, per spec.
+try {
+  (queueMicrotask as any)(42);
+  results.push(false);
+} catch (e) {
+  results.push(true);
+}
+
+results.every((r) => r === true);

--- a/tests/scripts/readable_stream_async_close_drain.ts
+++ b/tests/scripts/readable_stream_async_close_drain.ts
@@ -1,0 +1,55 @@
+// expect: true
+// #393 (follow-up): a "bytes" ReadableStream whose pull() enqueues a chunk
+// and then defers controller.close() to a later microtask - the exact shape
+// of undici's real extractBody() (async pull, queueMicrotask(() =>
+// controller.close())) - must actually reach `done: true` once that close
+// lands, not have pull() invoked again and again forever because the
+// consumer's `read()` calls raced ahead of the still-pending close().
+//
+// This traced back to top-level `await` resuming immediately when the
+// awaited promise was already settled, instead of always deferring through
+// a microtask hop (per spec) - which let it jump the FIFO line ahead of an
+// earlier-queued `queueMicrotask(() => controller.close())` and observe a
+// stream that looked "still open" when it was really about to close. See
+// tests/scripts/queue_microtask.ts for the narrower ordering-only repro and
+// tests/scripts/issue_393_text_encoder_bytelength.ts for the original bug.
+const results: unknown[] = [];
+
+async function main(): Promise<boolean> {
+  let pullCount = 0;
+  const encoder = new TextEncoder();
+  const rs = new ReadableStream({
+    async pull(controller: any) {
+      pullCount++;
+      const buffer = encoder.encode("hello world");
+      if (buffer.byteLength) {
+        controller.enqueue(buffer);
+      }
+      queueMicrotask(() => {
+        controller.close();
+      });
+    },
+    type: "bytes",
+  });
+
+  const reader = rs.getReader();
+  const chunks: number[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value.length);
+    if (chunks.length > 5) break; // safety net against a real runaway
+  }
+
+  results.push(pullCount === 1);
+  results.push(chunks.length === 1 && chunks[0] === 11);
+
+  // A second read past done:true must stay done, not resurrect pull().
+  const again = await reader.read();
+  results.push(again.done === true);
+  results.push(pullCount === 1);
+
+  return results.every((v) => v === true);
+}
+
+await main();

--- a/tests/scripts/top_level_await_reject_already_settled.ts
+++ b/tests/scripts/top_level_await_reject_already_settled.ts
@@ -1,0 +1,32 @@
+// expect: caught:caught-me,caught-settled:late
+// Companion to top_level_await_rejection.ts (the uncaught case) and
+// queue_microtask.ts/readable_stream_async_close_drain.ts (#393's
+// top-level-await-must-always-defer-through-a-microtask fix in vm.go's
+// OpAwait): a top-level `await` of an ALREADY-rejected promise, inside a
+// try/catch, must still reach the catch block - both for a freshly rejected
+// promise and for one that settled well before the await runs (#102 is
+// exactly this regressing for the fresh case; the settled-before-await case
+// is the one the top-level-await/queueMicrotask-ordering fix changed the
+// internal path for, since it now resumes via a deferred reaction instead
+// of reading the promise's state directly).
+const log: string[] = [];
+
+try {
+  await Promise.reject(new Error("caught-me"));
+} catch (e) {
+  log.push("caught:" + (e as Error).message);
+}
+
+const p = Promise.reject(new Error("late"));
+// Give `p` plenty of time to settle (it already has, synchronously) before
+// we ever await it.
+await new Promise<void>((resolve) => {
+  queueMicrotask(() => resolve());
+});
+try {
+  await p;
+} catch (e) {
+  log.push("caught-settled:" + (e as Error).message);
+}
+
+log.join(",");


### PR DESCRIPTION
Fixes #393.

## Root cause

`TextEncoder.prototype.encode()` returned a plain `Array` of byte values instead of a real `Uint8Array`. A plain `Array` has no `.byteLength`, so any `ReadableStream` `pull()` guarding `controller.enqueue(buffer)` on the chunk's own `.byteLength` — undici's `extractBody()` does exactly this — treated it as falsy and silently dropped/hung the stream. This matches the issue's full bisection table exactly (`.length` guard works, `.byteLength` guard fails).

- `pkg/builtins/text_codec_init.go`: `encode()` now returns a real `Uint8Array` view over a backing `ArrayBuffer`, using the same idiom as `ReadableStreamController.EnqueueBytes`.
- `pkg/builtins/globals_init.go`: added the `queueMicrotask()` global, which didn't exist at all — needed for the issue's own async repro (and undici's real source) to close the stream via `queueMicrotask(() => controller.close())`.

## A deeper bug found while verifying the real-world impact

The issue's "Real-world impact" section describes a `fetch()` body hanging indefinitely. Verifying that end-to-end (draining a stream to completion, not just one read) surfaced a second, unrelated bug — and disproved my own initial diagnosis that `readable_stream_init.go`'s `pull()`-invocation logic needed `closeRequested`/`pulling` state tracking. Empirically, wrapping the exact repro in a normal `async function` instead of top-level `await` already worked correctly (one `pull()` call, correct `done: true` on the next read), so the stream implementation wasn't the bug.

The actual bug: top-level `await` resumed *immediately*, skipping the microtask queue, whenever the awaited promise was already settled — violating "await ALWAYS suspends and schedules resumption as microtask," which the code's own comment stated but didn't implement for that case. That let an already-resolved `read()` promise's continuation jump ahead of an earlier-queued `queueMicrotask(() => controller.close())`, so the next `read()` saw a "still open" stream and re-invoked `pull()` forever.

- `pkg/vm/vm.go`: top-level await now goes through the same `addAwaitReactions`/`triggerPromiseReactions` path the async-function branch already used, so resumption always defers through a microtask — even for an already-settled promise — in FIFO order with anything queued earlier.

## Verification

- `go test ./tests -run TestScripts`, `go test ./...`, and `go test -race ./pkg/vm/... ./tests/...` all green.
- Checked the riskiest part of the `vm.go` change — the rejection path (issue #102's original concern) — both fresh and already-settled rejected promises inside `try/catch` are still caught; an uncaught rejection still reports "Uncaught (in promise)".
- Test262 pass rates identical before/after: `language/module-code` (504/592), `language/module-code/top-level-await` (241/251), `built-ins/Promise` (569/639) — no regressions.

## Tests added

- `tests/scripts/issue_393_text_encoder_bytelength.ts` — the issue's sync/async repros plus the empty-body branch of the guard.
- `tests/scripts/queue_microtask.ts` — ordering and non-callable-throws coverage for the new global.
- `tests/scripts/readable_stream_async_close_drain.ts` — full drain-to-completion of an undici-shaped byte stream that closes asynchronously via `queueMicrotask`.
- `tests/scripts/top_level_await_reject_already_settled.ts` — regression guard for the rejection path through the new `vm.go` code.