### PR TITLE
fix(vm): resync frame from where a throw actually unwound to (#404)

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -6683,7 +6683,7 @@ startExecution:
 					// ECMAScript 10.2.2 step 11c: derived constructor returning non-object, non-undefined
 					vm.ThrowTypeError("Derived constructors may only return object or undefined")
 					if !vm.unwinding {
-						frame = callerFrame
+						frame = &vm.frames[vm.frameCount-1]
 						closure = frame.closure
 						function = closure.Fn
 						code = function.Chunk.Code
@@ -6697,7 +6697,7 @@ startExecution:
 					// ECMAScript 10.2.2 step 13: derived constructor returned undefined without super()
 					vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
 					if !vm.unwinding {
-						frame = callerFrame
+						frame = &vm.frames[vm.frameCount-1]
 						closure = frame.closure
 						function = closure.Fn
 						code = function.Chunk.Code
@@ -6725,7 +6725,7 @@ startExecution:
 			}
 
 			// Restore cached variables for the caller frame
-			frame = callerFrame // Update local frame pointer
+			frame = &vm.frames[vm.frameCount-1] // Update local frame pointer
 			closure = frame.closure
 			function = closure.Fn
 			code = function.Chunk.Code
@@ -6926,7 +6926,7 @@ startExecution:
 					// ECMAScript 10.2.2 step 13: derived constructor returned undefined without super()
 					vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
 					if !vm.unwinding {
-						frame = callerFrame
+						frame = &vm.frames[vm.frameCount-1]
 						closure = frame.closure
 						function = closure.Fn
 						code = function.Chunk.Code
@@ -6952,7 +6952,7 @@ startExecution:
 			}
 
 			// Restore cached variables for the caller frame
-			frame = callerFrame // Update local frame pointer
+			frame = &vm.frames[vm.frameCount-1] // Update local frame pointer
 			closure = frame.closure
 			function = closure.Fn
 			code = function.Chunk.Code
@@ -15957,7 +15957,7 @@ startExecution:
 			}
 
 			// Restore cached variables for the caller frame
-			frame = callerFrame // Update local frame pointer
+			frame = &vm.frames[vm.frameCount-1] // Update local frame pointer
 			closure = frame.closure
 			function = closure.Fn
 			code = function.Chunk.Code
@@ -16204,7 +16204,7 @@ startExecution:
 						// ECMAScript 10.2.2 step 11c: derived constructor returning non-object, non-undefined
 						vm.ThrowTypeError("Derived constructors may only return object or undefined")
 						if !vm.unwinding {
-							frame = callerFrame
+							frame = &vm.frames[vm.frameCount-1]
 							closure = frame.closure
 							function = closure.Fn
 							code = function.Chunk.Code
@@ -16218,7 +16218,7 @@ startExecution:
 						// ECMAScript 10.2.2 step 13: derived constructor returned undefined without super()
 						vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
 						if !vm.unwinding {
-							frame = callerFrame
+							frame = &vm.frames[vm.frameCount-1]
 							closure = frame.closure
 							function = closure.Fn
 							code = function.Chunk.Code
@@ -16244,7 +16244,7 @@ startExecution:
 				}
 
 				// Restore cached variables for the caller frame
-				frame = callerFrame
+				frame = &vm.frames[vm.frameCount-1]
 				closure = frame.closure
 				function = closure.Fn
 				code = function.Chunk.Code
@@ -18587,7 +18587,7 @@ startExecution:
 					} else if result.Type() != TypeUndefined {
 						vm.ThrowTypeError("Derived constructors may only return object or undefined")
 						if !vm.unwinding {
-							frame = callerFrame
+							frame = &vm.frames[vm.frameCount-1]
 							closure = frame.closure
 							function = closure.Fn
 							code = function.Chunk.Code
@@ -18600,7 +18600,7 @@ startExecution:
 					} else if constructorThisValue.typ == TypeUninitialized {
 						vm.ThrowReferenceError("Must call super constructor in derived class before returning from derived constructor")
 						if !vm.unwinding {
-							frame = callerFrame
+							frame = &vm.frames[vm.frameCount-1]
 							closure = frame.closure
 							function = closure.Fn
 							code = function.Chunk.Code
@@ -18624,7 +18624,7 @@ startExecution:
 					return status, Undefined
 				}
 
-				frame = callerFrame
+				frame = &vm.frames[vm.frameCount-1]
 				closure = frame.closure
 				function = closure.Fn
 				code = function.Chunk.Code

--- a/tests/scripts/derived_ctor_throw_unwinds_past_immediate_caller.ts
+++ b/tests/scripts/derived_ctor_throw_unwinds_past_immediate_caller.ts
@@ -1,0 +1,40 @@
+// Regression for #404: a derived constructor returning a non-object,
+// non-undefined value throws a TypeError per spec (10.2.2 step 11c) *after*
+// its own frame has already been popped. OpReturn/OpReturnUndefined/
+// OpReturnFinally/OpHandlePending's ActionReturn arm all captured the
+// immediate caller's frame *before* throwing, then unconditionally resumed
+// execution there once the throw stopped unwinding (`if !vm.unwinding`) -
+// correct only when the handler that stopped the unwind lives in that exact
+// immediate-caller frame. When the immediate caller (callback() below) has
+// no handler of its own, the throw's own unwind pops callback's frame too on
+// its way to a handler further up (here, the top-level try/catch) - but the
+// code still resumed into the now-stale, already-popped caller-frame
+// pointer instead of wherever the throw actually landed. That silently
+// re-ran callback()'s own natural return a second time (over-reclaiming its
+// register window - caught immediately by vm.checkRegWindowRelease under
+// StrictRegWindowChecks, which this suite runs with) and, in production
+// (checks off), unwound frameCount all the way to 0 and returned as if the
+// whole script had completed normally - the catch block below never ran and
+// this script produced no output at all, not even "done".
+// expect: caught:Derived constructors may only return object or undefined:done
+class C extends Object {
+  constructor() {
+    return null as any;
+  }
+}
+
+// No try/catch in here - the handler is two frames up, in the top-level
+// script below. This is the shape that broke: unwinding from C's return has
+// to pop *this* frame too before it reaches a handler.
+function callback() {
+  new C();
+}
+
+let result = "";
+try {
+  callback();
+} catch (e) {
+  result = "caught:" + (e as Error).message;
+}
+result += ":done";
+result;


### PR DESCRIPTION
## Summary

Fixes #404: a derived constructor returning a non-object/non-undefined value throws a `TypeError` per spec (10.2.2 step 11c), but if the immediate caller has no handler of its own, the fix-up code resumed execution in a stale, already-popped frame pointer instead of wherever the throw actually unwound to.

## Root cause

`OpReturn`/`OpReturnUndefined`/`OpReturnFinally`/`OpHandlePending`'s `ActionReturn` arm each do the same thing when handling this case: pop the returning frame, capture `callerFrame := &vm.frames[vm.frameCount-1]`, throw, then (once `!vm.unwinding` says a handler was found) resume via `frame = callerFrame`.

That's only correct if the handler lives in exactly that immediate-caller frame. When the immediate caller has no handler of its own, `unwindException`'s own pop loop keeps popping past it to reach a handler further up — but `callerFrame` is a pointer into a fixed `vm.frames[]` slot, still holding that now-already-popped frame's stale `ip`/registers/closure. Resuming there silently re-executes whatever instruction was sitting at that stale `ip` — in the repro below, `callback()`'s own natural end (`OpReturnUndefined`) — which pops `callback`'s frame and reclaims its register window a *second* time, and since `vm.unwinding` is already `false` by then, happily returns `InterpretOK` as if the whole script completed normally. **The actual catch block, several frames up, never runs — the exception is silently swallowed.**

## Repro

```ts
class C extends Object {
  constructor() { return null as any; }
}
function callback() { new C(); }   // no handler of its own
try {
  callback();
} catch (e) {
  console.log("caught:", (e as Error).message);
}
console.log("done");
```

Before this fix: **no output at all**, exit 0. With `vm.StrictRegWindowChecks` on (this repo's own `go test ./tests` runs with it), the spurious second pop panics instead: `register window imbalance at OpReturnUndefined (func="callback"): ... over-reclaimed` — which is how #404 was originally found.

## Fix

Replace every `frame = callerFrame` reassignment with `frame = &vm.frames[vm.frameCount-1]`, re-reading fresh from wherever `frameCount` actually ended up. `unwindException` only ever decrements `frameCount` further, never restores it, so this is always safe once `!vm.unwinding` confirms a handler stopped the unwind. Applied uniformly at all sites with this pattern, including the handful where nothing unwinds in between (the ordinary non-throwing return path) — harmless there since `callerFrame` and a fresh read are identical at that point.

## Verification

- New smoke test (`tests/scripts/derived_ctor_throw_unwinds_past_immediate_caller.ts`) — confirmed to **fail** (panic under `StrictRegWindowChecks`) without this fix and pass with it via a temporary stash/restore, not a vacuous addition.
- Test262: zero diff before/after, both `language/` (23073/450) and `built-ins/` (16867/6427). The four `Function/internals/Construct/derived-*` tests #404 originally named were already passing both before and after — Test262's own test shape apparently never puts the handler more than one frame above the throw site, so it never exercised this specific case. Consistent with #404's own note that this was found by the invariant checker, not by a failing Test262 test.
- `go build ./...`, `go vet ./...`, `go test ./...` (incl. `TestScripts`, which runs with `StrictRegWindowChecks=true`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
