### PR TITLE
fix(builtins): Error instances no longer own "name"; own "message" only when supplied (#420)

### DIFF
--- a/pkg/builtins/disposable_stack_init.go
+++ b/pkg/builtins/disposable_stack_init.go
@@ -30,7 +30,6 @@ func newSuppressedError(vmInstance *vm.VM, errorVal, suppressedVal vm.Value) vm.
 	inst := vm.NewObject(proto).AsPlainObject()
 	inst.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
 	inst.SetOwnNonEnumerable("stack", vm.NewString(vmInstance.CaptureStackTrace()))
-	inst.SetOwnNonEnumerable("message", vm.NewString(""))
 	inst.SetOwnNonEnumerable("error", errorVal)
 	inst.SetOwnNonEnumerable("suppressed", suppressedVal)
 	return vm.NewValueFromPlainObject(inst)

--- a/pkg/builtins/error_init.go
+++ b/pkg/builtins/error_init.go
@@ -80,7 +80,7 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if thisValue.Type() == vm.TypeObject {
 			plainObj := thisValue.AsPlainObject()
 			// Step 3-4: Get name property, default to "Error"
-			if nameValue, exists := plainObj.GetOwn("name"); exists {
+			if nameValue, exists := plainObj.Get("name"); exists {
 				if nameValue.Type() == vm.TypeUndefined {
 					name = "Error"
 				} else {
@@ -88,7 +88,7 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 				}
 			}
 			// Step 5-6: Get message property, default to ""
-			if messageValue, exists := plainObj.GetOwn("message"); exists {
+			if messageValue, exists := plainObj.Get("message"); exists {
 				if messageValue.Type() == vm.TypeUndefined {
 					message = ""
 				} else {
@@ -97,14 +97,14 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 			}
 		} else if thisValue.Type() == vm.TypeDictObject {
 			dictObj := thisValue.AsDictObject()
-			if nameValue, exists := dictObj.GetOwn("name"); exists {
+			if nameValue, exists := dictObj.Get("name"); exists {
 				if nameValue.Type() == vm.TypeUndefined {
 					name = "Error"
 				} else {
 					name = nameValue.ToString()
 				}
 			}
-			if messageValue, exists := dictObj.GetOwn("message"); exists {
+			if messageValue, exists := dictObj.Get("message"); exists {
 				if messageValue.Type() == vm.TypeUndefined {
 					message = ""
 				} else {
@@ -130,8 +130,10 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	errorConstructor := vm.NewNativeFunction(1, true, "Error", func(args []vm.Value) (vm.Value, error) {
 		// Get message argument
 		var message string
+		hasMessage := false
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined {
 			message = args[0].ToString()
+			hasMessage = true
 		}
 
 		// Create new Error instance
@@ -141,9 +143,14 @@ func (e *ErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Set [[ErrorData]] internal slot (used by Error.isError to distinguish real errors)
 		errorInstancePtr.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
 
-		// Set properties
-		errorInstancePtr.SetOwnNonEnumerable("name", vm.NewString("Error"))
-		errorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		// Per spec, "name" lives only on the prototype: an instance has no own
+		// "name" until user code assigns one, and that assignment must create
+		// an ordinary enumerable own property (so it survives JSON.stringify).
+		// "message" is installed via CreateNonEnumerableDataPropertyOrThrow,
+		// and only when a message argument was actually supplied.
+		if hasMessage {
+			errorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		}
 
 		// Handle options parameter (ES2022 InstallErrorCause): new Error(message, { cause })
 		if len(args) > 1 && args[1].IsObject() {
@@ -359,15 +366,19 @@ func (e *AggregateErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 
 		// Get message (second argument)
 		var message string
+		hasMessage := false
 		if len(args) > 1 && args[1].Type() != vm.TypeUndefined {
 			message = args[1].ToString()
+			hasMessage = true
 		}
 
 		// Create instance
 		inst := vm.NewObject(vm.NewValueFromPlainObject(proto)).AsPlainObject()
 		inst.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
-		inst.SetOwnNonEnumerable("name", vm.NewString("AggregateError"))
-		inst.SetOwnNonEnumerable("message", vm.NewString(message))
+		// "name" lives only on the prototype (see Error constructor).
+		if hasMessage {
+			inst.SetOwnNonEnumerable("message", vm.NewString(message))
+		}
 		inst.SetOwnNonEnumerable("stack", vm.NewString(vmInstance.CaptureStackTrace()))
 
 		// Set errors property (per ECMAScript spec, this is an own data property)
@@ -513,8 +524,10 @@ func initErrorSubclass(ctx *RuntimeContext, name string) error {
 	// Per ECMAScript 19.5.6.2, NativeError constructors have length 1
 	ctor := vm.NewNativeFunction(1, true, name, func(args []vm.Value) (vm.Value, error) {
 		var message string
+		hasMessage := false
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined {
 			message = args[0].ToString()
+			hasMessage = true
 		}
 
 		// Per spec: OrdinaryCreateFromConstructor(newTarget, "%NativeErrorPrototype%")
@@ -531,8 +544,10 @@ func initErrorSubclass(ctx *RuntimeContext, name string) error {
 		inst := vm.NewObject(instProto).AsPlainObject()
 		// Set [[ErrorData]] internal slot (used by Error.isError to distinguish real errors)
 		inst.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
-		inst.SetOwnNonEnumerable("name", vm.NewString(name))
-		inst.SetOwnNonEnumerable("message", vm.NewString(message))
+		// "name" lives only on the prototype (see Error constructor).
+		if hasMessage {
+			inst.SetOwnNonEnumerable("message", vm.NewString(message))
+		}
 		inst.SetOwnNonEnumerable("stack", vm.NewString(vmInstance.CaptureStackTrace()))
 
 		// Per ECMAScript 20.5.8.1 InstallErrorCause:

--- a/pkg/builtins/fetch_init.go
+++ b/pkg/builtins/fetch_init.go
@@ -1176,8 +1176,8 @@ func newErrorValueWithPrototype(proto vm.Value, name, message string) vm.Value {
 func reasonToMessage(reason vm.Value) string {
 	if reason.Type() == vm.TypeObject {
 		obj := reason.AsPlainObject()
-		nameVal, hasName := obj.GetOwn("name")
-		msgVal, hasMsg := obj.GetOwn("message")
+		nameVal, hasName := obj.Get("name")
+		msgVal, hasMsg := obj.Get("message")
 		if hasName || hasMsg {
 			name := "Error"
 			if hasName && nameVal.Type() == vm.TypeString {

--- a/pkg/builtins/reference_error_init.go
+++ b/pkg/builtins/reference_error_init.go
@@ -62,8 +62,10 @@ func (r *ReferenceErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	referenceErrorConstructor := vm.NewNativeFunction(1, true, "ReferenceError", func(args []vm.Value) (vm.Value, error) {
 		// Get message argument
 		var message string
+		hasMessage := false
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined {
 			message = args[0].ToString()
+			hasMessage = true
 		}
 
 		// Per spec: OrdinaryCreateFromConstructor(newTarget, "%ReferenceErrorPrototype%")
@@ -83,9 +85,14 @@ func (r *ReferenceErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Set [[ErrorData]] internal slot (used by Error.isError to distinguish real errors)
 		referenceErrorInstancePtr.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
 
-		// Set properties (override name, set message and stack)
-		referenceErrorInstancePtr.SetOwnNonEnumerable("name", vm.NewString("ReferenceError"))
-		referenceErrorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		// Per spec, "name" lives only on the prototype: an instance has no own
+		// "name" until user code assigns one, and that assignment must create
+		// an ordinary enumerable own property (so it survives JSON.stringify).
+		// "message" is installed via CreateNonEnumerableDataPropertyOrThrow,
+		// and only when a message argument was actually supplied.
+		if hasMessage {
+			referenceErrorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		}
 
 		// Capture stack trace at the time of ReferenceError creation
 		stackTrace := vmInstance.CaptureStackTrace()

--- a/pkg/builtins/syntax_error_init.go
+++ b/pkg/builtins/syntax_error_init.go
@@ -62,8 +62,10 @@ func (s *SyntaxErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	syntaxErrorConstructor := vm.NewNativeFunction(1, true, "SyntaxError", func(args []vm.Value) (vm.Value, error) {
 		// Get message argument
 		var message string
+		hasMessage := false
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined {
 			message = args[0].ToString()
+			hasMessage = true
 		}
 
 		// Per spec: OrdinaryCreateFromConstructor(newTarget, "%SyntaxErrorPrototype%")
@@ -83,9 +85,14 @@ func (s *SyntaxErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Set [[ErrorData]] internal slot (used by Error.isError to distinguish real errors)
 		syntaxErrorInstancePtr.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
 
-		// Set properties (override name, set message and stack)
-		syntaxErrorInstancePtr.SetOwnNonEnumerable("name", vm.NewString("SyntaxError"))
-		syntaxErrorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		// Per spec, "name" lives only on the prototype: an instance has no own
+		// "name" until user code assigns one, and that assignment must create
+		// an ordinary enumerable own property (so it survives JSON.stringify).
+		// "message" is installed via CreateNonEnumerableDataPropertyOrThrow,
+		// and only when a message argument was actually supplied.
+		if hasMessage {
+			syntaxErrorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		}
 
 		// Capture stack trace at the time of SyntaxError creation
 		stackTrace := vmInstance.CaptureStackTrace()

--- a/pkg/builtins/type_error_init.go
+++ b/pkg/builtins/type_error_init.go
@@ -62,8 +62,10 @@ func (t *TypeErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 	typeErrorConstructor := vm.NewNativeFunction(1, true, "TypeError", func(args []vm.Value) (vm.Value, error) {
 		// Get message argument
 		var message string
+		hasMessage := false
 		if len(args) > 0 && args[0].Type() != vm.TypeUndefined {
 			message = args[0].ToString()
+			hasMessage = true
 		}
 
 		// Per spec: OrdinaryCreateFromConstructor(newTarget, "%TypeErrorPrototype%")
@@ -83,9 +85,14 @@ func (t *TypeErrorInitializer) InitRuntime(ctx *RuntimeContext) error {
 		// Set [[ErrorData]] internal slot (used by Error.isError to distinguish real errors)
 		typeErrorInstancePtr.SetOwnNonEnumerable("[[ErrorData]]", vm.Undefined)
 
-		// Set properties (override name, set message and stack)
-		typeErrorInstancePtr.SetOwnNonEnumerable("name", vm.NewString("TypeError"))
-		typeErrorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		// Per spec, "name" lives only on the prototype: an instance has no own
+		// "name" until user code assigns one, and that assignment must create
+		// an ordinary enumerable own property (so it survives JSON.stringify).
+		// "message" is installed via CreateNonEnumerableDataPropertyOrThrow,
+		// and only when a message argument was actually supplied.
+		if hasMessage {
+			typeErrorInstancePtr.SetOwnNonEnumerable("message", vm.NewString(message))
+		}
 
 		// Capture stack trace at the time of TypeError creation
 		stackTrace := vmInstance.CaptureStackTrace()

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -462,8 +462,8 @@ func (vm *VM) handleUncaughtException() {
 
 			// Check if this looks like an Error object (has name or message properties)
 			// First try to get name and message
-			nameVal, hasName := obj.GetOwn("name")
-			messageVal, hasMessage := obj.GetOwn("message")
+			nameVal, hasName := obj.Get("name")
+			messageVal, hasMessage := obj.Get("message")
 
 			if hasName || hasMessage {
 				// If we have name and/or message, format like Error.prototype.toString()
@@ -535,8 +535,8 @@ func (vm *VM) handleUncaughtException() {
 func (vm *VM) formatExceptionDisplay(exception Value) string {
 	if exception.IsObject() && exception.Type() == TypeObject {
 		obj := exception.AsPlainObject()
-		nameVal, hasName := obj.GetOwn("name")
-		messageVal, hasMessage := obj.GetOwn("message")
+		nameVal, hasName := obj.Get("name")
+		messageVal, hasMessage := obj.Get("message")
 
 		if hasName || hasMessage {
 			var name, message string

--- a/tests/scripts/error_name_assignment_enumerable.ts
+++ b/tests/scripts/error_name_assignment_enumerable.ts
@@ -1,0 +1,40 @@
+// expect: true
+// Regression test for #420: Error instances have no own "name" property, so
+// `err.name = "X"` creates an ordinary enumerable own property that survives
+// JSON.stringify / Object.keys. "message" is own (non-enumerable) only when
+// a message argument was actually supplied.
+const e = new Error("msg");
+(e as any).name = "MyName";
+const d = Object.getOwnPropertyDescriptor(e, "name")!;
+
+class MyError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "MyError";
+  }
+}
+const m = new MyError("oops");
+
+const t = new TypeError("tt");
+(t as any).name = "Renamed";
+
+const results = [
+  d.enumerable === true && d.writable === true && d.configurable === true,
+  JSON.stringify(e) === '{"name":"MyName"}',
+  JSON.stringify(m) === '{"name":"MyError"}',
+  Object.keys(m).join(",") === "name",
+  String(m) === "MyError: oops",
+  JSON.stringify(t) === '{"name":"Renamed"}',
+  // No own "name" on fresh instances; inherited from the prototype instead.
+  !new Error().hasOwnProperty("name") && new Error().name === "Error",
+  !new RangeError().hasOwnProperty("name") && new RangeError().name === "RangeError",
+  !new AggregateError([]).hasOwnProperty("name") && new AggregateError([]).name === "AggregateError",
+  // Own "message" only when a message argument was supplied.
+  !new Error().hasOwnProperty("message") && new Error().message === "",
+  new Error("a").hasOwnProperty("message") && Object.getOwnPropertyDescriptor(new Error("a"), "message")!.enumerable === false,
+  !new TypeError(undefined).hasOwnProperty("message"),
+  // Error.prototype.toString reads inherited name/message.
+  String(new SyntaxError("s")) === "SyntaxError: s",
+  String(new AggregateError([], "agg")) === "AggregateError: agg",
+];
+results.every((r) => r);


### PR DESCRIPTION
Fixes #420.

## Problem

Every Error constructor (`Error`, the NativeErrors, `AggregateError`) baked a non-enumerable own `name` onto each instance. So `err.name = "X"` hit `PlainObject.SetOwn`'s preserve-attributes branch and stayed non-enumerable, silently vanishing from `JSON.stringify`, `Object.keys`, `for...in`, and spread. The AWS SDK's generated exception classes (`this.name = "SomeServiceException"` after `super()`) rely on that property being enumerable, which is how this surfaced under noderati.

`message` was also baked unconditionally as `""`, even with no argument.

## Fix

- **`name` lives only on the prototype.** Removed the own `name` from instances in `error_init.go` (Error, AggregateError, shared NativeError helper) and the TypeError / ReferenceError / SyntaxError files. `OrdinarySet` then creates an ordinary enumerable own property on user assignment, matching V8.
- **`message` follows `CreateNonEnumerableDataPropertyOrThrow`.** Own non-enumerable `message` is installed only when a message argument was actually supplied. The `SuppressedError` built internally by `DisposeResources` likewise no longer gets an empty own `message`.
- **Readers walk the prototype chain.** `Error.prototype.toString`, the VM's uncaught-exception formatter (`pkg/vm/exceptions.go`), and fetch's abort-reason renderer used `GetOwn` for `name`/`message`; they now use `Get`.
- Regression smoke test: `tests/scripts/error_name_assignment_enumerable.ts`.

## Verification

Issue repro now matches Node exactly:
```
{"value":"MyName","writable":true,"enumerable":true,"configurable":true}
{"name":"MyName"}
{"name":"MyError"}
```

- `go test ./pkg/... ./tests/...` all green.
- Test262 vs baseline: **+2, 0 regressions** across `built-ins/Error`, `NativeErrors`, `AggregateError`, `SuppressedError`, `DisposableStack`, `AsyncDisposableStack`, `JSON`, and the full `language/` tree.
  - `+built-ins/Error/the-initial-value-of-errorprototypemessage-is-the-empty-string.js`
  - `+built-ins/AggregateError/message-undefined-no-prop.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
