### PR TITLE
fix(vm): repair register/frame lifetime bugs behind #399/#400/#401 (B1)

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6678,7 +6678,11 @@ startExecution:
 			if debugVM {
 				fmt.Printf("[DBG] Popping frame...\n")
 			}
-			returningFrameRegSize := function.RegisterSize
+			// Use allocatedRegSize (not function.RegisterSize) which tracks actual
+			// allocation - may differ from the current function's own RegisterSize
+			// because of TCO expansion by an earlier link in a tail-call chain
+			// (see the matching comment on OpReturn above, and #399/B1).
+			returningFrameRegSize := frame.allocatedRegSize
 			callerTargetRegister := frame.targetRegister
 			isConstructor := frame.isConstructorCall
 			constructorThisValue := frame.thisValue
@@ -12708,6 +12712,7 @@ startExecution:
 					newFrame.args = finalArgs
 					newFrame.argumentsObject = Undefined
 					newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
+					newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
 					vm.nextRegSlot += requiredRegs
 
 					// Copy combined args to registers
@@ -15688,7 +15693,11 @@ startExecution:
 			}
 
 			// Pop the current frame (same logic as OpReturn)
-			returningFrameRegSize := function.RegisterSize
+			// Use allocatedRegSize (not function.RegisterSize): it tracks actual
+			// allocation, which may exceed the current function's own RegisterSize
+			// because of TCO expansion by an earlier link in a tail-call chain
+			// (see the matching comment on OpReturn/OpReturnUndefined, and #399/B1).
+			returningFrameRegSize := frame.allocatedRegSize
 			callerTargetRegister := frame.targetRegister
 			isConstructor := frame.isConstructorCall
 			constructorThisValue := frame.thisValue
@@ -15883,7 +15892,9 @@ startExecution:
 				}
 
 				// Pop the current frame
-				returningFrameRegSize := function.RegisterSize
+				// Use allocatedRegSize (not function.RegisterSize): see the matching
+				// comment on OpReturn/OpReturnUndefined/OpReturnFinally (#399/B1).
+				returningFrameRegSize := frame.allocatedRegSize
 				callerTargetRegister := frame.targetRegister
 				isConstructor := frame.isConstructorCall
 				constructorThisValue := frame.thisValue
@@ -18229,10 +18240,211 @@ startExecution:
 				}
 				continue // Let exception unwinding take over
 			case ActionReturn:
-				// Resume the return with saved value
+				// Resume the return with saved value. This mirrors
+				// OpHandlePending's ActionReturn arm exactly (#401/B1): that
+				// opcode is the normal, compiler-emitted way a pending return
+				// gets completed after a finally block, and this generic
+				// fallback only exists in case some compiled shape reaches
+				// finallyDepth==0 without an OpHandlePending having run first.
+				// TODO(#401): factor this and OpHandlePending's/OpReturnFinally's
+				// near-identical pop-and-resume logic into one shared helper
+				// instead of three copies.
+
+				// Check if we have more finally or iterator cleanup handlers
+				// that need to run BEFORE completing the return.
+				if nextHandler := vm.findPendingHandler(frame.ip, true); nextHandler != nil {
+					// Keep pendingAction as ActionReturn so the chain continues.
+					frame.ip = nextHandler.HandlerPC
+					ip = nextHandler.HandlerPC
+					vm.finallyDepth++
+					continue
+				}
+
+				// No more handlers - execute the pending return.
+				result := vm.pendingValue
 				vm.pendingAction = ActionNone
-				_ = vm.pendingValue // TODO: Implement return logic
 				vm.pendingValue = Undefined
+
+				// Close upvalues for the returning frame (only if this function has captured locals)
+				if frame.openUpvalues != nil {
+					vm.closeFrameUpvalues(frame)
+				}
+
+				// Check if this is a generator function returning
+				if frame.generatorObj != nil {
+					frame.generatorObj.State = GeneratorCompleted
+					frame.generatorObj.Done = true
+					frame.generatorObj.ReturnValue = result
+					frame.generatorObj.Frame = nil
+					iterResult := NewObject(vm.ObjectPrototype).AsPlainObject()
+					iterResult.SetOwn("value", result)
+					iterResult.SetOwn("done", BooleanValue(true))
+					result = NewValueFromPlainObject(iterResult)
+				}
+
+				// Pop the current frame. Use allocatedRegSize (not
+				// function.RegisterSize): see the matching comment on
+				// OpReturn/OpReturnUndefined/OpReturnFinally (#399/B1).
+				returningFrameRegSize := frame.allocatedRegSize
+				callerTargetRegister := frame.targetRegister
+				isConstructor := frame.isConstructorCall
+				constructorThisValue := frame.thisValue
+				isDerivedConstructor := frame.closure != nil && frame.closure.Fn.IsDerivedConstructor
+
+				vm.frameCount--
+				vm.nextRegSlot -= returningFrameRegSize
+
+				if vm.frameCount == 0 {
+					return InterpretOK, result
+				}
+
+				// Check if we hit a sentinel frame - if so, return immediately with the result
+				if vm.frames[vm.frameCount-1].isSentinelFrame {
+					if isConstructor {
+						if result.IsObject() || result.IsCallable() {
+							// Return the explicit object
+						} else if !isDerivedConstructor {
+							result = constructorThisValue
+						} else if result.Type() != TypeUndefined {
+							vm.ThrowTypeError("Derived constructors may only return object or undefined")
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							return InterpretRuntimeError, vm.currentException
+						} else if constructorThisValue.typ == TypeUninitialized {
+							vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							return InterpretRuntimeError, vm.currentException
+						} else {
+							result = constructorThisValue
+						}
+					}
+					sentinelFrame := &vm.frames[vm.frameCount-1]
+					if sentinelFrame.registers != nil && int(callerTargetRegister) < len(sentinelFrame.registers) {
+						sentinelFrame.registers[callerTargetRegister] = result
+					}
+					vm.frameCount--
+					if vm.finallyDepth > 0 {
+						vm.finallyDepth--
+					}
+					return InterpretOK, result
+				}
+
+				// Handle the return value in the caller frame
+				if frame.isDirectCall {
+					var finalResult Value
+					if isConstructor {
+						if result.IsObject() || result.IsCallable() {
+							finalResult = result
+						} else if !isDerivedConstructor {
+							finalResult = constructorThisValue
+						} else if result.Type() != TypeUndefined {
+							vm.ThrowTypeError("Derived constructors may only return object or undefined")
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							return InterpretRuntimeError, vm.currentException
+						} else if constructorThisValue.typ == TypeUninitialized {
+							vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
+							if !vm.unwinding {
+								frame = &vm.frames[vm.frameCount-1]
+								closure = frame.closure
+								function = closure.Fn
+								code = function.Chunk.Code
+								constants = function.Chunk.Constants
+								registers = frame.registers
+								ip = frame.ip
+								continue
+							}
+							return InterpretRuntimeError, vm.currentException
+						} else {
+							finalResult = constructorThisValue
+						}
+					} else {
+						finalResult = result
+					}
+					return InterpretOK, finalResult
+				}
+
+				// Get the caller frame
+				callerFrame := &vm.frames[vm.frameCount-1]
+
+				var finalResult Value
+				if isConstructor {
+					if result.IsObject() || result.IsCallable() {
+						finalResult = result
+					} else if !isDerivedConstructor {
+						finalResult = constructorThisValue
+					} else if result.Type() != TypeUndefined {
+						vm.ThrowTypeError("Derived constructors may only return object or undefined")
+						if !vm.unwinding {
+							frame = callerFrame
+							closure = frame.closure
+							function = closure.Fn
+							code = function.Chunk.Code
+							constants = function.Chunk.Constants
+							registers = frame.registers
+							ip = frame.ip
+							continue
+						}
+						return InterpretRuntimeError, Undefined
+					} else if constructorThisValue.typ == TypeUninitialized {
+						vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
+						if !vm.unwinding {
+							frame = callerFrame
+							closure = frame.closure
+							function = closure.Fn
+							code = function.Chunk.Code
+							constants = function.Chunk.Constants
+							registers = frame.registers
+							ip = frame.ip
+							continue
+						}
+						return InterpretRuntimeError, Undefined
+					} else {
+						finalResult = constructorThisValue
+					}
+				} else {
+					finalResult = result
+				}
+
+				if int(callerTargetRegister) < len(callerFrame.registers) {
+					callerFrame.registers[callerTargetRegister] = finalResult
+				} else {
+					status := vm.runtimeError("Internal Error: Invalid target register %d for pending return.", callerTargetRegister)
+					return status, Undefined
+				}
+
+				frame = callerFrame
+				closure = frame.closure
+				function = closure.Fn
+				code = function.Chunk.Code
+				constants = function.Chunk.Constants
+				registers = frame.registers
+				ip = frame.ip
 				continue
 			default:
 				// Clear unknown pending action
@@ -20542,17 +20754,16 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 				if debugExceptions {
 					fmt.Printf("[DEBUG resumeGeneratorWithException] Popping stale direct call frame %d\n", vm.frameCount-1)
 				}
-				// Reclaim registers
-				if f.closure != nil && f.closure.Fn != nil {
-					vm.nextRegSlot -= f.closure.Fn.RegisterSize
-				}
+				// Reclaim registers. Use allocatedRegSize (not closure.Fn.RegisterSize):
+				// it tracks actual allocation, which may exceed the frame's current
+				// function's own RegisterSize because of TCO expansion earlier in a
+				// tail-call chain (see the matching OpReturn* comments, and #399/B1).
+				vm.nextRegSlot -= f.allocatedRegSize
 				vm.frameCount--
 				break
 			}
 			// Pop non-sentinel, non-direct frames (shouldn't happen normally)
-			if f.closure != nil && f.closure.Fn != nil {
-				vm.nextRegSlot -= f.closure.Fn.RegisterSize
-			}
+			vm.nextRegSlot -= f.allocatedRegSize
 			vm.frameCount--
 		}
 		vm.unwinding = false

--- a/tests/scripts/bound_constructor_regsize_leak.ts
+++ b/tests/scripts/bound_constructor_regsize_leak.ts
@@ -1,0 +1,25 @@
+// Regression for #400 (B1: frame/register lifetime): `new` on a bound
+// constructor pushed its frame without setting newFrame.allocatedRegSize,
+// so that stale frame-slot leftover value (not requiredRegs) was reclaimed
+// on return - permanently leaking (or over-reclaiming) registers on every
+// construction through a bound function. Enough iterations exhausted the
+// shared register stack and crashed with "Maximum call stack size exceeded".
+// See docs/runtime-production-roadmap.md#b1.
+// expect: 60000
+let count = 0;
+
+function Big(this: any) {
+  let b1 = 1, b2 = 2, b3 = 3, b4 = 4, b5 = 5, b6 = 6, b7 = 7, b8 = 8, b9 = 9, b10 = 10;
+  let b11 = 11, b12 = 12, b13 = 13, b14 = 14, b15 = 15, b16 = 16, b17 = 17, b18 = 18, b19 = 19, b20 = 20;
+  let b21 = 21, b22 = 22, b23 = 23, b24 = 24, b25 = 25, b26 = 26, b27 = 27, b28 = 28, b29 = 29, b30 = 30;
+  this.a = b1 + b30;
+  count++;
+}
+
+const Bound = Big.bind(null);
+
+for (let i = 0; i < 60000; i++) {
+  new (Bound as any)();
+}
+
+count;

--- a/tests/scripts/tco_regsize_leak_on_implicit_return.ts
+++ b/tests/scripts/tco_regsize_leak_on_implicit_return.ts
@@ -1,0 +1,38 @@
+// Regression for #399/#400/#401 (B1: frame/register lifetime): a tail-call
+// chain where an earlier link needs more registers than the final one, whose
+// final return is an implicit (undefined) return -> OpReturnUndefined.
+//
+// OpReturnUndefined used to reclaim function.RegisterSize (the final, small
+// function's own size) instead of frame.allocatedRegSize (the frame's actual
+// TCO-expanded allocation, which never shrinks), permanently leaking the
+// difference on every call. Enough iterations of this pattern exhausted the
+// shared register stack and crashed with "Register stack overflow" - this is
+// believed to be (part of) the root cause behind #399's tsc.js/lib.dom.d.ts
+// crash. See docs/runtime-production-roadmap.md#b1.
+// expect: 60000
+let counter = 0;
+
+function leaf(): void {
+  counter++;
+  // no return statement -> compiles to OpReturnUndefined
+}
+
+function big(): void {
+  let a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h = 8, i = 9, j = 10;
+  let k = 11, l = 12, m = 13, n = 14, o = 15, p = 16, q = 17, r = 18, s = 19, t = 20;
+  let u = 21, v = 22, w = 23, x = 24, y = 25, z = 26;
+  return leaf(); // tail call: TCO reuses big's frame, allocatedRegSize stays >= big's size
+}
+
+function driver(depth: number): void {
+  if (depth > 0) {
+    return driver(depth - 1); // tail self-recursion, stays in one frame via TCO
+  }
+  return big(); // tail call into the many-locals function
+}
+
+for (let i = 0; i < 60000; i++) {
+  driver(0);
+}
+
+counter;


### PR DESCRIPTION
Phase 1 of #402 (B1 frame/register lifetime spike).

## What this fixes

- **#400** - `new` on a bound constructor pushed its frame without setting `newFrame.allocatedRegSize`, so `OpReturn` later reclaimed a stale leftover value instead of the real allocation.
- **#399** - `OpReturnUndefined`, `OpReturnFinally`, and `OpHandlePending`'s `ActionReturn` arm all reclaimed `function.RegisterSize` (the currently executing function's own size) instead of `frame.allocatedRegSize` (the frame's actual, possibly TCO-expanded allocation - TCO never shrinks a frame). In a tail-call chain where an earlier link needed more registers than the one that ultimately returns through one of these three paths, this permanently leaked the difference on every call - matching #399's "+3 per call, frameCount pinned" signature exactly. `OpReturn` itself already had this right. Also fixed the same pattern in `resumeGeneratorWithException`'s stale-frame cleanup. Confirmed against the real noderati/tsc.js `lib.dom.d.ts` repro - see #399.
- **#401** - `ActionReturn`'s pending-action resumption was a no-op stub that discarded the return value and never popped the frame. Implemented it by mirroring `OpHandlePending`'s already-correct `ActionReturn` arm (constructor semantics, sentinel/direct/normal-caller resume all preserved). Left a `TODO(#401)` noting the three near-duplicate copies of this pop-and-resume logic should eventually be factored into one shared helper.

## Testing

- Added two smoke tests that reproduce a register-stack overflow before the fix (confirmed against a locally reverted build) and pass cleanly after:
  - `tests/scripts/tco_regsize_leak_on_implicit_return.ts`
  - `tests/scripts/bound_constructor_regsize_leak.ts`
- Full `TestScripts` smoke suite and `go test ./...` pass with no regressions.
- `#401`'s fix has no dedicated repro - its own investigation found the path currently unreachable by the compiler's output - but the full try/finally/generator test suite passes unchanged.
- The original tsc.js/`lib.dom.d.ts` crash from #399 was re-run against this branch on the noderati side and confirmed fixed (my own sibling-checkout attempt at reproducing it didn't hit the same code path either way - see the discussion on #399).

## Not in this PR

- The trigger-relative push/pop invariant checker #399 suggests, and a full audit sweep beyond the return/exception-unwind paths (tail-call replacement, cancellation, generator close, Reset were spot-checked, not exhaustively fuzzed).
- B4 (segmented register stack) - deferred until this lands, per the roadmap's own sequencing ("B1 must be correct first").

Closes #399, #400, #401.
Related to #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
