### PR TITLE
fix(vm): ordinary call-stack overflow throws a catchable RangeError (#407)

### DIFF
--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -25,6 +25,46 @@ func (e exceptionError) GetExceptionValue() Value {
 	return e.exception
 }
 
+// stackOverflowExceptionError builds prepareCall's error for "the frame
+// limit or the register-directory budget is exhausted" (#407). Real engines
+// throw a catchable RangeError("Maximum call stack size exceeded") for this,
+// for both ordinary recursive calls and `new`-expression recursion - but
+// prepareCall used to return a bare fmt.Errorf that every caller's own
+// `err != nil` handling wrapped into a generic Error instead (only the
+// `new`-expression path, handled directly inside run()'s own OpNew-family
+// switch cases rather than through prepareCall, got this right).
+//
+// The obvious fix - have prepareCall call vm.ThrowRangeError itself and
+// return (false, nil) - is broken: prepareCall is a plain Go function
+// reached from deep inside run()'s dispatch (via OpCall and several other
+// call sites), and each of those callers' post-prepareCall logic only knows
+// how to resume after a same-frame IP change or an escaped direct-call/
+// native boundary - not "the unwind popped several plain bytecode frames to
+// reach a handler, with nothing native in between", which is exactly what
+// happens for ordinary non-tail recursion overflowing deep inside itself.
+// Falling into neither branch, execution silently continued with stale
+// frame/ip state pointing at an already-popped frame, swallowing the
+// exception entirely (confirmed empirically: a script with a try/catch
+// around deep recursion produced no output at all, not even the catch
+// block's own console.log).
+//
+// Returning an ExceptionError instead - carrying an already-built RangeError
+// Value - lets every existing `if exceptionErr, ok := err.(ExceptionError);
+// ok { excVal = exceptionErr.GetExceptionValue() }` call site (there are
+// several, one per prepareCall caller) pick it up completely unchanged: the
+// value is thrown via that caller's own, already-correct
+// vm.throwException(excVal) + frame-reload sequence, the same as for any
+// other exception a native call produces. No caller needs to change.
+//
+// vm.newStackOverflowError() (vm.go, #231) already builds exactly this
+// Value by hand rather than via the RangeError constructor - deliberately,
+// for the same reason this needed a fix at all: at the point of overflow,
+// vm.frames may have no room for the constructor's own frame either. Reused
+// here rather than duplicated.
+func (vm *VM) stackOverflowExceptionError() error {
+	return exceptionError{exception: vm.newStackOverflowError()}
+}
+
 // setTailCallHomeObject gives a tail-called callee its [[HomeObject]] for
 // super property access (see prepareCall below). Arrow functions read
 // their captured [[HomeObject]] (frame.closure.CapturedHomeObject) at use
@@ -311,9 +351,7 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		// Check frame limit
 		if vm.frameCount >= len(vm.frames) {
 			currentFrame.ip = callerIP
-			trace := vm.CaptureStackTrace()
-			fmt.Printf("\n=== VM Stack (overflow) ===\n%s\n===========================\n", trace)
-			return false, fmt.Errorf("Stack overflow\nStack: %s", trace)
+			return false, vm.stackOverflowExceptionError()
 		}
 
 		// Register stack space is checked (and actually reserved) at the real
@@ -405,9 +443,7 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 		newWindow, windowStart, pushMark, ok := vm.regDir.push(requiredRegs)
 		if !ok {
 			currentFrame.ip = callerIP
-			trace := vm.CaptureStackTrace()
-			fmt.Printf("\n=== VM Stack (register overflow) ===\n%s\n====================================\n", trace)
-			return false, fmt.Errorf("Register stack overflow\nStack: %s", trace)
+			return false, vm.stackOverflowExceptionError()
 		}
 		newFrame.registers = newWindow
 		newFrame.allocatedRegSize = requiredRegs // Track actual allocation for proper cleanup

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -23191,13 +23191,20 @@ func (vm *VM) ThrowSyntaxError(message string) {
 
 // newStackOverflowError builds a RangeError-shaped exception value directly,
 // without calling any constructor (built-in or user-reassigned). Used by
-// executeUserFunctionSafe's call-stack-full guard (#231): at that point
-// vm.frames has no room for another frame, so going through vm.Call - as
-// ThrowRangeError's own constructor lookup would - risks hitting that exact
-// same guard again. See ThrowRangeError below for the normal, constructor-
-// backed path used everywhere the stack has room.
+// executeUserFunctionSafe's call-stack-full guard (#231) and by prepareCall's
+// own overflow returns (#407): at that point vm.frames has no room for
+// another frame, so going through vm.Call - as ThrowRangeError's own
+// constructor lookup would - risks hitting that exact same guard again. See
+// ThrowRangeError below for the normal, constructor-backed path used
+// everywhere the stack has room.
+//
+// Built on currentRealm.RangeErrorPrototype specifically (not the generic
+// ErrorPrototype this used before #407): only that prototype chain makes
+// `instanceof RangeError` and `.constructor.name === "RangeError"` true, both
+// of which real engines guarantee for this exact error and #407 was filed
+// over.
 func (vm *VM) newStackOverflowError() Value {
-	errObj := NewObject(vm.ErrorPrototype).AsPlainObject()
+	errObj := NewObject(vm.currentRealm.RangeErrorPrototype).AsPlainObject()
 	errObj.SetOwn("name", NewString("RangeError"))
 	errObj.SetOwn("message", NewString("Maximum call stack size exceeded"))
 	errObj.SetOwn("stack", NewString(vm.CaptureStackTrace()))

--- a/tests/scripts/deep_recursion_test.ts
+++ b/tests/scripts/deep_recursion_test.ts
@@ -1,6 +1,9 @@
 // Test for stack overflow with deep recursion
 // no-typecheck
-// expect_runtime_error: Stack overflow
+// #407: ordinary recursive calls now throw a catchable RangeError with the
+// same spec-correct message the `new`-expression overflow path already
+// used, instead of an uncatchable-as-RangeError generic "Stack overflow".
+// expect_runtime_error: Maximum call stack size exceeded
 
 function recurse(n) {
     if (n <= 0) return 0;

--- a/tests/scripts/ordinary_call_overflow_is_rangeerror.ts
+++ b/tests/scripts/ordinary_call_overflow_is_rangeerror.ts
@@ -1,0 +1,29 @@
+// no-typecheck
+// Regression test for #407: stack overflow from ordinary (non-`new`)
+// recursive function calls must throw a catchable RangeError with the
+// spec-correct "Maximum call stack size exceeded" message, matching the
+// `new`-expression overflow path (see ctor_stack_overflow_catchable.ts),
+// not a generic uncatchable-as-RangeError Error.
+//
+// Also pins down the actual bug #407 reported: naively converting the
+// overflow to a RangeError inside prepareCall itself broke resumption after
+// the throw entirely (the catch block below never ran, script exited with
+// no output at all) whenever the immediate caller had no handler of its own
+// and the unwind had to cross several plain bytecode frames with nothing
+// native in between - exactly what happens here.
+// expect: RangeError:Maximum call stack size exceeded
+function f() {
+  f();
+}
+
+function callback() {
+  f(); // no handler of its own - the catch below is one frame further out
+}
+
+let result = "";
+try {
+  callback();
+} catch (e) {
+  result = e.constructor.name + ":" + e.message;
+}
+result;


### PR DESCRIPTION
## Summary

Fixes #407: stack overflow from ordinary recursive function calls (`function f(){f()}`) threw a generic `Error("Stack overflow\nStack: ...")`, not the spec-compliant, catchable `RangeError("Maximum call stack size exceeded")` real engines throw. The `new`-expression overflow path (`function C(){return new C()}`) already got this right. Also removed a noisy, uncontrolled stdout stack-trace dump on overflow, even when the exception was caught and handled.

## Root cause

`prepareCall`'s two overflow checks (frame limit, register-directory budget) returned a bare `fmt.Errorf`, which every one of `prepareCall`'s ~6 callers' own `err != nil` handling wrapped into a generic `Error` via `vm.GetGlobal("Error")` + `vm.Call`.

The obvious fix — have `prepareCall` call `vm.ThrowRangeError` directly and return `(false, nil)` — is broken, confirmed empirically: `prepareCall` is a plain Go function reached from deep inside `run()`'s dispatch, and each caller's post-`prepareCall` logic only knows how to resume after a same-frame IP change or an escaped direct-call/native boundary — not "the unwind popped several plain bytecode frames to reach a handler, with nothing native in between," which is exactly what happens for ordinary non-tail recursion overflowing deep inside itself. Falling into neither branch, execution silently continued with stale frame/ip state pointing at an already-popped frame, **swallowing the exception entirely** — a script with try/catch around deep recursion produced no output at all.

## Fix

`prepareCall`'s two overflow branches now return `vm.stackOverflowExceptionError()`, wrapping the pre-existing `vm.newStackOverflowError()` (already used by `executeUserFunctionSafe`'s own call-stack-full guard, #231 — built by hand rather than via the RangeError constructor, since at the point of overflow there may be no room for the constructor's own frame either) in the existing `ExceptionError` interface. Every one of `prepareCall`'s callers already has an `if exceptionErr, ok := err.(ExceptionError); ok { excVal = exceptionErr.GetExceptionValue() }` branch that throws the value via its own, already-correct `vm.throwException` + frame-reload sequence. **None of those ~6 call sites needed to change.**

Also fixed `vm.newStackOverflowError()` itself (pre-existing, #231): it built the error object on `vm.ErrorPrototype` instead of `currentRealm.RangeErrorPrototype`, so `e.constructor.name` read `"Error"` even though `e.name` said `"RangeError"` — caught while verifying this fix.

## Verification

- New regression test (`ordinary_call_overflow_is_rangeerror.ts`): confirmed to produce the wrong error type/message without this fix (via temporary stash/restore) and the correct `RangeError` with it.
- Updated `deep_recursion_test.ts`'s expectation to match the corrected message.
- Manually verified all ~6 `prepareCall` call sites this fix does *not* touch (bound-function forwarding, `Function.prototype.call`, spread calls, Proxy apply-trap forwarding) now also correctly produce a catchable `RangeError` with zero changes of their own.
- Test262: zero diff before/after, both `language/` (23073/450) and `built-ins/` (16867/6427).
- `go build ./...`, `go vet ./...`, `go test ./...` (incl. `TestScripts`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
