### PR TITLE
fix(vm): add register-window release invariant checker (B4 prerequisite)

### DIFF
--- a/pkg/vm/async.go
+++ b/pkg/vm/async.go
@@ -124,16 +124,17 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 	// Set up the async function frame
 	frame := &vm.frames[vm.frameCount]
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize // Track actual allocation for proper cleanup
-	frame.ip = 0                     // Start from beginning
+	frame.allocatedRegSize = regSize         // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
+	frame.ip = 0                             // Start from beginning
 	frame.targetRegister = destReg
 	frame.thisValue = thisValue
 	frame.homeObject = funcObj.HomeObject // Set [[HomeObject]] for super property access (object literal methods)
 	frame.isConstructorCall = false
-	frame.isDirectCall = true      // Mark as direct call for proper return handling
-	frame.isSentinelFrame = false  // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
-	frame.promiseObj = promiseObj  // Link frame to promise object - critical for OpAwait!
-	frame.generatorObj = nil       // Clear generator object when reusing frame
+	frame.isDirectCall = true     // Mark as direct call for proper return handling
+	frame.isSentinelFrame = false // Clear sentinel flag - this frame slot may have been a sentinel in a previous call
+	frame.promiseObj = promiseObj // Link frame to promise object - critical for OpAwait!
+	frame.generatorObj = nil      // Clear generator object when reusing frame
 	// frame.args is the field OpGetArguments actually reads to build the
 	// `arguments` object (frame.argCount only sizes the register-copy loop
 	// below) - see its "args were copied when the frame was created in

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -406,7 +406,8 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		newFrame.argumentsObject = Undefined  // Initialize to Undefined (will be created on first access)
 		newFrame.calleeValue = originalCallee // Store original callee for arguments.callee
 		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+		newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
+		newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 		vm.nextRegSlot += requiredRegs
 
 		// Allocate spill slots if this function needs them (for register overflow)

--- a/pkg/vm/op_spreadnew.go
+++ b/pkg/vm/op_spreadnew.go
@@ -210,10 +210,10 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		newFrame.ip = 0
 		newFrame.targetRegister = destReg
 		newFrame.thisValue = newInstance
-		newFrame.homeObject = instancePrototype  // Set [[HomeObject]] for super property access in constructors
+		newFrame.homeObject = instancePrototype // Set [[HomeObject]] for super property access in constructors
 		newFrame.isConstructorCall = true
-		newFrame.isDirectCall = false            // Not a direct call (spread new)
-		newFrame.isSentinelFrame = false         // Clear sentinel flag when reusing frame
+		newFrame.isDirectCall = false    // Not a direct call (spread new)
+		newFrame.isSentinelFrame = false // Clear sentinel flag when reusing frame
 		// Clear any stale open-upvalue chain left by a prior occupant of this
 		// frame slot - every other frame-setup site does this (OpNew at
 		// vm.go, prepareCall's regular path at call.go), and this one didn't.
@@ -229,7 +229,8 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		newFrame.args = spreadArgs
 		newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
 		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+		newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
+		newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 		vm.nextRegSlot += requiredRegs
 
 		// Allocate spill slots if this function needs them (for register overflow)
@@ -334,10 +335,10 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		newFrame.ip = 0
 		newFrame.targetRegister = destReg
 		newFrame.thisValue = newInstance
-		newFrame.homeObject = instancePrototype  // Set [[HomeObject]] for super property access in constructors
+		newFrame.homeObject = instancePrototype // Set [[HomeObject]] for super property access in constructors
 		newFrame.isConstructorCall = true
-		newFrame.isDirectCall = false            // Not a direct call (spread new)
-		newFrame.isSentinelFrame = false         // Clear sentinel flag when reusing frame
+		newFrame.isDirectCall = false    // Not a direct call (spread new)
+		newFrame.isSentinelFrame = false // Clear sentinel flag when reusing frame
 		// Clear any stale open-upvalue chain left by a prior occupant of this
 		// frame slot - every other frame-setup site does this (OpNew at
 		// vm.go, prepareCall's regular path at call.go), and this one didn't.
@@ -352,7 +353,8 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		newFrame.args = spreadArgs
 		newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
 		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+		newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
+		newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 		vm.nextRegSlot += requiredRegs
 
 		// Allocate spill slots if this function needs them (for register overflow)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -147,6 +147,7 @@ type CallFrame struct {
 	registers           []Value
 	spillSlots          []Value  // Spill slots for register overflow (allocated only if needed)
 	allocatedRegSize    int      // Actual allocated register window size (may differ from function.RegisterSize due to TCO expansion)
+	regSlotBeforePush   int      // vm.nextRegSlot at the moment this frame's register window was allocated (i.e. the window's base offset). Recorded by every fresh-frame push site; checkRegWindowRelease asserts that reclaiming allocatedRegSize registers restores vm.nextRegSlot to exactly this value, catching a wrong reclaim size at its call site instead of a much-later, unexplained register-stack overflow (#399/#400/#402 B4 invariant). TCO expansion updates allocatedRegSize without touching this field, since the window's base doesn't move.
 	targetRegister      byte     // Which register in the CALLER the result should go into
 	thisValue           Value    // The 'this' value for method calls (undefined for regular function calls)
 	homeObject          Value    // The [[HomeObject]] for super property access (object where method is defined)
@@ -485,6 +486,57 @@ func funcName(fn *FunctionObject) string {
 		return fn.Name
 	}
 	return "<anonymous>"
+}
+
+// StrictRegWindowChecks gates checkRegWindowRelease's panic. Off by default:
+// a broad sweep while landing the checker turned up at least one pre-existing,
+// out-of-scope register-accounting mismatch reachable from real code (derived-
+// constructor construction whose return triggers the ECMAScript 10.2.2
+// non-object/uninitialized-this TypeError/ReferenceError while unwinding
+// through an already-popped caller frame - see the linked issue), which
+// over-reclaims but never leaks, so it stayed invisible until this checker
+// went looking. Panicking on that unconditionally would turn ~80 previously-
+// passing Test262 tests into new failures for a bug outside B1/B4's scope.
+// The paserati test suite (tests/scripts_test.go's TestMain) turns this on,
+// so tco_regsize_leak_on_implicit_return.ts and bound_constructor_regsize_leak.ts
+// still catch a real B1 regression immediately instead of only via later
+// exhaustion; ordinary/production/test262 runs stay exactly as before.
+var StrictRegWindowChecks = false
+
+// checkRegWindowRelease asserts that reclaiming `amount` registers for
+// `frame` restores vm.nextRegSlot to exactly the value recorded when this
+// frame's register window was allocated (CallFrame.regSlotBeforePush). This
+// is the exact invariant that #399/#400 violated - a frame-exit path that
+// reclaimed the wrong number of registers (a stale/wrong-function's
+// RegisterSize instead of this frame's actual allocatedRegSize), silently
+// leaking or over-reclaiming until a much later, unrelated call site hit
+// "Register stack overflow" or "Maximum call stack size exceeded" with no
+// clue which return path was actually responsible. Call this immediately
+// before performing the real `vm.nextRegSlot -= amount`; it never mutates
+// state itself, so it changes no behavior when the invariant holds, and -
+// only when StrictRegWindowChecks is on (see its own comment) - panics
+// immediately, at the guilty call site, when it doesn't.
+//
+// `site` is a short label (opcode/function name) identifying the caller,
+// included in the panic message. Once B4 replaces the flat register stack
+// with segments, this same check generalizes directly: regSlotBeforePush
+// becomes a (segment, offset) pair instead of a flat int, and the
+// comparison is unchanged in spirit.
+func (vm *VM) checkRegWindowRelease(frame *CallFrame, amount int, site string) {
+	if !StrictRegWindowChecks {
+		return
+	}
+	after := vm.nextRegSlot - amount
+	if after != frame.regSlotBeforePush {
+		funcN := "<nil closure>"
+		if frame.closure != nil {
+			funcN = funcName(frame.closure.Fn)
+		}
+		panic(fmt.Sprintf(
+			"register window imbalance at %s (func=%q): reclaiming %d registers would leave nextRegSlot=%d, expected %d (off by %d - %s)",
+			site, funcN, amount, after, frame.regSlotBeforePush, after-frame.regSlotBeforePush,
+			map[bool]string{true: "leaked", false: "over-reclaimed"}[after > frame.regSlotBeforePush]))
+	}
 }
 
 // dumpFrameStack prints a compact snapshot of the current VM frame stack for debugging.
@@ -1372,7 +1424,8 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	frame.closure = mainClosureObj
 	frame.ip = 0
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+scriptRegSize]
-	frame.allocatedRegSize = scriptRegSize // Track actual allocation for proper cleanup
+	frame.allocatedRegSize = scriptRegSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 
 	// For nested Interpret calls (eval), initialize registers to Undefined to avoid
 	// stale values from previous executions affecting the result
@@ -6393,6 +6446,7 @@ startExecution:
 			}
 
 			vm.frameCount--
+			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturn")
 			vm.nextRegSlot -= returningFrameRegSize // Reclaim register space
 
 			if debugVM {
@@ -6694,6 +6748,7 @@ startExecution:
 			}
 
 			vm.frameCount--
+			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnUndefined")
 			vm.nextRegSlot -= returningFrameRegSize
 
 			if debugVM {
@@ -11988,7 +12043,8 @@ startExecution:
 				}
 				newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
 				newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-				newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+				newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
+				newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 				vm.nextRegSlot += requiredRegs
 
 				// Allocate spill slots if this function needs them (for register overflow)
@@ -12223,7 +12279,8 @@ startExecution:
 				}
 				newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
 				newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-				newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+				newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
+				newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 				vm.nextRegSlot += requiredRegs
 
 				// Allocate spill slots if this function needs them (for register overflow)
@@ -12712,7 +12769,8 @@ startExecution:
 					newFrame.args = finalArgs
 					newFrame.argumentsObject = Undefined
 					newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-					newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+					newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
+					newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
 					vm.nextRegSlot += requiredRegs
 
 					// Copy combined args to registers
@@ -15703,6 +15761,7 @@ startExecution:
 			constructorThisValue := frame.thisValue
 
 			vm.frameCount--
+			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnFinally")
 			vm.nextRegSlot -= returningFrameRegSize // Reclaim register space
 
 			if vm.frameCount == 0 {
@@ -15901,6 +15960,7 @@ startExecution:
 				isDerivedConstructor := frame.closure != nil && frame.closure.Fn.IsDerivedConstructor
 
 				vm.frameCount--
+				vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpHandlePending:ActionReturn")
 				vm.nextRegSlot -= returningFrameRegSize
 
 				if vm.frameCount == 0 {
@@ -18292,6 +18352,7 @@ startExecution:
 				isDerivedConstructor := frame.closure != nil && frame.closure.Fn.IsDerivedConstructor
 
 				vm.frameCount--
+				vm.checkRegWindowRelease(frame, returningFrameRegSize, "ActionReturn-fallback")
 				vm.nextRegSlot -= returningFrameRegSize
 
 				if vm.frameCount == 0 {
@@ -18545,6 +18606,7 @@ func (vm *VM) popTopLevelScriptFrame(frame *CallFrame) {
 		vm.closeFrameUpvalues(frame)
 	}
 	vm.frameCount--
+	vm.checkRegWindowRelease(frame, frame.allocatedRegSize, "popTopLevelScriptFrame")
 	vm.nextRegSlot -= frame.allocatedRegSize
 	if vm.nextRegSlot < 0 {
 		vm.nextRegSlot = 0
@@ -20550,6 +20612,7 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	frame := &vm.frames[vm.frameCount]
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
 	frame.allocatedRegSize = regSize           // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot   // B4 invariant: record window base for checkRegWindowRelease
 	frame.ip = genObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg             // Target in sentinel frame
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
@@ -20758,11 +20821,13 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 				// it tracks actual allocation, which may exceed the frame's current
 				// function's own RegisterSize because of TCO expansion earlier in a
 				// tail-call chain (see the matching OpReturn* comments, and #399/B1).
+				vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleDirectCall")
 				vm.nextRegSlot -= f.allocatedRegSize
 				vm.frameCount--
 				break
 			}
 			// Pop non-sentinel, non-direct frames (shouldn't happen normally)
+			vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleNonDirect")
 			vm.nextRegSlot -= f.allocatedRegSize
 			vm.frameCount--
 		}
@@ -20825,6 +20890,7 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	frame := &vm.frames[vm.frameCount]
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
 	frame.allocatedRegSize = regSize           // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot   // B4 invariant: record window base for checkRegWindowRelease
 	frame.ip = genObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg             // Target in sentinel frame
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
@@ -21027,6 +21093,7 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 	frame := &vm.frames[vm.frameCount]
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
 	frame.allocatedRegSize = regSize           // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot   // B4 invariant: record window base for checkRegWindowRelease
 	frame.ip = genObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg             // Target in sentinel frame
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
@@ -21237,6 +21304,7 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 	frame := &vm.frames[vm.frameCount]
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
 	frame.allocatedRegSize = regSize               // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot       // B4 invariant: record window base for checkRegWindowRelease
 	frame.ip = promiseObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg                 // Target in sentinel frame
 	frame.thisValue = promiseObj.ThisValue         // Restore original this value
@@ -21390,6 +21458,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 	frame := &vm.frames[vm.frameCount]
 	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
 	frame.allocatedRegSize = regSize               // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot       // B4 invariant: record window base for checkRegWindowRelease
 	frame.ip = promiseObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg                 // Target in sentinel frame
 	frame.thisValue = promiseObj.ThisValue         // Restore original this value
@@ -21799,8 +21868,9 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	for i := range frame.registers {
 		frame.registers[i] = Undefined // slots above nextRegSlot hold stale values
 	}
-	frame.allocatedRegSize = scriptRegSize // Track actual allocation for proper cleanup
-	frame.targetRegister = 0               // a direct-call return writes no caller register
+	frame.allocatedRegSize = scriptRegSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
+	frame.targetRegister = 0                 // a direct-call return writes no caller register
 	frame.thisValue = Undefined
 	frame.homeObject = Undefined
 	frame.isConstructorCall = false

--- a/tests/scripts/bound_constructor_regsize_leak.ts
+++ b/tests/scripts/bound_constructor_regsize_leak.ts
@@ -2,10 +2,16 @@
 // constructor pushed its frame without setting newFrame.allocatedRegSize,
 // so that stale frame-slot leftover value (not requiredRegs) was reclaimed
 // on return - permanently leaking (or over-reclaiming) registers on every
-// construction through a bound function. Enough iterations exhausted the
-// shared register stack and crashed with "Maximum call stack size exceeded".
-// See docs/runtime-production-roadmap.md#b1.
-// expect: 60000
+// construction through a bound function. Confirmed fixed against the real
+// tsc.js/lib.dom.d.ts repro (see #399). See docs/runtime-production-roadmap.md#b1.
+//
+// A handful of iterations is enough: vm.checkRegWindowRelease (#402 B4
+// invariant checker) catches a wrong reclaim size on the very first bad
+// return, rather than needing tens of thousands of iterations to exhaust
+// the (pre-B4) fixed-size register file - this test used to need 60,000
+// iterations to overflow and fail; now one is enough, and it will keep
+// catching a regression even once B4 removes that fixed ceiling.
+// expect: 5
 let count = 0;
 
 function Big(this: any) {
@@ -18,7 +24,7 @@ function Big(this: any) {
 
 const Bound = Big.bind(null);
 
-for (let i = 0; i < 60000; i++) {
+for (let i = 0; i < 5; i++) {
   new (Bound as any)();
 }
 

--- a/tests/scripts/tco_regsize_leak_on_implicit_return.ts
+++ b/tests/scripts/tco_regsize_leak_on_implicit_return.ts
@@ -5,11 +5,17 @@
 // OpReturnUndefined used to reclaim function.RegisterSize (the final, small
 // function's own size) instead of frame.allocatedRegSize (the frame's actual
 // TCO-expanded allocation, which never shrinks), permanently leaking the
-// difference on every call. Enough iterations of this pattern exhausted the
-// shared register stack and crashed with "Register stack overflow" - this is
-// believed to be (part of) the root cause behind #399's tsc.js/lib.dom.d.ts
-// crash. See docs/runtime-production-roadmap.md#b1.
-// expect: 60000
+// difference on every call. This was (part of) the root cause behind #399's
+// tsc.js/lib.dom.d.ts crash, confirmed fixed there. See
+// docs/runtime-production-roadmap.md#b1.
+//
+// A handful of iterations is enough: vm.checkRegWindowRelease (#402 B4
+// invariant checker) catches a wrong reclaim size on the very first bad
+// return, rather than needing tens of thousands of iterations to exhaust
+// the (pre-B4) fixed-size register file - this test used to need 60,000
+// iterations to overflow and fail; now one is enough, and it will keep
+// catching a regression even once B4 removes that fixed ceiling.
+// expect: 5
 let counter = 0;
 
 function leaf(): void {
@@ -31,7 +37,7 @@ function driver(depth: number): void {
   return big(); // tail call into the many-locals function
 }
 
-for (let i = 0; i < 60000; i++) {
+for (let i = 0; i < 5; i++) {
   driver(0);
 }
 

--- a/tests/scripts_test.go
+++ b/tests/scripts_test.go
@@ -22,6 +22,16 @@ import (
 
 const scriptsDebug = false
 
+// TestMain turns on vm.StrictRegWindowChecks for this package's whole test
+// run, so a register-window release that doesn't match what was recorded at
+// push (the #399/#400/#402 B4 invariant) panics immediately instead of
+// silently drifting - see the checker's own doc comment for why this stays
+// off outside the test suite.
+func TestMain(m *testing.M) {
+	vm.StrictRegWindowChecks = true
+	os.Exit(m.Run())
+}
+
 // Expectation represents the expected outcome of a script.
 type Expectation struct {
 	ResultType string // "value", "runtime_error", "compile_error"


### PR DESCRIPTION
Phase 1's last item from #402 (the roadmap's B1/B4 spike), and a hard prerequisite for Phase 2 (B4): flagged by the advisor before starting B4 - the two regression tests landed in #403 (`tco_regsize_leak_on_implicit_return.ts`, `bound_constructor_regsize_leak.ts`) detect a leak only by exhausting the fixed `256*4096` register file and crashing. Once B4 replaces that fixed ceiling with on-demand segments, both tests would leak exactly as before and pass anyway - silently deleting the #399/#400 coverage in the same change that makes leaks harder to observe.

## What this does

- Adds `CallFrame.regSlotBeforePush`, recorded at every fresh register-window push (the same 14 sites that set `allocatedRegSize`).
- Adds `vm.checkRegWindowRelease`, called at every frame-exit path that reclaims a window (`OpReturn`, `OpReturnUndefined`, `OpReturnFinally`, `OpHandlePending`'s `ActionReturn` arm, the generic `ActionReturn` fallback, `popTopLevelScriptFrame`, and both stale-frame cleanup sites in `resumeGeneratorWithException`). It asserts that reclaiming the given amount restores `vm.nextRegSlot` to exactly the value recorded when that window was allocated - panicking immediately at the guilty call site instead of silently drifting until an unrelated, much-later call hits "Register stack overflow" with no clue why.
- Re-points the two #403 regression tests onto this: confirmed each now fails **immediately** (at the first bad return) when its underlying bug is manually reintroduced, instead of needing 45k-60k iterations to overflow. Shrunk both to 5 iterations accordingly.

## The gate, and #404

The checker's panic is gated behind `vm.StrictRegWindowChecks` (off by default; `tests/scripts_test.go`'s new `TestMain` turns it on for this repo's own `go test ./tests`). Landing it unconditionally surfaced a real, pre-existing, out-of-scope bug: derived-constructor-return `TypeError`/`ReferenceError` handling over-reclaims registers when the exception is caught above the immediate caller. It never crashes (over-reclaiming just frees too much, silently) and the JS-observable behavior is entirely correct, so it was invisible until this checker went looking - but it would have turned ~80 previously-passing Test262 `built-ins/` tests into new failures for a bug this PR isn't trying to fix. Filed as #404 with a minimal repro and a root-cause hypothesis; left for separate follow-up.

## Testing

- Full `TestScripts` smoke suite + `go test ./...` pass.
- Confirmed the checker fires correctly: manually reintroduced each of #403's two bugs one at a time and confirmed `go test ./tests` now fails immediately with a clear panic message identifying the exact opcode/function, instead of the old crash-via-exhaustion.
- Test262 `language/`+`built-ins/` dumps are back to exactly the pre-checker baseline (16706-16707/23294 built-ins, matching #403's post-merge numbers within known flaky-test noise) now that the gate is in place.
- A `fib(30)` call-throughput microbenchmark shows no measurable difference versus pre-checker (the check only runs at frame-exit, not per instruction).

## Not in this PR

- Fixing #404 (out of scope, filed separately).
- The segment directory itself (B4's main event) - next up.

Part of #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
