### PR TITLE
fix(builtins): Blob instances must inherit Blob.prototype, Response/Request.blob() must return real Blobs

### DIFF
--- a/pkg/builtins/blob_init.go
+++ b/pkg/builtins/blob_init.go
@@ -27,7 +27,8 @@ func (b *BlobInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("bytes", types.NewSimpleFunction([]types.Type{}, types.Any)).       // Returns Promise<Uint8Array>
 		WithProperty("text", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<string>
 		WithProperty("slice", types.NewSimpleFunction([]types.Type{types.Number, types.Number, types.String}, types.Any)).
-		WithProperty("stream", types.NewSimpleFunction([]types.Type{}, types.Any)) // Returns ReadableStream (stub)
+		WithProperty("stream", types.NewSimpleFunction([]types.Type{}, types.Any)). // Returns ReadableStream (stub)
+		WithProperty("constructor", types.Any)                                     // Avoid circular reference, use Any for constructor property
 
 	// BlobPropertyBag type
 	blobOptionsType := types.NewObjectType().

--- a/pkg/builtins/blob_init.go
+++ b/pkg/builtins/blob_init.go
@@ -87,7 +87,7 @@ func (b *BlobInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		}
 
-		return createBlobObject(vmInstance, blob, blobProto), nil
+		return createBlobObject(vmInstance, blob, vm.NewValueFromPlainObject(blobProto)), nil
 	}
 
 	blobConstructor := vm.NewConstructorWithProps(2, false, "Blob", blobConstructorFn)
@@ -137,8 +137,8 @@ func blobPartToBytes(part vm.Value) []byte {
 	return []byte{}
 }
 
-func createBlobObject(vmInstance *vm.VM, blob *Blob, _ *vm.PlainObject) vm.Value {
-	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+func createBlobObject(vmInstance *vm.VM, blob *Blob, proto vm.Value) vm.Value {
+	obj := vm.NewObject(proto).AsPlainObject()
 
 	// size property (read-only)
 	obj.SetOwn("size", vm.NumberValue(float64(len(blob.data))))
@@ -207,7 +207,7 @@ func createBlobObject(vmInstance *vm.VM, blob *Blob, _ *vm.PlainObject) vm.Value
 			mimeType: contentType,
 		}
 
-		return createBlobObject(vmInstance, newBlob, nil), nil
+		return createBlobObject(vmInstance, newBlob, proto), nil
 	}))
 
 	// stream() -> ReadableStream over the Blob's already-known bytes,

--- a/pkg/builtins/blob_init.go
+++ b/pkg/builtins/blob_init.go
@@ -101,6 +101,24 @@ func (b *BlobInitializer) InitRuntime(ctx *RuntimeContext) error {
 	return ctx.DefineGlobal("Blob", blobConstructor)
 }
 
+// NewBlobValue constructs a real Blob instance - correct instanceof,
+// constructor, and prototype chain (#395) - from raw bytes. Other builtins
+// that need to hand back a spec-correct Blob rather than a bare
+// Uint8Array/ArrayBuffer (e.g. fetch's Body.blob()) should use this instead
+// of building the object by hand.
+func NewBlobValue(vmInstance *vm.VM, data []byte, mimeType string) vm.Value {
+	blob := &Blob{data: data, mimeType: mimeType}
+
+	proto := vmInstance.ObjectPrototype
+	if ctor, ok := vmInstance.GetGlobal("Blob"); ok && ctor.Type() == vm.TypeNativeFunctionWithProps {
+		if p, exists := ctor.AsNativeFunctionWithProps().Properties.GetOwn("prototype"); exists {
+			proto = p
+		}
+	}
+
+	return createBlobObject(vmInstance, blob, proto)
+}
+
 // Blob represents binary data with a MIME type
 type Blob struct {
 	data     []byte

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -83,7 +83,7 @@ func (f *FetchInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("type", types.String).
 		WithProperty("text", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<string>
 		WithProperty("json", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<any>
-		WithProperty("blob", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<Uint8Array>
+		WithProperty("blob", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<Blob>
 		WithProperty("arrayBuffer", types.NewSimpleFunction([]types.Type{}, types.Any)). // Returns Promise<ArrayBuffer>
 		WithProperty("bytes", types.NewSimpleFunction([]types.Type{}, types.Any)).       // Returns Promise<Uint8Array>
 		WithProperty("clone", types.NewSimpleFunction([]types.Type{}, types.Any))        // Returns Response
@@ -1058,15 +1058,16 @@ func createResponseObject(vmInstance *vm.VM, r *FetchResponse) vm.Value {
 		}), nil
 	}))
 
-	// blob() -> Promise<Uint8Array>
+	// blob() -> Promise<Blob>
 	obj.SetOwnNonEnumerable("blob", vm.NewNativeFunction(0, false, "blob", func(args []vm.Value) (vm.Value, error) {
 		if r.bodyUsed {
 			return vmInstance.NewRejectedPromise(vm.NewString("body already used")), nil
 		}
 		r.bodyUsed = true
 		obj.SetOwn("bodyUsed", vm.True)
+		mimeType := blobTypeFromContentType(r.Headers.headers.Get("Content-Type"))
 		return drainBody(func(data []byte) (vm.Value, error) {
-			return bytesToValue(data), nil
+			return NewBlobValue(vmInstance, data, mimeType), nil
 		}), nil
 	}))
 
@@ -1204,13 +1205,25 @@ func newTypeError(vmInstance *vm.VM, message string) error {
 	return vmInstance.NewExceptionError(newTypeErrorValue(vmInstance, message))
 }
 
-// bytesToValue wraps raw bytes as a Uint8Array, the representation blob()/
-// bytes() resolve to.
+// bytesToValue wraps raw bytes as a Uint8Array, the representation bytes()
+// resolves to (blob() resolves to a real Blob - see NewBlobValue).
 func bytesToValue(data []byte) vm.Value {
 	arrayBufferValue := vm.NewArrayBuffer(len(data))
 	buffer := arrayBufferValue.AsArrayBuffer()
 	copy(buffer.GetData(), data)
 	return vm.NewTypedArray(vm.TypedArrayUint8, buffer, 0, -1)
+}
+
+// blobTypeFromContentType approximates the Fetch spec's Body.blob() "get the
+// MIME type" step: the MIME essence - type/subtype, without any
+// ";charset=..." parameters - lowercased, or "" if the header is absent.
+// Unlike the spec, this doesn't validate the essence as a real MIME type
+// (e.g. a garbage header like "not-a-mime-type" passes through unchanged
+// instead of yielding ""); good enough for undici's instanceof-based
+// Blob-shape checks without a full MIME parser.
+func blobTypeFromContentType(contentType string) string {
+	essence := strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
+	return strings.ToLower(essence)
 }
 
 // doFetchRequestWithContext performs the HTTP request with context support
@@ -1686,15 +1699,12 @@ func createRequestObject(vmInstance *vm.VM, req *FetchRequest, _ *vm.PlainObject
 		req.bodyUsed = true
 		obj.SetOwn("bodyUsed", vm.True)
 
+		mimeType := blobTypeFromContentType(req.Headers.headers.Get("Content-Type"))
 		if req.body == nil {
-			return vmInstance.NewResolvedPromise(vm.NewArrayBuffer(0)), nil
+			return vmInstance.NewResolvedPromise(NewBlobValue(vmInstance, nil, mimeType)), nil
 		}
 
-		arrayBuffer := vm.NewArrayBuffer(len(req.body))
-		buf := arrayBuffer.AsArrayBuffer()
-		copy(buf.GetData(), req.body)
-		uint8Array := vm.NewTypedArray(vm.TypedArrayUint8, buf, 0, -1)
-		return vmInstance.NewResolvedPromise(uint8Array), nil
+		return vmInstance.NewResolvedPromise(NewBlobValue(vmInstance, req.body, mimeType)), nil
 	}))
 
 	// json() -> Promise<any>

--- a/pkg/driver/builtin_modules_test.go
+++ b/pkg/driver/builtin_modules_test.go
@@ -240,7 +240,9 @@ func TestGlobalFetchAutoStringify(t *testing.T) {
 	}
 }
 
-// TestGlobalFetchBlob tests the Response.blob() method which returns Uint8Array
+// TestGlobalFetchBlob tests that Response.blob() resolves to a real Blob
+// instance (see #395/#396) - not a bare Uint8Array - whose bytes and type
+// round-trip correctly.
 func TestGlobalFetchBlob(t *testing.T) {
 	// Create a test server that returns binary data
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -265,22 +267,25 @@ func TestGlobalFetchBlob(t *testing.T) {
 			const response = await fetch("%s/binary");
 			console.log("Response status:", response.status);
 
-			// Get response as binary data (should be Uint8Array)
+			// Get response body as a Blob (per spec, not a Uint8Array).
 			const blob = await response.blob();
 			console.log("Blob type:", typeof blob);
 			console.log("Blob constructor:", blob.constructor?.name);
-			console.log("Blob length:", blob.length);
-			console.log("Blob byteLength:", blob.byteLength);
-			console.log("Blob buffer:", typeof blob.buffer);
+			console.log("Blob isBlobInstance:", blob instanceof Blob);
+			console.log("Blob size:", blob.size);
+			console.log("Blob mimeType:", blob.type);
 
-			// Check if it's a proper Uint8Array
-			const hasUint8ArrayFeatures = blob.length === 6 &&
-										  blob[0] === 1 &&
-										  blob[5] === 255 &&
-										  blob.byteLength === 6 &&
-										  typeof blob.buffer === "object";
+			const bytes = new Uint8Array(await blob.arrayBuffer());
 
-			return hasUint8ArrayFeatures ? "blob_test_passed" : "blob_test_failed";
+			const hasBlobFeatures = blob instanceof Blob &&
+									 blob.constructor?.name === "Blob" &&
+									 blob.size === 6 &&
+									 blob.type === "application/octet-stream" &&
+									 bytes.length === 6 &&
+									 bytes[0] === 1 &&
+									 bytes[5] === 255;
+
+			return hasBlobFeatures ? "blob_test_passed" : "blob_test_failed";
 		}
 
 		await runTest();

--- a/tests/scripts/blob_instanceof.ts
+++ b/tests/scripts/blob_instanceof.ts
@@ -1,0 +1,17 @@
+// expect: true
+
+// #395: new Blob(...) must produce a real Blob instance - constructor,
+// prototype chain, and instanceof must all agree, matching the DOM/File API
+// spec (and real Node/undici, which relies on `x instanceof Blob` to detect
+// Blob/File-shaped fetch bodies).
+const b = new Blob(["hi"]);
+const check1 = b instanceof Blob;
+const check2 = Object.getPrototypeOf(b) === Blob.prototype;
+
+// slice() must return an instance sharing the same prototype, not a bare
+// Object (it was previously constructed with vmInstance.ObjectPrototype).
+const sliced = b.slice(0, 1);
+const check3 = sliced instanceof Blob;
+const check4 = Object.getPrototypeOf(sliced) === Blob.prototype;
+
+check1 && check2 && check3 && check4;

--- a/tests/scripts/fetch_body_blob_test.ts
+++ b/tests/scripts/fetch_body_blob_test.ts
@@ -1,0 +1,37 @@
+// expect: true
+
+// #395 follow-up: Response.blob()/Request.blob() must resolve to a real
+// Blob (correct instanceof/prototype chain), not a bare Uint8Array, and
+// its "type" should come from the Content-Type header.
+async function run(): Promise<boolean> {
+  const res = new Response("hi there", {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+  const resBlob = await res.blob();
+  const check1 =
+    resBlob instanceof Blob &&
+    Object.getPrototypeOf(resBlob) === Blob.prototype &&
+    resBlob.type === "text/plain" &&
+    resBlob.size === 8;
+
+  const req = new Request("http://example.com", {
+    method: "POST",
+    body: "abc",
+    headers: { "Content-Type": "application/json" },
+  });
+  const reqBlob = await req.blob();
+  const check2 =
+    reqBlob instanceof Blob &&
+    Object.getPrototypeOf(reqBlob) === Blob.prototype &&
+    reqBlob.type === "application/json" &&
+    reqBlob.size === 3;
+
+  // Request with no body at all must still resolve to an empty Blob.
+  const emptyReq = new Request("http://example.com");
+  const emptyBlob = await emptyReq.blob();
+  const check3 = emptyBlob instanceof Blob && emptyBlob.size === 0;
+
+  return check1 && check2 && check3;
+}
+
+await run();


### PR DESCRIPTION
Fixes #395.

## Problem

`new Blob([...])` didn't produce a real `Blob` instance: `instanceof Blob`, `.constructor`, and `Object.getPrototypeOf()` all disagreed with a real Blob. Root cause: `createBlobObject()` accepted a `proto` parameter but discarded it, always building on `ObjectPrototype` instead of `Blob.prototype`. `slice()` had the same bug for its returned sub-Blob.

While in the area, fixed the related bug the issue's motivation actually depends on: `Response.blob()` / `Request.blob()` resolved to a bare `Uint8Array`/`ArrayBuffer` rather than a `Blob` at all — which is exactly what breaks undici's `isBlobLike` (`object instanceof Blob`) check named in the issue.

## Changes

- `createBlobObject()` now uses the `Blob.prototype` passed to it (constructor and `slice()` both thread it through correctly).
- Added `NewBlobValue()` as the shared way for other builtins to construct a spec-correct `Blob` instance instead of building one by hand.
- `Response.blob()` / `Request.blob()` now resolve to a real `Blob`, with `.type` derived from the `Content-Type` header (`blobTypeFromContentType`, a best-effort MIME-essence extraction, not full MIME validation — documented as such in the code).

## Testing

- `tests/scripts/blob_instanceof.ts` — instanceof/constructor/prototype-chain checks for `new Blob()` and `.slice()`.
- `tests/scripts/fetch_body_blob_test.ts` — `Response.blob()`/`Request.blob()` return real Blobs with the right `.type`/`.size`, including the empty-body case.
- `go test ./tests -run TestScripts` — full smoke suite green.
- `go build ./...` and `go vet ./...` clean.

## Out of scope (noted, not fixed here)

- `Request.formData()` is an unimplemented stub (rejects with "not yet implemented") — no Blob-shaped FormData entries exist yet to fix.
- `Blob.prototype` methods (`size`/`type`/`arrayBuffer`/etc.) are still defined per-instance rather than on the shared prototype — a separate cleanup.
