### PR TITLE
feat(vm): replace flat register stack with a lazily-allocated block directory (B4)

### DIFF
--- a/pkg/driver/host_suspended_upvalue_test.go
+++ b/pkg/driver/host_suspended_upvalue_test.go
@@ -692,3 +692,100 @@ func TestSpreadNewDoesNotCrossCloseSuspendedAsyncUpvalues(t *testing.T) {
 		t.Errorf("expected f(\"a\")'s closure to observe its own post-await mutation (101), got %s", value.Inspect())
 	}
 }
+
+// recursionPadding returns a body that recurses `depth` times, using ~26
+// registers per level (a non-tail recursive call, so B1's TCO can't reuse a
+// single frame across levels - each level genuinely pushes its own window),
+// then invokes `atBottom` once at the deepest point. Used to drive the B4
+// register directory (pkg/vm/register_directory.go) across many blocks
+// before/while running whatever `atBottom` does, so a generator/async frame
+// created or resumed from deep inside gets a real chance at having its own
+// window carved from a block a skip landed it in - not just block 0.
+func recursionPadding(depth int, atBottom string) string {
+	return `
+		function pad(depth) {
+			if (depth <= 0) {
+				` + atBottom + `
+				return 0;
+			}
+			let a=0,b=1,c=2,d=3,e=4,f=5,g=6,h=7,i=8,j=9,k=10,l=11,m=12,n=13,o=14,p=15,q=16,r=17,s=18,t=19,u=20,v=21,w=22,x=23,y=24,z=25;
+			// Non-tail: arithmetic after the recursive call keeps this out of
+			// tail position, so each level keeps its own register window live
+			// instead of TCO reusing a single frame across all ` + strconv.Itoa(depth) + ` levels.
+			let sub = pad(depth - 1);
+			return sub + a - a + b - b + c - c + z - z;
+		}
+		pad(` + strconv.Itoa(depth) + `);
+	`
+}
+
+// TestGeneratorClosureSurvivesAcrossRegisterBlockBoundary covers the one
+// case the B4 register directory (pkg/vm/register_directory.go) can get
+// wrong that no other test here reaches: a generator's own register window,
+// or one of its resumptions, landing via a block skip rather than at block
+// 0 - open upvalues are the mechanism every other test in this file
+// exercises, but always with the whole call stack shallow enough to stay in
+// a single block. Each of the three .next() calls below runs from a
+// different recursion depth (and so a different register-directory cursor
+// position), maximizing the chance that at least one of them lands the
+// generator's window via a skip - confirmed directly via
+// RegisterDirectoryBlockCount() rather than left to chance, so this test
+// fails loudly (not silently passing) if it ever stops actually exercising
+// a multi-block state.
+func TestGeneratorClosureSurvivesAcrossRegisterBlockBoundary(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	if _, errs := p.RunCode(`
+		function* g() {
+			let n = 1;
+			const get = () => n;
+			yield get();
+			n = n + 10;
+			yield get();
+			n = n + 100;
+			yield get();
+		}
+		let it = g();
+		let captured = [];
+	`, RunOptions{}); len(errs) > 0 {
+		t.Fatalf("setup errors: %v", errs)
+	}
+
+	// Three separate top-level runs, each recursing to a different depth
+	// before calling it.next() - so each .next() call's own frame push
+	// happens from a different register-directory cursor position.
+	for _, depth := range []int{3, 41, 17} {
+		src := recursionPadding(depth, "captured.push(it.next().value);")
+		if _, errs := p.RunCode(src, RunOptions{Script: true}); len(errs) > 0 {
+			t.Fatalf("depth=%d: RunCode failed: %v", depth, errs[0])
+		}
+	}
+
+	// Empirically 5 (== 1 + registerDirectoryReserveBlocks) once everything
+	// unwinds back to block 0 - trim() keeps that many past the final
+	// cursor regardless of exactly how deep the excursion peaked, as long as
+	// it reached at least that many blocks at some point (see trim's own
+	// doc comment). Asserting >=3 leaves margin against reasonable retuning
+	// of the padding/reserve constants while still ruling out "never left
+	// block 0" (which would leave only 1 block allocated, never trimmed).
+	if blocks := p.GetVM().RegisterDirectoryBlockCount(); blocks < 3 {
+		t.Fatalf("expected the padding to have driven the register directory across a block boundary (>=3 blocks retained), got %d - "+
+			"this test needs re-tuning (deeper recursion, or more registers per level) to actually exercise a block skip, "+
+			"or something now trims more eagerly than expected", blocks)
+	}
+
+	captured, ok := p.GetVM().GetGlobal("captured")
+	if !ok || !captured.IsArray() {
+		t.Fatalf("expected captured array, got %v", captured)
+	}
+	arr := captured.AsArray()
+	if arr.Length() != 3 {
+		t.Fatalf("expected 3 captured values, got %d", arr.Length())
+	}
+	got := [3]string{arr.Get(0).ToString(), arr.Get(1).ToString(), arr.Get(2).ToString()}
+	want := [3]string{"1", "11", "111"}
+	if got != want {
+		t.Errorf("generator closure's captured local was corrupted across a block-boundary-spanning suspend/resume: got %v, want %v", got, want)
+	}
+}

--- a/pkg/driver/host_suspended_upvalue_test.go
+++ b/pkg/driver/host_suspended_upvalue_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -787,5 +788,136 @@ func TestGeneratorClosureSurvivesAcrossRegisterBlockBoundary(t *testing.T) {
 	want := [3]string{"1", "11", "111"}
 	if got != want {
 		t.Errorf("generator closure's captured local was corrupted across a block-boundary-spanning suspend/resume: got %v, want %v", got, want)
+	}
+}
+
+// TestPlainClosureSurvivesAcrossRegisterBlockBoundary is the plain-closure
+// counterpart of the generator test above, exercising a different code path:
+// closeFrameUpvalues (ordinary return), not relocateOpenUpvalues
+// (generator/async suspend). A plain closure's upvalue is always closed
+// synchronously the instant its owning frame returns - well before popTo/
+// trim() can release or reuse that frame's block - so this is expected to
+// hold regardless of which block the frame's window came from, by
+// construction rather than by luck. This pins that invariant down directly:
+// makeClosure recurses `depth` levels deep (same non-tail, ~26-register-per-
+// level shape as recursionPadding, so it genuinely crosses block boundaries),
+// creates a closure over a local at the bottom, and returns it unchanged
+// through every one of those `depth` frames via ordinary `return sub;` (a
+// bare identifier is never tail-call-eligible - only a direct `return
+// call(...)` is - so this is never collapsed by TCO into a single reused
+// frame). The three escaped closures are only invoked afterward, once the
+// register directory has moved on and reused/trimmed the blocks their
+// upvalues originally closed over.
+func TestPlainClosureSurvivesAcrossRegisterBlockBoundary(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+
+	if _, errs := p.RunCode(`
+		function makeClosure(depth) {
+			if (depth <= 0) {
+				let n = 1;
+				const get = () => n;
+				return get;
+			}
+			let a=0,b=1,c=2,d=3,e=4,f=5,g=6,h=7,i=8,j=9,k=10,l=11,m=12,n=13,o=14,p=15,q=16,r=17,s=18,t=19,u=20,v=21,w=22,x=23,y=24,z=25;
+			let sub = makeClosure(depth - 1);
+			return sub;
+		}
+		let closures = [];
+	`, RunOptions{}); len(errs) > 0 {
+		t.Fatalf("setup errors: %v", errs)
+	}
+
+	for _, depth := range []int{3, 41, 17} {
+		src := fmt.Sprintf("closures.push(makeClosure(%d));", depth)
+		if _, errs := p.RunCode(src, RunOptions{Script: true}); len(errs) > 0 {
+			t.Fatalf("depth=%d: RunCode failed: %v", depth, errs[0])
+		}
+	}
+
+	if blocks := p.GetVM().RegisterDirectoryBlockCount(); blocks < 3 {
+		t.Fatalf("expected the recursion to have driven the register directory across a block boundary (>=3 blocks retained), got %d - "+
+			"this test needs re-tuning to actually exercise a block skip", blocks)
+	}
+
+	// Call the escaped closures only now, after further recursion has moved
+	// the directory's cursor on and trimmed/reused the blocks each closure's
+	// upvalue originally closed over.
+	if _, errs := p.RunCode(`let results = closures.map(f => f());`, RunOptions{Script: true}); len(errs) > 0 {
+		t.Fatalf("RunCode failed: %v", errs[0])
+	}
+	results, ok := p.GetVM().GetGlobal("results")
+	if !ok || !results.IsArray() {
+		t.Fatalf("expected results array, got %v", results)
+	}
+	arr := results.AsArray()
+	if arr.Length() != 3 {
+		t.Fatalf("expected 3 results, got %d", arr.Length())
+	}
+	for i := 0; i < 3; i++ {
+		if arr.Get(i).ToString() != "1" {
+			t.Errorf("closure %d: expected captured n=1, got %s - plain closure corrupted across a register-block boundary", i, arr.Get(i).Inspect())
+		}
+	}
+}
+
+// TestAsyncClosureSurvivesAcrossRegisterBlockBoundary is the async
+// counterpart of TestGeneratorClosureSurvivesAcrossRegisterBlockBoundary:
+// generators and async functions share the same suspend/resume relocation
+// mechanism (relocateOpenUpvalues), but reach it through different call
+// sites (executeAsyncFunctionBody, resumeAsyncFunction*, vs.
+// startGenerator/resumeGenerator*) that were converted separately during the
+// B4 port. f() is invoked from three different recursion depths (varying the
+// register-directory cursor position each of its own initial frames is
+// carved from), and each instance suspends twice (two awaits) before
+// returning a closure's view of its own mutated local - across whatever
+// block skips that invocation and the recursion surrounding the other two
+// instances produced.
+func TestAsyncClosureSurvivesAcrossRegisterBlockBoundary(t *testing.T) {
+	p := newHostTimerPaserati()
+
+	if _, errs := p.RunCode(`
+		async function asyncF() {
+			let n = 1;
+			const get = () => n;
+			await new Promise((r) => setTimeout(r, 0));
+			n = n + 10;
+			await new Promise((r) => setTimeout(r, 0));
+			n = n + 100;
+			return get();
+		}
+		let results = [];
+	`, RunOptions{}); len(errs) > 0 {
+		t.Fatalf("setup errors: %v", errs)
+	}
+
+	// Note: recursionPadding's own pad() body declares single-letter locals
+	// a..z (including f), so the injected atBottom code below must not name
+	// its own async function `f` - it would be shadowed by pad's local `f`
+	// and hit that local's TDZ instead of the outer async function.
+	for _, depth := range []int{3, 41, 17} {
+		src := recursionPadding(depth, `asyncF().then((r) => { results.push(r); });`)
+		if _, errs := p.RunCode(src, RunOptions{Script: true}); len(errs) > 0 {
+			t.Fatalf("depth=%d: RunCode failed: %v", depth, errs[0])
+		}
+	}
+
+	if blocks := p.GetVM().RegisterDirectoryBlockCount(); blocks < 3 {
+		t.Fatalf("expected the padding to have driven the register directory across a block boundary (>=3 blocks retained), got %d - "+
+			"this test needs re-tuning to actually exercise a block skip", blocks)
+	}
+
+	results, ok := p.GetVM().GetGlobal("results")
+	if !ok || !results.IsArray() {
+		t.Fatalf("expected results array, got %v", results)
+	}
+	arr := results.AsArray()
+	if arr.Length() != 3 {
+		t.Fatalf("expected 3 results, got %d", arr.Length())
+	}
+	got := [3]string{arr.Get(0).ToString(), arr.Get(1).ToString(), arr.Get(2).ToString()}
+	want := [3]string{"111", "111", "111"}
+	if got != want {
+		t.Errorf("async closure's captured local was corrupted across a block-boundary-spanning suspend/resume: got %v, want %v", got, want)
 	}
 }

--- a/pkg/vm/async.go
+++ b/pkg/vm/async.go
@@ -93,7 +93,7 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 
 	// Save current VM state so we can restore after vm.run() returns
 	savedFrameCount := vm.frameCount
-	savedNextRegSlot := vm.nextRegSlot
+	savedRegMark := vm.regDir.mark()
 
 	// Set up caller context for sentinel frame approach
 	callerRegisters := make([]Value, 1)
@@ -116,17 +116,19 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 
 	// Allocate registers for the async function
 	regSize := funcObj.RegisterSize
-	if vm.nextRegSlot+regSize > len(vm.registerStack) {
+	newWindow, windowStart, pushMark, ok := vm.regDir.push(regSize)
+	if !ok {
 		vm.frameCount = savedFrameCount // Restore
 		return Undefined, fmt.Errorf("Out of registers")
 	}
 
 	// Set up the async function frame
 	frame := &vm.frames[vm.frameCount]
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize         // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-	frame.ip = 0                             // Start from beginning
+	frame.registers = newWindow
+	frame.allocatedRegSize = regSize // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
+	frame.ip = 0                       // Start from beginning
 	frame.targetRegister = destReg
 	frame.thisValue = thisValue
 	frame.homeObject = funcObj.HomeObject // Set [[HomeObject]] for super property access (object literal methods)
@@ -256,11 +258,10 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 
 	// Update VM state
 	vm.frameCount++
-	vm.nextRegSlot += regSize
 
 	if debugAsyncAwait {
-		fmt.Printf("[ASYNC-BODY] func=%s starting execution, regSize=%d, args=%d, frameCount=%d, nextRegSlot=%d\n",
-			funcObj.Name, regSize, len(args), vm.frameCount, vm.nextRegSlot)
+		fmt.Printf("[ASYNC-BODY] func=%s starting execution, regSize=%d, args=%d, frameCount=%d, regCursor=%+v\n",
+			funcObj.Name, regSize, len(args), vm.frameCount, vm.regDir.mark())
 		for i := 0; i < len(frame.registers) && i < 5; i++ {
 			fmt.Printf("[ASYNC-BODY]   R%d = %s\n", i, frame.registers[i].Inspect())
 		}
@@ -276,7 +277,7 @@ func (vm *VM) executeAsyncFunctionBody(calleeVal Value, thisValue Value, args []
 	// We can detect this by checking if frameCount is still higher than what we saved.
 	if vm.frameCount > savedFrameCount {
 		vm.frameCount = savedFrameCount
-		vm.nextRegSlot = savedNextRegSlot
+		vm.regDir.popTo(savedRegMark)
 	}
 
 	if status == InterpretRuntimeError {

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -316,14 +316,11 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			return false, fmt.Errorf("Stack overflow\nStack: %s", trace)
 		}
 
-		// Check register stack space
+		// Register stack space is checked (and actually reserved) at the real
+		// push below, once the frame's other fields are staged - nothing
+		// between here and there can invoke user code that would change how
+		// much register space is available in the meantime.
 		requiredRegs := calleeFunc.RegisterSize
-		if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
-			currentFrame.ip = callerIP
-			trace := vm.CaptureStackTrace()
-			fmt.Printf("\n=== VM Stack (register overflow) ===\n%s\n====================================\n", trace)
-			return false, fmt.Errorf("Register stack overflow\nStack: %s", trace)
-		}
 
 		// Store return IP in current frame
 		currentFrame.ip = callerIP
@@ -405,10 +402,17 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		newFrame.args = args
 		newFrame.argumentsObject = Undefined  // Initialize to Undefined (will be created on first access)
 		newFrame.calleeValue = originalCallee // Store original callee for arguments.callee
-		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-		newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
-		newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-		vm.nextRegSlot += requiredRegs
+		newWindow, windowStart, pushMark, ok := vm.regDir.push(requiredRegs)
+		if !ok {
+			currentFrame.ip = callerIP
+			trace := vm.CaptureStackTrace()
+			fmt.Printf("\n=== VM Stack (register overflow) ===\n%s\n====================================\n", trace)
+			return false, fmt.Errorf("Register stack overflow\nStack: %s", trace)
+		}
+		newFrame.registers = newWindow
+		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+		newFrame.regSlotBeforePush = pushMark    // B4 invariant: record window start for checkRegWindowRelease
+		newFrame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 		// Allocate spill slots if this function needs them (for register overflow)
 		if calleeFunc.Chunk.NumSpillSlots > 0 {

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -281,17 +281,25 @@ func (vm *VM) unwindException() bool {
 	return false
 }
 
-// reclaimUnwoundRegisters restores the register-file invariant after
+// reclaimUnwoundRegisters restores the register-directory invariant after
 // unwindException has popped one or more frames to reach a handler.
 //
 // unwindException's pop loop decrements vm.frameCount without giving back the
 // popped frames' register windows (doing it there risks double-counting against
-// the ad-hoc `nextRegSlot -= regSize` reclamation in the native-boundary error
-// paths - see issue #61 / the note in truncateFramesTo). Instead, once we've
-// settled on the frame that will actually resume bytecode execution, snap
-// vm.nextRegSlot back to the top of that frame's window. This only ever *lowers*
-// nextRegSlot (reclaiming leaked windows); it never raises it, and it no-ops for
-// frames whose registers are not carved from vm.registerStack (sentinel/native).
+// the ad-hoc reclamation in the native-boundary error paths - see issue #61 /
+// the note in truncateFramesTo). Instead, once we've settled on the frame that
+// will actually resume bytecode execution, snap vm.regDir's cursor back to the
+// top of that frame's window. This only ever *lowers* the cursor (reclaiming
+// leaked windows); it never raises it, and it no-ops for frames whose
+// registers aren't carved from vm.regDir (sentinel/native).
+//
+// B4 note: this used to reconstruct the frame's window base via
+// `len(vm.registerStack) - cap(frame.registers)`, a pointer-arithmetic trick
+// that made sense for one flat backing array but has no equivalent once
+// storage is split across many separately-allocated blocks. regSlotBeforePush
+// (recorded at push time for exactly this kind of reclamation - see
+// checkRegWindowRelease) already carries the same information directly and
+// unambiguously, so this is simpler now, not just adapted.
 func (vm *VM) reclaimUnwoundRegisters() {
 	if vm.frameCount == 0 {
 		return
@@ -303,15 +311,13 @@ func (vm *VM) reclaimUnwoundRegisters() {
 	if len(frame.registers) == 0 {
 		return
 	}
-	// frame.registers was formed as vm.registerStack[base : base+n] (a 2-index
-	// slice), so cap(frame.registers) == len(vm.registerStack) - base.
-	base := len(vm.registerStack) - cap(frame.registers)
-	if base < 0 || base > len(vm.registerStack) {
-		return // not a registerStack-backed window; leave nextRegSlot untouched
+	windowEnd := registerMark{
+		block:  frame.regWindowStart.block,
+		offset: frame.regWindowStart.offset + frame.allocatedRegSize,
 	}
-	top := base + frame.allocatedRegSize
-	if top >= 0 && top < vm.nextRegSlot {
-		vm.nextRegSlot = top
+	cur := vm.regDir.mark()
+	if cur.block > windowEnd.block || (cur.block == windowEnd.block && cur.offset > windowEnd.offset) {
+		vm.regDir.popTo(windowEnd)
 	}
 }
 

--- a/pkg/vm/op_spreadnew.go
+++ b/pkg/vm/op_spreadnew.go
@@ -158,7 +158,7 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 			return InterpretRuntimeError, Undefined
 		}
 		requiredRegs := constructorFunc.RegisterSize
-		if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
+		if !vm.regDir.wouldFit(requiredRegs) {
 			frame.ip = callerIP
 			vm.ThrowRangeError("Maximum call stack size exceeded")
 			if !vm.unwinding {
@@ -228,10 +228,20 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		// (If `arguments` is accessed, NewArguments will allocate as needed.)
 		newFrame.args = spreadArgs
 		newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
-		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-		newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
-		newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-		vm.nextRegSlot += requiredRegs
+		newWindow, windowStart, pushMark, pushOK := vm.regDir.push(requiredRegs)
+		if !pushOK {
+			// wouldFit already checked this above; see that call's comment.
+			frame.ip = callerIP
+			vm.ThrowRangeError("Maximum call stack size exceeded")
+			if !vm.unwinding {
+				return InterpretOK, Undefined
+			}
+			return InterpretRuntimeError, Undefined
+		}
+		newFrame.registers = newWindow
+		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+		newFrame.regSlotBeforePush = pushMark    // B4 invariant: record window start for checkRegWindowRelease
+		newFrame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 		// Allocate spill slots if this function needs them (for register overflow)
 		if constructorFunc.Chunk.NumSpillSlots > 0 {
@@ -283,7 +293,7 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 			return InterpretRuntimeError, Undefined
 		}
 		requiredRegs := constructorFunc.RegisterSize
-		if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
+		if !vm.regDir.wouldFit(requiredRegs) {
 			frame.ip = callerIP
 			vm.ThrowRangeError("Maximum call stack size exceeded")
 			if !vm.unwinding {
@@ -352,10 +362,20 @@ func (vm *VM) handleOpSpreadNew(code []byte, ip *int, frame *CallFrame, register
 		// Avoid per-call allocation: keep a view of spreadArgs for OpGetArguments.
 		newFrame.args = spreadArgs
 		newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
-		newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-		newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
-		newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-		vm.nextRegSlot += requiredRegs
+		newWindow, windowStart, pushMark, pushOK := vm.regDir.push(requiredRegs)
+		if !pushOK {
+			// wouldFit already checked this above; see that call's comment.
+			frame.ip = callerIP
+			vm.ThrowRangeError("Maximum call stack size exceeded")
+			if !vm.unwinding {
+				return InterpretOK, Undefined
+			}
+			return InterpretRuntimeError, Undefined
+		}
+		newFrame.registers = newWindow
+		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+		newFrame.regSlotBeforePush = pushMark    // B4 invariant: record window start for checkRegWindowRelease
+		newFrame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 		// Allocate spill slots if this function needs them (for register overflow)
 		if constructorFunc.Chunk.NumSpillSlots > 0 {

--- a/pkg/vm/register_directory.go
+++ b/pkg/vm/register_directory.go
@@ -117,19 +117,37 @@ func newRegisterDirectory(maxBlocks int) *registerDirectory {
 	}
 }
 
-// reset clears every Value in every block currently in use (releasing any
-// object/closure/etc. references they hold, so Reset() doesn't leak large
-// retained values across VM reuse) and returns the cursor to the very
+// reset clears every Value in every block currently allocated (releasing
+// any object/closure/etc. references they hold, so Reset() doesn't leak
+// large retained values across VM reuse) and returns the cursor to the very
 // start, trimming blocks back to the reserve exactly as popTo would from a
 // popTo(registerMark{0,0}).
+//
+// This clears the *entire* d.blocks slice, not just blocks up to d.cur.block:
+// popTo's trim() deliberately keeps up to registerDirectoryReserveBlocks
+// blocks allocated past the cursor as reuse slack (see its own doc comment),
+// and those still hold whatever Values were last written into them. Only
+// clearing up to d.cur.block would silently leave that reserve's stale
+// references reachable, defeating Reset()'s entire purpose for exactly the
+// blocks most likely to have just been in active use.
 func (d *registerDirectory) reset() {
-	for i := 0; i <= d.cur.block && i < len(d.blocks); i++ {
-		blk := d.blocks[i]
+	for _, blk := range d.blocks {
 		for j := range blk.data {
 			blk.data[j] = Undefined
 		}
 	}
 	d.popTo(registerMark{block: 0, offset: 0})
+}
+
+// RegisterDirectoryBlockCount returns the number of blocks currently
+// allocated in the VM's register directory (B4). Test-only instrumentation:
+// production code has no use for this - it exists so tests can confirm a
+// scenario actually exercised more than one block (e.g. a generator/async
+// frame suspended with its window carved from a block a skip landed it in)
+// rather than silently passing without ever touching the code path it means
+// to cover.
+func (vm *VM) RegisterDirectoryBlockCount() int {
+	return len(vm.regDir.blocks)
 }
 
 // mark returns the directory's current cursor - the position the next push

--- a/pkg/vm/register_directory.go
+++ b/pkg/vm/register_directory.go
@@ -1,0 +1,320 @@
+package vm
+
+import "fmt"
+
+// This file implements the B4 register-stack redesign
+// (docs/runtime-production-roadmap.md#b4): a directory of lazily allocated,
+// fixed-capacity blocks in place of one eagerly allocated flat
+// `RegFileSize * MaxFrames` array. See registerDirectory's own doc comment
+// for the design; this header covers why it's shaped the way it is.
+//
+// Two invariants make this safe:
+//
+//  1. Every frame's register window fits in exactly one block. The compiler
+//     caps a function's RegisterSize at 255 (pkg/compiler/regalloc.go's
+//     registerLimit; Register is a uint8 and Alloc/AllocContiguous panic into
+//     a proper compile error - "register exhaustion: expression too deeply
+//     nested" - well before that, turning what would otherwise be silent
+//     truncation into a normal, catchable failure). TCO's in-place expansion
+//     (OpTailCall) only ever grows a frame's allocatedRegSize to
+//     max(oldSize, calleeFunc.RegisterSize) across a tail-call chain, never a
+//     sum. So no window this VM can ever produce exceeds 255 registers, and
+//     registerBlockSize (256) always has room to spare. The "oversized
+//     window needs a dedicated block" case the roadmap anticipates is
+//     therefore provably unreachable - push() panics if it's ever hit, which
+//     would mean one of the two facts above stopped being true.
+//
+//  2. A block, once allocated, is never resized or moved. Only the
+//     directory's own slice of block *pointers* grows or shrinks; each
+//     block's backing array is a fixed-size field of the heap-allocated
+//     registerBlock struct it belongs to. So a raw *Value taken into a
+//     block's data (an open upvalue) stays valid for as long as that block
+//     is retained, independent of how much the directory itself grows,
+//     shrinks, or reallocates its outer slice - exactly the pointer-stability
+//     guarantee the flat array gave open upvalues before, and the same
+//     guarantee VM.frames already has for frame records (it's allocated once
+//     at len(MaxFrames) and never reallocated - so this file only needs to
+//     solve the register-storage half of "frame records also need stable
+//     storage where pointers to them survive calls").
+
+// registerBlockSize is the fixed capacity, in Values, of every block. See
+// invariant 1 above for why this is always enough for any single frame's
+// window.
+const registerBlockSize = RegFileSize
+
+// registerDirectoryReserveBlocks is how many trailing empty blocks popTo
+// keeps allocated (rather than releasing to the GC) after the cursor
+// retreats past them. Zero would make every pop-then-push crossing a block
+// boundary alloc/free a block; a small fixed slack absorbs that oscillation
+// (e.g. a loop that recurses just deep enough to cross a boundary and
+// returns) without unboundedly retaining blocks from one deep, one-off
+// excursion (the roadmap's "keep only a bounded reserve of empty segments
+// after a deep request").
+const registerDirectoryReserveBlocks = 4
+
+// registerMark identifies a position in the register directory: a block
+// index plus an offset within that block. It is the B4 replacement for a
+// bare `nextRegSlot int` - the value recorded before a push
+// (CallFrame.regSlotBeforePush) and restored on pop.
+type registerMark struct {
+	block  int
+	offset int
+}
+
+// registerBlock is one fixed-capacity chunk of the register directory. See
+// invariant 2 above for why its address is stable for as long as it's
+// retained.
+type registerBlock struct {
+	data [registerBlockSize]Value
+}
+
+// registerDirectory replaces VM.registerStack ([]Value) + VM.nextRegSlot
+// (int) with a growable list of fixed-capacity blocks and a single logical
+// cursor (`cur`) that moves forward on push and backward on pop - the same
+// shape as nextRegSlot, just expressed as (block, offset) instead of one
+// flat int.
+//
+// Push and pop are strictly LIFO, matching the call stack's own discipline:
+// a frame's window is always released before any frame pushed after it (the
+// same assumption the old nextRegSlot design already depended on). That
+// means pop never needs arithmetic - popTo just restores a previously
+// recorded mark - which is what eliminates the entire class of bug B1 fixed
+// (reclaiming the wrong *amount* of registers): there is no amount to get
+// wrong anymore, only a mark to restore.
+//
+// A push that doesn't fit in the current block's tail moves to the next
+// block, wasting the unused tail slots for as long as the frame that forced
+// the move (or anything above it) stays active. That waste is bounded
+// (< registerBlockSize per skip) and self-healing: popping back below the
+// block that has room makes those slots available again. This is the
+// standard tradeoff of packing many small frames into fixed-size blocks
+// instead of giving every frame its own precisely-sized allocation - it's
+// where B4's memory savings come from, and the reason a frame's window
+// "must remain contiguous within one block" per the roadmap rather than
+// spanning two.
+type registerDirectory struct {
+	blocks []*registerBlock
+	cur    registerMark
+	// maxBlocks is the hard cap on the number of blocks in use (cur.block),
+	// the B4 equivalent of the old flat array's fixed length
+	// (RegFileSize*MaxFrames). It is set to MaxFrames at construction: the
+	// worst case - every active frame forcing its own block skip, zero
+	// packing benefit - needs exactly one block per frame, so this preserves
+	// the exact same absolute worst-case register-space ceiling the flat
+	// array had, while typical workloads (many frames packed per block) use
+	// far less.
+	maxBlocks int
+}
+
+// newRegisterDirectory creates an empty directory with no blocks allocated
+// yet (the first push lazily allocates the first block) and a hard cap of
+// maxBlocks blocks in use at once.
+func newRegisterDirectory(maxBlocks int) *registerDirectory {
+	return &registerDirectory{
+		blocks:    make([]*registerBlock, 0, 8),
+		cur:       registerMark{block: 0, offset: 0},
+		maxBlocks: maxBlocks,
+	}
+}
+
+// reset clears every Value in every block currently in use (releasing any
+// object/closure/etc. references they hold, so Reset() doesn't leak large
+// retained values across VM reuse) and returns the cursor to the very
+// start, trimming blocks back to the reserve exactly as popTo would from a
+// popTo(registerMark{0,0}).
+func (d *registerDirectory) reset() {
+	for i := 0; i <= d.cur.block && i < len(d.blocks); i++ {
+		blk := d.blocks[i]
+		for j := range blk.data {
+			blk.data[j] = Undefined
+		}
+	}
+	d.popTo(registerMark{block: 0, offset: 0})
+}
+
+// mark returns the directory's current cursor - the position the next push
+// will start at, and the value to record as a frame's regSlotBeforePush
+// immediately before pushing its window.
+func (d *registerDirectory) mark() registerMark {
+	return d.cur
+}
+
+// push allocates a contiguous window of n registers. It returns:
+//
+//   - window: the register slice itself (for CallFrame.registers).
+//   - start: the mark identifying where the window actually lives (for
+//     CallFrame.regWindowStart - what TCO's tryExpand/move, reclaimUnwoundRegisters,
+//     and checkRegWindowRelease need to reason about this window's own bounds).
+//   - release: the directory's cursor as it was *before* this push (for
+//     CallFrame.regSlotBeforePush - what popTo needs to correctly restore
+//     when this window is released).
+//   - ok=false if the register-space budget (maxBlocks) is exhausted, the
+//     direct analog of the old `nextRegSlot+n > len(registerStack)` check.
+//
+// start and release are equal exactly when the window fit in the current
+// block's tail (the common case - most pushes). They diverge when the push
+// had to skip to a fresh block, wasting the old block's remaining tail
+// slots: start then points into the new block, while release still points
+// at the old cursor position, just before those wasted slots. Popping with
+// release (not start) is what makes that waste self-healing - see popTo and
+// registerDirectory's own doc comment. A caller that used `start` for both
+// roles would never recover the wasted slots: every return would leave the
+// cursor sitting at the block boundary instead of back where the caller's
+// own cursor was before making the call, permanently stranding a growing
+// number of blocks over a long call chain that crosses many block
+// boundaries. This was exactly the first (and only) real bug the B4 wiring
+// hit - caught immediately by the smoke suite once StrictRegWindowChecks
+// was on, rather than shipping as a slow, hard-to-attribute memory leak.
+func (d *registerDirectory) push(n int) (window []Value, start registerMark, release registerMark, ok bool) {
+	release = d.cur
+
+	if n > registerBlockSize {
+		// See invariant 1 in the file header: no real function/TCO chain can
+		// produce a window this large. Panicking (instead of silently
+		// handling it) keeps that assumption honest if it's ever violated.
+		panic(fmt.Sprintf(
+			"registerDirectory.push: requested window of %d registers exceeds block size %d - "+
+				"impossible for any window this VM can produce (compiler caps a function's "+
+				"RegisterSize at 255, and TCO only ever takes the max across a tail-call chain, "+
+				"never a sum); this means that invariant was violated elsewhere",
+			n, registerBlockSize))
+	}
+
+	if d.cur.offset+n > registerBlockSize {
+		// Doesn't fit in the current block's tail: move to a fresh block.
+		if d.cur.block+1 >= d.maxBlocks {
+			return nil, registerMark{}, registerMark{}, false
+		}
+		d.cur = registerMark{block: d.cur.block + 1, offset: 0}
+	}
+
+	if d.cur.block >= len(d.blocks) {
+		d.blocks = append(d.blocks, &registerBlock{})
+	}
+
+	start = d.cur
+	window = d.blocks[d.cur.block].data[d.cur.offset : d.cur.offset+n]
+	d.cur.offset += n
+	return window, start, release, true
+}
+
+// window returns the slice for an already-allocated (start, n) window,
+// without allocating anything - used when a frame's mark/size is already
+// known (e.g. a suspended generator/async frame resuming into the window it
+// was given when its body first started, or TCO recomputing the current
+// frame's slice after expanding it).
+func (d *registerDirectory) window(start registerMark, n int) []Value {
+	return d.blocks[start.block].data[start.offset : start.offset+n]
+}
+
+// popTo restores the directory's cursor to a previously recorded mark,
+// releasing every register allocated since (LIFO, so this is always exactly
+// "everything the popped frame and anything it called are done with") and
+// opportunistically trims trailing now-empty blocks back to a bounded
+// reserve. Because push/pop are strictly LIFO, this alone is always
+// correct - unlike the old `nextRegSlot -= amount`, there is no amount that
+// can be wrong.
+func (d *registerDirectory) popTo(mark registerMark) {
+	d.cur = mark
+	d.trim()
+}
+
+// trim releases blocks beyond a small fixed reserve past the current
+// cursor, letting the GC reclaim them. See registerDirectoryReserveBlocks
+// for why a reserve is kept rather than trimming to exactly cur.block.
+func (d *registerDirectory) trim() {
+	keep := d.cur.block + 1 + registerDirectoryReserveBlocks
+	if len(d.blocks) > keep {
+		d.blocks = d.blocks[:keep]
+	}
+}
+
+// wouldFit reports whether a push of n registers would currently succeed,
+// without allocating or mutating anything. Used at call sites that want to
+// report a clean overflow error *before* doing unrelated setup work (e.g.
+// resolving a constructor's prototype) that would otherwise be wasted -
+// the same early-bailout role the old `nextRegSlot+n > len(registerStack)`
+// check played, kept separate from the actual push done later at the point
+// where the frame's window is really allocated.
+func (d *registerDirectory) wouldFit(n int) bool {
+	if n > registerBlockSize {
+		return false
+	}
+	if d.cur.offset+n <= registerBlockSize {
+		return true
+	}
+	return d.cur.block+1 < d.maxBlocks
+}
+
+// wouldFitExpansion reports, without allocating or mutating anything,
+// whether expanding the topmost window (starting at `start`) to newSize
+// would succeed - either in place, or via a move to a fresh block. Used by
+// TCO (OpTailCall) to decide whether it can proceed *before* closing the
+// current frame's upvalues, which must happen before an actual move (so the
+// move doesn't leave a stale open upvalue pointing at contents that have
+// been copied elsewhere) - tryExpand's in-place case doesn't have that
+// ordering requirement, but checking both cases here up front keeps the
+// caller's decide-then-commit structure simple.
+func (d *registerDirectory) wouldFitExpansion(start registerMark, newSize int) bool {
+	if start.offset+newSize <= registerBlockSize {
+		return true // Fits in place.
+	}
+	// Doesn't fit in place: a move would need a fresh block. Any single
+	// block always has room for newSize (invariant 1: no real window
+	// exceeds 255 registers), so this is just asking whether one more block
+	// is available at all.
+	return start.block+1 < d.maxBlocks
+}
+
+// tryExpand grows an in-place window from oldSize to newSize without moving
+// it, when the window's block has room right after it. Used by TCO
+// (OpTailCall), which reuses the *current, topmost* frame's window and must
+// never shrink it - `start` must be the most recently pushed window (i.e.
+// sit exactly at the cursor before this call), which is always true for TCO
+// since it only ever expands the frame currently on top of the stack.
+//
+// ok=false means the window's block doesn't have room; the caller should
+// fall back to move(), which relocates the window instead.
+func (d *registerDirectory) tryExpand(start registerMark, oldSize, newSize int) (window []Value, ok bool) {
+	if newSize <= oldSize {
+		return d.window(start, oldSize), true // Never shrinks; nothing to do.
+	}
+	if start.offset+newSize > registerBlockSize {
+		return nil, false
+	}
+	d.cur = registerMark{block: start.block, offset: start.offset + newSize}
+	return d.blocks[start.block].data[start.offset : start.offset+newSize], true
+}
+
+// move relocates a window to a fresh push and copies its live contents,
+// used by TCO as the fallback when tryExpand can't satisfy the new size in
+// place (the window's current block doesn't have enough room after it).
+// Unlike an ordinary call - which always allocates a brand new window - TCO
+// reuses an existing one, so growing it can require an actual move+copy
+// that the old flat-array design never needed (there, "expand" was always
+// just extending the same contiguous slice).
+//
+// This is only safe because the caller has already closed the frame's open
+// upvalues (closeFrameUpvalues) before calling move: closing converts any
+// raw *Value pointing into the window's old slots into a value copied
+// elsewhere, so nothing is left holding a pointer into the slots being
+// abandoned here.
+//
+// ok=false (register-space exhausted) leaves the directory untouched and
+// `start`'s window still valid at its old location/size, so the caller can
+// still report a clean overflow rather than being left with a corrupted
+// window.
+func (d *registerDirectory) move(oldStart registerMark, oldSize, newSize int) (window []Value, newStart registerMark, ok bool) {
+	// The old window is the current topmost allocation (same precondition as
+	// tryExpand): releasing it first lets push reuse its space if possible.
+	saved := d.cur
+	d.cur = oldStart
+	newWindow, start, _, ok := d.push(newSize)
+	if !ok {
+		d.cur = saved // Restore: the old window is still there, unchanged.
+		return nil, registerMark{}, false
+	}
+	oldWindow := d.blocks[oldStart.block].data[oldStart.offset : oldStart.offset+oldSize]
+	copy(newWindow, oldWindow)
+	return newWindow, start, true
+}

--- a/pkg/vm/register_directory_test.go
+++ b/pkg/vm/register_directory_test.go
@@ -1,0 +1,306 @@
+package vm
+
+import "testing"
+
+func TestRegisterDirectoryBasicPushPop(t *testing.T) {
+	d := newRegisterDirectory(10)
+
+	win, m0, _, ok := d.push(5)
+	if !ok {
+		t.Fatalf("push(5) failed")
+	}
+	if m0 != (registerMark{block: 0, offset: 0}) {
+		t.Fatalf("expected first push at (0,0), got %+v", m0)
+	}
+	if len(win) != 5 {
+		t.Fatalf("expected window of 5, got %d", len(win))
+	}
+
+	win2, m1, _, ok := d.push(3)
+	if !ok {
+		t.Fatalf("push(3) failed")
+	}
+	if m1 != (registerMark{block: 0, offset: 5}) {
+		t.Fatalf("expected second push at (0,5), got %+v", m1)
+	}
+	if len(win2) != 3 {
+		t.Fatalf("expected window of 3, got %d", len(win2))
+	}
+
+	// LIFO pop of the second window must restore the mark exactly.
+	d.popTo(m1)
+	if d.mark() != m1 {
+		t.Fatalf("expected cursor at %+v after popTo, got %+v", m1, d.mark())
+	}
+	d.popTo(m0)
+	if d.mark() != m0 {
+		t.Fatalf("expected cursor at %+v after popTo, got %+v", m0, d.mark())
+	}
+}
+
+func TestRegisterDirectoryTailWasteAcrossBlockBoundary(t *testing.T) {
+	d := newRegisterDirectory(10)
+
+	// Fill block 0 to offset 200, leaving 56 slots in its tail.
+	_, _, _, ok := d.push(200)
+	if !ok {
+		t.Fatalf("push(200) failed")
+	}
+
+	// A window of 100 doesn't fit in the remaining 56 - must skip to block 1,
+	// wasting the 56-slot tail rather than splitting across blocks.
+	win, start, _, ok := d.push(100)
+	if !ok {
+		t.Fatalf("push(100) failed")
+	}
+	if start.block != 1 || start.offset != 0 {
+		t.Fatalf("expected skip to (1,0), got %+v", start)
+	}
+	if len(win) != 100 {
+		t.Fatalf("expected window of 100, got %d", len(win))
+	}
+	if len(d.blocks) != 2 {
+		t.Fatalf("expected 2 blocks allocated, got %d", len(d.blocks))
+	}
+
+	// Popping back below block 0's mark must make its wasted tail available
+	// again: the very next push that fits should land back in block 0.
+	d.popTo(registerMark{block: 0, offset: 200})
+	win2, start2, _, ok := d.push(50)
+	if !ok {
+		t.Fatalf("push(50) after popTo failed")
+	}
+	if start2.block != 0 || start2.offset != 200 {
+		t.Fatalf("expected reuse of block 0's wasted tail at (0,200), got %+v", start2)
+	}
+	if len(win2) != 50 {
+		t.Fatalf("expected window of 50, got %d", len(win2))
+	}
+}
+
+// TestRegisterDirectoryPushReturnsDistinctReleaseAndWindowStartAcrossSkip
+// pins down the exact bug the B4 VM wiring hit on first attempt: when a push
+// skips to a fresh block, the window's own location (`start`) and the mark
+// that must be restored on release (`release`) are DIFFERENT, and a caller
+// that conflates them (using `start` for both, as CallFrame.regSlotBeforePush
+// originally did) never recovers the wasted tail slots - every return would
+// leave the cursor sitting at the block boundary instead of back where the
+// caller's own cursor was before the call, permanently stranding blocks over
+// a long call chain. See push's own doc comment for the full story.
+func TestRegisterDirectoryPushReturnsDistinctReleaseAndWindowStartAcrossSkip(t *testing.T) {
+	d := newRegisterDirectory(10)
+
+	// Fill block 0 to offset 254, leaving only 2 slots in its tail.
+	_, _, _, ok := d.push(254)
+	if !ok {
+		t.Fatalf("push(254) failed")
+	}
+	preSkipMark := d.mark() // {block:0, offset:254} - what a caller's cursor looks like right before the next push
+
+	// A window of 18 doesn't fit in the remaining 2 - must skip to block 1.
+	_, start, release, ok := d.push(18)
+	if !ok {
+		t.Fatalf("push(18) failed")
+	}
+	if start == release {
+		t.Fatalf("expected start and release to diverge across a block skip, both were %+v", start)
+	}
+	if release != preSkipMark {
+		t.Fatalf("expected release to equal the pre-push cursor %+v, got %+v", preSkipMark, release)
+	}
+	if start != (registerMark{block: 1, offset: 0}) {
+		t.Fatalf("expected the window itself to live at (1,0), got %+v", start)
+	}
+
+	// Releasing with `release` (as CallFrame.regSlotBeforePush does) must
+	// restore the pre-skip position, recovering the wasted tail slots.
+	d.popTo(release)
+	if d.mark() != preSkipMark {
+		t.Fatalf("popTo(release) should restore %+v, got %+v", preSkipMark, d.mark())
+	}
+	// The 2 wasted slots at the end of block 0 must be reusable again now.
+	_, reuseStart, _, ok := d.push(2)
+	if !ok {
+		t.Fatalf("push(2) after popTo(release) failed")
+	}
+	if reuseStart != preSkipMark {
+		t.Fatalf("expected the wasted tail slots to be reused at %+v, got %+v", preSkipMark, reuseStart)
+	}
+}
+
+func TestRegisterDirectoryWindowNeverSpansBlocks(t *testing.T) {
+	d := newRegisterDirectory(10)
+	_, _, _, _ = d.push(250) // leaves 6 slots in block 0's tail
+
+	_, start, _, ok := d.push(10) // doesn't fit in 6 remaining - must move to block 1 entirely
+	if !ok {
+		t.Fatalf("push(10) failed")
+	}
+	if start.block != 1 {
+		t.Fatalf("expected window to move entirely into block 1, got block %d", start.block)
+	}
+}
+
+func TestRegisterDirectoryOverflowAtMaxBlocks(t *testing.T) {
+	d := newRegisterDirectory(2) // only 2 blocks allowed
+
+	_, _, _, ok := d.push(registerBlockSize) // fills block 0 exactly
+	if !ok {
+		t.Fatalf("push(registerBlockSize) failed")
+	}
+	_, _, _, ok = d.push(registerBlockSize) // fills block 1 exactly
+	if !ok {
+		t.Fatalf("second push(registerBlockSize) failed")
+	}
+	_, _, _, ok = d.push(1) // no room for a 3rd block
+	if ok {
+		t.Fatalf("expected overflow at maxBlocks=2, but push succeeded")
+	}
+}
+
+func TestRegisterDirectoryPushExceedingBlockSizePanics(t *testing.T) {
+	d := newRegisterDirectory(10)
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("expected push(registerBlockSize+1) to panic")
+		}
+	}()
+	d.push(registerBlockSize + 1)
+}
+
+func TestRegisterDirectoryTrimReleasesDeepExcursion(t *testing.T) {
+	d := newRegisterDirectory(1000)
+
+	// Simulate a deep excursion: push+pop repeatedly to build up many blocks,
+	// then return to shallow depth in one popTo.
+	var marks []registerMark
+	for i := 0; i < 50; i++ {
+		_, m, _, ok := d.push(registerBlockSize) // one full block per push
+		if !ok {
+			t.Fatalf("push %d failed", i)
+		}
+		marks = append(marks, m)
+	}
+	if len(d.blocks) < 50 {
+		t.Fatalf("expected at least 50 blocks allocated during excursion, got %d", len(d.blocks))
+	}
+
+	// Pop all the way back to the start.
+	d.popTo(registerMark{block: 0, offset: 0})
+
+	maxKept := 1 + registerDirectoryReserveBlocks
+	if len(d.blocks) > maxKept {
+		t.Fatalf("expected trim to release blocks beyond the reserve (%d), got %d blocks retained", maxKept, len(d.blocks))
+	}
+}
+
+func TestRegisterDirectoryTryExpandInPlace(t *testing.T) {
+	d := newRegisterDirectory(10)
+	win, start, _, ok := d.push(10)
+	if !ok {
+		t.Fatalf("push(10) failed")
+	}
+	for i := range win {
+		win[i] = IntegerValue(int32(i))
+	}
+
+	expanded, ok := d.tryExpand(start, 10, 20)
+	if !ok {
+		t.Fatalf("tryExpand in place failed")
+	}
+	if len(expanded) != 20 {
+		t.Fatalf("expected expanded window of 20, got %d", len(expanded))
+	}
+	// Original contents must be preserved (same backing array, no copy needed).
+	for i := 0; i < 10; i++ {
+		if expanded[i].AsInteger() != int32(i) {
+			t.Fatalf("expected expanded[%d]=%d, got %v", i, i, expanded[i])
+		}
+	}
+	if d.mark() != (registerMark{block: 0, offset: 20}) {
+		t.Fatalf("expected cursor advanced to (0,20), got %+v", d.mark())
+	}
+}
+
+func TestRegisterDirectoryTryExpandFailsNearBlockEnd(t *testing.T) {
+	d := newRegisterDirectory(10)
+	_, first, _, _ := d.push(240) // leaves 16 slots in block 0
+	// first isn't the topmost window anymore once we push again, but here
+	// we test tryExpand directly on the still-topmost window.
+	expanded, ok := d.tryExpand(first, 240, 250) // needs 10 more; only 16 left - fits
+	if !ok {
+		t.Fatalf("expected expand to 250 (needs 10 more of 16 remaining) to succeed")
+	}
+	if len(expanded) != 250 {
+		t.Fatalf("expected window of 250, got %d", len(expanded))
+	}
+
+	_, ok = d.tryExpand(first, 250, 256+1)
+	if ok {
+		t.Fatalf("expected expand past registerBlockSize to fail")
+	}
+}
+
+func TestRegisterDirectoryMoveRelocatesAndCopies(t *testing.T) {
+	d := newRegisterDirectory(10)
+	_, _, _, _ = d.push(10) // padding, so the frame's window starts at a non-zero offset
+	win, start, _, ok := d.push(240)
+	if !ok {
+		t.Fatalf("push(240) failed")
+	}
+	if start.offset != 10 {
+		t.Fatalf("expected frame window to start at offset 10, got %d", start.offset)
+	}
+	for i := range win {
+		win[i] = IntegerValue(int32(i))
+	}
+
+	// tryExpand must fail here: offset 10 + 250 = 260 > registerBlockSize, so
+	// it doesn't fit in place even though 250 itself is a legal window size -
+	// move should relocate to a fresh block and preserve contents.
+	if _, ok := d.tryExpand(start, 240, 250); ok {
+		t.Fatalf("expected tryExpand to fail so move is exercised")
+	}
+
+	moved, newStart, ok := d.move(start, 240, 250)
+	if !ok {
+		t.Fatalf("move failed")
+	}
+	if newStart.block == start.block {
+		t.Fatalf("expected move to relocate to a different block, stayed at block %d", newStart.block)
+	}
+	if len(moved) != 250 {
+		t.Fatalf("expected moved window of 250, got %d", len(moved))
+	}
+	for i := 0; i < 240; i++ {
+		if moved[i].AsInteger() != int32(i) {
+			t.Fatalf("expected moved[%d]=%d after copy, got %v", i, i, moved[i])
+		}
+	}
+}
+
+func TestRegisterDirectoryMoveOverflowLeavesOldWindowIntact(t *testing.T) {
+	d := newRegisterDirectory(1) // only 1 block available - no room to move into
+	_, _, _, _ = d.push(10)         // padding, so the frame's window starts at offset 10
+	win, start, _, ok := d.push(240)
+	if !ok {
+		t.Fatalf("push(240) failed")
+	}
+	win[0] = IntegerValue(42)
+
+	// offset 10 + 250 = 260 > registerBlockSize, so this can't stay in place,
+	// and with maxBlocks=1 there's no second block to relocate into either.
+	_, _, ok = d.move(start, 240, 250)
+	if ok {
+		t.Fatalf("expected move to fail (no second block available)")
+	}
+	// Old window must remain exactly as it was - readable at its original
+	// location with its original contents, and the cursor unchanged.
+	still := d.window(start, 240)
+	if still[0].AsInteger() != 42 {
+		t.Fatalf("expected old window contents preserved after failed move")
+	}
+	if d.mark() != (registerMark{block: start.block, offset: start.offset + 240}) {
+		t.Fatalf("expected cursor restored to just past the untouched old window")
+	}
+}

--- a/pkg/vm/register_directory_test.go
+++ b/pkg/vm/register_directory_test.go
@@ -168,6 +168,48 @@ func TestRegisterDirectoryPushExceedingBlockSizePanics(t *testing.T) {
 	d.push(registerBlockSize + 1)
 }
 
+// TestRegisterDirectoryResetClearsReserveBlocksToo guards against reset()
+// only clearing blocks up to the cursor: popTo's trim() deliberately keeps
+// a small reserve of blocks allocated *past* the cursor for reuse, and those
+// still hold whatever was last written into them. reset() must clear the
+// entire block list, not stop at d.cur.block, or those reserve blocks keep
+// retaining large objects/closures across VM reuse - defeating Reset()'s
+// purpose for exactly the blocks most likely to have just been active.
+func TestRegisterDirectoryResetClearsReserveBlocksToo(t *testing.T) {
+	d := newRegisterDirectory(1000)
+
+	// Push into several blocks, write a recognizable value into the last
+	// one, then pop back to the start - trim() will keep that block (and a
+	// few more) in the reserve rather than releasing it immediately.
+	var win []Value
+	for i := 0; i < registerDirectoryReserveBlocks+2; i++ {
+		w, _, _, ok := d.push(registerBlockSize)
+		if !ok {
+			t.Fatalf("push %d failed", i)
+		}
+		win = w
+	}
+	win[0] = IntegerValue(99)
+	blocksBeforeReset := len(d.blocks)
+
+	d.popTo(registerMark{block: 0, offset: 0})
+	if len(d.blocks) == 0 {
+		t.Fatalf("expected trim to keep at least the reserve, got 0 blocks")
+	}
+
+	d.reset()
+
+	// Every block still allocated (the reserve trim kept) must have been
+	// cleared, not just the ones up to the post-reset cursor (block 0).
+	for i, blk := range d.blocks {
+		for j, v := range blk.data {
+			if v != Undefined {
+				t.Fatalf("expected reset() to clear block %d slot %d, found %v (blocksBeforeReset=%d)", i, j, v, blocksBeforeReset)
+			}
+		}
+	}
+}
+
 func TestRegisterDirectoryTrimReleasesDeepExcursion(t *testing.T) {
 	d := newRegisterDirectory(1000)
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -24,13 +24,17 @@ import (
 const RegFileSize = 256 // Max registers per function call frame
 
 // MaxFrames is the maximum call stack depth (number of simultaneously live
-// activations) and, multiplied by RegFileSize, the size of the VM-wide register
-// file. It is a var, not a const, so embedders can tune it before creating a VM
-// (see SetMaxFrames); the backing arrays (VM.frames, VM.registerStack) are
-// allocated once in NewVM from its then-current value and never reallocated, so
-// raw *Value pointers held by open upvalues stay valid for the VM's lifetime.
+// activations) and also the hard cap on the register directory's block count
+// (see registerDirectory.maxBlocks) - i.e. the worst-case register-space
+// ceiling, matching what a flat RegFileSize*MaxFrames array would have held
+// before B4 (pkg/vm/register_directory.go). It is a var, not a const, so
+// embedders can tune it before creating a VM (see SetMaxFrames); VM.frames is
+// allocated once in NewVM from its then-current value and never reallocated,
+// so &frames[i] stays stable for the VM's lifetime - the register directory's
+// own blocks give open upvalues the equivalent guarantee (see its own doc
+// comment), just via lazy per-block allocation instead of one upfront array.
 //
-// Total register file = RegFileSize * MaxFrames * sizeof(Value) (~24B):
+// Register file, worst case = RegFileSize * MaxFrames * sizeof(Value) (~24B):
 // 4096 frames => ~24MB, allocated lazily per VM. Deep recursive workloads (e.g.
 // running tsc's binder) need more than the historical 512.
 var MaxFrames = 4096
@@ -1385,7 +1389,7 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	vm.errors = vm.errors[:0]
 
 	// --- Sanity Check: Ensure enough stack space BEFORE pushing frame ---
-	// We need space for the new frame in frames array and registers in registerStack.
+	// We need space for the new frame in the frames array and its register window in the register directory.
 	if vm.frameCount >= len(vm.frames) {
 		// Cannot add another frame.
 		placeholderToken := errors.Position{Line: 0, Column: 0} // TODO: Better position?
@@ -1584,16 +1588,17 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 		//
 		// Take ownership of the exception here, the same way a native
 		// boundary caller does: extract it, clear the VM's unwind state, and
-		// restore frameCount/nextRegSlot to exactly what they were before we
-		// pushed - the same truncateFramesTo(frameCountAtEntry) idiom
-		// executeUserFunctionSafe uses for its own native boundary, rather
-		// than assuming unwindException left exactly our one frame to pop:
-		// some run() exit paths return InterpretRuntimeError while frames
-		// above ours are still live (e.g. OpDirectEval's reassigned-eval
-		// fallback), and popping only one frame would under-restore then.
-		// truncateFramesTo closes upvalues for every frame it drops but
-		// doesn't touch nextRegSlot (its other callers' pushed frames aren't
-		// carved from vm.registerStack), so that part is ours to do here.
+		// restore frameCount/the register directory's cursor to exactly what
+		// they were before we pushed - the same truncateFramesTo(frameCountAtEntry)
+		// idiom executeUserFunctionSafe uses for its own native boundary,
+		// rather than assuming unwindException left exactly our one frame to
+		// pop: some run() exit paths return InterpretRuntimeError while
+		// frames above ours are still live (e.g. OpDirectEval's
+		// reassigned-eval fallback), and popping only one frame would
+		// under-restore then. truncateFramesTo closes upvalues for every
+		// frame it drops but doesn't touch the register directory's cursor
+		// (its other callers' pushed frames aren't carved from it), so
+		// that part is ours to do here.
 		// Report the exception via a fresh local slice rather than
 		// vm.errors: the caller's own execution keeps running after we
 		// return (this is a *nested* Interpret call), and nothing clears

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -147,7 +147,27 @@ type CallFrame struct {
 	registers           []Value
 	spillSlots          []Value  // Spill slots for register overflow (allocated only if needed)
 	allocatedRegSize    int      // Actual allocated register window size (may differ from function.RegisterSize due to TCO expansion)
-	regSlotBeforePush   int      // vm.nextRegSlot at the moment this frame's register window was allocated (i.e. the window's base offset). Recorded by every fresh-frame push site; checkRegWindowRelease asserts that reclaiming allocatedRegSize registers restores vm.nextRegSlot to exactly this value, catching a wrong reclaim size at its call site instead of a much-later, unexplained register-stack overflow (#399/#400/#402 B4 invariant). TCO expansion updates allocatedRegSize without touching this field, since the window's base doesn't move.
+	// regSlotBeforePush is vm.regDir's cursor as it was *immediately before*
+	// this frame's register window was pushed - the "release mark". It is
+	// what vm.regDir.popTo uses on every return path to give this window's
+	// space back. It is NOT necessarily this window's own location: a push
+	// that couldn't fit in the current block's tail skips to a fresh block,
+	// wasting that block's remaining slots - regSlotBeforePush still points
+	// at the old cursor position, just before the wasted slots, so popTo
+	// reclaims them too once this frame (and everything above it) is gone.
+	// See registerDirectory.push's own doc comment for the full reasoning.
+	// Recorded once, by whatever site first pushes this frame; never
+	// touched again by TCO (a tail call reuses the frame but its eventual
+	// real return still gives back everything since this same original mark).
+	regSlotBeforePush registerMark
+	// regWindowStart is where this frame's register window actually lives -
+	// equal to regSlotBeforePush except after a block-skip (see above), when
+	// it points into the new block instead. This is what TCO's
+	// tryExpand/move and checkRegWindowRelease reason about: "does my own
+	// window, possibly TCO-expanded, end where I think it does". TCO updates
+	// this field (not regSlotBeforePush) when it relocates the window via
+	// move(); tryExpand doesn't move it, so leaves it unchanged.
+	regWindowStart registerMark
 	targetRegister      byte     // Which register in the CALLER the result should go into
 	thisValue           Value    // The 'this' value for method calls (undefined for regular function calls)
 	homeObject          Value    // The [[HomeObject]] for super property access (object where method is defined)
@@ -190,12 +210,13 @@ type VM struct {
 	frames     []CallFrame
 	frameCount int
 
-	// Register file, treated as a stack. Each CallFrame gets a window into this.
-	// This avoids reallocating register arrays for every call. Allocated once in
-	// NewVM (len == RegFileSize*MaxFrames) and never reallocated, so raw *Value
-	// pointers held by open upvalues stay valid for the VM's lifetime.
-	registerStack []Value
-	nextRegSlot   int // Points to the next available slot in registerStack
+	// Register storage: a directory of lazily allocated fixed-capacity blocks
+	// (pkg/vm/register_directory.go, B4) rather than one eagerly allocated
+	// RegFileSize*MaxFrames flat array. Each CallFrame's `registers` field is
+	// still a plain []Value slice into this storage - a window into whichever
+	// block holds it - so raw *Value pointers held by open upvalues stay valid
+	// for as long as that block is retained, exactly as before.
+	regDir *registerDirectory
 
 	// sentinelRegPool is a LIFO free-list of 1-element register slices reused as
 	// the sentinel frame's result holder on native->JS reentry
@@ -504,38 +525,52 @@ func funcName(fn *FunctionObject) string {
 var StrictRegWindowChecks = false
 
 // checkRegWindowRelease asserts that reclaiming `amount` registers for
-// `frame` restores vm.nextRegSlot to exactly the value recorded when this
-// frame's register window was allocated (CallFrame.regSlotBeforePush). This
-// is the exact invariant that #399/#400 violated - a frame-exit path that
-// reclaimed the wrong number of registers (a stale/wrong-function's
-// RegisterSize instead of this frame's actual allocatedRegSize), silently
-// leaking or over-reclaiming until a much later, unrelated call site hit
-// "Register stack overflow" or "Maximum call stack size exceeded" with no
-// clue which return path was actually responsible. Call this immediately
-// before performing the real `vm.nextRegSlot -= amount`; it never mutates
-// state itself, so it changes no behavior when the invariant holds, and -
-// only when StrictRegWindowChecks is on (see its own comment) - panics
-// immediately, at the guilty call site, when it doesn't.
+// `frame` - i.e. the upcoming vm.regDir.popTo(frame.regSlotBeforePush) - is
+// popping back exactly as far as this frame's own window and no further:
+// vm.regDir's cursor right now must equal frame.regSlotBeforePush advanced
+// by `amount`. This is the exact invariant that #399/#400 violated - a
+// frame-exit path that reclaimed the wrong number of registers (a
+// stale/wrong-function's RegisterSize instead of this frame's actual
+// allocatedRegSize), silently leaking or over-reclaiming until a much
+// later, unrelated call site hit "Register stack overflow" or "Maximum
+// call stack size exceeded" with no clue which return path was actually
+// responsible. Call this immediately before performing the real
+// vm.regDir.popTo(frame.regSlotBeforePush); it never mutates state itself,
+// so it changes no behavior when the invariant holds, and - only when
+// StrictRegWindowChecks is on (see its own comment) - panics immediately,
+// at the guilty call site, when it doesn't.
 //
 // `site` is a short label (opcode/function name) identifying the caller,
-// included in the panic message. Once B4 replaces the flat register stack
-// with segments, this same check generalizes directly: regSlotBeforePush
-// becomes a (segment, offset) pair instead of a flat int, and the
-// comparison is unchanged in spirit.
+// included in the panic message. B4 (pkg/vm/register_directory.go) already
+// generalized regSlotBeforePush from a flat int to a (block, offset) mark;
+// this check is unchanged in spirit from before that change, just phrased
+// as "does the cursor match the expected mark" instead of "does subtracting
+// amount from nextRegSlot reach the expected int" - popTo itself has no
+// arithmetic left to get wrong, which is exactly the point of the B4
+// redesign, but a caller can still pass the wrong `amount` (this frame's
+// stale RegisterSize instead of its real allocatedRegSize) or call this out
+// of LIFO order, both of which this still catches.
 func (vm *VM) checkRegWindowRelease(frame *CallFrame, amount int, site string) {
 	if !StrictRegWindowChecks {
 		return
 	}
-	after := vm.nextRegSlot - amount
-	if after != frame.regSlotBeforePush {
+	before := frame.regWindowStart
+	expected := registerMark{block: before.block, offset: before.offset + amount}
+	cur := vm.regDir.mark()
+	if cur != expected {
 		funcN := "<nil closure>"
 		if frame.closure != nil {
 			funcN = funcName(frame.closure.Fn)
 		}
+		var mismatch string
+		if cur.block > expected.block || (cur.block == expected.block && cur.offset > expected.offset) {
+			mismatch = "more is actually allocated above this window than `amount` accounts for (the caller's size claim is too small - e.g. a stale RegisterSize instead of this frame's real allocatedRegSize)"
+		} else {
+			mismatch = "less is actually allocated above this window than `amount` accounts for (the caller's size claim is too large, or this was called out of LIFO order)"
+		}
 		panic(fmt.Sprintf(
-			"register window imbalance at %s (func=%q): reclaiming %d registers would leave nextRegSlot=%d, expected %d (off by %d - %s)",
-			site, funcN, amount, after, frame.regSlotBeforePush, after-frame.regSlotBeforePush,
-			map[bool]string{true: "leaked", false: "over-reclaimed"}[after > frame.regSlotBeforePush]))
+			"register window imbalance at %s (func=%q): about to pop to window start %+v claiming to reclaim %d registers (implying cursor=%+v), but the cursor is actually %+v - %s",
+			site, funcN, before, amount, expected, cur, mismatch))
 	}
 }
 
@@ -544,7 +579,7 @@ func dumpFrameStack(vm *VM, context string) {
 	if !debugVM {
 		return
 	}
-	fmt.Printf("[DBG Frames] %s: frameCount=%d nextRegSlot=%d\n", context, vm.frameCount, vm.nextRegSlot)
+	fmt.Printf("[DBG Frames] %s: frameCount=%d regCursor=%+v\n", context, vm.frameCount, vm.regDir.mark())
 	for i := 0; i < vm.frameCount; i++ {
 		fr := &vm.frames[i]
 		name := "<no-fn>"
@@ -565,15 +600,15 @@ func dumpFrameStack(vm *VM, context string) {
 // NewVM creates a new VM instance.
 func NewVM() *VM {
 	vm := &VM{
-		// frameCount and nextRegSlot initialized to 0
-		frames:                  make([]CallFrame, MaxFrames),         // Call stack (never reallocated)
-		registerStack:           make([]Value, RegFileSize*MaxFrames), // VM-wide register file (never reallocated)
-		propCache:               make(map[int]*PropInlineCache),       // Initialize inline cache
-		cacheStats:              ICacheStats{},                        // Initialize cache statistics
-		errors:                  make([]errors.PaseratiError, 0),      // Initialize error list
-		moduleContexts:          make(map[string]*ModuleContext),      // Initialize module context cache
-		completionStack:         make([]Completion, 0, 4),             // Initialize completion stack
-		globalsFromGlobalObject: make(map[uint16]bool),                // Track globals read from GlobalObject
+		// frameCount initialized to 0
+		frames:                  make([]CallFrame, MaxFrames),    // Call stack (never reallocated)
+		regDir:                  newRegisterDirectory(MaxFrames), // Register storage (B4: lazily allocated blocks)
+		propCache:               make(map[int]*PropInlineCache),  // Initialize inline cache
+		cacheStats:              ICacheStats{},                   // Initialize cache statistics
+		errors:                  make([]errors.PaseratiError, 0), // Initialize error list
+		moduleContexts:          make(map[string]*ModuleContext), // Initialize module context cache
+		completionStack:         make([]Completion, 0, 4),        // Initialize completion stack
+		globalsFromGlobalObject: make(map[uint16]bool),           // Track globals read from GlobalObject
 	}
 
 	// Create and initialize the default realm
@@ -1301,14 +1336,12 @@ func (vm *VM) Reset() {
 		vm.frames[i].newTargetValue = Undefined
 	}
 
-	// Clear register stack values to release references to objects
-	// This prevents memory leaks from retaining large objects/arrays/closures
-	for i := 0; i < vm.nextRegSlot; i++ {
-		vm.registerStack[i] = Undefined
-	}
+	// Clear register values to release references to objects (prevents memory
+	// leaks from retaining large objects/arrays/closures) and return the
+	// directory's cursor to the start.
+	vm.regDir.reset()
 
 	vm.frameCount = 0
-	vm.nextRegSlot = 0
 	vm.errors = vm.errors[:0] // Clear errors slice
 	vm.callDepth = 0          // Reset call depth counter
 	// Clear inline cache (with lock to prevent concurrent access)
@@ -1384,17 +1417,6 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	}
 	mainClosureObj := &ClosureObject{Fn: mainFuncObj, Upvalues: []*Upvalue{}}
 
-	// Check if enough space in the global register stack for this new frame
-	if vm.nextRegSlot+scriptRegSize > len(vm.registerStack) {
-		placeholderToken := errors.Position{Line: 0, Column: 0} // TODO: Better position?
-		runtimeErr := &errors.RuntimeError{
-			Position: placeholderToken,
-			Msg:      fmt.Sprintf("Register stack overflow (needed %d, available %d)", scriptRegSize, len(vm.registerStack)-vm.nextRegSlot),
-		}
-		vm.errors = append(vm.errors, runtimeErr)
-		return Undefined, vm.errors
-	}
-
 	// With no live frames there are no live register windows either, so a
 	// top-level run always starts from the bottom of the register stack. This
 	// reclaims what an uncaught exception left behind: unwindException pops
@@ -1404,18 +1426,19 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	// Popped frames have had their upvalues closed, so nothing still aliases
 	// those slots.
 	if vm.frameCount == 0 {
-		vm.nextRegSlot = 0
+		vm.regDir.popTo(registerMark{block: 0, offset: 0})
 	}
 
 	// Remembered so the InterpretRuntimeError handling below can restore
-	// frameCount/nextRegSlot exactly, the same way executeUserFunctionSafe's
-	// frameCountAtEntry + truncateFramesTo does for its own native boundary,
-	// rather than assuming unwindException left exactly one frame (ours) to
-	// pop: some run() exit paths return InterpretRuntimeError while frames
-	// above ours are still live (e.g. OpDirectEval's reassigned-eval
-	// fallback), and a single-frame pop would silently under-restore then.
+	// frameCount/the register cursor exactly, the same way
+	// executeUserFunctionSafe's frameCountAtEntry + truncateFramesTo does for
+	// its own native boundary, rather than assuming unwindException left
+	// exactly one frame (ours) to pop: some run() exit paths return
+	// InterpretRuntimeError while frames above ours are still live (e.g.
+	// OpDirectEval's reassigned-eval fallback), and a single-frame pop would
+	// silently under-restore then.
 	entryFrameCount := vm.frameCount
-	entryNextRegSlot := vm.nextRegSlot
+	entryMark := vm.regDir.mark()
 
 	// --- Push the new frame ---
 	frame := &vm.frames[vm.frameCount] // Get pointer to the frame slot
@@ -1423,9 +1446,20 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 	// IMPORTANT: Initialize ALL fields to avoid stale values from previous frame usage
 	frame.closure = mainClosureObj
 	frame.ip = 0
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+scriptRegSize]
-	frame.allocatedRegSize = scriptRegSize   // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
+	regWindow, windowStart, pushMark, ok := vm.regDir.push(scriptRegSize)
+	if !ok {
+		placeholderToken := errors.Position{Line: 0, Column: 0} // TODO: Better position?
+		runtimeErr := &errors.RuntimeError{
+			Position: placeholderToken,
+			Msg:      fmt.Sprintf("Register stack overflow (needed %d)", scriptRegSize),
+		}
+		vm.errors = append(vm.errors, runtimeErr)
+		return Undefined, vm.errors
+	}
+	frame.registers = regWindow
+	frame.allocatedRegSize = scriptRegSize // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark     // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 	// For nested Interpret calls (eval), initialize registers to Undefined to avoid
 	// stale values from previous executions affecting the result
@@ -1485,7 +1519,6 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 		frame.spillSlots = nil
 	}
 
-	vm.nextRegSlot += scriptRegSize
 	vm.frameCount++
 
 	// Mark var declaration globals as non-configurable (DontDelete) per ECMAScript spec
@@ -1572,7 +1605,7 @@ func (vm *VM) Interpret(chunk *Chunk) (Value, []errors.PaseratiError) {
 			vm.unwinding = false
 			vm.currentException = Null
 			vm.truncateFramesTo(entryFrameCount)
-			vm.nextRegSlot = entryNextRegSlot
+			vm.regDir.popTo(entryMark)
 			runtimeErr := errors.NewRuntimeError(
 				errors.Position{Line: vm.lastThrowLine, Column: vm.lastThrowColumn},
 				"Uncaught "+vm.formatExceptionDisplay(exc),
@@ -4197,12 +4230,15 @@ startExecution:
 			}
 
 			// 3. Check if we can perform TCO
-			var totalNeeded, availableInStack int
+			var canGrowRegisters bool
 			if canPerformTCO {
-				totalNeeded = calleeFunc.RegisterSize
-				availableInStack = len(vm.registerStack) - vm.nextRegSlot + len(registers)
+				if calleeFunc.RegisterSize <= frame.allocatedRegSize {
+					canGrowRegisters = true // No growth needed.
+				} else {
+					canGrowRegisters = vm.regDir.wouldFitExpansion(frame.regWindowStart, calleeFunc.RegisterSize)
+				}
 
-				if totalNeeded <= availableInStack {
+				if canGrowRegisters {
 					// We can perform TCO!
 					if debugCalls {
 						fmt.Printf("[TCO] OpTailCall performing TCO, reusing frame, old func=%s, new func=%s\n",
@@ -4217,11 +4253,19 @@ startExecution:
 					// 5. Expand register window if needed (but never shrink)
 					oldRegSize := frame.allocatedRegSize
 					if calleeFunc.RegisterSize > oldRegSize {
-						// Need more registers - expand the slice into registerStack
-						baseOffset := vm.nextRegSlot - oldRegSize
-						frame.registers = vm.registerStack[baseOffset : baseOffset+calleeFunc.RegisterSize]
+						// Need more registers: try to grow in place first (common
+						// case - no copy needed), falling back to relocating the
+						// window to a fresh block. wouldFitExpansion already
+						// confirmed one of these two will succeed.
+						if newWindow, ok := vm.regDir.tryExpand(frame.regWindowStart, oldRegSize, calleeFunc.RegisterSize); ok {
+							frame.registers = newWindow
+						} else if newWindow, newStart, ok := vm.regDir.move(frame.regWindowStart, oldRegSize, calleeFunc.RegisterSize); ok {
+							frame.regWindowStart = newStart
+							frame.registers = newWindow
+						} else {
+							panic("OpTailCall: wouldFitExpansion reported room but move failed - B4 invariant violated")
+						}
 						registers = frame.registers
-						vm.nextRegSlot = baseOffset + calleeFunc.RegisterSize
 						frame.allocatedRegSize = calleeFunc.RegisterSize // Update tracked allocation size
 					}
 					// Note: We do NOT shrink! Bytecode may reference registers beyond RegisterSize
@@ -4313,7 +4357,7 @@ startExecution:
 			}
 
 			// If we didn't perform TCO, handle as regular call using prepareCall
-			if !canPerformTCO || totalNeeded > availableInStack {
+			if !canPerformTCO || !canGrowRegisters {
 				if debugCalls {
 					fmt.Printf("[TCO FALLBACK] OpTailCall falling back to prepareCall, canPerformTCO=%v\n", canPerformTCO)
 				}
@@ -4429,13 +4473,16 @@ startExecution:
 			}
 
 			// 3. Check if we can perform TCO (not generator, not native, not async)
-			var totalNeeded, availableInStack int
+			var canGrowRegisters bool
 			if canPerformTCO {
 				// 4. Check if new function can fit in register stack
-				totalNeeded = calleeFunc.RegisterSize
-				availableInStack = len(vm.registerStack) - vm.nextRegSlot + len(registers)
+				if calleeFunc.RegisterSize <= frame.allocatedRegSize {
+					canGrowRegisters = true // No growth needed.
+				} else {
+					canGrowRegisters = vm.regDir.wouldFitExpansion(frame.regWindowStart, calleeFunc.RegisterSize)
+				}
 
-				if totalNeeded <= availableInStack {
+				if canGrowRegisters {
 					// We can perform TCO!
 
 					// 5. Close upvalues for current frame BEFORE overwriting (only if needed)
@@ -4446,11 +4493,19 @@ startExecution:
 					// 6. Expand register window if needed (but never shrink)
 					oldRegSize := frame.allocatedRegSize
 					if calleeFunc.RegisterSize > oldRegSize {
-						// Need more registers - expand the slice into registerStack
-						baseOffset := vm.nextRegSlot - oldRegSize
-						frame.registers = vm.registerStack[baseOffset : baseOffset+calleeFunc.RegisterSize]
+						// Need more registers: try to grow in place first (common
+						// case - no copy needed), falling back to relocating the
+						// window to a fresh block. wouldFitExpansion already
+						// confirmed one of these two will succeed.
+						if newWindow, ok := vm.regDir.tryExpand(frame.regWindowStart, oldRegSize, calleeFunc.RegisterSize); ok {
+							frame.registers = newWindow
+						} else if newWindow, newStart, ok := vm.regDir.move(frame.regWindowStart, oldRegSize, calleeFunc.RegisterSize); ok {
+							frame.regWindowStart = newStart
+							frame.registers = newWindow
+						} else {
+							panic("OpTailCallMethod: wouldFitExpansion reported room but move failed - B4 invariant violated")
+						}
 						registers = frame.registers
-						vm.nextRegSlot = baseOffset + calleeFunc.RegisterSize
 						frame.allocatedRegSize = calleeFunc.RegisterSize // Update tracked allocation size
 					}
 					// Note: We do NOT shrink! Bytecode may reference registers beyond RegisterSize
@@ -4535,7 +4590,7 @@ startExecution:
 			}
 
 			// If we didn't perform TCO (generator, not enough space, etc.), handle inline
-			if !canPerformTCO || totalNeeded > availableInStack {
+			if !canPerformTCO || !canGrowRegisters {
 				// destReg was already saved before ip was advanced
 				callerRegisters := registers
 				callerIP := ip
@@ -6447,10 +6502,10 @@ startExecution:
 
 			vm.frameCount--
 			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturn")
-			vm.nextRegSlot -= returningFrameRegSize // Reclaim register space
+			vm.regDir.popTo(frame.regSlotBeforePush) // Reclaim register space
 
 			if debugVM {
-				fmt.Printf("[DBG OpReturn] After pop: frameCount=%d, nextRegSlot=%d\n", vm.frameCount, vm.nextRegSlot)
+				fmt.Printf("[DBG OpReturn] After pop: frameCount=%d, regCursor=%+v\n", vm.frameCount, vm.regDir.mark())
 			}
 
 			if vm.frameCount == 0 {
@@ -6749,10 +6804,10 @@ startExecution:
 
 			vm.frameCount--
 			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnUndefined")
-			vm.nextRegSlot -= returningFrameRegSize
+			vm.regDir.popTo(frame.regSlotBeforePush)
 
 			if debugVM {
-				fmt.Printf("[DBG OpReturnUndefined] After pop: frameCount=%d, nextRegSlot=%d\n", vm.frameCount, vm.nextRegSlot)
+				fmt.Printf("[DBG OpReturnUndefined] After pop: frameCount=%d, regCursor=%+v\n", vm.frameCount, vm.regDir.mark())
 			}
 
 			if vm.frameCount == 0 {
@@ -11943,7 +11998,7 @@ startExecution:
 					return InterpretRuntimeError, Undefined
 				}
 				requiredRegs := constructorFunc.RegisterSize
-				if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
+				if !vm.regDir.wouldFit(requiredRegs) {
 					frame.ip = callerIP
 					vm.ThrowRangeError("Maximum call stack size exceeded")
 					if !vm.unwinding {
@@ -12042,10 +12097,29 @@ startExecution:
 					}
 				}
 				newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
-				newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-				newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
-				newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-				vm.nextRegSlot += requiredRegs
+				newWindow, windowStart, pushMark, pushOK := vm.regDir.push(requiredRegs)
+				if !pushOK {
+					// wouldFit already checked this above; only reachable if
+					// something between then and now consumed the space this
+					// was gated on (see wouldFit's own doc comment).
+					frame.ip = callerIP
+					vm.ThrowRangeError("Maximum call stack size exceeded")
+					if !vm.unwinding {
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					return InterpretRuntimeError, Undefined
+				}
+				newFrame.registers = newWindow
+				newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+				newFrame.regSlotBeforePush = pushMark    // B4 invariant: record window start for checkRegWindowRelease
+				newFrame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 				// Allocate spill slots if this function needs them (for register overflow)
 				if constructorFunc.Chunk.NumSpillSlots > 0 {
@@ -12065,7 +12139,7 @@ startExecution:
 							newFrame.registers[i] = Undefined
 						}
 					} else {
-						vm.nextRegSlot -= requiredRegs
+						vm.regDir.popTo(newFrame.regSlotBeforePush)
 						frame.ip = callerIP
 						status := vm.runtimeError("Internal Error: Argument register index out of bounds during constructor call setup.")
 						return status, Undefined
@@ -12180,7 +12254,7 @@ startExecution:
 					return InterpretRuntimeError, Undefined
 				}
 				requiredRegs := constructorFunc.RegisterSize
-				if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
+				if !vm.regDir.wouldFit(requiredRegs) {
 					frame.ip = callerIP
 					vm.ThrowRangeError("Maximum call stack size exceeded")
 					if !vm.unwinding {
@@ -12278,10 +12352,29 @@ startExecution:
 					}
 				}
 				newFrame.argumentsObject = Undefined // Initialize to Undefined (will be created on first access)
-				newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-				newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
-				newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-				vm.nextRegSlot += requiredRegs
+				newWindow, windowStart, pushMark, pushOK := vm.regDir.push(requiredRegs)
+				if !pushOK {
+					// wouldFit already checked this above; only reachable if
+					// something between then and now consumed the space this
+					// was gated on (see wouldFit's own doc comment).
+					frame.ip = callerIP
+					vm.ThrowRangeError("Maximum call stack size exceeded")
+					if !vm.unwinding {
+						frame = &vm.frames[vm.frameCount-1]
+						closure = frame.closure
+						function = closure.Fn
+						code = function.Chunk.Code
+						constants = function.Chunk.Constants
+						registers = frame.registers
+						ip = frame.ip
+						continue
+					}
+					return InterpretRuntimeError, Undefined
+				}
+				newFrame.registers = newWindow
+				newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+				newFrame.regSlotBeforePush = pushMark    // B4 invariant: record window start for checkRegWindowRelease
+				newFrame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 				// Allocate spill slots if this function needs them (for register overflow)
 				if constructorFunc.Chunk.NumSpillSlots > 0 {
@@ -12301,7 +12394,7 @@ startExecution:
 							newFrame.registers[i] = Undefined
 						}
 					} else {
-						vm.nextRegSlot -= requiredRegs
+						vm.regDir.popTo(newFrame.regSlotBeforePush)
 						frame.ip = callerIP
 						status := vm.runtimeError("Internal Error: Argument register index out of bounds during constructor call setup.")
 						return status, Undefined
@@ -12721,7 +12814,7 @@ startExecution:
 						return InterpretRuntimeError, Undefined
 					}
 					requiredRegs := constructorFunc.RegisterSize
-					if vm.nextRegSlot+requiredRegs > len(vm.registerStack) {
+					if !vm.regDir.wouldFit(requiredRegs) {
 						frame.ip = callerIP
 						vm.ThrowRangeError("Maximum call stack size exceeded")
 						if !vm.unwinding {
@@ -12768,10 +12861,27 @@ startExecution:
 					newFrame.argCount = finalArgCount
 					newFrame.args = finalArgs
 					newFrame.argumentsObject = Undefined
-					newFrame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+requiredRegs]
-					newFrame.allocatedRegSize = requiredRegs    // Track actual allocation for proper cleanup
-					newFrame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-					vm.nextRegSlot += requiredRegs
+					newWindow, windowStart, pushMark, pushOK := vm.regDir.push(requiredRegs)
+					if !pushOK {
+						// wouldFit already checked this above; see that call's comment.
+						frame.ip = callerIP
+						vm.ThrowRangeError("Maximum call stack size exceeded")
+						if !vm.unwinding {
+							frame = &vm.frames[vm.frameCount-1]
+							closure = frame.closure
+							function = closure.Fn
+							code = function.Chunk.Code
+							constants = function.Chunk.Constants
+							registers = frame.registers
+							ip = frame.ip
+							continue
+						}
+						return InterpretRuntimeError, Undefined
+					}
+					newFrame.registers = newWindow
+					newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup
+					newFrame.regSlotBeforePush = pushMark    // B4 invariant: record window start for checkRegWindowRelease
+					newFrame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 
 					// Copy combined args to registers
 					for i := 0; i < len(newFrame.registers); i++ {
@@ -14451,7 +14561,7 @@ startExecution:
 					if toStringMethod.IsCallable() {
 						// Save state before calling
 						savedFrameCount := vm.frameCount
-						savedNextRegSlot := vm.nextRegSlot
+						savedRegMark := vm.regDir.mark()
 						savedUnwinding := vm.unwinding
 						savedCurrentException := vm.currentException
 
@@ -14471,7 +14581,7 @@ startExecution:
 
 							// Restore state to prevent unwinding
 							vm.frameCount = savedFrameCount
-							vm.nextRegSlot = savedNextRegSlot
+							vm.regDir.popTo(savedRegMark)
 							vm.unwinding = savedUnwinding
 							vm.currentException = savedCurrentException
 
@@ -15762,7 +15872,7 @@ startExecution:
 
 			vm.frameCount--
 			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnFinally")
-			vm.nextRegSlot -= returningFrameRegSize // Reclaim register space
+			vm.regDir.popTo(frame.regSlotBeforePush)
 
 			if vm.frameCount == 0 {
 				// Returned from the top-level script frame.
@@ -15961,7 +16071,7 @@ startExecution:
 
 				vm.frameCount--
 				vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpHandlePending:ActionReturn")
-				vm.nextRegSlot -= returningFrameRegSize
+				vm.regDir.popTo(frame.regSlotBeforePush)
 
 				if vm.frameCount == 0 {
 					// Returned from the top-level script frame
@@ -18353,7 +18463,7 @@ startExecution:
 
 				vm.frameCount--
 				vm.checkRegWindowRelease(frame, returningFrameRegSize, "ActionReturn-fallback")
-				vm.nextRegSlot -= returningFrameRegSize
+				vm.regDir.popTo(frame.regSlotBeforePush)
 
 				if vm.frameCount == 0 {
 					return InterpretOK, result
@@ -18607,10 +18717,7 @@ func (vm *VM) popTopLevelScriptFrame(frame *CallFrame) {
 	}
 	vm.frameCount--
 	vm.checkRegWindowRelease(frame, frame.allocatedRegSize, "popTopLevelScriptFrame")
-	vm.nextRegSlot -= frame.allocatedRegSize
-	if vm.nextRegSlot < 0 {
-		vm.nextRegSlot = 0
-	}
+	vm.regDir.popTo(frame.regSlotBeforePush)
 }
 
 // relocateOpenUpvalues redirects every open upvalue in the list that
@@ -20263,10 +20370,14 @@ func (vm *VM) executeGeneratorPrologue(genObj *GeneratorObject) InterpretResult 
 	// Set generator state to GeneratorStart to indicate prologue execution
 	logGeneratorStateTransition(genObj, GeneratorStart, "executeGeneratorPrologue")
 
-	// Save register size for cleanup
+	// Save register size and window start for cleanup - captured now because
+	// the "zero out the generator frame" step below (success path) wipes
+	// regSlotBeforePush before the frame is actually popped.
 	regSize := 0
+	var regMark registerMark
 	if vm.frameCount > 0 {
 		regSize = len(vm.frames[vm.frameCount-1].registers)
+		regMark = vm.frames[vm.frameCount-1].regSlotBeforePush
 	}
 
 	if debugGeneratorStates {
@@ -20313,7 +20424,7 @@ func (vm *VM) executeGeneratorPrologue(genObj *GeneratorObject) InterpretResult 
 				fmt.Printf("[GEN STATE] executeGeneratorPrologue: Frame not popped by unwinding, popping it now\n")
 			}
 			vm.frameCount--
-			vm.nextRegSlot -= regSize
+			vm.regDir.popTo(regMark)
 		} else {
 			if debugGeneratorStates {
 				fmt.Printf("[GEN STATE] executeGeneratorPrologue: Frame was already popped by exception unwinding\n")
@@ -20347,7 +20458,7 @@ func (vm *VM) executeGeneratorPrologue(genObj *GeneratorObject) InterpretResult 
 	// Clean up frame (only on success)
 	if vm.frameCount > 0 {
 		vm.frameCount--
-		vm.nextRegSlot -= regSize
+		vm.regDir.popTo(regMark)
 		if debugGeneratorStates {
 			fmt.Printf("[GEN STATE] executeGeneratorPrologue: Cleaned up frame, frameCount now=%d\n", vm.frameCount)
 		}
@@ -20473,10 +20584,12 @@ func (vm *VM) startGenerator(genObj *GeneratorObject, sentValue Value) (Value, e
 	// Initialize generator state
 	genObj.State = GeneratorExecuting
 
-	// Get register size for cleanup
+	// Get register size/window for cleanup
 	regSize := 0
+	var regMark registerMark
 	if vm.frameCount > 1 {
 		regSize = len(vm.frames[vm.frameCount-1].registers)
+		regMark = vm.frames[vm.frameCount-1].regSlotBeforePush
 	}
 
 	// Execute the VM run loop - it will return when the generator yields or the sentinel frame is hit
@@ -20492,7 +20605,7 @@ func (vm *VM) startGenerator(genObj *GeneratorObject, sentValue Value) (Value, e
 		// During exception, frames may still be on the stack
 		vm.frameCount-- // Pop generator frame (or already popped during unwind)
 		if vm.frameCount > 0 && regSize > 0 {
-			vm.nextRegSlot -= regSize
+			vm.regDir.popTo(regMark)
 		}
 		// Pop the sentinel frame if present
 		if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
@@ -20526,7 +20639,7 @@ func (vm *VM) startGenerator(genObj *GeneratorObject, sentValue Value) (Value, e
 	if genObj.State == GeneratorSuspendedYield && regSize > 0 {
 		// Generator yielded - frames are still active, need to pop them
 		vm.frameCount-- // Pop generator frame
-		vm.nextRegSlot -= regSize
+		vm.regDir.popTo(regMark)
 
 		// Pop the sentinel frame
 		if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
@@ -20603,16 +20716,18 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 
 	// Allocate registers for the generator function
 	regSize := funcObj.RegisterSize
-	if vm.nextRegSlot+regSize > len(vm.registerStack) {
+	newWindow, windowStart, pushMark, ok := vm.regDir.push(regSize)
+	if !ok {
 		vm.frameCount-- // Remove sentinel frame
 		return Undefined, fmt.Errorf("Out of registers")
 	}
 
 	// Manually set up the generator frame for resumption (bypass prepareCall since we need custom setup)
 	frame := &vm.frames[vm.frameCount]
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize           // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot   // B4 invariant: record window base for checkRegWindowRelease
+	frame.registers = newWindow
+	frame.allocatedRegSize = regSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 	frame.ip = genObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg             // Target in sentinel frame
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
@@ -20714,7 +20829,6 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 
 	// Update VM state
 	vm.frameCount++
-	vm.nextRegSlot += regSize
 
 	// Update generator state
 	genObj.State = GeneratorExecuting
@@ -20731,7 +20845,7 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 		// During exception, frames may still be on the stack
 		vm.frameCount-- // Pop generator frame (or already popped during unwind)
 		if vm.frameCount > 0 {
-			vm.nextRegSlot -= regSize
+			vm.regDir.popTo(pushMark)
 		}
 		// Pop the sentinel frame if present
 		if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
@@ -20770,7 +20884,7 @@ func (vm *VM) resumeGenerator(genObj *GeneratorObject, sentValue Value) (Value, 
 	if genObj.State == GeneratorSuspendedYield {
 		// Generator yielded - frames are still active, need to pop them
 		vm.frameCount-- // Pop generator frame
-		vm.nextRegSlot -= regSize
+		vm.regDir.popTo(pushMark)
 		// Clear the popped frame to avoid stale references
 		vm.frames[vm.frameCount].generatorObj = nil
 		vm.frames[vm.frameCount].closure = nil
@@ -20822,13 +20936,13 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 				// function's own RegisterSize because of TCO expansion earlier in a
 				// tail-call chain (see the matching OpReturn* comments, and #399/B1).
 				vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleDirectCall")
-				vm.nextRegSlot -= f.allocatedRegSize
+				vm.regDir.popTo(f.regSlotBeforePush)
 				vm.frameCount--
 				break
 			}
 			// Pop non-sentinel, non-direct frames (shouldn't happen normally)
 			vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleNonDirect")
-			vm.nextRegSlot -= f.allocatedRegSize
+			vm.regDir.popTo(f.regSlotBeforePush)
 			vm.frameCount--
 		}
 		vm.unwinding = false
@@ -20881,16 +20995,18 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 
 	// Allocate registers for the generator function
 	regSize := funcObj.RegisterSize
-	if vm.nextRegSlot+regSize > len(vm.registerStack) {
+	newWindow, windowStart, pushMark, ok := vm.regDir.push(regSize)
+	if !ok {
 		vm.frameCount-- // Remove sentinel frame
 		return Undefined, fmt.Errorf("Out of registers")
 	}
 
 	// Manually set up the generator frame for resumption (bypass prepareCall since we need custom setup)
 	frame := &vm.frames[vm.frameCount]
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize           // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot   // B4 invariant: record window base for checkRegWindowRelease
+	frame.registers = newWindow
+	frame.allocatedRegSize = regSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 	frame.ip = genObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg             // Target in sentinel frame
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
@@ -20928,7 +21044,6 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 
 	// Update VM state
 	vm.frameCount++
-	vm.nextRegSlot += regSize
 
 	// Update generator state
 	genObj.State = GeneratorExecuting
@@ -20961,7 +21076,7 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 		// Pop frames we pushed
 		if vm.frameCount > 0 {
 			vm.frameCount-- // Pop generator frame
-			vm.nextRegSlot -= regSize
+			vm.regDir.popTo(pushMark)
 		}
 		if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
 			vm.frameCount-- // Pop sentinel frame
@@ -20991,7 +21106,7 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 		if vm.frameCount > 0 {
 			vm.frameCount--
 			if vm.frameCount > 0 {
-				vm.nextRegSlot -= regSize
+				vm.regDir.popTo(pushMark)
 			}
 		}
 		if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
@@ -21011,7 +21126,7 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 	if genObj.State == GeneratorSuspendedYield {
 		// Generator yielded - frames are still active, need to pop them
 		vm.frameCount-- // Pop generator frame
-		vm.nextRegSlot -= regSize
+		vm.regDir.popTo(pushMark)
 		// Clear the popped frame to avoid stale references
 		vm.frames[vm.frameCount].generatorObj = nil
 		vm.frames[vm.frameCount].closure = nil
@@ -21084,16 +21199,18 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 
 	// Allocate registers for the generator function
 	regSize := funcObj.RegisterSize
-	if vm.nextRegSlot+regSize > len(vm.registerStack) {
+	newWindow, windowStart, pushMark, ok := vm.regDir.push(regSize)
+	if !ok {
 		vm.frameCount-- // Remove sentinel frame
 		return Undefined, fmt.Errorf("Out of registers")
 	}
 
 	// Manually set up the generator frame for resumption (bypass prepareCall since we need custom setup)
 	frame := &vm.frames[vm.frameCount]
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize           // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot   // B4 invariant: record window base for checkRegWindowRelease
+	frame.registers = newWindow
+	frame.allocatedRegSize = regSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 	frame.ip = genObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg             // Target in sentinel frame
 	frame.thisValue = genObj.Frame.thisValue   // Restore the saved 'this' value
@@ -21131,7 +21248,6 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 
 	// Update VM state
 	vm.frameCount++
-	vm.nextRegSlot += regSize
 
 	// Update generator state
 	genObj.State = GeneratorExecuting
@@ -21193,7 +21309,7 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 			if vm.frameCount > 0 {
 				vm.frameCount--
 				if vm.frameCount > 0 {
-					vm.nextRegSlot -= regSize
+					vm.regDir.popTo(pushMark)
 				}
 			}
 			if vm.frameCount > 0 && vm.frames[vm.frameCount-1].isSentinelFrame {
@@ -21232,7 +21348,7 @@ func (vm *VM) resumeGeneratorWithReturn(genObj *GeneratorObject, returnValue Val
 
 		// Pop the generator frame
 		vm.frameCount--
-		vm.nextRegSlot -= regSize
+		vm.regDir.popTo(pushMark)
 
 		// Pop the sentinel frame
 		vm.frameCount--
@@ -21272,7 +21388,7 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 
 	// Save current VM state so we can restore if function suspends again
 	savedFrameCount := vm.frameCount
-	savedNextRegSlot := vm.nextRegSlot
+	savedRegMark := vm.regDir.mark()
 
 	// Set up caller context for sentinel frame approach
 	callerRegisters := make([]Value, 1)
@@ -21295,16 +21411,18 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 
 	// Allocate registers for the async function
 	regSize := funcObj.RegisterSize
-	if vm.nextRegSlot+regSize > len(vm.registerStack) {
+	newWindow, windowStart, pushMark, ok := vm.regDir.push(regSize)
+	if !ok {
 		vm.frameCount = savedFrameCount // Restore
 		return Undefined, fmt.Errorf("Out of registers")
 	}
 
 	// Manually set up the async function frame for resumption (bypass prepareCall since we need custom setup)
 	frame := &vm.frames[vm.frameCount]
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize               // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot       // B4 invariant: record window base for checkRegWindowRelease
+	frame.registers = newWindow
+	frame.allocatedRegSize = regSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 	frame.ip = promiseObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg                 // Target in sentinel frame
 	frame.thisValue = promiseObj.ThisValue         // Restore original this value
@@ -21347,7 +21465,6 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 
 	// Update VM state
 	vm.frameCount++
-	vm.nextRegSlot += regSize
 
 	// Clear the saved frame since we're resuming
 	// promiseObj.Frame = nil  // Don't clear yet - might await again
@@ -21376,7 +21493,7 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 		vm.unwinding = false
 		vm.unwindingCrossedNative = false
 		vm.frameCount = savedFrameCount
-		vm.nextRegSlot = savedNextRegSlot
+		vm.regDir.popTo(savedRegMark)
 		promiseObj.Frame = nil
 		if exc != Null {
 			return Undefined, exceptionError{exception: exc}
@@ -21390,7 +21507,7 @@ func (vm *VM) resumeAsyncFunction(promiseObj *PromiseObject, resolvedValue Value
 	if vm.frameCount > savedFrameCount {
 		// Function suspended at another await - clean up frames
 		vm.frameCount = savedFrameCount
-		vm.nextRegSlot = savedNextRegSlot
+		vm.regDir.popTo(savedRegMark)
 		// promiseObj.Frame remains set for the next resumption
 	} else {
 		// Function completed normally - clear saved frame to signal completion
@@ -21426,7 +21543,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 
 	// Save current VM state so we can restore if function suspends again
 	savedFrameCount := vm.frameCount
-	savedNextRegSlot := vm.nextRegSlot
+	savedRegMark := vm.regDir.mark()
 
 	// Set up caller context for sentinel frame approach
 	callerRegisters := make([]Value, 1)
@@ -21449,16 +21566,18 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 
 	// Allocate registers for the async function
 	regSize := funcObj.RegisterSize
-	if vm.nextRegSlot+regSize > len(vm.registerStack) {
+	newWindow, windowStart, pushMark, ok := vm.regDir.push(regSize)
+	if !ok {
 		vm.frameCount = savedFrameCount // Restore
 		return Undefined, fmt.Errorf("Out of registers")
 	}
 
 	// Manually set up the async function frame for resumption
 	frame := &vm.frames[vm.frameCount]
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+regSize]
-	frame.allocatedRegSize = regSize               // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot       // B4 invariant: record window base for checkRegWindowRelease
+	frame.registers = newWindow
+	frame.allocatedRegSize = regSize   // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
 	frame.ip = promiseObj.Frame.pc                 // Resume from saved PC
 	frame.targetRegister = destReg                 // Target in sentinel frame
 	frame.thisValue = promiseObj.ThisValue         // Restore original this value
@@ -21489,7 +21608,6 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 
 	// Update VM state
 	vm.frameCount++
-	vm.nextRegSlot += regSize
 
 	// Throw the exception at the await point
 	// This will be handled by the VM's exception handling system
@@ -21521,7 +21639,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 		vm.unwinding = false
 		vm.unwindingCrossedNative = false
 		vm.frameCount = savedFrameCount
-		vm.nextRegSlot = savedNextRegSlot
+		vm.regDir.popTo(savedRegMark)
 		promiseObj.Frame = nil
 		return Undefined, exceptionError{exception: exc}
 	}
@@ -21553,7 +21671,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 		vm.unwinding = false
 		vm.unwindingCrossedNative = false
 		vm.frameCount = savedFrameCount
-		vm.nextRegSlot = savedNextRegSlot
+		vm.regDir.popTo(savedRegMark)
 		promiseObj.Frame = nil
 		if exc != Null {
 			return Undefined, exceptionError{exception: exc}
@@ -21565,7 +21683,7 @@ func (vm *VM) resumeAsyncFunctionWithException(promiseObj *PromiseObject, except
 	if vm.frameCount > savedFrameCount {
 		// Function suspended at another await - clean up frames
 		vm.frameCount = savedFrameCount
-		vm.nextRegSlot = savedNextRegSlot
+		vm.regDir.popTo(savedRegMark)
 		// promiseObj.Frame remains set for the next resumption
 	} else {
 		// Function completed normally - clear saved frame to signal completion
@@ -21835,16 +21953,11 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	}
 	mainClosureObj := &ClosureObject{Fn: mainFuncObj, Upvalues: []*Upvalue{}}
 
-	// Check register space
-	if vm.nextRegSlot+scriptRegSize > len(vm.registerStack) {
-		return vm.runtimeError("Register stack overflow during module execution"), Undefined
-	}
-
 	// Save current frame state. The module frame is popped by its own OpReturn,
 	// or left in place by an uncaught exception; either way both are restored
 	// below.
 	savedFrameCount := vm.frameCount
-	savedNextRegSlot := vm.nextRegSlot
+	savedRegMark := vm.regDir.mark()
 	savedCrossedNative := vm.unwindingCrossedNative
 	if vm.frameCount >= len(vm.frames) {
 		return vm.runtimeError("Frame stack overflow during module execution"), Undefined
@@ -21864,13 +21977,18 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	frame := &vm.frames[vm.frameCount]
 	frame.closure = mainClosureObj
 	frame.ip = 0
-	frame.registers = vm.registerStack[vm.nextRegSlot : vm.nextRegSlot+scriptRegSize]
-	for i := range frame.registers {
-		frame.registers[i] = Undefined // slots above nextRegSlot hold stale values
+	regWindow, windowStart, pushMark, ok := vm.regDir.push(scriptRegSize)
+	if !ok {
+		return vm.runtimeError("Register stack overflow during module execution"), Undefined
 	}
-	frame.allocatedRegSize = scriptRegSize   // Track actual allocation for proper cleanup
-	frame.regSlotBeforePush = vm.nextRegSlot // B4 invariant: record window base for checkRegWindowRelease
-	frame.targetRegister = 0                 // a direct-call return writes no caller register
+	frame.registers = regWindow
+	for i := range frame.registers {
+		frame.registers[i] = Undefined // freshly allocated slots may hold stale values from a prior occupant
+	}
+	frame.allocatedRegSize = scriptRegSize // Track actual allocation for proper cleanup
+	frame.regSlotBeforePush = pushMark     // B4 invariant: record window start for checkRegWindowRelease
+	frame.regWindowStart = windowStart // B4 invariant: this window's actual location (may differ from regSlotBeforePush after a block-skip)
+	frame.targetRegister = 0               // a direct-call return writes no caller register
 	frame.thisValue = Undefined
 	frame.homeObject = Undefined
 	frame.isConstructorCall = false
@@ -21900,7 +22018,6 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	} else {
 		frame.spillSlots = nil
 	}
-	vm.nextRegSlot += scriptRegSize
 	vm.frameCount++
 
 	// Run the module; vm.run() returns when the module frame returns (direct
@@ -21934,7 +22051,7 @@ func (vm *VM) executeModule(modulePath string) (InterpretResult, Value) {
 	// Restore frame state after module execution (pops the module frame, and
 	// anything an uncaught exception left above it)
 	vm.frameCount = savedFrameCount
-	vm.nextRegSlot = savedNextRegSlot
+	vm.regDir.popTo(savedRegMark)
 	// fmt.Printf("// [VM DEBUG] executeModule: Module '%s' completed, frameCount restored to %d\n", modulePath, vm.frameCount)
 
 	// With unified heap, no need to copy globals back to module context

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6506,7 +6506,9 @@ startExecution:
 			}
 
 			vm.frameCount--
-			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturn")
+			if StrictRegWindowChecks {
+				vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturn")
+			}
 			vm.regDir.popTo(frame.regSlotBeforePush) // Reclaim register space
 
 			if debugVM {
@@ -6808,7 +6810,9 @@ startExecution:
 			}
 
 			vm.frameCount--
-			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnUndefined")
+			if StrictRegWindowChecks {
+				vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnUndefined")
+			}
 			vm.regDir.popTo(frame.regSlotBeforePush)
 
 			if debugVM {
@@ -15876,7 +15880,9 @@ startExecution:
 			constructorThisValue := frame.thisValue
 
 			vm.frameCount--
-			vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnFinally")
+			if StrictRegWindowChecks {
+				vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpReturnFinally")
+			}
 			vm.regDir.popTo(frame.regSlotBeforePush)
 
 			if vm.frameCount == 0 {
@@ -16075,7 +16081,9 @@ startExecution:
 				isDerivedConstructor := frame.closure != nil && frame.closure.Fn.IsDerivedConstructor
 
 				vm.frameCount--
-				vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpHandlePending:ActionReturn")
+				if StrictRegWindowChecks {
+					vm.checkRegWindowRelease(frame, returningFrameRegSize, "OpHandlePending:ActionReturn")
+				}
 				vm.regDir.popTo(frame.regSlotBeforePush)
 
 				if vm.frameCount == 0 {
@@ -18467,7 +18475,9 @@ startExecution:
 				isDerivedConstructor := frame.closure != nil && frame.closure.Fn.IsDerivedConstructor
 
 				vm.frameCount--
-				vm.checkRegWindowRelease(frame, returningFrameRegSize, "ActionReturn-fallback")
+				if StrictRegWindowChecks {
+					vm.checkRegWindowRelease(frame, returningFrameRegSize, "ActionReturn-fallback")
+				}
 				vm.regDir.popTo(frame.regSlotBeforePush)
 
 				if vm.frameCount == 0 {
@@ -18721,7 +18731,9 @@ func (vm *VM) popTopLevelScriptFrame(frame *CallFrame) {
 		vm.closeFrameUpvalues(frame)
 	}
 	vm.frameCount--
-	vm.checkRegWindowRelease(frame, frame.allocatedRegSize, "popTopLevelScriptFrame")
+	if StrictRegWindowChecks {
+		vm.checkRegWindowRelease(frame, frame.allocatedRegSize, "popTopLevelScriptFrame")
+	}
 	vm.regDir.popTo(frame.regSlotBeforePush)
 }
 
@@ -20940,13 +20952,17 @@ func (vm *VM) resumeGeneratorWithException(genObj *GeneratorObject, exception Va
 				// it tracks actual allocation, which may exceed the frame's current
 				// function's own RegisterSize because of TCO expansion earlier in a
 				// tail-call chain (see the matching OpReturn* comments, and #399/B1).
-				vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleDirectCall")
+				if StrictRegWindowChecks {
+					vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleDirectCall")
+				}
 				vm.regDir.popTo(f.regSlotBeforePush)
 				vm.frameCount--
 				break
 			}
 			// Pop non-sentinel, non-direct frames (shouldn't happen normally)
-			vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleNonDirect")
+			if StrictRegWindowChecks {
+				vm.checkRegWindowRelease(f, f.allocatedRegSize, "resumeGeneratorWithException:staleNonDirect")
+			}
 			vm.regDir.popTo(f.regSlotBeforePush)
 			vm.frameCount--
 		}


### PR DESCRIPTION
## Summary

Implements roadmap item [B4](https://github.com/nooga/paserati/blob/main/docs/runtime-production-roadmap.md#b4-replace-eager-maximum-register-allocation-with-stable-segments): replaces the eager `256 * 4096` flat register array (~24 MiB reserved before any frame or builtin runs) with a directory of lazily-allocated, fixed-capacity (256-slot) blocks.

Part of #402 (Phase 2 checklist).

## Design

- A frame's register window must stay contiguous within one block. Since `Register` is `uint8` and the compiler enforces a hard 255-register cap per frame (`registerExhaustionPanic` → `CompileError`, never silent truncation — verified from source and empirically with a 300-argument call), a single 256-slot block always suffices for any one frame's window; the roadmap's "oversized window needs a dedicated block" case is provably unreachable.
- `registerDirectory` tracks a `cur` mark (`{block, offset}`) and a slice of `*registerBlock` (pointer-stable once allocated, so raw `*Value` pointers into open upvalues stay valid across directory growth).
- `push()` returns two marks, not one: `start` (where the new window landed) and `release` (the cursor as it was immediately before the push). These are the same value in the common case but diverge whenever a push has to skip to a fresh block to fit — conflating them was the core bug caught during development (see commit history): recording only `start` as "what to restore on pop" permanently strands the old block's wasted tail slots, so a deep call chain crossing block boundaries would never release blocks. `CallFrame` carries both marks now (`regSlotBeforePush` for pop/restore, `regWindowStart` for TCO/reclaim).
- `trim()` bounds how many idle blocks are retained after a deep excursion, with a small reserve for pop/push hysteresis right at a boundary.
- `vm.frames []CallFrame` was already a fixed-size, never-reallocated array, so frame-record pointer stability needed no changes — only the register-storage half was in scope.

## Verification

- **Cold-start memory** — built both binaries (pre-B4 and this branch), ran each 3x back-to-back via `scratch/coldstart` (not `go run`, whose own toolchain footprint distorts RSS): HeapAlloc 26.8MB → 2.9MB (**-89%**), peak RSS via `/usr/bin/time -l` "maximum resident set size" 42.5MB → 17.8MB (**-58%**). Measured on one machine only (this repo has no declared multi-host measurement setup).
- **Test262** — built both binaries and diffed `-dump` output directly (not the `-diff baseline.txt` shortcut, which this repo's own notes flag as unreliable): byte-for-byte identical pass/fail sets before/after across `language/` (23073/450) and `built-ins/` (16867/6427), reconfirmed after the last commit on this branch.
- **Call-path performance — a real, small regression exists, and one contributor is fixed here:**
  - `bench-ratchet`'s single-sample percentages weren't trustworthy on their own: running `check` twice, unchanged, produced a completely different set of ">5%" rows each time (e.g. `BenchmarkGetOwn`, which never touches the register directory, swung from +6.8% to -0.8%) — proof that most of that noise is measurement noise, not a B4 effect.
  - Cross-checking with `benchstat` over 10 independent runs (tight, `p=0.000`) isolated one real, reproducible effect: `BenchmarkFactorial` (deliberately shallow recursion, depth ≤9, so it never crosses a register-block boundary) was **~3% slower**, confirmed independently with a standalone timing probe outside the test harness (~465ms → ~474ms, 3 runs each side). `Add`/`Arith`/`SetIndex`/`MatrixMult` showed no reproducible effect once alloc-count noise from `go test`'s benchmark harness itself (a floor-division artifact, ruled out with a direct `runtime.MemStats` probe) was excluded.
  - CPU-profiled `BenchmarkFactorial` to find the cause: `checkRegWindowRelease` (a no-op in production — gated behind `StrictRegWindowChecks`, default `false`) was showing up at ~0.8% of samples because it was called unconditionally at all 8 frame-pop sites and Go won't inline a function whose body contains a `panic`+`fmt.Sprintf`. Guarding those 8 call sites (latest commit) removes it from the profile entirely, verified by re-profiling. This is a pure win with no behavior change.
  - The remaining ~2% is `registerDirectory.push`/`popTo` themselves — real, inherent overhead from the segmented design's mark-struct bookkeeping versus the old flat array's single-int arithmetic, on a call path that never touches a second block. Disclosed as an accepted tradeoff against the memory win above, not further optimized in this PR.
- Audited every place a `CallFrame`'s registers do *not* come from `regDir.push` (sentinel/native frames): confirmed they're only ever released via a bare `frameCount--`, never through the checked pop path, so their zero-value marks are never misread.
- New end-to-end test forces a generator to suspend/resume across a register-block boundary (`TestGeneratorClosureSurvivesAcrossRegisterBlockBoundary`), confirmed via a test-only accessor that ≥3 blocks were actually exercised.
- **Closures and async suspension across a block boundary — traced, then pinned by dedicated tests, not just left to the generator test above:**
  - Plain closures at ordinary return (`closeFrameUpvalues`) are closed *synchronously the instant their owning frame returns* — always before `popTo`/`trim()` could release or reuse that frame's block. That makes this safe by construction regardless of which block the frame's window came from, not by luck. `TestPlainClosureSurvivesAcrossRegisterBlockBoundary` pins it down directly: a closure created several block-boundary-crossings deep, returned unchanged through every level via `return sub;` (never TCO-eligible — a bare identifier isn't a tail call), invoked only after further recursion has trimmed/reused the blocks it closed over. Passes without any implementation change.
  - Async suspension shares the exact relocation mechanism (`relocateOpenUpvalues`) the generator test above already exercises, just through different call sites (`executeAsyncFunctionBody`, `resumeAsyncFunction*`). `TestAsyncClosureSurvivesAcrossRegisterBlockBoundary` mirrors the generator test with `async`/`await` instead of a generator, invoked from three different recursion depths. Also passes without any implementation change.
- Full suite green: `go build ./...`, `go vet ./...`, `go test ./...`, `go test ./tests -run TestScripts` (runs with `StrictRegWindowChecks=true`).

## What this does *not* close out

- **F3** (formal statistical regression methodology) doesn't exist as tooling in this repo; the `benchstat`/profiling work above is a rigorous approximation for the one workload shape it was pointed at, not a general answer, and not a claim of meeting F3.
- The ~2% residual call/return overhead on shallow, non-block-crossing recursion (see above) is disclosed, not eliminated.
- Cold-start memory was measured on one developer machine, not the "declared hosts" the roadmap's acceptance criterion refers to.
- #404 (derived-constructor-return over-reclaim) is a separate, pre-existing bug found while landing the invariant checker in #405 — out of scope here, tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

