### PR TITLE
fix(compiler): class expression's extends target resolves outer spilled bindings via closure (#416)

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -5507,13 +5507,24 @@ func (c *Compiler) compileClassExpression(node *parser.ClassDeclaration, hint Re
 							superConstructorReg = c.regAlloc.Alloc()
 							needToFreeSuperReg = true
 							c.emitGetGlobal(superConstructorReg, symbol.GlobalIndex, node.Token.Line)
-						} else if symbol.IsSpilled {
-							superConstructorReg = c.regAlloc.Alloc()
-							needToFreeSuperReg = true
-							c.emitLoadSpill(superConstructorReg, symbol.SpillIndex, node.Token.Line)
 						} else if !c.isInCurrentScopeChain(defTable) && c.enclosing != nil {
 							// Symbol from enclosing function's scope - compile as expression
-							// for proper upvalue access through the closure mechanism
+							// for proper upvalue access through the closure mechanism.
+							// This must be checked BEFORE the IsSpilled branch below: a
+							// spilled symbol can belong to an ENCLOSING function's own
+							// spill-slot array, not this function's. Spill slots are
+							// per-chunk (see AllocSpillSlot/NumSpillSlots), so emitting a
+							// direct OpLoadSpill here - as the old code did whenever
+							// symbol.IsSpilled was true, regardless of which function
+							// defined it - reads slot N out of *this* function's own
+							// (possibly smaller, or zero) spill array instead of capturing
+							// it as an upvalue through the closure mechanism the normal
+							// identifier-reference path already uses (see the analogous
+							// ordering in compileNode's Identifier case). That produced a
+							// VM panic ("OpLoadSpill: invalid spill slot index") for a
+							// `class extends Base {}` returned from a nested function whose
+							// `Base` superclass was a spilled binding one function further
+							// out (#416).
 							superConstructorReg = c.regAlloc.Alloc()
 							needToFreeSuperReg = true
 							_, err := c.compileNode(node.SuperClass, superConstructorReg)
@@ -5524,6 +5535,10 @@ func (c *Compiler) compileClassExpression(node *parser.ClassDeclaration, hint Re
 								c.regAlloc.Free(superConstructorReg)
 								return BadRegister, err
 							}
+						} else if symbol.IsSpilled {
+							superConstructorReg = c.regAlloc.Alloc()
+							needToFreeSuperReg = true
+							c.emitLoadSpill(superConstructorReg, symbol.SpillIndex, node.Token.Line)
 						} else {
 							superConstructorReg = symbol.Register
 							needToFreeSuperReg = false

--- a/tests/scripts/class_expr_extends_call_nested_function.ts
+++ b/tests/scripts/class_expr_extends_call_nested_function.ts
@@ -1,0 +1,28 @@
+// expect: true
+// Regression test for #416: a `class` expression returned from a function
+// and used directly as another class's `extends` target panicked the VM
+// with "OpLoadSpill: invalid spill slot index", but only when the whole
+// pattern was nested one level inside an enclosing function (the same
+// extra-nesting shape #406 needed).
+//
+// Root cause: compileClassExpression's superclass-resolution code checked
+// `symbol.IsSpilled` before checking whether the symbol was defined in an
+// ENCLOSING function's scope. A spilled binding from an outer function
+// lives in that outer function's own spill-slot array (spill slots are
+// per-chunk), so emitting a direct OpLoadSpill for it - as the old code
+// did whenever IsSpilled was true, regardless of which function defined
+// it - read out of the wrong (current, possibly smaller) spill array
+// instead of capturing the value as an upvalue through the closure
+// mechanism, the way an ordinary identifier reference to the same binding
+// already correctly does.
+(function () {
+  class Base {
+    constructor() {}
+  }
+  function build() {
+    return class extends Base {};
+  }
+  class Sub extends build() {}
+  globalThis.__classExprExtendsCallResult = new Sub() instanceof Base;
+})();
+globalThis.__classExprExtendsCallResult;


### PR DESCRIPTION
## Summary

Fixes #416: a `class` expression returned from a nested function and used directly as another class's `extends` target panicked the VM with `OpLoadSpill: invalid spill slot index`, whenever the whole pattern was nested one level inside an enclosing function (the same extra-nesting shape #406 needed).

Real-world trigger: `@aws-sdk/client-bedrock-runtime`'s generated command classes, each shaped like `class ConverseCommand extends client.Command.classBuilder()....build() {}`, where `.build()` returns a `class extends Command {...}` expression.

## Root cause

`compileClassExpression`'s superclass-resolution code checked `symbol.IsSpilled` *before* checking whether the symbol was defined in an **enclosing** function's scope. Spill slots are per-function-chunk, so a binding spilled in an *outer* function got read via a direct `OpLoadSpill` against the *current* (inner) function's own spill array instead of being captured as an upvalue through the closure mechanism — reading an out-of-range slot in a frame with no spill slots of its own.

This is the same category of bug as #406: an enclosing-scope check placed after a check that should have deferred to it. The ordinary identifier-reference path (`compileNode`'s `Identifier` case) already gets this ordering right, so the fix reorders `compileClassExpression`'s superclass resolution to match.

## Verification

- Original repro now returns `true` (was panicking).
- New regression test: `tests/scripts/class_expr_extends_call_nested_function.ts`.
- Probed the adjacent named-class-expression path (which legitimately spills its own inner class-name binding locally) — confirmed unaffected.
- `go build ./...`, `go vet ./...`, `go test ./...` (incl. `TestScripts` smoke suite) all green.
- test262 `language/statements/class` subtree: identical 4306 pass / 61 fail before and after — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)