### PR TITLE
fix(vm): Object.setPrototypeOf rejects typed-array-family values as non-object (#418)

### DIFF
--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -2409,6 +2409,55 @@ func objectGetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 	}
 }
 
+// applyExoticPrototype stores proto as obj's per-instance [[Prototype]]
+// override via store (one of the void SetPrototype methods in subclass.go's
+// storage list - ArrayObject.SetPrototype, MapObject.SetPrototype, ...),
+// applying the same OrdinarySetPrototypeOf checks (ECMAScript 10.1.2) that
+// PlainObject/DictObject/Array already enforce inside their own bool-
+// returning SetPrototype: a no-op when proto doesn't actually change the
+// current *effective* prototype (vmInstance.PrototypeOf, not the raw
+// per-instance field, so a fresh instance whose field is still unset
+// compares against its intrinsic prototype rather than Undefined),
+// rejection when obj is non-extensible, and rejection of the direct
+// one-step cycle setPrototypeOf(x, x). Without this, every case added for
+// #418 would silently accept a change on a frozen/sealed instance and even
+// let it become its own prototype - since those void setters, unlike
+// PlainObject/DictObject's, have nowhere to report failure except through
+// this wrapper.
+//
+// Returns nil on success, or the TypeError to raise. The two rejections get
+// distinct messages (matching the spec's own distinct steps 4 and 7b) rather
+// than one generic string - otherwise `Object.setPrototypeOf(x, x)` on a
+// perfectly extensible x would confusingly report it as non-extensible.
+func applyExoticPrototype(vmInstance *vm.VM, obj vm.Value, proto vm.Value, store func(vm.Value)) error {
+	if proto.Is(vmInstance.PrototypeOf(obj)) {
+		return nil
+	}
+	if !isExoticExtensible(vmInstance, obj) {
+		return vmInstance.NewTypeError("Cannot set prototype of non-extensible object")
+	}
+	if proto.Is(obj) {
+		return vmInstance.NewTypeError("Cyclic __proto__ value")
+	}
+	store(proto)
+	return nil
+}
+
+// isExoticExtensible reuses Object.isExtensible's own answer for obj, so
+// applyExoticPrototype's notion of "extensible" never drifts from what
+// Object.isExtensible/preventExtensions actually track for each kind (the
+// side table for Map/Set/RegExp/Promise, nothing at all yet for WeakMap/
+// WeakSet/WeakRef/FinalizationRegistry/ArrayBuffer/SharedArrayBuffer/
+// DataView/TypedArray - those report "true" the same way Object.isExtensible
+// does for them today).
+func isExoticExtensible(vmInstance *vm.VM, obj vm.Value) bool {
+	result, err := objectIsExtensibleWithVM(vmInstance, []vm.Value{obj})
+	if err != nil {
+		return true
+	}
+	return result.IsTruthy()
+}
+
 func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, error) {
 	if len(args) < 2 {
 		return vm.Undefined, vmInstance.NewTypeError("Object.setPrototypeOf requires 2 arguments")
@@ -2465,16 +2514,15 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		return objectSetPrototypeOfWithVM(vmInstance, []vm.Value{proxy.Target(), proto})
 	}
 
-	// First argument must be an object (including functions, arrays, etc.)
-	// In JavaScript, functions are objects and their [[Prototype]] can be changed
-	objIsObject := obj.Type() == vm.TypeObject ||
-		obj.IsCallable() ||
-		obj.Type() == vm.TypeArray ||
-		obj.Type() == vm.TypeGenerator ||
-		obj.Type() == vm.TypeAsyncGenerator ||
-		obj.Type() == vm.TypeRegExp ||
-		obj.Type() == vm.TypeMap ||
-		obj.Type() == vm.TypeSet
+	// First argument must be an object (including functions, arrays, typed
+	// arrays, etc.) - anything IsObject() reports (the contiguous
+	// TypeObject..TypeProxy span, which includes TypedArray/DataView/
+	// ArrayBuffer/Map/Set/WeakMap/... - see Value.IsObject()'s doc comment)
+	// or a callable. The previous hand-rolled list of "object-ish" kinds
+	// omitted the typed-array family entirely, so Object.setPrototypeOf
+	// rejected every Uint8Array/DataView/ArrayBuffer value as non-object
+	// even though typeof/instanceof correctly treated them as objects (#418).
+	objIsObject := obj.IsObject() || obj.IsCallable()
 	if !objIsObject {
 		return vm.Undefined, vmInstance.NewTypeError("Object.setPrototypeOf called on non-object")
 	}
@@ -2492,17 +2540,18 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		}
 	}
 
-	// Set the prototype based on object type
+	// Set the prototype based on object type. Every exotic kind that carries
+	// its own per-instance [[Prototype]] storage (see subclass.go's storage
+	// note) needs its own case here - falling through to "do nothing" would
+	// report success while silently discarding the new prototype.
 	success := true
 	switch obj.Type() {
 	case vm.TypeObject:
-		if obj.Type() == vm.TypeObject {
-			plainObj := obj.AsPlainObject()
-			success = plainObj.SetPrototype(proto)
-		} else if obj.Type() == vm.TypeDictObject {
-			dictObj := obj.AsDictObject()
-			success = dictObj.SetPrototype(proto)
-		}
+		plainObj := obj.AsPlainObject()
+		success = plainObj.SetPrototype(proto)
+	case vm.TypeDictObject:
+		dictObj := obj.AsDictObject()
+		success = dictObj.SetPrototype(proto)
 	case vm.TypeFunction:
 		// For FunctionObject, set the Prototype field
 		fn := obj.AsFunction()
@@ -2520,12 +2569,63 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 	case vm.TypeBoundFunction:
 		// Bound functions don't have their own prototype
 		success = true
-	default:
-		// For other object types (Map, Set, Generator, etc.), try setting via AsPlainObject
-		if obj.Type() == vm.TypeObject {
-			plainObj := obj.AsPlainObject()
-			success = plainObj.SetPrototype(proto)
+	case vm.TypeArray:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsArray().SetPrototype); err != nil {
+			return vm.Undefined, err
 		}
+	case vm.TypeMap:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsMap().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeSet:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsSet().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeWeakMap:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsWeakMap().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeWeakSet:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsWeakSet().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeWeakRef:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsWeakRef().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeFinalizationRegistry:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsFinalizationRegistry().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeRegExp:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsRegExpObject().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeArrayBuffer:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsArrayBuffer().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeSharedArrayBuffer:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsSharedArrayBuffer().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeDataView:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsDataView().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeTypedArray:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsTypedArray().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypePromise:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsPromise().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	default:
+		// Generator/AsyncGenerator (and any other kind reaching here) only
+		// carry a *PlainObject prototype slot, not an arbitrary Value, so an
+		// arbitrary [[Prototype]] isn't representable there yet - leave as a
+		// no-op success rather than throwing, matching prior behavior.
 	}
 
 	if !success {

--- a/pkg/builtins/object_init.go
+++ b/pkg/builtins/object_init.go
@@ -1365,19 +1365,39 @@ func lookupSymbolProp(vmInstance *vm.VM, val vm.Value, symKey vm.PropertyKey, sy
 	case vm.TypePromise:
 		return lookupSymbolPropFromProto(vmInstance, vmInstance.PromisePrototype, symKey, symObj, depth)
 	case vm.TypeGenerator:
-		// Check the generator's own prototype chain (genFn.prototype → Generator.prototype)
+		// Check the generator's own prototype chain (genFn.prototype → Generator.prototype).
+		// Prototype is a plain vm.Value now, not always a *PlainObject (#418):
+		// TypeObject preserves the exact prior behavior (receiver=val, so an
+		// accessor defined on the subclass's own .prototype reads correct
+		// instance state); TypeUndefined means never resolved (shouldn't
+		// normally happen - call.go sets this eagerly at creation) and falls
+		// back to the intrinsic exactly as before; anything else (an
+		// explicit null, or some other object-kind override via
+		// Object.setPrototypeOf) goes through the generic proto dispatch,
+		// same as every other exotic kind's case in this switch already
+		// does - it can't preserve the original receiver, but neither do they.
 		genObj := val.AsGenerator()
-		if genObj.Prototype != nil {
-			return lookupSymbolPropInPlainObj(vmInstance, val, genObj.Prototype, symKey, symObj, depth)
+		switch genObj.Prototype.Type() {
+		case vm.TypeObject:
+			return lookupSymbolPropInPlainObj(vmInstance, val, genObj.Prototype.AsPlainObject(), symKey, symObj, depth)
+		case vm.TypeUndefined:
+			return lookupSymbolPropFromProto(vmInstance, vmInstance.GeneratorPrototype, symKey, symObj, depth)
+		default:
+			return lookupSymbolPropFromProto(vmInstance, genObj.Prototype, symKey, symObj, depth)
 		}
-		return lookupSymbolPropFromProto(vmInstance, vmInstance.GeneratorPrototype, symKey, symObj, depth)
 	case vm.TypeAsyncGenerator:
-		// Check the async generator's own prototype chain
+		// Check the async generator's own prototype chain - see the
+		// TypeGenerator case just above for why each Prototype.Type() is
+		// handled the way it is.
 		asyncGenObj := val.AsAsyncGenerator()
-		if asyncGenObj.Prototype != nil {
-			return lookupSymbolPropInPlainObj(vmInstance, val, asyncGenObj.Prototype, symKey, symObj, depth)
+		switch asyncGenObj.Prototype.Type() {
+		case vm.TypeObject:
+			return lookupSymbolPropInPlainObj(vmInstance, val, asyncGenObj.Prototype.AsPlainObject(), symKey, symObj, depth)
+		case vm.TypeUndefined:
+			return lookupSymbolPropFromProto(vmInstance, vmInstance.AsyncGeneratorPrototype, symKey, symObj, depth)
+		default:
+			return lookupSymbolPropFromProto(vmInstance, asyncGenObj.Prototype, symKey, symObj, depth)
 		}
-		return lookupSymbolPropFromProto(vmInstance, vmInstance.AsyncGeneratorPrototype, symKey, symObj, depth)
 	case vm.TypeArrayBuffer:
 		return lookupSymbolPropFromProto(vmInstance, vmInstance.ArrayBufferPrototype, symKey, symObj, depth)
 	case vm.TypeSharedArrayBuffer:
@@ -2306,21 +2326,22 @@ func objectGetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		}
 		return vmInstance.WeakMapPrototype, nil
 	case vm.TypeGenerator:
-		// For generators, return their custom prototype or GeneratorPrototype
+		// In practice unreachable: InstancePrototypeOverride's own
+		// TypeGenerator case (subclass.go) already returned above, since
+		// Prototype is a plain vm.Value now (#418) and call.go always
+		// resolves it eagerly at creation time. Kept as a defensive
+		// fallback, matching the WeakMap case just above.
 		genObj := obj.AsGenerator()
-		if genObj != nil && genObj.Prototype != nil {
-			return vm.NewValueFromPlainObject(genObj.Prototype), nil
+		if genObj != nil && genObj.Prototype.Type() != vm.TypeUndefined {
+			return genObj.Prototype, nil
 		}
-		// Return the default GeneratorPrototype
-		return vm.Null, nil // TODO: Return proper GeneratorPrototype
+		return vmInstance.GeneratorPrototype, nil
 	case vm.TypeAsyncGenerator:
-		// For async generators, return their custom prototype or AsyncGeneratorPrototype
 		asyncGenObj := obj.AsAsyncGenerator()
-		if asyncGenObj != nil && asyncGenObj.Prototype != nil {
-			return vm.NewValueFromPlainObject(asyncGenObj.Prototype), nil
+		if asyncGenObj != nil && asyncGenObj.Prototype.Type() != vm.TypeUndefined {
+			return asyncGenObj.Prototype, nil
 		}
-		// Return the default AsyncGeneratorPrototype
-		return vm.Null, nil // TODO: Return proper AsyncGeneratorPrototype
+		return vmInstance.AsyncGeneratorPrototype, nil
 	case vm.TypeProxy:
 		// For proxies, call the getPrototypeOf trap if present
 		proxy := obj.AsProxy()
@@ -2621,11 +2642,17 @@ func objectSetPrototypeOfWithVM(vmInstance *vm.VM, args []vm.Value) (vm.Value, e
 		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsPromise().SetPrototype); err != nil {
 			return vm.Undefined, err
 		}
+	case vm.TypeGenerator:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsGenerator().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
+	case vm.TypeAsyncGenerator:
+		if err := applyExoticPrototype(vmInstance, obj, proto, obj.AsAsyncGenerator().SetPrototype); err != nil {
+			return vm.Undefined, err
+		}
 	default:
-		// Generator/AsyncGenerator (and any other kind reaching here) only
-		// carry a *PlainObject prototype slot, not an arbitrary Value, so an
-		// arbitrary [[Prototype]] isn't representable there yet - leave as a
-		// no-op success rather than throwing, matching prior behavior.
+		// Any other kind reaching here is left as a no-op success, matching
+		// prior behavior.
 	}
 
 	if !success {

--- a/pkg/builtins/typedarray_common.go
+++ b/pkg/builtins/typedarray_common.go
@@ -213,6 +213,11 @@ func typedArrayEffectivePrototype(vmInstance *vm.VM, val vm.Value) vm.Value {
 	}
 	if p := ta.GetPrototype(); p.IsObject() {
 		return p
+	} else if p.Type() == vm.TypeNull {
+		// An explicit Object.setPrototypeOf(typedArray, null) (#418) must
+		// end the chain here, not fall back to the intrinsic below -
+		// TypeNull is a deliberately-stored override, not "unset".
+		return vm.Null
 	}
 	switch ta.GetElementType() {
 	case vm.TypedArrayInt8:

--- a/pkg/vm/call.go
+++ b/pkg/vm/call.go
@@ -249,12 +249,9 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			// If .prototype is an object, use it as the generator's prototype
 			// Otherwise, use the default AsyncGeneratorPrototype
 			if prototypeVal.IsObject() && prototypeVal.Type() == TypeObject {
-				genObj.Prototype = prototypeVal.AsPlainObject()
+				genObj.Prototype = prototypeVal
 			} else {
-				// Use default AsyncGeneratorPrototype
-				if vm.AsyncGeneratorPrototype.Type() == TypeObject {
-					genObj.Prototype = vm.AsyncGeneratorPrototype.AsPlainObject()
-				}
+				genObj.Prototype = vm.AsyncGeneratorPrototype
 			}
 
 			callerRegisters[destReg] = genVal
@@ -305,12 +302,9 @@ func (vm *VM) prepareCallWithGeneratorMode(calleeVal Value, thisValue Value, arg
 			// If .prototype is an object, use it as the generator's prototype
 			// Otherwise, use the default GeneratorPrototype
 			if prototypeVal.IsObject() && prototypeVal.Type() == TypeObject {
-				genObj.Prototype = prototypeVal.AsPlainObject()
+				genObj.Prototype = prototypeVal
 			} else {
-				// Use default GeneratorPrototype
-				if vm.GeneratorPrototype.Type() == TypeObject {
-					genObj.Prototype = vm.GeneratorPrototype.AsPlainObject()
-				}
+				genObj.Prototype = vm.GeneratorPrototype
 			}
 
 			if debugPrepareCall {

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -661,42 +661,20 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 			*dest = v
 			return true, InterpretOK, *dest
 		}
-		// Walk the prototype chain. For instances of subclasses (`class S
-		// extends Array {}`), arr.prototype points at S.prototype, whose
-		// [[Prototype]] chains through Array.prototype → Object.prototype.
-		// For plain arrays the per-instance override is unset and we fall
-		// through to the realm's intrinsic Array.prototype.
-		proto := arr.prototype
-		if !proto.IsObject() {
-			proto = vm.ArrayPrototype
-		}
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk up the chain
-			current := po.GetPrototype()
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					if current.Type() == TypeObject {
-						p := current.AsPlainObject()
-						if v, ok := p.GetOwn(propName); ok {
-							*dest = v
-							return true, InterpretOK, *dest
-						}
-						current = p.GetPrototype()
-					} else {
-						break
-					}
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Walk the prototype chain via the shared, non-panicking helper -
+		// not a hand-rolled walk assuming arr.prototype (when set, e.g. by
+		// `class S extends Array {}`, or explicitly via
+		// Object.setPrototypeOf) is always a PlainObject or unset. Since
+		// Object.setPrototypeOf can now store *any* object-kind value or an
+		// explicit null there (#418), the previous `!proto.IsObject()`
+		// fallback-to-intrinsic check also mishandled an explicit null
+		// override (indistinguishable from "unset") and the walk itself
+		// would panic in AsPlainObject() the first time it reached a
+		// non-PlainObject link (e.g. another Array or a Map as the
+		// prototype). finishProtoChainGet -> plainPrototypeOf goes through
+		// InstancePrototypeOverride, which now tells null and unset apart,
+		// and stops cleanly instead of panicking on any other kind.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 9. Map objects - check user-defined properties first, then prototype chain
@@ -709,36 +687,11 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 				return true, InterpretOK, *dest
 			}
 		}
-		// Consult the per-instance prototype (set by subclass ctor for
-		// `class S extends Map {}`) before falling back to the realm
-		// intrinsic Map.prototype.
-		proto := mapObj.prototype
-		if !proto.IsObject() {
-			proto = vm.MapPrototype
-		}
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Walk the prototype chain via the shared, non-panicking helper -
+		// see the Array case above for why a hand-rolled walk here is
+		// unsafe now that Object.setPrototypeOf can store any object-kind
+		// value or an explicit null on a Map instance (#418).
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10. Set objects - check user-defined properties first, then prototype chain
@@ -751,35 +704,11 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 				return true, InterpretOK, *dest
 			}
 		}
-		// Consult the per-instance prototype (set by subclass ctor for
-		// `class S extends Set {}`) before falling back to the intrinsic.
-		proto := setObj.prototype
-		if !proto.IsObject() {
-			proto = vm.SetPrototype
-		}
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Walk the prototype chain via the shared, non-panicking helper -
+		// see the Array case above for why a hand-rolled walk here is
+		// unsafe now that Object.setPrototypeOf can store any object-kind
+		// value or an explicit null on a Set instance (#418).
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10aa. Promise objects - check user-defined properties first, then prototype chain
@@ -792,35 +721,11 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 				return true, InterpretOK, *dest
 			}
 		}
-		// Consult the per-instance prototype (set by subclass ctor for
-		// `class S extends Promise {}`) before falling back to the intrinsic.
-		proto := promiseObj.prototype
-		if !proto.IsObject() {
-			proto = vm.PromisePrototype
-		}
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Walk the prototype chain via the shared, non-panicking helper -
+		// see the Array case above for why a hand-rolled walk here is
+		// unsafe now that Object.setPrototypeOf can store any object-kind
+		// value or an explicit null on a Promise instance (#418).
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10a. WeakMap objects - consult WeakMap.prototype chain for properties like get, set, has, delete
@@ -847,66 +752,22 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 	// the constructor via GetPrototypeFromConstructor for cross-realm support),
 	// falling back to vm.WeakRefPrototype if absent.
 	if objVal.Type() == TypeWeakRef {
-		wr := objVal.AsWeakRef()
-		proto := wr.GetPrototype()
-		if !proto.IsObject() {
-			proto = vm.WeakRefPrototype
-		}
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Walk the prototype chain via the shared, non-panicking helper -
+		// see the Array case above for why a hand-rolled walk here is
+		// unsafe now that Object.setPrototypeOf can store any object-kind
+		// value or an explicit null on a WeakRef instance (#418).
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10b''. FinalizationRegistry objects - consult the instance's stored
 	// prototype (set by the constructor via GetPrototypeFromConstructor for
 	// cross-realm support), falling back to vm.FinalizationRegistryPrototype.
 	if objVal.Type() == TypeFinalizationRegistry {
-		fr := objVal.AsFinalizationRegistry()
-		proto := fr.GetPrototype()
-		if !proto.IsObject() {
-			proto = vm.FinalizationRegistryPrototype
-		}
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					cpo := current.AsPlainObject()
-					if v, ok := cpo.GetOwn(propName); ok {
-						*dest = v
-						return true, InterpretOK, *dest
-					}
-					current = cpo.prototype
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Walk the prototype chain via the shared, non-panicking helper -
+		// see the Array case above for why a hand-rolled walk here is
+		// unsafe now that Object.setPrototypeOf can store any object-kind
+		// value or an explicit null on a FinalizationRegistry instance (#418).
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 10c. SharedArrayBuffer objects - check own properties first, then prototype chain

--- a/pkg/vm/op_getprop.go
+++ b/pkg/vm/op_getprop.go
@@ -821,73 +821,21 @@ func (vm *VM) opGetProp(frame *CallFrame, ip int, objVal *Value, propName string
 
 	// 11. Generator objects
 	if objVal.Type() == TypeGenerator {
-		// Generator objects: consult Generator.prototype chain for regular properties
-		proto := vm.GeneratorPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					if current.Type() == TypeObject {
-						proto2 := current.AsPlainObject()
-						if v, ok := proto2.GetOwn(propName); ok {
-							*dest = v
-							return true, InterpretOK, *dest
-						}
-						current = proto2.prototype
-					} else if current.Type() == TypeDictObject {
-						dict := current.AsDictObject()
-						current = dict.prototype
-					} else {
-						break
-					}
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// Generator objects: consult the prototype chain via the shared,
+		// non-panicking helper - not the hardcoded vm.GeneratorPrototype
+		// this used to always use regardless of any per-instance override.
+		// handlePrimitiveMethod (called earlier, at the top of opGetProp)
+		// deliberately does NOT handle TypeGenerator any more, since its
+		// Prototype field is a plain Value now (#418, can hold any
+		// object-kind value or an explicit null) that only
+		// finishProtoChainGet -> plainPrototypeOf -> InstancePrototypeOverride
+		// walks correctly - this block is the sole real handler.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	if objVal.Type() == TypeAsyncGenerator {
-		// AsyncGenerator objects: consult AsyncGenerator.prototype chain for regular properties
-		proto := vm.AsyncGeneratorPrototype
-		if proto.IsObject() {
-			po := proto.AsPlainObject()
-			if v, ok := po.GetOwn(propName); ok {
-				*dest = v
-				return true, InterpretOK, *dest
-			}
-			// Walk the prototype chain
-			current := po.prototype
-			for current.typ != TypeNull && current.typ != TypeUndefined {
-				if current.IsObject() {
-					if current.Type() == TypeObject {
-						proto2 := current.AsPlainObject()
-						if v, ok := proto2.GetOwn(propName); ok {
-							*dest = v
-							return true, InterpretOK, *dest
-						}
-						current = proto2.prototype
-					} else if current.Type() == TypeDictObject {
-						dict := current.AsDictObject()
-						current = dict.prototype
-					} else {
-						break
-					}
-				} else {
-					break
-				}
-			}
-		}
-		*dest = Undefined
-		return true, InterpretOK, *dest
+		// AsyncGenerator objects - see the TypeGenerator case just above.
+		return vm.finishProtoChainGet(frame, ip, frameWasNil, propName, *objVal, dest)
 	}
 
 	// 12. RegExp objects (after special properties are handled)

--- a/pkg/vm/promise.go
+++ b/pkg/vm/promise.go
@@ -651,18 +651,17 @@ func (vm *VM) iterableToArrayBounded(value Value) (Value, error) {
 				continue
 			}
 		case TypeGenerator:
+			// Prototype is a plain Value now (not always a *PlainObject; see
+			// GeneratorObject's Prototype field, changed for #418) - the
+			// loop's own Null/Undefined check at the top handles both "no
+			// override" and an explicit Object.setPrototypeOf(gen, null),
+			// so no separate nil guard is needed here.
 			genObj := current.AsGenerator()
-			if genObj.Prototype == nil {
-				return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
-			}
-			current = NewValueFromPlainObject(genObj.Prototype)
+			current = genObj.Prototype
 			continue
 		case TypeAsyncGenerator:
 			genObj := current.AsAsyncGenerator()
-			if genObj.Prototype == nil {
-				return Undefined, vm.NewTypeError(fmt.Sprintf("%s is not iterable", value.TypeName()))
-			}
-			current = NewValueFromPlainObject(genObj.Prototype)
+			current = genObj.Prototype
 			continue
 		case TypeDictObject:
 			// DictObjects don't support symbol keys, so there's nothing to

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -746,22 +746,14 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 		if vm.BigIntPrototype.Type() == TypeObject {
 			prototype = vm.BigIntPrototype.AsPlainObject()
 		}
-	case TypeGenerator:
-		// Check if generator has a custom prototype, otherwise use default
-		genObj := objVal.AsGenerator()
-		if genObj.Prototype != nil {
-			prototype = genObj.Prototype
-		} else if vm.GeneratorPrototype.Type() == TypeObject {
-			prototype = vm.GeneratorPrototype.AsPlainObject()
-		}
-	case TypeAsyncGenerator:
-		// Check if async generator has a custom prototype, otherwise use default
-		asyncGenObj := objVal.AsAsyncGenerator()
-		if asyncGenObj.Prototype != nil {
-			prototype = asyncGenObj.Prototype
-		} else if vm.AsyncGeneratorPrototype.Type() == TypeObject {
-			prototype = vm.AsyncGeneratorPrototype.AsPlainObject()
-		}
+	// TypeGenerator/TypeAsyncGenerator are deliberately NOT handled here
+	// (unlike every other exotic kind above): their per-instance Prototype
+	// field can hold any object-kind Value or an explicit Null override
+	// since #418, which this function's *PlainObject-typed `prototype` local
+	// can't represent. opGetProp's own dedicated Generator/AsyncGenerator
+	// blocks (which run right after this function returns unhandled) use
+	// finishProtoChainGet instead, which walks correctly regardless of what
+	// kind of value is in the chain - see those blocks for the real logic.
 	case TypePromise:
 		if pr := objVal.AsPromise(); pr != nil && pr.prototype.Type() == TypeObject {
 			// Per-instance [[Prototype]] override set by a subclass ctor

--- a/pkg/vm/property_helpers.go
+++ b/pkg/vm/property_helpers.go
@@ -696,26 +696,47 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 		// prototype whose chain runs S.prototype -> Array.prototype, so a method
 		// override on the subclass resolves before the intrinsic builtin. Normal
 		// arrays leave it unset and fall back to the realm's Array.prototype.
+		// An explicit Object.setPrototypeOf(arr, null) (#418) must leave
+		// `prototype` nil rather than fall to the intrinsic below it -
+		// TypeNull is a real, deliberately-stored override (see subclass.go's
+		// InstancePrototypeOverride), not "unset".
 		if arr := objVal.AsArray(); arr != nil && arr.prototype.Type() == TypeObject {
 			prototype = arr.prototype.AsPlainObject()
-		} else {
+		} else if arr == nil || arr.prototype.Type() != TypeNull {
 			prototype = vm.ArrayPrototype.AsPlainObject()
 		}
 	case TypeMap:
 		if mp := objVal.AsMap(); mp != nil && mp.prototype.Type() == TypeObject {
 			prototype = mp.prototype.AsPlainObject()
-		} else if vm.MapPrototype.Type() == TypeObject {
-			prototype = vm.MapPrototype.AsPlainObject()
+		} else if mp == nil || mp.prototype.Type() != TypeNull {
+			if vm.MapPrototype.Type() == TypeObject {
+				prototype = vm.MapPrototype.AsPlainObject()
+			}
 		}
 	case TypeSet:
 		if st := objVal.AsSet(); st != nil && st.prototype.Type() == TypeObject {
 			prototype = st.prototype.AsPlainObject()
-		} else if vm.SetPrototype.Type() == TypeObject {
-			prototype = vm.SetPrototype.AsPlainObject()
+		} else if st == nil || st.prototype.Type() != TypeNull {
+			if vm.SetPrototype.Type() == TypeObject {
+				prototype = vm.SetPrototype.AsPlainObject()
+			}
 		}
 	case TypeRegExp:
-		if vm.RegExpPrototype.Type() == TypeObject {
-			prototype = vm.RegExpPrototype.AsPlainObject()
+		// Same per-instance override handling as TypeArray/TypeMap/TypeSet/
+		// TypePromise above (subclassing, or an explicit
+		// Object.setPrototypeOf - #418): this case used to ignore any
+		// override entirely and always resolve through the intrinsic
+		// RegExp.prototype, which both silently defeated `class S extends
+		// RegExp {}` method overrides and, worse, kept resolving methods
+		// like `.test` through the intrinsic even after
+		// Object.setPrototypeOf(re, null) - disagreeing with
+		// Object.getPrototypeOf(re), which correctly reported null.
+		if re := objVal.AsRegExpObject(); re != nil && re.GetPrototype().Type() == TypeObject {
+			prototype = re.GetPrototype().AsPlainObject()
+		} else if re == nil || re.GetPrototype().Type() != TypeNull {
+			if vm.RegExpPrototype.Type() == TypeObject {
+				prototype = vm.RegExpPrototype.AsPlainObject()
+			}
 		}
 	case TypeSymbol:
 		if vm.SymbolPrototype.Type() == TypeObject {
@@ -748,8 +769,12 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 			// overridden method like `then` resolves to the subclass's
 			// before falling back to the intrinsic - see paserati#198.
 			prototype = pr.prototype.AsPlainObject()
-		} else if vm.PromisePrototype.Type() == TypeObject {
-			prototype = vm.PromisePrototype.AsPlainObject()
+		} else if pr == nil || pr.prototype.Type() != TypeNull {
+			// An explicit Object.setPrototypeOf(promise, null) (#418) must
+			// leave `prototype` nil, not fall back to the intrinsic.
+			if vm.PromisePrototype.Type() == TypeObject {
+				prototype = vm.PromisePrototype.AsPlainObject()
+			}
 		}
 	case TypeTypedArray:
 		// Get the appropriate typed array prototype based on element type
@@ -765,6 +790,13 @@ func (vm *VM) handlePrimitiveMethod(objVal Value, propName string) (Value, bool)
 			// over the intrinsic default resolved below.
 			if ta.GetPrototype().Type() == TypeObject {
 				prototype = ta.GetPrototype().AsPlainObject()
+				break
+			}
+			// An explicit Object.setPrototypeOf(typedArray, null) (#418)
+			// must leave `prototype` nil (no prototype at all) rather than
+			// fall through to the intrinsic %TypedArray%.prototype resolved
+			// below - TypeNull is a deliberately-stored override, not "unset".
+			if ta.GetPrototype().Type() == TypeNull {
 				break
 			}
 			// Resolve prototype dynamically via global constructors to avoid missing VM fields
@@ -939,6 +971,11 @@ func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 			arr := objVal.AsArray()
 			if proto := arr.GetPrototype(); proto.IsObject() {
 				return proto
+			} else if proto.Type() == TypeNull {
+				// An explicit Object.setPrototypeOf(arr, null) (#418) must
+				// end the chain here, not fall back to the intrinsic below -
+				// TypeNull is a deliberately-stored override, not "unset".
+				return Null
 			}
 		}
 		return vm.ArrayPrototype
@@ -947,6 +984,8 @@ func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 			mp := objVal.AsMap()
 			if proto := mp.GetPrototype(); proto.IsObject() {
 				return proto
+			} else if proto.Type() == TypeNull {
+				return Null
 			}
 		}
 		return vm.MapPrototype
@@ -955,6 +994,8 @@ func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 			st := objVal.AsSet()
 			if proto := st.GetPrototype(); proto.IsObject() {
 				return proto
+			} else if proto.Type() == TypeNull {
+				return Null
 			}
 		}
 		return vm.SetPrototype
@@ -963,6 +1004,8 @@ func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 			wr := objVal.AsWeakRef()
 			if proto := wr.GetPrototype(); proto.IsObject() {
 				return proto
+			} else if proto.Type() == TypeNull {
+				return Null
 			}
 		}
 		return vm.WeakRefPrototype
@@ -970,6 +1013,8 @@ func (vm *VM) effectiveBuiltinPrototype(objVal Value) Value {
 		if fr := objVal.AsFinalizationRegistry(); fr != nil {
 			if proto := fr.GetPrototype(); proto.IsObject() {
 				return proto
+			} else if proto.Type() == TypeNull {
+				return Null
 			}
 		}
 		return vm.FinalizationRegistryPrototype

--- a/pkg/vm/proto.go
+++ b/pkg/vm/proto.go
@@ -95,15 +95,21 @@ func (vm *VM) prototypeOf(v Value) Value {
 	case TypeNativeFunction, TypeBoundFunction, TypeAsyncNativeFunction:
 		return vm.FunctionPrototype
 	case TypeGenerator:
+		// In practice this case is unreachable: Prototype is a plain Value
+		// now (#418) and InstancePrototypeOverride's own TypeGenerator case
+		// (subclass.go) already returns it via the InstancePrototypeOverride
+		// check at the top of this function, since call.go always resolves
+		// it eagerly at creation time. Kept as a defensive fallback for the
+		// same reason the other exotic kinds above have one.
 		genObj := v.AsGenerator()
-		if genObj.Prototype != nil {
-			return NewValueFromPlainObject(genObj.Prototype)
+		if genObj.Prototype.Type() != TypeUndefined {
+			return genObj.Prototype
 		}
 		return vm.GeneratorPrototype
 	case TypeAsyncGenerator:
 		asyncGenObj := v.AsAsyncGenerator()
-		if asyncGenObj.Prototype != nil {
-			return NewValueFromPlainObject(asyncGenObj.Prototype)
+		if asyncGenObj.Prototype.Type() != TypeUndefined {
+			return asyncGenObj.Prototype
 		}
 		return vm.AsyncGeneratorPrototype
 	case TypeString:

--- a/pkg/vm/subclass.go
+++ b/pkg/vm/subclass.go
@@ -100,7 +100,16 @@ func (vm *VM) InstancePrototypeOverride(v Value) (Value, bool) {
 	default:
 		return Undefined, false
 	}
-	if p.IsObject() {
+	// The zero Value is TypeUndefined ("no override set" - the field's
+	// natural default), and applySubclassPrototype only ever stores an
+	// object. But Object.setPrototypeOf legitimately stores an explicit
+	// TypeNull override too (setPrototypeOf(v, null) - see
+	// objectSetPrototypeOfWithVM in pkg/builtins/object_init.go), which
+	// `p.IsObject()` alone would misreport as "no override", falling back
+	// to the intrinsic prototype instead of the null the caller asked for
+	// (#418). Undefined is never a legitimately stored override, so "not
+	// Undefined" is the correct presence check for both cases.
+	if p.Type() != TypeUndefined {
 		return p, true
 	}
 	return Undefined, false

--- a/pkg/vm/subclass.go
+++ b/pkg/vm/subclass.go
@@ -10,8 +10,12 @@ package vm
 //
 // Storage: PlainObject/DictObject/Array/Map/Set/WeakRef/WeakMap and FunctionObject
 // carry their own [[Prototype]] field; the remaining exotic types (RegExp,
-// ArrayBuffer, SharedArrayBuffer, DataView, TypedArray, Promise, WeakSet) gained a
-// per-instance `prototype` field for this purpose. Undefined means "use intrinsic".
+// ArrayBuffer, SharedArrayBuffer, DataView, TypedArray, Promise, WeakSet,
+// Generator, AsyncGenerator) gained a per-instance `prototype`/`Prototype`
+// field for this purpose. Undefined means "use intrinsic" for all of them
+// except Generator/AsyncGenerator, whose field call.go resolves eagerly at
+// creation time (to the generator function's own .prototype, or the
+// intrinsic) - so Undefined effectively never occurs there in practice.
 
 // applySubclassPrototype sets instance's per-instance [[Prototype]] to
 // newTarget's "prototype" property. Callers must only invoke this for genuine
@@ -59,6 +63,10 @@ func (vm *VM) applySubclassPrototype(instance Value, newTarget Value) {
 		instance.AsFinalizationRegistry().SetPrototype(proto)
 	case TypeFunction:
 		instance.AsFunction().subclassPrototype = proto
+	case TypeGenerator:
+		instance.AsGenerator().SetPrototype(proto)
+	case TypeAsyncGenerator:
+		instance.AsAsyncGenerator().SetPrototype(proto)
 	}
 }
 
@@ -97,6 +105,10 @@ func (vm *VM) InstancePrototypeOverride(v Value) (Value, bool) {
 		p = v.AsPromise().GetPrototype()
 	case TypeFunction:
 		p = v.AsFunction().subclassPrototype
+	case TypeGenerator:
+		p = v.AsGenerator().GetPrototype()
+	case TypeAsyncGenerator:
+		p = v.AsAsyncGenerator().GetPrototype()
 	default:
 		return Undefined, false
 	}

--- a/pkg/vm/value.go
+++ b/pkg/vm/value.go
@@ -387,13 +387,31 @@ type GeneratorObject struct {
 	Done                  bool            // True when generator is exhausted
 	Args                  []Value         // Arguments passed when the generator was created
 	This                  Value           // The 'this' value for the generator context
-	Prototype             *PlainObject    // Custom prototype (if set via function.prototype)
+	Prototype             Value           // Per-instance [[Prototype]]: the generator function's own .prototype property (resolved eagerly at creation time per ECMAScript 14.4.10/14.5.10), or the intrinsic Generator/AsyncGeneratorPrototype - and, since #418, an arbitrary override via Object.setPrototypeOf (any object-kind Value, or an explicit Null)
 	DelegatedIterator     Value           // Iterator being delegated to (for yield* forwarding of .return()/.throw())
 	DelegationResult      Value           // Result value when delegation completed via external throw/return with done:true
 	DelegationResultReady bool            // Flag indicating DelegationResult is set (needed because result could be undefined)
 }
 
 type AsyncGeneratorObject GeneratorObject
+
+// SetPrototype overrides the per-instance [[Prototype]] (for subclassing, or
+// an explicit Object.setPrototypeOf - #418).
+func (g *GeneratorObject) SetPrototype(prototype Value) { g.Prototype = prototype }
+
+// GetPrototype returns the per-instance prototype, or Undefined if unset
+// (callers should fall back to the realm's GeneratorPrototype) - in
+// practice always set, since call.go resolves it eagerly at creation time.
+func (g *GeneratorObject) GetPrototype() Value { return g.Prototype }
+
+// SetPrototype overrides the per-instance [[Prototype]] (for subclassing, or
+// an explicit Object.setPrototypeOf - #418).
+func (g *AsyncGeneratorObject) SetPrototype(prototype Value) { g.Prototype = prototype }
+
+// GetPrototype returns the per-instance prototype, or Undefined if unset
+// (callers should fall back to the realm's AsyncGeneratorPrototype) - in
+// practice always set, since call.go resolves it eagerly at creation time.
+func (g *AsyncGeneratorObject) GetPrototype() Value { return g.Prototype }
 
 type MapObject struct {
 	Object
@@ -2026,8 +2044,18 @@ func (v Value) Is(other Value) bool {
 	case TypeSymbol:
 		// Symbols are only equal if they are the *same* object (reference)
 		return v.obj == other.obj
-	case TypeObject, TypeArray, TypeArguments, TypeFunction, TypeClosure, TypeNativeFunction, TypeNativeFunctionWithProps, TypeBoundFunction, TypeRegExp, TypeMap, TypeSet, TypeProxy:
-		// Objects (including arrays, functions, regex, maps, sets, proxies, etc.) are equal only by reference
+	case TypeObject, TypeDictObject, TypeArray, TypeArguments, TypeFunction, TypeClosure,
+		TypeNativeFunction, TypeNativeFunctionWithProps, TypeAsyncNativeFunction, TypeBoundFunction,
+		TypeRegExp, TypeMap, TypeSet, TypeWeakMap, TypeWeakSet, TypeWeakRef, TypeFinalizationRegistry,
+		TypeArrayBuffer, TypeSharedArrayBuffer, TypeTypedArray, TypeDataView, TypePromise,
+		TypeGenerator, TypeAsyncGenerator, TypeProxy:
+		// Every other object-kind ValueType (the two function-kind types plus
+		// the whole IsObject() span) is equal only by reference. This list
+		// used to cover just a handful of common kinds and panic on the
+		// rest - latent until applyExoticPrototype (#418) started calling
+		// Is() on arbitrary exotic-kind values (e.g. Object.setPrototypeOf(x,
+		// x) on a TypedArray/Promise/WeakMap/.../Generator), which is a
+		// completely ordinary thing to compare and must not crash the VM.
 		return v.obj == other.obj
 	default:
 		panic(fmt.Sprintf("Unhandled type in Is comparison: %v", v.typ)) // Should not happen

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -19479,21 +19479,19 @@ func (vm *VM) extractSpreadArguments(iterableVal Value) ([]Value, error) {
 
 				current = obj.prototype
 			} else if current.Type() == TypeGenerator {
-				// Generator objects delegate to their prototype
+				// Generator objects delegate to their prototype - a plain
+				// Value now (not always a *PlainObject; see GeneratorObject's
+				// Prototype field, changed for #418), so an explicit
+				// Object.setPrototypeOf(gen, null) correctly ends the walk
+				// here via the loop's own Null/Undefined check below, rather
+				// than needing its own nil guard.
 				genObj := current.AsGenerator()
-				if genObj.Prototype != nil {
-					current = NewValueFromPlainObject(genObj.Prototype)
-				} else {
-					break
-				}
+				current = genObj.Prototype
 			} else if current.Type() == TypeAsyncGenerator {
-				// AsyncGenerator objects delegate to their prototype
+				// AsyncGenerator objects delegate to their prototype - see
+				// the TypeGenerator case just above.
 				genObj := current.AsAsyncGenerator()
-				if genObj.Prototype != nil {
-					current = NewValueFromPlainObject(genObj.Prototype)
-				} else {
-					break
-				}
+				current = genObj.Prototype
 			} else if current.Type() == TypeDictObject {
 				// DictObject support (simplified)
 				// DictObjects don't typically use Symbols or complex prototype chains in this VM

--- a/tests/scripts/object_setprototypeof_typed_array.ts
+++ b/tests/scripts/object_setprototypeof_typed_array.ts
@@ -1,0 +1,141 @@
+// expect: true
+// Regression test for #418: Object.setPrototypeOf rejected every
+// typed-array-family value (TypedArray/DataView/ArrayBuffer) as
+// "non-object", even though typeof/instanceof correctly treated them as
+// objects. Fixing that surfaced several sibling bugs in the same code path
+// (Array/Map/Set/... prototype mutation silently no-op'd instead of taking
+// effect, an explicit null override was indistinguishable from "unset" on
+// several read paths, a non-PlainObject prototype override could panic the
+// VM, and non-extensible/cyclic-prototype rejection was missing) - this
+// file covers all of them, not just the original report.
+
+let customProto: any = { tag: "custom" };
+
+let u8: any = new Uint8Array(3);
+Object.setPrototypeOf(u8, customProto);
+let test1 = Object.getPrototypeOf(u8) === customProto && u8.tag === "custom";
+
+let i32: any = new Int32Array(3);
+Object.setPrototypeOf(i32, customProto);
+let test2 = Object.getPrototypeOf(i32) === customProto;
+
+let f64: any = new Float64Array(3);
+Object.setPrototypeOf(f64, customProto);
+let test3 = Object.getPrototypeOf(f64) === customProto;
+
+let dv: any = new DataView(new ArrayBuffer(8));
+Object.setPrototypeOf(dv, customProto);
+let test4 = Object.getPrototypeOf(dv) === customProto;
+
+let ab: any = new ArrayBuffer(8);
+Object.setPrototypeOf(ab, customProto);
+let test5 = Object.getPrototypeOf(ab) === customProto;
+
+// Array prototype assignment must actually take effect, not silently no-op.
+let arr: any = [1, 2, 3];
+Object.setPrototypeOf(arr, customProto);
+let test6 = Object.getPrototypeOf(arr) === customProto;
+
+let m: any = new Map();
+Object.setPrototypeOf(m, customProto);
+let test7 = Object.getPrototypeOf(m) === customProto;
+
+// An explicit null override must actually cut the chain off - both for
+// Object.getPrototypeOf (the InstancePrototypeOverride path) and for real
+// method/property lookup (opGetProp's fast paths and handlePrimitiveMethod),
+// which is a distinct code path that previously kept resolving to the
+// intrinsic prototype's methods even after setPrototypeOf(x, null).
+let u8b: any = new Uint8Array(3);
+Object.setPrototypeOf(u8b, null);
+let test8 =
+  Object.getPrototypeOf(u8b) === null && u8b.subarray === undefined;
+
+let arrNull: any = [1];
+Object.setPrototypeOf(arrNull, null);
+let test9 = Object.getPrototypeOf(arrNull) === null && arrNull.push === undefined;
+
+let mapNull: any = new Map();
+Object.setPrototypeOf(mapNull, null);
+let test10 = Object.getPrototypeOf(mapNull) === null && mapNull.get === undefined;
+
+let setNull: any = new Set();
+Object.setPrototypeOf(setNull, null);
+let test11 = Object.getPrototypeOf(setNull) === null && setNull.has === undefined;
+
+let promiseNull: any = Promise.resolve(1);
+Object.setPrototypeOf(promiseNull, null);
+let test12 =
+  Object.getPrototypeOf(promiseNull) === null && promiseNull.then === undefined;
+
+// RegExp's per-instance prototype override was ignored entirely by the
+// method-lookup fast path (unlike Array/Map/Set/Promise/TypedArray above,
+// which at least respected a TypeObject override before this fix) - it
+// always resolved through the intrinsic RegExp.prototype regardless, so
+// `.test` kept working even after setPrototypeOf(re, null).
+let reNull: any = /a/;
+Object.setPrototypeOf(reNull, null);
+let test12b = Object.getPrototypeOf(reNull) === null && reNull.test === undefined;
+
+// A non-extensible instance must reject an actual prototype change.
+let frozenArr: any = [1];
+Object.preventExtensions(frozenArr);
+let test13 = false;
+try {
+  Object.setPrototypeOf(frozenArr, {});
+} catch (e: any) {
+  test13 = e instanceof TypeError;
+}
+
+// ...but a same-value "change" (setting the prototype it already
+// effectively has) must still be a no-op success even when non-extensible.
+let frozenArr2: any = [1];
+let itsProto = Object.getPrototypeOf(frozenArr2);
+Object.preventExtensions(frozenArr2);
+let test14 = Object.setPrototypeOf(frozenArr2, itsProto) === frozenArr2;
+
+// Direct self-reference must be rejected (distinct from the
+// non-extensible case above - both are real, different rejections).
+let selfArr: any = [1];
+let test15 = false;
+try {
+  Object.setPrototypeOf(selfArr, selfArr);
+} catch (e: any) {
+  test15 = e instanceof TypeError;
+}
+
+// Setting one instance's prototype to a different exotic-kind instance
+// (not a PlainObject) must not crash property lookup afterward.
+let crossKind: any = [1];
+Object.setPrototypeOf(crossKind, new Map());
+let test16 = crossKind.whatever === undefined;
+
+// A getter inherited through Array.prototype must still be reachable
+// through ordinary property access (op_getprop.go's migration to the
+// shared, accessor-invoking prototype-chain walker).
+Object.defineProperty(Array.prototype, "__test418Getter", {
+  get: function () {
+    return 7;
+  },
+  configurable: true,
+});
+let test17 = ([1] as any).__test418Getter === 7;
+delete (Array.prototype as any).__test418Getter;
+
+test1 &&
+  test2 &&
+  test3 &&
+  test4 &&
+  test5 &&
+  test6 &&
+  test7 &&
+  test8 &&
+  test9 &&
+  test10 &&
+  test11 &&
+  test12 &&
+  test12b &&
+  test13 &&
+  test14 &&
+  test15 &&
+  test16 &&
+  test17;

--- a/tests/scripts/object_setprototypeof_typed_array.ts
+++ b/tests/scripts/object_setprototypeof_typed_array.ts
@@ -121,6 +121,62 @@ Object.defineProperty(Array.prototype, "__test418Getter", {
 let test17 = ([1] as any).__test418Getter === 7;
 delete (Array.prototype as any).__test418Getter;
 
+// Self-reference on a non-Array exotic kind must also throw, not panic -
+// Value.Is() (used by the cycle/same-value checks) used to handle only a
+// handful of object-kind ValueTypes and panicked ("Unhandled type in Is
+// comparison") on any of the rest, including every type newly made
+// mutable by this fix (TypedArray, Promise, WeakMap, Generator, ...).
+function selfCycleThrows(makeInstance: () => any): boolean {
+  let instance = makeInstance();
+  try {
+    Object.setPrototypeOf(instance, instance);
+    return false;
+  } catch (e: any) {
+    return e instanceof TypeError;
+  }
+}
+let test18 = selfCycleThrows(() => new Uint8Array(3));
+let test19 = selfCycleThrows(() => Promise.resolve(1));
+let test20 = selfCycleThrows(() => new WeakMap());
+let test21 = selfCycleThrows(() => new ArrayBuffer(4));
+
+// Generator/AsyncGenerator instances: the per-instance prototype slot used
+// to be typed *PlainObject, so Object.setPrototypeOf on one was a silent
+// no-op success. Both getPrototypeOf and real method lookup must agree.
+function* genFn() {
+  yield 1;
+}
+let gen: any = genFn();
+let genProto: any = { tag: "gen-custom" };
+Object.setPrototypeOf(gen, genProto);
+let test22 =
+  Object.getPrototypeOf(gen) === genProto &&
+  gen.tag === "gen-custom" &&
+  gen.next === undefined;
+
+let genNull: any = genFn();
+Object.setPrototypeOf(genNull, null);
+let test23 = Object.getPrototypeOf(genNull) === null && genNull.next === undefined;
+
+async function* asyncGenFn() {
+  yield 1;
+}
+let asyncGen: any = asyncGenFn();
+let asyncGenProto: any = { tag: "async-gen-custom" };
+Object.setPrototypeOf(asyncGen, asyncGenProto);
+let test24 =
+  Object.getPrototypeOf(asyncGen) === asyncGenProto &&
+  asyncGen.tag === "async-gen-custom" &&
+  asyncGen.next === undefined;
+
+// An unmodified generator must still behave completely normally.
+function* plainGen() {
+  yield 1;
+  yield 2;
+}
+let pg = plainGen();
+let test25 = pg.next().value === 1 && pg.next().value === 2;
+
 test1 &&
   test2 &&
   test3 &&
@@ -138,4 +194,12 @@ test1 &&
   test14 &&
   test15 &&
   test16 &&
-  test17;
+  test17 &&
+  test18 &&
+  test19 &&
+  test20 &&
+  test21 &&
+  test22 &&
+  test23 &&
+  test24 &&
+  test25;


### PR DESCRIPTION
## Summary

Fixes #418: `Object.setPrototypeOf` threw `TypeError: Object.setPrototypeOf called on non-object` for every typed-array-family value (`Uint8Array`, `Int32Array`, `Float64Array`, `DataView`, `ArrayBuffer`, ...), even though the same value passes `typeof x === "object"` and `x instanceof Uint8Array` correctly.

Chasing the fix turned up several sibling bugs sharing the same root cause: a switch statement whose case list didn't cover the full set of object-kind `ValueType`s.

### First commit

1. **The rejection itself** (`objectSetPrototypeOfWithVM`'s hand-rolled "is this object-ish" check for the first argument omitted the typed-array family entirely). Replaced with `obj.IsObject() || obj.IsCallable()`, matching how the second argument (the prototype) was already validated a few lines above.

2. **Silent no-op prototype mutation.** The prototype-mutation switch had dead `else if obj.Type() == vm.TypeDictObject` / `if obj.Type() == vm.TypeObject` branches inside cases where `obj.Type()` could never match them — meaning `Object.setPrototypeOf` on Array/Map/Set/WeakMap/WeakSet/WeakRef/FinalizationRegistry/RegExp/ArrayBuffer/SharedArrayBuffer/DataView/TypedArray/Promise all silently no-op'd instead of actually changing anything. Added real cases wired to each type's `SetPrototype`, plus a new `applyExoticPrototype`/`isExoticExtensible` helper pair so those void setters get the same `OrdinarySetPrototypeOf` checks (ECMA-262 10.1.2) that `PlainObject`/`DictObject`/`Array` already had: a no-op when the value doesn't actually change, rejection on a non-extensible instance, and rejection of the direct one-step cycle `setPrototypeOf(x, x)` — with a distinct `"Cyclic __proto__ value"` message rather than reusing the non-extensible one.

3. **null vs. "unset" conflation.** An explicit `Object.setPrototypeOf(x, null)` was indistinguishable from "no override was ever set" in four places — `subclass.go`'s `InstancePrototypeOverride` (gated on `p.IsObject()`), and three read-path helpers with the same shape: `handlePrimitiveMethod`, `effectiveBuiltinPrototype`, and `typedArrayEffectivePrototype`. Each fell back to the intrinsic prototype instead of stopping the chain, so e.g. `Object.setPrototypeOf(u8, null); u8.subarray` kept resolving through `%TypedArray%.prototype` while `Object.getPrototypeOf(u8)` correctly reported `null`. Fixed by telling "unset" (`TypeUndefined`, the zero value) apart from an explicit `TypeNull` override. Also fixed the same gap in `RegExp`'s case, which didn't even attempt to check for an override at all.

4. **VM panic on cross-kind prototypes.** Once (2) made these types' prototype slots actually mutable, Array's `opGetProp` fast path (and the same hand-rolled pattern in Map/Set/Promise/WeakRef/FinalizationRegistry) assumed the slot was always a `PlainObject` or unset, and panicked via `AsPlainObject()` the first time it held some other object-kind value (e.g. one array's prototype set to another array). Migrated all six to `finishProtoChainGet`, the shared walker already used by WeakMap/WeakSet/RegExp/ArrayBuffer/SharedArrayBuffer/DataView, which walks safely regardless of what's in the chain.

Two intentional, non-obvious behavior changes fall out of fix 4: the migrated types' prototype-chain walks now invoke inherited getters (the hand-rolled walks they replace only ever did `GetOwn`), and the self-cycle rejection now reports `"Cyclic __proto__ value"` instead of the generic non-extensible message.

### Second commit

Generator/AsyncGenerator were the one remaining exotic kind where `Object.setPrototypeOf` was still a silent no-op, because their per-instance `[[Prototype]]` slot (`GeneratorObject.Prototype`) was typed `*PlainObject` rather than `vm.Value`. Changed the field type and threaded it through every read/write site (`call.go`'s eager per-instance resolution at creation time, `subclass.go`'s override machinery, `object_init.go`, `promise.go`'s and `vm.go`'s mixed-kind chain walks, and `objectSetPrototypeOfWithVM`'s switch), and migrated `op_getprop.go`'s Generator/AsyncGenerator property-lookup blocks to `finishProtoChainGet` (they previously ignored any per-instance override entirely).

Manual verification while testing this surfaced a real bug the first commit had made newly *reachable*: `Value.Is()` (used by `applyExoticPrototype`'s same-value and self-cycle checks) only handled a hand-picked subset of object-kind `ValueType`s and paniced ("Unhandled type in Is comparison") on the rest. The gap itself is old, but it was unreachable from ordinary JS until `applyExoticPrototype` started comparing arbitrary exotic values — exactly what `Object.setPrototypeOf(x, x)` does for any `x`. So `Object.setPrototypeOf(typedArray, typedArray)` (and the same for `Promise`, `WeakMap`, `ArrayBuffer`, `DataView`, `Generator`, ...) crashed the whole VM process instead of throwing a catchable `TypeError`. Filled in the missing cases with the same reference-equality semantics the existing ones already used (`TypeUninitialized`, an internal-only TDZ marker, is deliberately left unhandled).

## Testing

- `tests/scripts/object_setprototypeof_typed_array.ts` — 25 sub-checks covering all of the above.
- `go test ./tests -run TestScripts` — green.
- Before/after Test262 diffs across `built-ins/{Object,Reflect,Array,Map,Set,Promise,TypedArray,DataView,ArrayBuffer,RegExp,GeneratorFunction,AsyncGeneratorFunction}` — all clean except RegExp, where the delta was confirmed to be pre-existing timeout flakiness at the 0.2s budget (the same generated property-escape tests individually pass with headroom at a longer timeout, and the diff is a bidirectional swap, not a one-directional loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)