### PR TITLE
test(driver): pin frame-count as the recursion-depth guard (B4 prep)

### DIFF
--- a/pkg/driver/depth_limit_test.go
+++ b/pkg/driver/depth_limit_test.go
@@ -1,0 +1,122 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// TestRecursionDepthLimitIsFrameCountNotRegisterSpace pins down which of the
+// VM's two independent overflow guards (pkg/vm/call.go's "frame limit" check
+// on vm.frameCount, and its separate "register stack space" check on
+// vm.nextRegSlot) is what actually bounds ordinary deep recursion today.
+//
+// docs/runtime-production-roadmap.md#b4 wants the eager `RegFileSize *
+// MaxFrames` register reservation replaced with on-demand segments. Once
+// registers grow on demand, the register-space check stops being able to
+// fire at all, and vm.frameCount becomes the *only* thing bounding
+// recursion depth - so the "Maximum call stack size exceeded" RangeError a
+// JS program can already catch today must, even now, actually be coming
+// from the frame-count check for ordinary small-register recursion, not
+// incidentally from register exhaustion (which - because the register file
+// is sized as exactly RegFileSize*MaxFrames - would only ever bind at the
+// same depth or later for any single call needing at most RegFileSize
+// registers, never sooner). If that assumption is wrong, or something
+// changes it later, B4 would silently change recursion-depth semantics
+// instead of only removing a redundant backstop.
+//
+// This shrinks MaxFrames to a small number via vm.SetMaxFrames so the test
+// is fast and the expected depth is unambiguous, then counts exactly how
+// many recursive calls happened before the overflow was caught. A
+// small-register recursive function run against a VM whose frames array
+// was sized for `wantMaxFrames` must overflow at (very close to) that
+// depth - many orders of magnitude short of what register exhaustion alone
+// would allow (RegFileSize*wantMaxFrames calls' worth of headroom for a
+// handful of registers per frame) - which is only possible if frameCount,
+// not register space, is the guard that actually fired.
+//
+// NOTE: this deliberately does NOT assert `e instanceof RangeError`. Today
+// ordinary function-call recursion overflow (unlike the OpNew-family
+// constructor-call path) throws a generic Error with a non-spec message
+// ("Stack overflow") instead of a catchable RangeError("Maximum call stack
+// size exceeded") - see the issue filed for that gap. This test only pins
+// the frame-count-is-the-guard property that B4 must preserve; it is not
+// about the exception's type or message.
+func TestRecursionDepthLimitIsFrameCountNotRegisterSpace(t *testing.T) {
+	origMaxFrames := vm.MaxFrames
+	defer vm.SetMaxFrames(origMaxFrames)
+
+	const wantMaxFrames = 80 // vm.SetMaxFrames clamps below 64, so this stays above that floor
+	vm.SetMaxFrames(wantMaxFrames)
+
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	src := `
+let depth = 0;
+function recurse() {
+  depth++;
+  recurse();
+}
+let caught = false;
+try {
+  recurse();
+} catch (e) {
+  caught = true;
+}
+JSON.stringify({ caught: caught, depth: depth });
+`
+	result, errs := p.RunString(src)
+	if len(errs) > 0 {
+		t.Fatalf("RunString failed: %v", errs[0])
+	}
+
+	out := result.ToString()
+	if !strings.Contains(out, `"caught":true`) {
+		t.Fatalf("expected the overflow to be caught, got: %s", out)
+	}
+
+	// Extract the depth value with a tiny manual scan rather than pulling in
+	// an encoding/json dependency for one integer.
+	const marker = `"depth":`
+	_, depthStr, found := strings.Cut(out, marker)
+	if !found {
+		t.Fatalf("could not find depth in result: %s", out)
+	}
+	if end := strings.IndexAny(depthStr, "}, "); end >= 0 {
+		depthStr = depthStr[:end]
+	}
+
+	// The bound to check against: how deep register exhaustion ALONE could
+	// have gone for this tiny-register-footprint function, if frameCount
+	// were not the actual guard. recurse() only ever needs a couple of
+	// registers, so this is generous on purpose - any depth anywhere near
+	// this bound (as opposed to anywhere near wantMaxFrames) would mean the
+	// frame-count check was not what fired.
+	registerExhaustionFloor := vm.RegFileSize * wantMaxFrames / 4 // /4: still far short of the true register-only bound, comfortably above any plausible frame-count-driven depth
+
+	depth := parseSmallInt(depthStr)
+	if depth <= 0 {
+		t.Fatalf("expected recurse() to run at least once before overflowing, got depth=%d", depth)
+	}
+	if depth >= registerExhaustionFloor {
+		t.Fatalf("recursion reached depth=%d before overflowing (MaxFrames=%d) - "+
+			"that's deep enough that register exhaustion, not the frame-count check, "+
+			"looks like what actually fired; expected depth close to MaxFrames",
+			depth, wantMaxFrames)
+	}
+}
+
+// parseSmallInt is a tiny, dependency-free decimal parser sufficient for the
+// small non-negative integers this test extracts from a JSON fragment.
+func parseSmallInt(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}


### PR DESCRIPTION
## What

Adds `TestRecursionDepthLimitIsFrameCountNotRegisterSpace` in [pkg/driver/depth_limit_test.go](pkg/driver/depth_limit_test.go), confirming that ordinary function-call recursion overflows at `vm.frameCount` (the frame-limit check in `prepareCall`), not at register-stack exhaustion, for a small-register-footprint recursive function.

## Why (B4 prep, per docs/runtime-production-roadmap.md#b4)

`prepareCall` currently has two independent overflow guards: a frame-count check and a register-space check. B4 replaces the eager flat `RegFileSize * MaxFrames` register reservation with on-demand segments — once registers grow on demand, the register-space check stops being able to fire at all. So `frameCount` must *already* be the guard that actually bounds ordinary recursion today, not an incidental backstop that happens to agree with it. This test pins that down empirically (shrinks `MaxFrames` to 80 via `vm.SetMaxFrames`, confirms overflow happens near depth 80, not near `RegFileSize * 80`).

## Backstory / scope correction

This started as "decouple the depth limit from register exhaustion" (Phase 2 step 2 of the B4 plan). Turned up that there was nothing to decouple — the frame-count check is already independent of and checked before the register-space check at every call site. So this PR is just the regression test that pins the invariant, not an architecture change.

While poking at the two overflow guards, also found a real (but orthogonal) bug: ordinary recursive calls throw a generic `Error("Stack overflow...")` instead of a catchable `RangeError("Maximum call stack size exceeded")`, unlike the `new`-expression overflow path, which already gets this right. Filed as #407 rather than fixed here — it's unrelated to B4's register-allocation changes, a first attempt at the obvious fix broke exception propagation entirely, and it touches 6+ call sites in the hottest path in the VM. The new test deliberately does not assert `e instanceof RangeError`, with a comment explaining why.

## Verification

- `go build ./...` — clean
- `go test ./tests -run TestScripts` — pass (smoke suite green)
- `go test ./...` — pass (all packages)
- Test-only change (no VM/runtime code touched), so a Test262 diff is a guaranteed no-op — skipped.

Related: #399, #400, #401, #404, #405, #407, docs/runtime-production-roadmap.md#b4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
