### PR TITLE
fix(compiler): stop function-declaration hoisting from resolving into an enclosing scope (#406)

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1963,8 +1963,29 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 			}
 			sort.Strings(hoistedNames)
 			// Pre-allocate registers (or spill slots) for all hoisted function names to enable mutual recursion with stable locations
+			//
+			// Must check only THIS scope chain (stopping at c.scopeBoundary), not the
+			// full Resolve() walk: Resolve() crosses straight into the enclosing
+			// compiler's symbol table (a function scope's Outer chain links directly to
+			// its enclosing compiler's currentSymbolTable - see newFunctionCompiler), so
+			// it can find a same-named binding from an OUTER function (e.g. an outer
+			// `var Foo`) and conclude this hoisted `function Foo` is "already defined"
+			// purely because of that unrelated outer binding, skipping the local
+			// register allocation below entirely. Per ECMAScript, a function
+			// declaration must always get its own binding in its own scope, shadowing
+			// any outer variable of the same name for every reference within that
+			// scope - it must never be conflated with, or skip allocation because of,
+			// an outer scope's same-named symbol. When that happened, the later emit
+			// loop's `c.currentSymbolTable.Resolve(name)` would also cross into the
+			// outer scope and reuse the OUTER function's register number as if it were
+			// local, emitting an OpClosure into a register index that could be beyond
+			// this (inner) function's own RegisterSize, causing a VM index-out-of-range
+			// panic - while every *reference* to the name elsewhere in this same scope
+			// (correctly, via isDefinedInEnclosingCompiler) resolved to an upvalue
+			// capture of the outer binding, so the two disagreed on which binding
+			// "Foo" was (#406).
 			for _, name := range hoistedNames {
-				if sym, _, found := c.currentSymbolTable.Resolve(name); !found || sym.Register == nilRegister {
+				if sym, _, found := c.currentSymbolTable.ResolveUpTo(name, c.scopeBoundary); !found || sym.Register == nilRegister {
 					reg, ok := c.regAlloc.TryAllocForVariable()
 					if ok {
 						c.currentSymbolTable.Define(name, reg)

--- a/tests/scripts/nested_iife_shadowed_function_name.ts
+++ b/tests/scripts/nested_iife_shadowed_function_name.ts
@@ -1,0 +1,27 @@
+// expect: 1
+// Regression test for #406: an inner function declaration that shares its name
+// with an outer `var` binding must get its own local register/binding in its
+// own scope, shadowing the outer one for every reference within that scope
+// (per real ECMAScript scoping). Previously the hoisting pre-check for a
+// nested function declaration used a full (cross-function) symbol resolve,
+// so it found the outer `var Foo` and skipped allocating a local slot for the
+// inner `function Foo`, while every reference to `Foo` inside the inner
+// scope still (correctly) resolved to a captured upvalue of that same outer
+// binding via a separate check - these two decisions disagreed, and the
+// closure's emitted register index (borrowed from the outer scope) could
+// land outside the inner function's own register file, panicking the VM
+// with "index out of range".
+(function () {
+  var Foo = (function () {
+    function Foo() {
+      this.x = 1;
+    }
+    Foo.prototype.bar = function () {
+      return this.x;
+    };
+    return Foo;
+  })();
+  const f = new Foo();
+  globalThis.__nestedIifeShadowResult = f.bar();
+})();
+globalThis.__nestedIifeShadowResult;

--- a/tests/scripts/shadowed_function_name_toplevel.ts
+++ b/tests/scripts/shadowed_function_name_toplevel.ts
@@ -1,0 +1,18 @@
+// expect: 1
+// Regression test for #406 (shallower variant): with one less level of
+// nesting, the same outer-var/inner-function-declaration name collision
+// resolved every reference inside the inner scope to the OUTER (not yet
+// assigned) `var Foo` instead of the inner hoisted `function Foo`, throwing
+// "Cannot read property 'prototype' of undefined" instead of panicking.
+// Same root cause as nested_iife_shadowed_function_name.ts, different
+// symptom depending on nesting depth.
+var Foo = (function () {
+  function Foo() {
+    this.x = 1;
+  }
+  Foo.prototype.bar = function () {
+    return this.x;
+  };
+  return Foo;
+})();
+new Foo().bar();


### PR DESCRIPTION
## Summary

Fixes #406: a nested function declaration sharing its name with an outer `var` binding panicked the VM (`index out of range`). This is the classic TypeScript ES5-class-emit shape (`var Foo = (function () { function Foo() {...}; Foo.prototype.x = ...; return Foo; })();`), found via a real dependency (`@aws-crypto/crc32`) several levels deep in an AWS SDK package.

## Root cause

The hoisting pre-check that decides whether a nested function declaration needs its own local register/spill slot used a full, unbounded `SymbolTable.Resolve(name)` — which walks straight through the current function's own boundary into whatever encloses it (needed for ordinary closures to find outer bindings for upvalue capture). When the inner scope's own hoisted `function Foo` hadn't been locally defined yet, this found the **outer** `var Foo` instead — already holding a real register — so the "already defined" check came back false, and the inner declaration's own register allocation was skipped entirely. The emit loop then reused that outer register number verbatim as if it were local to the inner chunk, landing `OpClosure` outside the inner function's own (smaller) `RegisterSize`.

Meanwhile every ordinary *reference* to `Foo` inside that same inner scope (`Foo.prototype.bar = ...`, `return Foo`) went through a different, correctly-scoped path that rightly resolved it as an upvalue capture of the outer binding. These two checks disagreed about whose `Foo` was meant — one crossed the function boundary, one didn't — which also explains why a shallower variant (one less level of nesting) hits the same root cause but produces a *different* symptom: every reference resolving to the not-yet-assigned outer `var Foo` instead (`TypeError: Cannot read property 'prototype' of undefined`).

## Fix

Use the existing `ResolveUpTo(name, c.scopeBoundary)` idiom (already used two lines away for `arguments` shadowing) instead of `Resolve`, stopping the hoisting pre-check at this function's own scope boundary.

## Verification

- Two new regression tests (`nested_iife_shadowed_function_name.ts` — the panic; `shadowed_function_name_toplevel.ts` — the TypeError variant) both reproduce their exact original symptom without the fix and pass with it.
- `go build ./...`, `go vet ./...`, `go test ./...` (incl. `TestScripts`) all green.
- Test262: byte-for-byte zero diff before/after, both `language/` (23073/450) and `built-ins/` (16867/6427).
- Original real-world repro now returns `1`, matching real Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
