### PR TITLE
fix(builtins): implement Request/Response.formData() parsing (#397)

### DIFF
--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -86,6 +86,7 @@ func (f *FetchInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("blob", types.NewSimpleFunction([]types.Type{}, types.Any)).        // Returns Promise<Blob>
 		WithProperty("arrayBuffer", types.NewSimpleFunction([]types.Type{}, types.Any)). // Returns Promise<ArrayBuffer>
 		WithProperty("bytes", types.NewSimpleFunction([]types.Type{}, types.Any)).       // Returns Promise<Uint8Array>
+		WithProperty("formData", types.NewSimpleFunction([]types.Type{}, types.Any)).    // Returns Promise<FormData>
 		WithProperty("clone", types.NewSimpleFunction([]types.Type{}, types.Any))        // Returns Response
 
 	// ResponseInit type
@@ -1085,6 +1086,19 @@ func createResponseObject(vmInstance *vm.VM, r *FetchResponse) vm.Value {
 		}), nil
 	}))
 
+	// formData() -> Promise<FormData> (#397)
+	obj.SetOwnNonEnumerable("formData", vm.NewNativeFunction(0, false, "formData", func(args []vm.Value) (vm.Value, error) {
+		if r.bodyUsed {
+			return vmInstance.NewRejectedPromise(vm.NewString("body already used")), nil
+		}
+		r.bodyUsed = true
+		obj.SetOwn("bodyUsed", vm.True)
+		contentType := r.Headers.headers.Get("Content-Type")
+		return drainBody(func(data []byte) (vm.Value, error) {
+			return parseMultipartFormData(vmInstance, contentType, data)
+		}), nil
+	}))
+
 	// bytes() -> Promise<Uint8Array> (same as blob, but standard name)
 	obj.SetOwnNonEnumerable("bytes", vm.NewNativeFunction(0, false, "bytes", func(args []vm.Value) (vm.Value, error) {
 		if r.bodyUsed {
@@ -1740,9 +1754,19 @@ func createRequestObject(vmInstance *vm.VM, req *FetchRequest, _ *vm.PlainObject
 		return vmInstance.NewResolvedPromise(vm.NewString(string(req.body))), nil
 	}))
 
-	// formData() -> Promise<FormData> (stub - would need FormData parsing)
+	// formData() -> Promise<FormData> (#397)
 	obj.SetOwnNonEnumerable("formData", vm.NewNativeFunction(0, false, "formData", func(args []vm.Value) (vm.Value, error) {
-		return vmInstance.NewRejectedPromise(vm.NewString("formData() parsing not yet implemented")), nil
+		if req.bodyUsed {
+			return vmInstance.NewRejectedPromise(vm.NewString("body already used")), nil
+		}
+		req.bodyUsed = true
+		obj.SetOwn("bodyUsed", vm.True)
+
+		fdValue, err := parseMultipartFormData(vmInstance, req.Headers.headers.Get("Content-Type"), req.body)
+		if err != nil {
+			return vmInstance.NewRejectedPromise(vm.NewString(err.Error())), nil
+		}
+		return vmInstance.NewResolvedPromise(fdValue), nil
 	}))
 
 	return vm.NewValueFromPlainObject(obj)

--- a/pkg/builtins/formdata_init.go
+++ b/pkg/builtins/formdata_init.go
@@ -30,7 +30,8 @@ func (f *FormDataInitializer) InitTypes(ctx *TypeContext) error {
 		WithProperty("entries", types.NewSimpleFunction([]types.Type{}, types.Any)).
 		WithProperty("keys", types.NewSimpleFunction([]types.Type{}, types.Any)).
 		WithProperty("values", types.NewSimpleFunction([]types.Type{}, types.Any)).
-		WithProperty("forEach", types.NewSimpleFunction([]types.Type{types.Any}, types.Undefined))
+		WithProperty("forEach", types.NewSimpleFunction([]types.Type{types.Any}, types.Undefined)).
+		WithProperty("constructor", types.Any) // Avoid circular reference, use Any for constructor property
 
 	// FormData constructor type
 	formDataConstructorType := types.NewObjectType().
@@ -51,7 +52,7 @@ func (f *FormDataInitializer) InitRuntime(ctx *RuntimeContext) error {
 		fd := &FormData{
 			entries: make([]FormDataEntry, 0),
 		}
-		return createFormDataObject(vmInstance, fd, formDataProto), nil
+		return createFormDataObject(vmInstance, fd, vm.NewValueFromPlainObject(formDataProto)), nil
 	}
 
 	formDataConstructor := vm.NewConstructorWithProps(0, false, "FormData", formDataConstructorFn)
@@ -77,8 +78,23 @@ type FormData struct {
 	entries []FormDataEntry
 }
 
-func createFormDataObject(vmInstance *vm.VM, fd *FormData, _ *vm.PlainObject) vm.Value {
-	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+// NewFormDataValue constructs a real FormData instance - correct
+// instanceof/constructor/prototype chain (mirrors NewBlobValue, #395) -
+// from an already-populated *FormData. Other builtins that need to hand
+// back a spec-correct FormData (e.g. Request/Response.formData(), #397)
+// should use this instead of building the object by hand.
+func NewFormDataValue(vmInstance *vm.VM, fd *FormData) vm.Value {
+	proto := vmInstance.ObjectPrototype
+	if ctor, ok := vmInstance.GetGlobal("FormData"); ok && ctor.Type() == vm.TypeNativeFunctionWithProps {
+		if p, exists := ctor.AsNativeFunctionWithProps().Properties.GetOwn("prototype"); exists {
+			proto = p
+		}
+	}
+	return createFormDataObject(vmInstance, fd, proto)
+}
+
+func createFormDataObject(vmInstance *vm.VM, fd *FormData, proto vm.Value) vm.Value {
+	obj := vm.NewObject(proto).AsPlainObject()
 
 	// append(name, value) or append(name, blob, filename)
 	obj.SetOwnNonEnumerable("append", vm.NewNativeFunction(3, false, "append", func(args []vm.Value) (vm.Value, error) {

--- a/pkg/builtins/formdata_multipart.go
+++ b/pkg/builtins/formdata_multipart.go
@@ -1,0 +1,83 @@
+package builtins
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"strings"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// parseMultipartFormData parses a `multipart/form-data` body - per the
+// Content-Type header's boundary parameter - into a real FormData instance
+// (#397). Matches FormData's existing runtime representation
+// (formdata_init.go): each part becomes a FormDataEntry, and a file-shaped
+// part (one whose Content-Disposition carries a filename) becomes a real
+// Blob (via NewBlobValue, added for #396) with its `.type` taken from the
+// part's own Content-Type header, not the outer body's - so undici-style
+// isBlobLike()/isFormDataLike() checks succeed on the round trip.
+//
+// Uses multipart.NewReader + NextPart() rather than the stdlib's
+// (*multipart.Reader).ReadForm, which spills large parts to temp files on
+// disk above a memory threshold - everything here is read fully in memory,
+// consistent with how the rest of this runtime treats bodies.
+//
+// contentType must carry a "multipart/form-data" media type with a
+// boundary parameter; anything else (missing header, wrong media type, no
+// boundary) is a plain error - callers turn that into a rejected promise,
+// matching how Request/Response's other body-parsing methods (json(),
+// e.g.) already reject with a bare error message rather than a typed
+// exception.
+func parseMultipartFormData(vmInstance *vm.VM, contentType string, data []byte) (vm.Value, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return vm.Value{}, errors.New("Failed to parse body as FormData: could not parse Content-Type")
+	}
+	if !strings.EqualFold(mediaType, "multipart/form-data") {
+		return vm.Value{}, errors.New("Failed to parse body as FormData: Content-Type is not multipart/form-data")
+	}
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return vm.Value{}, errors.New("Failed to parse body as FormData: missing boundary in Content-Type")
+	}
+
+	fd := &FormData{entries: make([]FormDataEntry, 0)}
+	reader := multipart.NewReader(bytes.NewReader(data), boundary)
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return vm.Value{}, errors.New("Failed to parse body as FormData: " + err.Error())
+		}
+
+		content, err := io.ReadAll(part)
+		part.Close()
+		if err != nil {
+			return vm.Value{}, errors.New("Failed to parse body as FormData: " + err.Error())
+		}
+
+		name := part.FormName()
+		filename := part.FileName()
+
+		var value vm.Value
+		if filename != "" {
+			mimeType := blobTypeFromContentType(part.Header.Get("Content-Type"))
+			value = NewBlobValue(vmInstance, content, mimeType)
+		} else {
+			value = vm.NewString(string(content))
+		}
+
+		fd.entries = append(fd.entries, FormDataEntry{
+			name:     name,
+			value:    value,
+			filename: filename,
+		})
+	}
+
+	return NewFormDataValue(vmInstance, fd), nil
+}

--- a/tests/scripts/fetch_formdata_test.ts
+++ b/tests/scripts/fetch_formdata_test.ts
@@ -1,0 +1,52 @@
+// expect: true
+
+// #397: Request/Response.formData() must parse a multipart/form-data body
+// into a real FormData - text fields as strings, file-shaped parts
+// (a Content-Disposition filename) as real Blob instances (#396) whose
+// .type comes from the part's own Content-Type, not the outer body's.
+const boundary = "----paseratiTestBoundary";
+const body =
+  `--${boundary}\r\n` +
+  `Content-Disposition: form-data; name="field1"\r\n\r\n` +
+  `value1\r\n` +
+  `--${boundary}\r\n` +
+  `Content-Disposition: form-data; name="file1"; filename="a.txt"\r\n` +
+  `Content-Type: text/plain\r\n\r\n` +
+  `hello file\r\n` +
+  `--${boundary}--\r\n`;
+const contentType = `multipart/form-data; boundary=${boundary}`;
+
+async function run(): Promise<boolean> {
+  const res = new Response(body, { headers: { "Content-Type": contentType } });
+  const resFd = await res.formData();
+  const file = resFd.get("file1");
+  const check1 =
+    resFd.get("field1") === "value1" &&
+    file instanceof Blob &&
+    file.type === "text/plain" &&
+    file.size === 10 &&
+    (await file.text()) === "hello file";
+
+  const req = new Request("http://example.com", {
+    method: "POST",
+    body: body,
+    headers: { "Content-Type": contentType },
+  });
+  const reqFd = await req.formData();
+  const check2 = reqFd.get("field1") === "value1";
+
+  // formData() must reject a body whose Content-Type isn't multipart/form-data.
+  let check3 = false;
+  try {
+    const badRes = new Response("hi", {
+      headers: { "Content-Type": "text/plain" },
+    });
+    await badRes.formData();
+  } catch (e) {
+    check3 = true;
+  }
+
+  return check1 && check2 && check3;
+}
+
+await run();

--- a/tests/scripts/formdata_instanceof_test.ts
+++ b/tests/scripts/formdata_instanceof_test.ts
@@ -1,0 +1,9 @@
+// expect: true
+
+// FormData instances must inherit FormData.prototype (same bug class as
+// #395's Blob instanceof fix) - undici-style isFormDataLike() checks and
+// plain `instanceof FormData` both depend on this.
+const fd = new FormData();
+fd instanceof FormData &&
+  fd.constructor === FormData &&
+  Object.getPrototypeOf(fd) === FormData.prototype;


### PR DESCRIPTION
## Summary

Fixes #397. `Request.prototype.formData()` was a stub that always rejected; `Response.prototype.formData()` didn't exist at all.

- Adds a `multipart/form-data` body parser (`pkg/builtins/formdata_multipart.go`, using `mime`/`mime/multipart` in-memory - not `ReadForm`, which spills large parts to disk) that builds a real `FormData` from the `Content-Type` header's boundary: text parts become strings, file-shaped parts (a `filename` in `Content-Disposition`) become real `Blob` instances (#396) via `NewBlobValue`, with `.type` taken from the part's own `Content-Type`.
- Wires it into `Request.formData()` (replacing the stub, and now setting `bodyUsed` like every sibling method already does) and adds `Response.formData()` (both the runtime object and its TS type - it didn't exist as a property at all before), routed through the existing `drainBody` so it also works against a still-streaming `fetch()` response.
- Rejections use a bare-string message, matching how `text()`/`json()`/`blob()` already reject on `Request`/`Response` in this file.

**Prerequisite fix included**: `new FormData() instanceof FormData` was `false` - the same bug class as #395's Blob fix (the constructor built instances via `vm.NewObject(vmInstance.ObjectPrototype)`, ignoring `FormData.prototype` entirely). Fixed with `NewFormDataValue`, mirroring `NewBlobValue`. Landed as its own commit since it's a fix to a different (pre-existing) bug that this feature happens to depend on.

## Out of scope (per #397)

- `application/x-www-form-urlencoded` bodies through `formData()`.
- Encoding a `FormData` as an outgoing request body (`new Request(url, { body: formData })`) - separately unimplemented; a candidate for its own issue.

## Testing

- `go build ./...` clean.
- `go test ./tests -run TestScripts` - full smoke suite green.
- New smoke tests:
  - `tests/scripts/formdata_instanceof_test.ts` - `instanceof`/`constructor`/prototype chain for `new FormData()`.
  - `tests/scripts/fetch_formdata_test.ts` - `Request`/`Response.formData()` end-to-end: a text field, a file field (`instanceof Blob`, `.type`, `.size`, content), and rejection on a non-multipart `Content-Type`.