### PR TITLE
WritableStream/TransformStream (#413) + a register-window leak they surfaced (#414)

### DIFF
--- a/pkg/builtins/readable_stream_init.go
+++ b/pkg/builtins/readable_stream_init.go
@@ -49,10 +49,20 @@ func (r *ReadableStreamInitializer) InitTypes(ctx *TypeContext) error {
 	streamType.WithProperty("tee", types.NewSimpleFunction([]types.Type{}, &types.TupleType{
 		ElementTypes: []types.Type{streamType, streamType},
 	}))
+	// pipeTo/pipeThrough: kept Any-typed (both the destination/pair argument
+	// and pipeThrough's return) so any WritableStream-shaped or
+	// {readable,writable}-shaped object works without cross-file structural
+	// friction between ReadableStream/WritableStream/TransformStream's
+	// separately-declared types - see pipeReadableTo below for the runtime
+	// behavior (#413).
+	streamType.WithProperty("pipeTo", types.NewSimpleFunction([]types.Type{types.Any}, types.Any))      // Promise<void>
+	streamType.WithProperty("pipeThrough", types.NewSimpleFunction([]types.Type{types.Any}, types.Any)) // returns the pair's `readable`
 
 	streamCtorType := types.NewObjectType().
-		WithSimpleCallSignature([]types.Type{}, streamType).             // new ReadableStream()
-		WithSimpleCallSignature([]types.Type{types.Any}, streamType).    // new ReadableStream(underlyingSource)
+		WithSimpleCallSignature([]types.Type{}, streamType).               // new ReadableStream()
+		WithSimpleCallSignature([]types.Type{types.Any}, streamType).      // new ReadableStream(underlyingSource)
+		WithSimpleConstructSignature([]types.Type{}, streamType).          // super() from a subclass, no args
+		WithSimpleConstructSignature([]types.Type{types.Any}, streamType). // super(underlyingSource) from a subclass
 		WithProperty("prototype", streamType)
 
 	return ctx.DefineGlobal("ReadableStream", streamCtorType)
@@ -228,6 +238,25 @@ func (s *readableStreamState) errorOut(reason vm.Value) {
 	for _, pr := range pending {
 		s.vmInstance.RejectPromise(pr.promise, reason)
 	}
+}
+
+// desiredSizeValue computes the WHATWG-style backpressure signal for a
+// stream with the given highWaterMark: null once errored, 0 once closed,
+// highWaterMark minus the current queue length otherwise. ReadableStream
+// itself doesn't expose desiredSize; this exists so TransformStream's
+// controller (#413, transform_stream_init.go) can report a live number
+// instead of a fixed placeholder - the queue it needs to see lives on this,
+// the readable side's own state.
+func (s *readableStreamState) desiredSizeValue(highWaterMark int) vm.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.errored {
+		return vm.Null
+	}
+	if s.closed {
+		return vm.NumberValue(0)
+	}
+	return vm.NumberValue(float64(highWaterMark - len(s.queue)))
 }
 
 // read implements reader.read()/the async-iterator's next(). Unlike
@@ -463,6 +492,34 @@ func createReadableStreamObject(vmInstance *vm.VM, state *readableStreamState, s
 		return vm.NewArrayWithArgs([]vm.Value{branch1Val, branch2Val}), nil
 	}))
 
+	obj.SetOwnNonEnumerable("pipeTo", vm.NewNativeFunction(1, false, "pipeTo", func(args []vm.Value) (vm.Value, error) {
+		if len(args) == 0 {
+			return vm.Undefined, vmInstance.NewTypeError("pipeTo requires a destination WritableStream")
+		}
+		return pipeReadableTo(vmInstance, state, args[0]), nil
+	}))
+
+	obj.SetOwnNonEnumerable("pipeThrough", vm.NewNativeFunction(1, false, "pipeThrough", func(args []vm.Value) (vm.Value, error) {
+		if len(args) == 0 {
+			return vm.Undefined, vmInstance.NewTypeError("pipeThrough requires a { readable, writable } pair")
+		}
+		pair := args[0]
+		writableSide, err := vmInstance.GetProperty(pair, "writable")
+		if err != nil {
+			return vm.Undefined, err
+		}
+		readableSide, err := vmInstance.GetProperty(pair, "readable")
+		if err != nil {
+			return vm.Undefined, err
+		}
+		// Per spec, pipeThrough's own pipe-completion promise isn't exposed
+		// to the caller - only the piped-through `readable` is returned.
+		// Errors on that internal pipe still propagate through the readable
+		// side (pipeReadableTo cancels/aborts both ends on failure).
+		pipeReadableTo(vmInstance, state, writableSide)
+		return readableSide, nil
+	}))
+
 	// [Symbol.asyncIterator] - the surface every real SDK's own
 	// ReadableStreamToAsyncIterable shim tries first (#205's scope note).
 	asyncIterFn := vm.NewNativeFunction(0, false, "[Symbol.asyncIterator]", func(args []vm.Value) (vm.Value, error) {
@@ -611,6 +668,103 @@ func (c *ReadableStreamController) Close() { c.state.close() }
 // Error signals an abnormal end of stream, rejecting every pending and
 // future read() with reason.
 func (c *ReadableStreamController) Error(reason vm.Value) { c.state.errorOut(reason) }
+
+// pipeReadableTo implements the runtime behavior behind both
+// ReadableStream.prototype.pipeTo (called directly) and .pipeThrough (called
+// internally with the pair's `writable`, #413). It duck-types dest as
+// anything with a WritableStream-shaped getWriter()/write()/close()/abort(),
+// so it works on a real WritableStream and (transitively, since
+// TransformStream.writable is one) a TransformStream's writable side too.
+//
+// Simplifications vs. the full spec (matching this file's existing tee()/
+// read() scope note): no preventClose/preventAbort/preventCancel/signal
+// options - closing, aborting and cancelling always propagate both ways.
+func pipeReadableTo(vmInstance *vm.VM, src *readableStreamState, dest vm.Value) vm.Value {
+	resultVal := vmInstance.NewPendingPromise()
+	resultPromise := resultVal.AsPromise()
+
+	getWriterFn, err := vmInstance.GetProperty(dest, "getWriter")
+	if err != nil {
+		vmInstance.RejectPromise(resultPromise, errorValueFromGoError(err))
+		return resultVal
+	}
+	if !getWriterFn.IsCallable() {
+		reason := errorValueFromGoError(vmInstance.NewTypeError("pipeTo destination is not a WritableStream"))
+		vmInstance.RejectPromise(resultPromise, reason)
+		return resultVal
+	}
+	writerVal, callErr := vmInstance.Call(getWriterFn, dest, nil)
+	if callErr != nil {
+		vmInstance.RejectPromise(resultPromise, errorValueFromGoError(callErr))
+		return resultVal
+	}
+
+	var pump func()
+	pump = func() {
+		readVal := src.read()
+		vmInstance.AddPromiseReaction(readVal, true, func(v vm.Value) {
+			resultObj := v.AsPlainObject()
+			if resultObj == nil {
+				vmInstance.ResolvePromise(resultPromise, vm.Undefined)
+				return
+			}
+			doneVal, _ := resultObj.GetOwn("done")
+			if doneVal.AsBoolean() {
+				closeFn, err := vmInstance.GetProperty(writerVal, "close")
+				if err != nil || !closeFn.IsCallable() {
+					vmInstance.ResolvePromise(resultPromise, vm.Undefined)
+					return
+				}
+				closeResult, callErr := vmInstance.Call(closeFn, writerVal, nil)
+				if callErr != nil {
+					vmInstance.RejectPromise(resultPromise, errorValueFromGoError(callErr))
+					return
+				}
+				closeSettled := vmInstance.NewPendingPromise()
+				vmInstance.ResolvePromise(closeSettled.AsPromise(), closeResult)
+				vmInstance.AddPromiseReaction(closeSettled, true, func(vm.Value) {
+					vmInstance.ResolvePromise(resultPromise, vm.Undefined)
+				})
+				vmInstance.AddPromiseReaction(closeSettled, false, func(r vm.Value) {
+					vmInstance.RejectPromise(resultPromise, r)
+				})
+				return
+			}
+			chunkVal, _ := resultObj.GetOwn("value")
+			writeFn, err := vmInstance.GetProperty(writerVal, "write")
+			if err != nil || !writeFn.IsCallable() {
+				reason := errorValueFromGoError(vmInstance.NewTypeError("pipeTo destination writer has no write()"))
+				vmInstance.RejectPromise(resultPromise, reason)
+				return
+			}
+			writeResult, callErr := vmInstance.Call(writeFn, writerVal, []vm.Value{chunkVal})
+			if callErr != nil {
+				reason := errorValueFromGoError(callErr)
+				vmInstance.RejectPromise(resultPromise, reason)
+				src.cancel(reason)
+				return
+			}
+			writeSettled := vmInstance.NewPendingPromise()
+			vmInstance.ResolvePromise(writeSettled.AsPromise(), writeResult)
+			vmInstance.AddPromiseReaction(writeSettled, true, func(vm.Value) {
+				pump()
+			})
+			vmInstance.AddPromiseReaction(writeSettled, false, func(r vm.Value) {
+				vmInstance.RejectPromise(resultPromise, r)
+				src.cancel(r)
+			})
+		})
+		vmInstance.AddPromiseReaction(readVal, false, func(r vm.Value) {
+			vmInstance.RejectPromise(resultPromise, r)
+			if abortFn, err := vmInstance.GetProperty(writerVal, "abort"); err == nil && abortFn.IsCallable() {
+				_, _ = vmInstance.Call(abortFn, writerVal, []vm.Value{r})
+			}
+		})
+	}
+	pump()
+
+	return resultVal
+}
 
 // NewHostFedReadableStream creates a ReadableStream with no JS-authored
 // underlying source, whose contents are instead fed entirely from Go via the

--- a/pkg/builtins/standard.go
+++ b/pkg/builtins/standard.go
@@ -56,6 +56,8 @@ func GetStandardInitializers() []BuiltinInitializer {
 	initializers = append(initializers, &ProxyInitializer{})
 	initializers = append(initializers, &ConsoleInitializer{})
 	initializers = append(initializers, &ReadableStreamInitializer{})
+	initializers = append(initializers, &WritableStreamInitializer{})
+	initializers = append(initializers, &TransformStreamInitializer{})
 	initializers = append(initializers, &BlobInitializer{})
 	initializers = append(initializers, &FormDataInitializer{})
 	initializers = append(initializers, &AbortControllerInitializer{})

--- a/pkg/builtins/transform_stream_init.go
+++ b/pkg/builtins/transform_stream_init.go
@@ -1,0 +1,213 @@
+package builtins
+
+import (
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// PriorityTransformStream places TransformStream after both ReadableStream
+// (185) and WritableStream (186), since it composes one of each (#413).
+const PriorityTransformStream = 187
+
+// TransformStreamInitializer implements a minimal TransformStream: a
+// ReadableStream/WritableStream pair joined by a transform algorithm, per
+// the WHATWG Streams spec's `Transformer` interface. This is what real,
+// unmodified SDK code (the AWS SDK's @smithy/core checksum stream, its
+// middleware-websocket package's own `class X extends TransformStream`)
+// actually reaches for (#413) - ReadableStream (#205) alone isn't enough.
+//
+//	new TransformStream({
+//	  start(controller),                    // optional
+//	  transform(chunk, controller),         // optional - default: enqueue chunk unchanged
+//	  flush(controller),                    // optional
+//	}) -> {
+//	  readable: ReadableStream,
+//	  writable: WritableStream,
+//	}
+//
+// controller (TransformStreamDefaultController) exposes enqueue(chunk),
+// error(reason) and terminate().
+//
+// Wiring: every chunk written to `.writable` runs the transform algorithm,
+// which typically calls controller.enqueue() to push output chunks onto
+// `.readable`; closing `.writable` runs flush() (if given) and then closes
+// `.readable`; erroring or terminating propagates to both sides. Writes are
+// processed strictly in order (WritableStream's own tail-chaining, see
+// writable_stream_init.go) so transform() sees chunks in write() order.
+//
+// Simplifications: no readableType/writableType (BYOB) support, and
+// desiredSize on the controller is a fixed placeholder rather than tracking
+// real queue occupancy - matching this package's established
+// ReadableStream/WritableStream scope notes.
+type TransformStreamInitializer struct{}
+
+func (t *TransformStreamInitializer) Name() string  { return "TransformStream" }
+func (t *TransformStreamInitializer) Priority() int { return PriorityTransformStream }
+
+func (t *TransformStreamInitializer) InitTypes(ctx *TypeContext) error {
+	// readable/writable are kept Any-typed: ReadableStream/WritableStream's
+	// own declared types live in separate initializers, and Any avoids
+	// coupling this constructor's type to their exact structural shape.
+	streamType := types.NewObjectType().
+		WithProperty("readable", types.Any).
+		WithProperty("writable", types.Any)
+
+	streamCtorType := types.NewObjectType().
+		WithSimpleCallSignature([]types.Type{}, streamType).
+		WithSimpleCallSignature([]types.Type{types.Any}, streamType).
+		WithSimpleConstructSignature([]types.Type{}, streamType).
+		WithSimpleConstructSignature([]types.Type{types.Any}, streamType).
+		WithProperty("prototype", streamType)
+
+	return ctx.DefineGlobal("TransformStream", streamCtorType)
+}
+
+func (t *TransformStreamInitializer) InitRuntime(ctx *RuntimeContext) error {
+	vmInstance := ctx.VM
+
+	streamProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	transformStreamProto = streamProto
+
+	ctorFn := func(args []vm.Value) (vm.Value, error) {
+		var transformer vm.Value = vm.Undefined
+		if len(args) > 0 {
+			transformer = args[0]
+		}
+
+		readableState := newReadableStreamState(vmInstance)
+		writableState := newWritableStreamState(vmInstance)
+
+		controllerVal := createTransformStreamControllerObject(vmInstance, readableState, writableState)
+
+		// Every chunk written to .writable runs the transform algorithm; by
+		// default (no transform() given) it just enqueues the chunk
+		// unchanged, per spec.
+		writableState.goWrite = func(chunk vm.Value) vm.Value {
+			if transformFn, err := vmInstance.GetProperty(transformer, "transform"); err == nil && transformFn.IsCallable() {
+				return callAlgorithm(vmInstance, transformFn, transformer, []vm.Value{chunk, controllerVal})
+			}
+			readableState.enqueue(chunk)
+			return vmInstance.NewResolvedPromise(vm.Undefined)
+		}
+
+		// Closing .writable runs flush() (if given), then closes .readable.
+		writableState.goClose = func() vm.Value {
+			flushVal := callAlgorithmIfPresent(vmInstance, transformer, "flush", []vm.Value{controllerVal})
+			resultVal := vmInstance.NewPendingPromise()
+			resultPromise := resultVal.AsPromise()
+			vmInstance.AddPromiseReaction(flushVal, true, func(vm.Value) {
+				readableState.close()
+				vmInstance.ResolvePromise(resultPromise, vm.Undefined)
+			})
+			vmInstance.AddPromiseReaction(flushVal, false, func(r vm.Value) {
+				readableState.errorOut(r)
+				vmInstance.RejectPromise(resultPromise, r)
+			})
+			return resultVal
+		}
+
+		// Aborting .writable (from outside, e.g. writer.abort()) errors the
+		// readable side too, per spec.
+		writableState.goAbort = func(reason vm.Value) vm.Value {
+			readableState.errorOut(reason)
+			return vmInstance.NewResolvedPromise(vm.Undefined)
+		}
+
+		// Cancelling .readable errors the writable side, per spec (no more
+		// chunks can usefully be transformed once the consumer walked away).
+		readableState.goCancel = func(reason vm.Value) vm.Value {
+			writableState.errorOut(reason)
+			return vmInstance.NewResolvedPromise(vm.Undefined)
+		}
+
+		readableVal := createReadableStreamObject(vmInstance, readableState, readableStreamProto, readableStreamReaderProto)
+		writableVal := createWritableStreamObject(vmInstance, writableState, writableStreamProto)
+
+		obj := vm.NewObject(vm.NewValueFromPlainObject(streamProto)).AsPlainObject()
+		obj.SetOwnNonEnumerable("readable", readableVal)
+		obj.SetOwnNonEnumerable("writable", writableVal)
+
+		if transformer.Type() == vm.TypeObject || transformer.Type() == vm.TypeDictObject {
+			if startFn, err := vmInstance.GetProperty(transformer, "start"); err == nil && startFn.IsCallable() {
+				if _, callErr := vmInstance.Call(startFn, transformer, []vm.Value{controllerVal}); callErr != nil {
+					return vm.Undefined, callErr
+				}
+			}
+		}
+
+		return vm.NewValueFromPlainObject(obj), nil
+	}
+
+	ctor := vm.NewConstructorWithProps(0, false, "TransformStream", ctorFn)
+	if ctor.Type() == vm.TypeNativeFunctionWithProps {
+		ctor.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(streamProto))
+	}
+	streamProto.SetOwnNonEnumerable("constructor", ctor)
+
+	return ctx.DefineGlobal("TransformStream", ctor)
+}
+
+// Package-level prototype, set once during InitRuntime - see the identical
+// convention on readableStreamProto/writableStreamProto.
+var transformStreamProto *vm.PlainObject
+
+// callAlgorithmIfPresent looks up an optional hook (transformer.flush, etc.)
+// and calls it if present and callable, wrapping the result the same way
+// callAlgorithm does; if absent, it's a no-op that resolves immediately -
+// the correct default per spec for every optional Transformer hook.
+func callAlgorithmIfPresent(vmInstance *vm.VM, obj vm.Value, name string, args []vm.Value) vm.Value {
+	if obj.Type() != vm.TypeObject && obj.Type() != vm.TypeDictObject {
+		return vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	fn, err := vmInstance.GetProperty(obj, name)
+	if err != nil || !fn.IsCallable() {
+		return vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	return callAlgorithm(vmInstance, fn, obj, args)
+}
+
+// createTransformStreamControllerObject builds the
+// TransformStreamDefaultController handed to transformer.start()/
+// transform()/flush(): enqueue(chunk) pushes onto the readable side,
+// error(reason) errors both sides, terminate() closes the readable side and
+// errors the writable side (per spec, "the stream is being closed").
+func createTransformStreamControllerObject(vmInstance *vm.VM, readableState *readableStreamState, writableState *writableStreamState) vm.Value {
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	// A real accessor (not a value snapshotted at controller-creation time,
+	// which would go stale after the first enqueue/close/error) - backed by
+	// the readable side's own queue via readableStreamState.desiredSizeValue.
+	desiredSizeGetter := vm.NewNativeFunction(0, false, "desiredSize", func(args []vm.Value) (vm.Value, error) {
+		return readableState.desiredSizeValue(1), nil
+	})
+	enumerable, configurable := true, true
+	obj.DefineAccessorProperty("desiredSize", desiredSizeGetter, true, vm.Undefined, false, &enumerable, &configurable)
+
+	obj.SetOwnNonEnumerable("enqueue", vm.NewNativeFunction(1, false, "enqueue", func(args []vm.Value) (vm.Value, error) {
+		var chunk vm.Value = vm.Undefined
+		if len(args) > 0 {
+			chunk = args[0]
+		}
+		readableState.enqueue(chunk)
+		return vm.Undefined, nil
+	}))
+
+	obj.SetOwnNonEnumerable("error", vm.NewNativeFunction(1, false, "error", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		readableState.errorOut(reason)
+		writableState.errorOut(reason)
+		return vm.Undefined, nil
+	}))
+
+	obj.SetOwnNonEnumerable("terminate", vm.NewNativeFunction(0, false, "terminate", func(args []vm.Value) (vm.Value, error) {
+		readableState.close()
+		reason := errorValueFromGoError(vmInstance.NewTypeError("The transform stream has been terminated"))
+		writableState.errorOut(reason)
+		return vm.Undefined, nil
+	}))
+
+	return vm.NewValueFromPlainObject(obj)
+}

--- a/pkg/builtins/writable_stream_init.go
+++ b/pkg/builtins/writable_stream_init.go
@@ -1,0 +1,519 @@
+package builtins
+
+import (
+	"sync"
+
+	"github.com/nooga/paserati/pkg/types"
+	"github.com/nooga/paserati/pkg/vm"
+)
+
+// PriorityWritableStream places WritableStream right after ReadableStream
+// (185), so TransformStream (187, #413) can compose both.
+const PriorityWritableStream = 186
+
+// WritableStreamInitializer implements a minimal WritableStream /
+// WritableStreamDefaultWriter, sized the same way ReadableStreamInitializer
+// is (see that file's doc comment, #205): enough surface for real streaming
+// consumers - here, primarily TransformStream.writable (#413) and any real
+// SDK code that does `stream.getWriter().write(chunk)`.
+//
+//	new WritableStream(underlyingSink) -> {
+//	  locked: boolean,
+//	  getWriter() -> {
+//	    write(chunk): Promise<void>,
+//	    close(): Promise<void>,
+//	    abort(reason?): Promise<void>,
+//	    releaseLock(): void,
+//	    ready: Promise<void>,
+//	    closed: Promise<void>,
+//	    desiredSize: number | null,
+//	  },
+//	  abort(reason?): Promise<void>,
+//	}
+//
+// underlyingSink may implement start(controller)/write(chunk, controller)/
+// close()/abort(reason). controller exposes error(reason).
+//
+// Simplifications vs. the full spec (matching ReadableStream's own scope
+// note): no real highWaterMark/queue-size backpressure accounting -
+// desiredSize is a plain 0-or-1 signal (0 while a write/close is in flight,
+// 1 once it settles) and `ready` simply mirrors the in-flight op's own
+// promise. Writes and the eventual close are still strictly ordered (see
+// writableStreamState.tail below) - that ordering is what TransformStream's
+// transform()/flush() correctness actually depends on, unlike the exact
+// backpressure numbers.
+type WritableStreamInitializer struct{}
+
+func (w *WritableStreamInitializer) Name() string  { return "WritableStream" }
+func (w *WritableStreamInitializer) Priority() int { return PriorityWritableStream }
+
+func (w *WritableStreamInitializer) InitTypes(ctx *TypeContext) error {
+	writerType := types.NewObjectType().
+		WithProperty("write", types.NewOptionalFunction([]types.Type{types.Any}, types.Any, []bool{true})).
+		WithProperty("close", types.NewSimpleFunction([]types.Type{}, types.Any)).
+		WithProperty("abort", types.NewOptionalFunction([]types.Type{types.Any}, types.Any, []bool{true})).
+		WithProperty("releaseLock", types.NewSimpleFunction([]types.Type{}, types.Undefined)).
+		WithProperty("ready", types.Any).
+		WithProperty("closed", types.Any).
+		WithProperty("desiredSize", types.Any)
+
+	streamType := types.NewObjectType().
+		WithProperty("locked", types.Boolean).
+		WithProperty("getWriter", types.NewSimpleFunction([]types.Type{}, writerType)).
+		WithProperty("abort", types.NewOptionalFunction([]types.Type{types.Any}, types.Any, []bool{true}))
+
+	streamCtorType := types.NewObjectType().
+		WithSimpleCallSignature([]types.Type{}, streamType).
+		WithSimpleCallSignature([]types.Type{types.Any}, streamType).
+		WithSimpleConstructSignature([]types.Type{}, streamType).
+		WithSimpleConstructSignature([]types.Type{types.Any}, streamType).
+		WithProperty("prototype", streamType)
+
+	return ctx.DefineGlobal("WritableStream", streamCtorType)
+}
+
+func (w *WritableStreamInitializer) InitRuntime(ctx *RuntimeContext) error {
+	vmInstance := ctx.VM
+
+	streamProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+	writerProto := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	// Stashed so TransformStream (transform_stream_init.go) can build a
+	// writable side sharing these prototypes without a JS underlyingSink,
+	// mirroring readableStreamProto/readableStreamReaderProto's convention.
+	writableStreamProto = streamProto
+	writableStreamWriterProto = writerProto
+
+	ctorFn := func(args []vm.Value) (vm.Value, error) {
+		state := newWritableStreamState(vmInstance)
+		if len(args) > 0 {
+			state.underlyingSink = args[0]
+		}
+		streamVal := createWritableStreamObject(vmInstance, state, streamProto)
+
+		if state.underlyingSink.Type() == vm.TypeObject || state.underlyingSink.Type() == vm.TypeDictObject {
+			if startFn, err := vmInstance.GetProperty(state.underlyingSink, "start"); err == nil && startFn.IsCallable() {
+				controllerVal := createWritableStreamControllerObject(vmInstance, state)
+				if _, callErr := vmInstance.Call(startFn, state.underlyingSink, []vm.Value{controllerVal}); callErr != nil {
+					return vm.Undefined, callErr
+				}
+			}
+		}
+
+		return streamVal, nil
+	}
+
+	ctor := vm.NewConstructorWithProps(1, false, "WritableStream", ctorFn)
+	if ctor.Type() == vm.TypeNativeFunctionWithProps {
+		ctor.AsNativeFunctionWithProps().Properties.DefineFixedProperty("prototype", vm.NewValueFromPlainObject(streamProto))
+	}
+	streamProto.SetOwnNonEnumerable("constructor", ctor)
+
+	return ctx.DefineGlobal("WritableStream", ctor)
+}
+
+// Package-level prototypes, set once during InitRuntime - see the identical
+// convention on readableStreamProto/readableStreamReaderProto.
+var (
+	writableStreamProto       *vm.PlainObject
+	writableStreamWriterProto *vm.PlainObject
+)
+
+// callAlgorithm invokes a JS hook function and wraps whatever it returns (a
+// plain value, undefined, or a thenable) into a Promise<value> - i.e. the
+// spec's implicit "Promise.resolve(fn())" around every sink/transformer
+// algorithm. vmInstance.ResolvePromise already does the thenable-chaining
+// work (and settles synchronously for a plain value), so this is a thin
+// wrapper. Shared with transform_stream_init.go (#413).
+func callAlgorithm(vmInstance *vm.VM, fn vm.Value, thisArg vm.Value, args []vm.Value) vm.Value {
+	if !fn.IsCallable() {
+		return vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	result, err := vmInstance.Call(fn, thisArg, args)
+	if err != nil {
+		return vmInstance.NewRejectedPromise(errorValueFromGoError(err))
+	}
+	p := vmInstance.NewPendingPromise()
+	vmInstance.ResolvePromise(p.AsPromise(), result)
+	return p
+}
+
+// writableStreamState is the internal, non-JS-visible state backing a
+// WritableStream. Unlike readableStreamState, nothing here is fed from a
+// background goroutine - every entry point (write/close/abort) is only ever
+// reached synchronously from a JS native-function call, so the mutex here is
+// purely defensive/for-consistency-with-the-rest-of-the-package, not load
+// bearing the way it is for ReadableStream's goroutine-fed case.
+type writableStreamState struct {
+	mu sync.Mutex
+
+	vmInstance *vm.VM
+	streamObj  *vm.PlainObject
+	writerObj  *vm.PlainObject // the current writer, kept in sync with ready/closed/desiredSize; nil once released
+
+	locked bool
+
+	closing    bool // close() called, not yet settled
+	closed     bool
+	errored    bool
+	errorValue vm.Value
+
+	underlyingSink vm.Value // Undefined if none was given
+
+	// tail is the promise the next scheduled operation (write or close)
+	// chains onto, so operations reach the sink/goWrite hook in the exact
+	// order write()/close() were called - see scheduleOp.
+	tail vm.Value
+
+	// closedVal is the writer's `closed` promise, lazily created by
+	// currentClosedVal() the first time anything needs it (a getWriter()
+	// call, or an early error/abort/close before any writer exists).
+	closedVal vm.Value
+
+	// goWrite/goClose/goAbort let a Go-authored sink (TransformStream's
+	// writable side) hook write()/close()/abort() without a JS
+	// underlyingSink object - mirrors readableStreamState's goPull/goCancel.
+	goWrite func(chunk vm.Value) vm.Value
+	goClose func() vm.Value
+	goAbort func(reason vm.Value) vm.Value
+}
+
+func newWritableStreamState(vmInstance *vm.VM) *writableStreamState {
+	return &writableStreamState{
+		vmInstance:     vmInstance,
+		underlyingSink: vm.Undefined,
+		tail:           vmInstance.NewResolvedPromise(vm.Undefined),
+	}
+}
+
+// syncWriterProps mirrors state's current ready/closed/desiredSize onto the
+// live writer object, the same "keep a plain own property in sync by hand"
+// convention ReadableStream uses for `locked` (see createReadableStreamObject).
+func (s *writableStreamState) syncWriterProps(ready, closed vm.Value, desiredSize vm.Value) {
+	if s.writerObj == nil {
+		return
+	}
+	s.writerObj.SetOwn("ready", ready)
+	s.writerObj.SetOwn("closed", closed)
+	s.writerObj.SetOwn("desiredSize", desiredSize)
+}
+
+// scheduleOp chains run onto the state's op tail so writes (and the eventual
+// close) reach the sink in call order, and returns a promise settling with
+// run's own outcome. Must be called with s.mu held; it releases the lock
+// itself once it has snapshotted/replaced s.tail.
+func (s *writableStreamState) scheduleOp(run func() vm.Value) vm.Value {
+	resultVal := s.vmInstance.NewPendingPromise()
+	resultPromise := resultVal.AsPromise()
+	prevTail := s.tail
+	s.tail = resultVal
+	s.mu.Unlock()
+
+	s.vmInstance.AddPromiseReaction(prevTail, true, func(vm.Value) {
+		opVal := run()
+		s.vmInstance.AddPromiseReaction(opVal, true, func(v vm.Value) {
+			s.vmInstance.ResolvePromise(resultPromise, v)
+		})
+		s.vmInstance.AddPromiseReaction(opVal, false, func(r vm.Value) {
+			s.errorOut(r)
+			s.vmInstance.RejectPromise(resultPromise, r)
+		})
+	})
+	s.vmInstance.AddPromiseReaction(prevTail, false, func(r vm.Value) {
+		// A prior op in the chain already failed (and already errored the
+		// stream via the reaction above) - this one never runs.
+		s.vmInstance.RejectPromise(resultPromise, r)
+	})
+
+	return resultVal
+}
+
+// performWrite calls the sink/goWrite hook for one chunk.
+func (s *writableStreamState) performWrite(chunk vm.Value) vm.Value {
+	if s.goWrite != nil {
+		return s.goWrite(chunk)
+	}
+	sink := s.underlyingSink
+	if sink.Type() != vm.TypeObject && sink.Type() != vm.TypeDictObject {
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	writeFn, err := s.vmInstance.GetProperty(sink, "write")
+	if err != nil || !writeFn.IsCallable() {
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	controllerVal := createWritableStreamControllerObject(s.vmInstance, s)
+	return callAlgorithm(s.vmInstance, writeFn, sink, []vm.Value{chunk, controllerVal})
+}
+
+// performClose calls the sink/goClose hook.
+func (s *writableStreamState) performClose() vm.Value {
+	if s.goClose != nil {
+		return s.goClose()
+	}
+	sink := s.underlyingSink
+	if sink.Type() != vm.TypeObject && sink.Type() != vm.TypeDictObject {
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	closeFn, err := s.vmInstance.GetProperty(sink, "close")
+	if err != nil || !closeFn.IsCallable() {
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	return callAlgorithm(s.vmInstance, closeFn, sink, nil)
+}
+
+// performAbort calls the sink/goAbort hook.
+func (s *writableStreamState) performAbort(reason vm.Value) vm.Value {
+	if s.goAbort != nil {
+		return s.goAbort(reason)
+	}
+	sink := s.underlyingSink
+	if sink.Type() != vm.TypeObject && sink.Type() != vm.TypeDictObject {
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	abortFn, err := s.vmInstance.GetProperty(sink, "abort")
+	if err != nil || !abortFn.IsCallable() {
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	return callAlgorithm(s.vmInstance, abortFn, sink, []vm.Value{reason})
+}
+
+// write implements writer.write(chunk).
+func (s *writableStreamState) write(chunk vm.Value) vm.Value {
+	s.mu.Lock()
+	if s.errored {
+		reason := s.errorValue
+		s.mu.Unlock()
+		return s.vmInstance.NewRejectedPromise(reason)
+	}
+	if s.closing || s.closed {
+		s.mu.Unlock()
+		reason := errorValueFromGoError(s.vmInstance.NewTypeError("Cannot write to a WritableStream that is closing or has already been closed"))
+		return s.vmInstance.NewRejectedPromise(reason)
+	}
+	resultVal := s.scheduleOp(func() vm.Value { return s.performWrite(chunk) })
+
+	s.mu.Lock()
+	s.syncWriterProps(resultVal, s.currentClosedVal(), vm.NumberValue(0))
+	s.mu.Unlock()
+
+	// Once this write settles, desiredSize goes back to "ready for more"
+	// (approximate backpressure - see the type doc comment's scope note).
+	s.vmInstance.AddPromiseReaction(resultVal, true, func(vm.Value) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if !s.errored && !s.closed {
+			s.syncWriterProps(s.vmInstance.NewResolvedPromise(vm.Undefined), s.currentClosedVal(), vm.NumberValue(1))
+		}
+	})
+
+	return resultVal
+}
+
+// currentClosedVal returns the writer's current `closed` value. Must be
+// called with s.mu held. Lazily created so a writer whose stream was never
+// closed/errored doesn't need one until asked.
+func (s *writableStreamState) currentClosedVal() vm.Value {
+	if s.closedVal.Type() == 0 {
+		s.closedVal = s.vmInstance.NewPendingPromise()
+	}
+	return s.closedVal
+}
+
+// close implements writer.close().
+func (s *writableStreamState) close() vm.Value {
+	s.mu.Lock()
+	if s.errored {
+		reason := s.errorValue
+		s.mu.Unlock()
+		return s.vmInstance.NewRejectedPromise(reason)
+	}
+	if s.closing || s.closed {
+		closedVal := s.currentClosedVal()
+		s.mu.Unlock()
+		return closedVal
+	}
+	s.closing = true
+	closedVal := s.currentClosedVal()
+	// scheduleOp expects s.mu held and releases it itself - kept locked
+	// across the two statements above rather than re-locking, same as write().
+	resultVal := s.scheduleOp(func() vm.Value { return s.performClose() })
+
+	s.vmInstance.AddPromiseReaction(resultVal, true, func(vm.Value) {
+		s.mu.Lock()
+		s.closing = false
+		s.closed = true
+		obj := s.streamObj
+		s.syncWriterProps(s.vmInstance.NewResolvedPromise(vm.Undefined), closedVal, vm.NumberValue(0))
+		s.mu.Unlock()
+		if obj != nil {
+			obj.SetOwn("locked", s.snapshotLocked())
+		}
+		s.vmInstance.ResolvePromise(closedVal.AsPromise(), vm.Undefined)
+	})
+	s.vmInstance.AddPromiseReaction(resultVal, false, func(r vm.Value) {
+		s.mu.Lock()
+		s.closing = false
+		s.mu.Unlock()
+		s.vmInstance.RejectPromise(closedVal.AsPromise(), r)
+	})
+
+	return closedVal
+}
+
+// snapshotLocked reports the `locked` value to publish on the stream object
+// after close settles - always false would be wrong if a writer released
+// itself mid-close, so this reads the live flag under lock.
+func (s *writableStreamState) snapshotLocked() vm.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.locked {
+		return vm.True
+	}
+	return vm.False
+}
+
+// abort implements writer.abort(reason)/stream.abort(reason): immediately
+// errors the stream (rejecting the closed promise and any writes still
+// chained onto tail) and forwards to the sink/goAbort hook.
+func (s *writableStreamState) abort(reason vm.Value) vm.Value {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	if s.errored {
+		s.mu.Unlock()
+		return s.vmInstance.NewResolvedPromise(vm.Undefined)
+	}
+	s.errored = true
+	s.errorValue = reason
+	closedVal := s.currentClosedVal()
+	s.mu.Unlock()
+
+	s.vmInstance.RejectPromise(closedVal.AsPromise(), reason)
+
+	return s.performAbort(reason)
+}
+
+// errorOut marks the stream errored (e.g. from
+// WritableStreamDefaultController.error()) without invoking the sink's
+// abort() hook - matching the spec distinction between controller.error()
+// (an internal signal) and an explicit abort() call.
+func (s *writableStreamState) errorOut(reason vm.Value) {
+	s.mu.Lock()
+	if s.closed || s.errored {
+		s.mu.Unlock()
+		return
+	}
+	s.errored = true
+	s.errorValue = reason
+	closedVal := s.currentClosedVal()
+	s.mu.Unlock()
+
+	s.vmInstance.RejectPromise(closedVal.AsPromise(), reason)
+}
+
+// release implements writer.releaseLock().
+func (s *writableStreamState) release() {
+	s.mu.Lock()
+	s.locked = false
+	s.writerObj = nil
+	obj := s.streamObj
+	s.mu.Unlock()
+	if obj != nil {
+		obj.SetOwn("locked", vm.False)
+	}
+}
+
+func createWritableStreamObject(vmInstance *vm.VM, state *writableStreamState, streamProto *vm.PlainObject) vm.Value {
+	obj := vm.NewObject(vm.NewValueFromPlainObject(streamProto)).AsPlainObject()
+	state.streamObj = obj
+	obj.SetOwn("locked", vm.False)
+
+	obj.SetOwnNonEnumerable("getWriter", vm.NewNativeFunction(0, false, "getWriter", func(args []vm.Value) (vm.Value, error) {
+		state.mu.Lock()
+		if state.locked {
+			state.mu.Unlock()
+			return vm.Undefined, vmInstance.NewTypeError("WritableStream is already locked to a writer")
+		}
+		state.locked = true
+		state.mu.Unlock()
+		obj.SetOwn("locked", vm.True)
+		return createWritableStreamWriterObject(state, writableStreamWriterProto), nil
+	}))
+
+	obj.SetOwnNonEnumerable("abort", vm.NewNativeFunction(1, false, "abort", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		return state.abort(reason), nil
+	}))
+
+	return vm.NewValueFromPlainObject(obj)
+}
+
+func createWritableStreamWriterObject(state *writableStreamState, writerProto *vm.PlainObject) vm.Value {
+	obj := vm.NewObject(vm.NewValueFromPlainObject(writerProto)).AsPlainObject()
+
+	state.mu.Lock()
+	state.writerObj = obj
+	closedVal := state.currentClosedVal()
+	readyVal := state.tail
+	desiredSize := vm.NumberValue(1)
+	if state.closed {
+		desiredSize = vm.NumberValue(0)
+	} else if state.errored {
+		desiredSize = vm.Null
+	}
+	state.mu.Unlock()
+
+	obj.SetOwn("ready", readyVal)
+	obj.SetOwn("closed", closedVal)
+	obj.SetOwn("desiredSize", desiredSize)
+
+	obj.SetOwnNonEnumerable("write", vm.NewNativeFunction(1, false, "write", func(args []vm.Value) (vm.Value, error) {
+		var chunk vm.Value = vm.Undefined
+		if len(args) > 0 {
+			chunk = args[0]
+		}
+		return state.write(chunk), nil
+	}))
+
+	obj.SetOwnNonEnumerable("close", vm.NewNativeFunction(0, false, "close", func(args []vm.Value) (vm.Value, error) {
+		return state.close(), nil
+	}))
+
+	obj.SetOwnNonEnumerable("abort", vm.NewNativeFunction(1, false, "abort", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		return state.abort(reason), nil
+	}))
+
+	obj.SetOwnNonEnumerable("releaseLock", vm.NewNativeFunction(0, false, "releaseLock", func(args []vm.Value) (vm.Value, error) {
+		state.release()
+		return vm.Undefined, nil
+	}))
+
+	return vm.NewValueFromPlainObject(obj)
+}
+
+// createWritableStreamControllerObject builds the controller object handed
+// to a JS-authored underlying sink's start(controller)/write(chunk,
+// controller) hooks.
+func createWritableStreamControllerObject(vmInstance *vm.VM, state *writableStreamState) vm.Value {
+	obj := vm.NewObject(vmInstance.ObjectPrototype).AsPlainObject()
+
+	obj.SetOwnNonEnumerable("error", vm.NewNativeFunction(1, false, "error", func(args []vm.Value) (vm.Value, error) {
+		var reason vm.Value = vm.Undefined
+		if len(args) > 0 {
+			reason = args[0]
+		}
+		state.errorOut(reason)
+		return vm.Undefined, nil
+	}))
+
+	return vm.NewValueFromPlainObject(obj)
+}

--- a/pkg/vm/vm_init.go
+++ b/pkg/vm/vm_init.go
@@ -2433,16 +2433,37 @@ func (vm *VM) putSentinelReg(r []Value) {
 // frame's bytecode) would find crossedNative already true and blow
 // straight through its own boundary too.
 //
-// This does NOT reclaim vm.nextRegSlot for the dropped frame(s)' register
-// windows. That's a real leaked-registers gap (unwindException's own
-// frame-popping loop has the same gap: it decrements vm.frameCount without
-// touching vm.nextRegSlot for every frame it walks past), but register
-// space is only reclaimed in bulk relative to the frame the dispatch loop
-// eventually resumes at, not frame-by-frame during unwinding - subtracting
-// an additional, independently-computed delta here corrupted that
-// accounting and broke a previously-working reproducer (nextRegSlot went
-// negative). Left as a documented pre-existing gap rather than a local fix
-// that isn't provably correct; see issue #61.
+// This function itself does NOT reclaim vm.regDir's cursor for the dropped
+// frame(s)' register windows - only frameCount and upvalues. unwindException's
+// own frame-popping loop has the same gap: it decrements vm.frameCount
+// without touching vm.regDir for every frame it walks past, because register
+// space during a multi-boundary unwind is only reclaimed in bulk relative to
+// the frame the dispatch loop eventually resumes at, not frame-by-frame
+// while walking past intermediate native boundaries - see issue #61, which
+// remains open for that general case.
+//
+// executeUserFunctionSafe/executeUserFunctionWithNewTarget are a narrower,
+// fully-solvable case, however: by the time either calls this, it already
+// knows exactly which single register-directory mark to restore to - the
+// cursor as it was before it pushed its own sentinel frame (their own
+// `entryRegMark`, captured with vm.regDir.mark() before that push, since a
+// sentinel frame never itself goes through regDir.push). Both callers do
+// vm.regDir.popTo(entryRegMark) themselves, right after every call to this
+// that follows an actual exception (vm.run() returning InterpretRuntimeError,
+// or an inline exception raised before any frame switch) - the only paths
+// that can genuinely have registers left to reclaim. Their plain
+// call-completed-without-switching-frames and prepareCall-returned-an-error
+// exits deliberately do NOT call popTo even though the cursor is expected to
+// already equal entryRegMark there too (see the comments at those call
+// sites): asserting that via popTo on a path with nothing to reclaim would
+// silently paper over the invariant no longer holding, converting a loud
+// checkRegWindowRelease panic into silent corruption instead - worse than
+// leaving it caught. Left as this function's own caller's responsibility
+// rather than folded in here because the *other*
+// class of caller (a bare unwindException walk with no single call frame to
+// scope a mark to) has no equivalent fixed point to restore to - see #414
+// for the fix and the leak it closes, and the comment above for why #61
+// itself is a different, still-open case.
 func (vm *VM) truncateFramesTo(entryCount int) {
 	// unwindException leaves the native-boundary frame it stopped at on the
 	// stack without popping it; dropping it here retires it for good, so its
@@ -2469,6 +2490,15 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 	// at without popping, once we've taken ownership of the exception as a
 	// Go error.
 	frameCountAtEntry := vm.frameCount
+	// truncateFramesTo (see its own doc comment, #414) drops frames but
+	// deliberately doesn't touch the register directory's cursor - that's
+	// this call's own register space to reclaim, the same way Interpret's
+	// nested-call error path already does for itself (vm.go, "entryMark").
+	// Captured before the sentinel frame push below: sentinel frames reuse a
+	// pooled 1-element slice rather than going through regDir.push, so the
+	// cursor here is exactly where it will still be once every frame this
+	// call pushed - sentinel included - is gone.
+	entryRegMark := vm.regDir.mark()
 
 	// Set up the caller context (pooled 1-element result holder, not a per-call alloc)
 	callerRegisters := vm.getSentinelReg()
@@ -2499,11 +2529,28 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 
 	shouldSwitch, err := vm.prepareCall(fn, effectiveThis, args, destReg, callerRegisters, callerIP)
 	if err != nil {
+		// No vm.regDir.popTo(entryRegMark) needed here (unlike the exception
+		// paths below): prepareCall only ever returns a non-nil err before it
+		// has pushed a register window for the callee (a frame-limit check,
+		// or regDir.push itself failing - which per its own doc comment
+		// never mutates the cursor on failure), so the cursor is already
+		// exactly entryRegMark. Deliberately not added defensively either -
+		// popTo's trim() isn't free, and silently popping here if that
+		// invariant ever changed would convert a loud, catchable
+		// checkRegWindowRelease panic into silent register-space corruption
+		// instead (#414).
 		vm.frameCount--
 		return Undefined, err
 	}
 
 	if !shouldSwitch {
+		// Same reasoning as the err != nil case just above: a native
+		// function ran synchronously and returned normally without pushing
+		// anything here itself. If it made its own nested vm.Call that threw
+		// and got absorbed, that nested call's own error path (this
+		// function or executeUserFunctionSafe) already restored its own
+		// window before returning to us - so the cursor is already back to
+		// entryRegMark by the time we get here regardless.
 		vm.frameCount--
 		return callerRegisters[destReg], nil
 	}
@@ -2537,6 +2584,7 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 			vm.currentException = Null
 			vm.unwinding = false
 			vm.truncateFramesTo(frameCountAtEntry)
+			vm.regDir.popTo(entryRegMark)
 			return Undefined, exceptionError{exception: ex}
 		}
 		return Undefined, fmt.Errorf("runtime error during constructor execution")
@@ -2547,6 +2595,7 @@ func (vm *VM) executeUserFunctionWithNewTarget(fn Value, thisValue Value, args [
 		vm.currentException = Null
 		vm.unwinding = false
 		vm.truncateFramesTo(frameCountAtEntry)
+		vm.regDir.popTo(entryRegMark)
 		return Undefined, exceptionError{exception: ex}
 	}
 
@@ -2620,6 +2669,21 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 	// caller (e.g. DisposableStack running several dispose() callbacks in
 	// sequence, each via its own executeUserFunctionSafe call).
 	frameCountAtEntry := vm.frameCount
+	// truncateFramesTo (see its own doc comment, #414) drops frames but
+	// deliberately doesn't touch the register directory's cursor - that's
+	// this call's own register space to reclaim, the same way Interpret's
+	// nested-call error path already does for itself (vm.go, "entryMark").
+	// Captured before the sentinel frame push below: sentinel frames reuse a
+	// pooled 1-element slice rather than going through regDir.push, so the
+	// cursor here is exactly where it will still be once every frame this
+	// call pushed - sentinel included - is gone. Without this, a promise
+	// reaction whose handler throws (triggerPromiseReactions in promise.go
+	// absorbs the resulting Go error from exactly this call) leaked the
+	// callee's whole register window into whatever frame is resumed next -
+	// harmless in isolation, but flagged by checkRegWindowRelease under
+	// StrictRegWindowChecks the next time that frame (often the top-level
+	// script itself, via top-level await) finally pops (#414).
+	entryRegMark := vm.regDir.mark()
 
 	// Remember whether we were already unwinding *with* a live exception at
 	// entry (the cleanup just above only scrubs the currentException==Null
@@ -2670,7 +2734,16 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 	// Use prepareCall to set up the function call
 	shouldSwitch, err := vm.prepareCall(fn, thisValue, args, destReg, callerRegisters, callerIP)
 	if err != nil {
-		// Remove sentinel frame on error
+		// No vm.regDir.popTo(entryRegMark) needed here (unlike the exception
+		// paths below): prepareCall only ever returns a non-nil err before it
+		// has pushed a register window for the callee (a frame-limit check,
+		// or regDir.push itself failing - which per its own doc comment
+		// never mutates the cursor on failure), so the cursor is already
+		// exactly entryRegMark. Deliberately not added defensively either -
+		// popTo's trim() isn't free, and silently popping here if that
+		// invariant ever changed would convert a loud, catchable
+		// checkRegWindowRelease panic into silent register-space corruption
+		// instead (#414).
 		vm.frameCount--
 		return Undefined, err
 	}
@@ -2705,10 +2778,16 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 			vm.currentException = Null
 			vm.unwinding = false
 			vm.truncateFramesTo(frameCountAtEntry)
+			vm.regDir.popTo(entryRegMark)
 			return Undefined, exceptionError{exception: ex}
 		}
-		// Native function was executed directly
-		// Remove sentinel frame
+		// Native function was executed directly. Remove sentinel frame - no
+		// popTo needed: it may have made its own nested vm.Call that threw
+		// and got absorbed, but that nested call's own error path (this
+		// function or executeUserFunctionWithNewTarget) already restored its
+		// own window before returning to us, so the cursor is already back
+		// to entryRegMark regardless. Same reasoning as the err != nil case
+		// above (#414).
 		vm.frameCount--
 		return callerRegisters[destReg], nil
 	}
@@ -2762,6 +2841,7 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 			// frameCountAtEntry) so they can't be mistaken for a live boundary
 			// by a later, unrelated throw.
 			vm.truncateFramesTo(frameCountAtEntry)
+			vm.regDir.popTo(entryRegMark)
 			return Undefined, exceptionError{exception: ex}
 		}
 		if msg := vm.lastRecordedErrorMessage(); msg != "" {
@@ -2776,6 +2856,7 @@ func (vm *VM) executeUserFunctionSafe(fn Value, thisValue Value, args []Value) (
 		vm.currentException = Null
 		vm.unwinding = false // see the matching comment above (#142)
 		vm.truncateFramesTo(frameCountAtEntry)
+		vm.regDir.popTo(entryRegMark)
 		return Undefined, exceptionError{exception: ex}
 	}
 

--- a/tests/scripts/promise_reaction_throw_regwindow_leak.ts
+++ b/tests/scripts/promise_reaction_throw_regwindow_leak.ts
@@ -1,0 +1,35 @@
+// expect: true
+// #414: a promise reaction whose JS handler throws is invoked via
+// triggerPromiseReactions's vm.Call(reaction.Handler, ...) (pkg/vm/
+// promise.go); when the callee throws, that vm.Call returns the exception
+// as a Go error (via executeUserFunctionSafe), which the reaction absorbs
+// into a rejection instead of re-throwing. executeUserFunctionSafe's (and
+// executeUserFunctionWithNewTarget's) error paths dropped the frame(s)
+// unwinding stopped at via truncateFramesTo, but - like Interpret's own
+// nested-call error path already knew to guard against - truncateFramesTo
+// deliberately doesn't reclaim the register directory's cursor for those
+// frames (see its own doc comment, #61). Left unreclaimed, that call's
+// whole register window stayed allocated above whatever frame resumes
+// next - typically the top-level script frame itself, resuming from an
+// unrelated `await` - which is exactly the shape this test pins: it
+// doesn't need to observe the leaked promise at all, only that a LATER,
+// unrelated await still works and the top-level frame's own register
+// window is left in the state it started in.
+//
+// Under plain execution this always ran fine and produced the correct
+// value; only this suite's strict register-window checks
+// (vm.StrictRegWindowChecks, tests/scripts_test.go's TestMain) turn the
+// leak into a hard panic at the top-level frame's eventual pop
+// (popTopLevelScriptFrame -> checkRegWindowRelease), which is exactly why
+// this needs a smoke test rather than being "harmless in production".
+const p = Promise.resolve(undefined).then(() => {
+  throw new Error("leak");
+});
+// Deliberately never awaited/caught - the leak happens the moment this
+// reaction runs and throws, regardless of whether anything ever consumes
+// the resulting rejection.
+void p;
+
+const marker = await Promise.resolve(42);
+
+marker === 42;

--- a/tests/scripts/readable_stream_pipe.ts
+++ b/tests/scripts/readable_stream_pipe.ts
@@ -1,0 +1,106 @@
+// expect: true
+// #413: ReadableStream.prototype.pipeTo/pipeThrough - needed once
+// TransformStream exists, since real SDK code chains
+// `source.pipeThrough(transform)` (see transform_stream_basic.ts).
+const results: unknown[] = [];
+
+async function main(): Promise<boolean> {
+  // pipeTo(): drains this stream into a WritableStream, closing it at the end.
+  const source = new ReadableStream({
+    start(c: any) {
+      c.enqueue(1);
+      c.enqueue(2);
+      c.enqueue(3);
+      c.close();
+    },
+  });
+  const collected: unknown[] = [];
+  let destClosed = false;
+  const dest = new WritableStream({
+    write(chunk: any) {
+      collected.push(chunk);
+    },
+    close() {
+      destClosed = true;
+    },
+  });
+  await source.pipeTo(dest);
+  results.push(collected.length === 3 && collected[0] === 1 && collected[1] === 2 && collected[2] === 3);
+  results.push(destClosed === true);
+
+  // pipeTo() propagates a write failure back by cancelling the source.
+  // (#414: this exact shape - a rejection whose value came from a vm.Call
+  // throwing inside a native reaction, then awaited/caught at the top level
+  // - used to panic under this suite's strict register-window checks with a
+  // spurious "register window imbalance ... popTopLevelScriptFrame". Fixed
+  // by reclaiming the register directory's cursor in
+  // executeUserFunctionSafe/executeUserFunctionWithNewTarget's error paths,
+  // the same way Interpret's own nested-call error path already did.)
+  let cancelled = false;
+  const source2 = new ReadableStream({
+    start(c: any) {
+      c.enqueue("a");
+      c.enqueue("b");
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  const failingDest = new WritableStream({
+    write(chunk: any) {
+      if (chunk === "b") throw new Error("write failed");
+    },
+  });
+  let pipeRejected = false;
+  try {
+    await source2.pipeTo(failingDest);
+  } catch (e) {
+    pipeRejected = (e as any).message === "write failed";
+  }
+  results.push(pipeRejected);
+  results.push(cancelled === true);
+
+  // pipeThrough({readable, writable}): pipes into `writable`, returns
+  // `readable` - works for any duck-typed pair, not just a real
+  // TransformStream (that combination is covered by transform_stream_basic.ts).
+  const upperSource = new ReadableStream({
+    start(c: any) {
+      c.enqueue("x");
+      c.enqueue("y");
+      c.close();
+    },
+  });
+  const manual: unknown[] = [];
+  let resolvePipeDone: (v: unknown) => void = () => {};
+  const pipeDone = new Promise<unknown>((resolve) => {
+    resolvePipeDone = resolve;
+  });
+  const manualWritable = new WritableStream({
+    write(chunk: any) {
+      manual.push(String(chunk).toUpperCase());
+    },
+    close() {
+      resolvePipeDone(undefined);
+    },
+  });
+  const manualReadable = new ReadableStream({
+    start(c: any) {
+      c.enqueue("already-here");
+      c.close();
+    },
+  });
+  const returned = upperSource.pipeThrough({ readable: manualReadable, writable: manualWritable }) as any;
+  results.push(returned === manualReadable);
+  const out: unknown[] = [];
+  for await (const chunk of returned) out.push(chunk);
+  results.push(out.length === 1 && out[0] === "already-here");
+  // Wait for the background pipe (upperSource -> manualWritable) to finish -
+  // pipeThrough() doesn't expose that pipe's own completion promise (matching
+  // spec), so this test observes it indirectly via manualWritable.close().
+  await pipeDone;
+  results.push(manual.length === 2 && manual[0] === "X" && manual[1] === "Y");
+
+  return results.every((v) => v === true);
+}
+
+await main();

--- a/tests/scripts/reflect_construct_throw_regwindow_leak.ts
+++ b/tests/scripts/reflect_construct_throw_regwindow_leak.ts
@@ -1,0 +1,29 @@
+// expect: true
+// #414: the constructor-call sibling of promise_reaction_throw_regwindow_leak.ts.
+// Reflect.construct(ctor, args) is the one built-in path that reaches
+// executeUserFunctionWithNewTarget (vm.ConstructWithNewTarget, per
+// pkg/builtins/reflect_init.go) from native Go code, exactly the way a
+// promise reaction's handler reaches executeUserFunctionSafe via vm.Call.
+// When ctor's body throws, that call's error path used to drop the frame(s)
+// via truncateFramesTo without reclaiming the register directory's cursor
+// (see truncateFramesTo's own doc comment) - the same leak as the plain
+// vm.Call case, just through executeUserFunctionWithNewTarget instead of
+// executeUserFunctionSafe. Verified by temporarily reverting the
+// vm.regDir.popTo(entryRegMark) calls added to executeUserFunctionWithNewTarget
+// (pkg/vm/vm_init.go) and confirming this test fails the same way.
+class Thrower {
+  constructor() {
+    throw new Error("ctor leak");
+  }
+}
+
+const p = Promise.resolve(undefined).then(() => {
+  Reflect.construct(Thrower, []);
+});
+// Deliberately never awaited/caught - see the sibling test's comment for why
+// that doesn't matter: the leak happens the moment this reaction runs.
+void p;
+
+const marker = await Promise.resolve(42);
+
+marker === 42;

--- a/tests/scripts/transform_stream_basic.ts
+++ b/tests/scripts/transform_stream_basic.ts
@@ -1,0 +1,173 @@
+// expect: true
+// #413: TransformStream joins a ReadableStream and a WritableStream through
+// a Transformer's transform()/flush() - the shape real, unmodified SDK code
+// (e.g. AWS SDK's @smithy/core checksum stream, its middleware-websocket
+// package's `class X extends TransformStream`) actually reaches for.
+const results: unknown[] = [];
+
+async function main(): Promise<boolean> {
+  // Basic transform(): uppercases each chunk written.
+  const upper = new TransformStream({
+    transform(chunk: any, controller: any) {
+      controller.enqueue(String(chunk).toUpperCase());
+    },
+  });
+  const uWriter = upper.writable.getWriter();
+  uWriter.write("hello");
+  uWriter.write("world");
+  uWriter.close();
+  const collected: unknown[] = [];
+  for await (const chunk of upper.readable as any) {
+    collected.push(chunk);
+  }
+  results.push(collected.length === 2 && collected[0] === "HELLO" && collected[1] === "WORLD");
+
+  // controller.desiredSize is a live accessor (highWaterMark(1) minus the
+  // readable side's current queue length), not a fixed placeholder: it
+  // drops once a chunk is enqueued-but-not-yet-read, and recovers once it's
+  // read.
+  let sizeDuringTransform: unknown = null;
+  const sized = new TransformStream({
+    transform(chunk: any, controller: any) {
+      controller.enqueue(chunk);
+      sizeDuringTransform = controller.desiredSize;
+    },
+  });
+  const sizedWriter = sized.writable.getWriter();
+  const sizedReader = sized.readable.getReader();
+  await sizedWriter.write("a");
+  results.push(sizeDuringTransform === 0);
+  await sizedReader.read();
+  results.push(sizeDuringTransform === 0); // snapshotted during transform(), doesn't retroactively change
+
+  // No transform() given: default algorithm passes chunks through unchanged.
+  const passthrough = new TransformStream();
+  const pWriter = passthrough.writable.getWriter();
+  pWriter.write(1);
+  pWriter.write(2);
+  pWriter.close();
+  const passed: unknown[] = [];
+  for await (const chunk of passthrough.readable as any) {
+    passed.push(chunk);
+  }
+  results.push(passed.length === 2 && passed[0] === 1 && passed[1] === 2);
+
+  // flush(): runs once, after the last write, before the readable side closes.
+  const withFlush = new TransformStream({
+    transform(chunk: any, controller: any) {
+      controller.enqueue(chunk);
+    },
+    flush(controller: any) {
+      controller.enqueue("FLUSHED");
+    },
+  });
+  const fWriter = withFlush.writable.getWriter();
+  fWriter.write("a");
+  await fWriter.close();
+  const flushed: unknown[] = [];
+  const fReader = withFlush.readable.getReader();
+  let fr = await fReader.read();
+  while (!fr.done) {
+    flushed.push(fr.value);
+    fr = await fReader.read();
+  }
+  results.push(flushed.length === 2 && flushed[0] === "a" && flushed[1] === "FLUSHED");
+
+  // extends TransformStream + super(transformer) - the issue's own repro
+  // shape (subclassing a native constructor with an explicit super() call).
+  class Upper extends TransformStream {
+    constructor() {
+      super({
+        transform(chunk: any, controller: any) {
+          controller.enqueue(String(chunk).toUpperCase());
+        },
+      });
+    }
+  }
+  const t = new Upper();
+  const writer = (t as any).writable.getWriter();
+  writer.write("hello");
+  writer.close();
+  const reader = (t as any).readable.getReader();
+  const result = await reader.read();
+  results.push(result.value === "HELLO");
+
+  // ReadableStream.pipeThrough(transformStream): pipes through and returns
+  // the transform's readable side.
+  const source = new ReadableStream({
+    start(c: any) {
+      c.enqueue("x");
+      c.enqueue("y");
+      c.close();
+    },
+  });
+  const piped = new TransformStream({
+    transform(chunk: any, controller: any) {
+      controller.enqueue(String(chunk).toUpperCase());
+    },
+  });
+  const pipedReadable = source.pipeThrough(piped) as any;
+  const pipedOut: unknown[] = [];
+  for await (const chunk of pipedReadable) {
+    pipedOut.push(chunk);
+  }
+  results.push(pipedOut.length === 2 && pipedOut[0] === "X" && pipedOut[1] === "Y");
+
+  // Breaking out of a for-await-of early calls the async iterator's
+  // return(), which cancels the readable side - and per spec, cancelling a
+  // TransformStream's readable side errors its writable side too (the
+  // background pipe driving pipeThrough's own write loop then fails and
+  // cancels the upstream source in turn). That cascade is intentional; this
+  // just pins down that an early break neither hangs nor crashes.
+  const breakSource = new ReadableStream({
+    start(c: any) {
+      c.enqueue("x");
+      c.enqueue("y");
+      c.enqueue("z");
+      c.close();
+    },
+  });
+  const breakTransform = new TransformStream({
+    transform(chunk: any, controller: any) {
+      controller.enqueue(String(chunk).toUpperCase());
+    },
+  });
+  const breakReadable = breakSource.pipeThrough(breakTransform) as any;
+  const breakOut: unknown[] = [];
+  for await (const chunk of breakReadable) {
+    breakOut.push(chunk);
+    if (chunk === "X") break;
+  }
+  results.push(breakOut.length === 1 && breakOut[0] === "X");
+
+  // controller.error() errors both the readable and writable sides.
+  const erroring = new TransformStream({
+    transform(chunk: any, controller: any) {
+      if (chunk === "boom") controller.error(new Error("boom"));
+      else controller.enqueue(chunk);
+    },
+  });
+  const eWriter = erroring.writable.getWriter();
+  const eReader = erroring.readable.getReader();
+  eWriter.write("ok");
+  await eReader.read();
+  eWriter.write("boom");
+  let readErrored = false;
+  try {
+    await eReader.read();
+  } catch (e) {
+    readErrored = (e as any).message === "boom";
+  }
+  results.push(readErrored);
+  let writeErrored = false;
+  try {
+    await eWriter.write("more");
+  } catch (e) {
+    writeErrored = (e as any).message === "boom";
+  }
+  results.push(writeErrored);
+
+  return results.every((v) => v === true);
+}
+
+await main();

--- a/tests/scripts/writable_stream_basic.ts
+++ b/tests/scripts/writable_stream_basic.ts
@@ -1,0 +1,111 @@
+// expect: true
+// #413: a minimal WritableStream/WritableStreamDefaultWriter, sized to what
+// TransformStream.writable (and real streaming SDK sink consumers) need:
+// getWriter() -> { write(), close(), abort(), releaseLock(), ready, closed,
+// desiredSize }.
+const results: unknown[] = [];
+
+async function main(): Promise<boolean> {
+  // Basic write()/close(), with a start() and controller.error() left unused.
+  const written: unknown[] = [];
+  let closedCalled = false;
+  const sink = new WritableStream({
+    write(chunk: any) {
+      written.push(chunk);
+    },
+    close() {
+      closedCalled = true;
+    },
+  });
+  const writer = sink.getWriter();
+  await writer.write("a");
+  await writer.write("b");
+  await writer.close();
+  results.push(written.length === 2 && written[0] === "a" && written[1] === "b");
+  results.push(closedCalled === true);
+
+  // locked / getWriter() single-lock enforcement.
+  const lockable = new WritableStream({ write() {} });
+  results.push(lockable.locked === false);
+  const w1 = lockable.getWriter();
+  results.push(lockable.locked === true);
+  let threw = false;
+  try {
+    lockable.getWriter();
+  } catch {
+    threw = true;
+  }
+  results.push(threw);
+  w1.releaseLock();
+  results.push(lockable.locked === false);
+
+  // Writes are processed in order even without awaiting each one.
+  const order: unknown[] = [];
+  const ordered = new WritableStream({
+    write(chunk: any) {
+      order.push(chunk);
+    },
+  });
+  const oWriter = ordered.getWriter();
+  const p1 = oWriter.write(1);
+  const p2 = oWriter.write(2);
+  const p3 = oWriter.write(3);
+  await Promise.all([p1, p2, p3]);
+  results.push(order.length === 3 && order[0] === 1 && order[1] === 2 && order[2] === 3);
+
+  // write() after close() rejects.
+  const closed = new WritableStream({ write() {} });
+  const cWriter = closed.getWriter();
+  await cWriter.close();
+  let rejectedAfterClose = false;
+  try {
+    await cWriter.write("late");
+  } catch {
+    rejectedAfterClose = true;
+  }
+  results.push(rejectedAfterClose);
+
+  // abort() forwards the reason to the sink and rejects writer.closed.
+  let abortReason = "";
+  const abortable = new WritableStream({
+    write() {},
+    abort(reason: any) {
+      abortReason = reason;
+    },
+  });
+  const aWriter = abortable.getWriter();
+  await aWriter.abort("bye");
+  results.push(abortReason === "bye");
+  let closedRejected = false;
+  try {
+    await aWriter.closed;
+  } catch (e) {
+    closedRejected = (e as any) === "bye";
+  }
+  results.push(closedRejected);
+
+  // controller.error() rejects subsequent writes without invoking abort().
+  let abortCalledOnError = false;
+  const erroring = new WritableStream({
+    write(chunk: any, controller: any) {
+      if (chunk === "boom") controller.error(new Error("boom"));
+    },
+    abort() {
+      abortCalledOnError = true;
+    },
+  });
+  const eWriter = erroring.getWriter();
+  await eWriter.write("boom");
+  let rejectedAfterError = false;
+  try {
+    await eWriter.write("more");
+  } catch (e) {
+    rejectedAfterError = (e as any).message === "boom";
+  }
+  results.push(rejectedAfterError);
+  results.push(abortCalledOnError === false);
+
+  return results.every((v) => v === true);
+}
+
+await main();


### PR DESCRIPTION
## Summary

Two logically separate but related changes, kept as separate commits:

1. **`fix(vm)`** - a register-directory leak in `executeUserFunctionSafe`/`executeUserFunctionWithNewTarget`'s exception-absorption paths (fixes #414).
2. **`feat(builtins)`** - `WritableStream` and `TransformStream`, which don't exist at all today (fixes #413). Restoring `readable_stream_pipe.ts`'s write-failure-propagation assertion is what actually surfaced #414 during #413's own testing, which is why the VM fix comes first.

### `fix(vm)`: register-window leak on exception absorption (#414)

`truncateFramesTo` drops the frame(s) an absorbed exception's unwind stopped at, but never reclaimed the register directory's cursor for their register windows - a gap its own doc comment already flagged. `executeUserFunctionSafe`/`executeUserFunctionWithNewTarget` (the paths `vm.Call`/`vm.Construct` go through - so `.then()`/`.catch()` handler dispatch, and anything like `ReadableStream.pipeTo()` that calls into JS from a native reaction) hit this on every exception their callee raised: the callee's whole register window stayed allocated above whatever frame resumed next, most visibly the top-level script frame at its next unrelated `await`.

Both functions now capture `entryRegMark := vm.regDir.mark()` before pushing their sentinel frame and call `vm.regDir.popTo(entryRegMark)` after every `truncateFramesTo` that follows a genuine exception - mirroring the identical idiom `Interpret`'s own nested-call error path already used for itself. Deliberately *not* added to the plain no-exception exit paths (see the comments there for why - it would convert a loud, catchable panic into silent corruption if that invariant ever broke).

Verified by temporarily reverting the fix and confirming both new regression tests fail with the exact panic from #414. `test262` `language/`+`built-ins/` diffs against baseline: net +0.

### `feat(builtins)`: WritableStream + TransformStream (#413)

`TransformStream`/`WritableStream` didn't exist at all - not even as unusable stubs - unlike `ReadableStream` (#205). Blocked real, unmodified AWS SDK for JS packages: `@aws-sdk/middleware-websocket`'s own code does `class X extends TransformStream { ... }` at module top level, and `@smithy/core`'s serde code constructs a real `new TransformStream({ transform, flush })`.

- `WritableStream`/`WritableStreamDefaultWriter`: `getWriter()`, ordered `write()`/`close()`/`abort()`, `releaseLock()`, `ready`/`closed`/`desiredSize`, controller `error()`.
- `TransformStream`: composes a `ReadableStream`+`WritableStream` pair via a `Transformer`'s `start()`/`transform()`/`flush()`, with a live `desiredSize` accessor and controller `terminate()`/`error()`.
- `ReadableStream` gains `pipeTo()`/`pipeThrough()` and construct signatures so `class X extends ReadableStream/WritableStream/TransformStream { constructor() { super(...) } }` type-checks.

The issue's own repro (a class extending `TransformStream` with an explicit `super()` call) now works end-to-end, both with and without type checking.

## Test plan

- `go test ./tests -run TestScripts` green at every commit (verified commit 1 in an isolated worktree too).
- `test262` `language/` and `built-ins/` diffs against `baseline.txt`: net +0 for the VM fix commit.
- Manually ran the issue's exact repro (`class Upper extends TransformStream { ... }`) under both `--no-typecheck` and normal type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
