### PR TITLE
fix(vm): async catch/finally rethrow no longer leaks the original awaited rejection (#422)

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -17065,8 +17065,25 @@ startExecution:
 						// Resume async function with rejected value (it will throw)
 						result, err := vm.resumeAsyncFunctionWithException(asyncPromise, reason)
 						if err != nil {
-							// Exception wasn't caught - reject the async promise
-							vm.rejectPromise(asyncPromise, reason)
+							// Exception wasn't caught (or the async function's own
+							// catch/finally threw something new before propagating
+							// out) - reject the async promise with the value that
+							// actually reached us, not the original rejection
+							// `reason` this closure captured as its own argument.
+							// resumeAsyncFunctionWithException/vm.throwException may
+							// have replaced that value along the way (e.g. `catch
+							// (e) { throw somethingElse }` inside the resumed
+							// function), and it's err's ExceptionError, not `reason`,
+							// that carries whatever ultimately propagated. Mirrors
+							// the identical extraction the Resolve handler above
+							// already does.
+							var propagated Value
+							if ee, ok := err.(ExceptionError); ok {
+								propagated = ee.GetExceptionValue()
+							} else {
+								propagated = NewString(err.Error())
+							}
+							vm.rejectPromise(asyncPromise, propagated)
 						} else if asyncPromise.Frame != nil {
 							// Async function hit another await and suspended again
 							// Don't resolve - the new await's handlers will take over

--- a/tests/scripts/async_catch_rethrow_new_value.ts
+++ b/tests/scripts/async_catch_rethrow_new_value.ts
@@ -1,0 +1,74 @@
+// expect: no-loop:REPLACED|loop:REPLACED|finally:FINALLY_REPLACED|string:STRING_REPLACED
+// Regression test for #422: when an async function's own catch/finally
+// block, entered by an awaited rejection, itself throws a DIFFERENT value
+// than the one it caught, that NEW value must be what the async function's
+// promise rejects with - not the original awaited rejection reason.
+//
+// Root cause: the internal await-rejection resumption path
+// (resumeAsyncFunctionWithException's Reject reaction in pkg/vm/vm.go)
+// rejected the async function's promise with the closure's captured
+// `reason` (the ORIGINAL awaited rejection) instead of the exception
+// actually returned by resumeAsyncFunctionWithException, which may have
+// been replaced along the way. This was masked whenever a rethrow reused
+// the same value it caught - only a genuine substitution exposed it.
+//
+// The bug's own report guessed a loop was a necessary ingredient (a plain,
+// non-looped try/catch "did not reproduce"); it isn't - the loop was
+// incidental, and every shape below (no loop, loop, finally, non-Error
+// thrown value) hit the same bug before the fix. Covering all four here
+// so the invariant, not one instance of it, stays pinned.
+async function refresh() {
+    throw new Error("INNER");
+}
+
+async function noLoop() {
+    try {
+        await refresh();
+    } catch (e) {
+        throw new Error("REPLACED");
+    }
+}
+
+async function withLoop() {
+    for (let i = 0; i < 1; i++) {
+        let lastError = new Error("REPLACED");
+        try {
+            await refresh();
+        } catch (refreshError) {
+            throw lastError;
+        }
+    }
+}
+
+async function withFinally() {
+    try {
+        await refresh();
+    } finally {
+        throw "FINALLY_REPLACED";
+    }
+}
+
+async function withStringThrow() {
+    try {
+        await refresh();
+    } catch (e) {
+        throw "STRING_REPLACED";
+    }
+}
+
+async function run(label: string, fn: () => Promise<void>): Promise<string> {
+    try {
+        await fn();
+        return label + ":no-error";
+    } catch (e) {
+        return label + ":" + (e instanceof Error ? e.message : e);
+    }
+}
+
+const results = [
+    await run("no-loop", noLoop),
+    await run("loop", withLoop),
+    await run("finally", withFinally),
+    await run("string", withStringThrow),
+];
+results.join("|");


### PR DESCRIPTION
Fixes #422.

## Root cause

`pkg/vm/vm.go`'s await-rejection resumption (the `Reject` `PromiseReaction` registered by `OpAwait` for resuming an async function from a rejected awaited promise) calls `vm.resumeAsyncFunctionWithException(asyncPromise, reason)`. When that returned a non-nil `err` (an exception propagated out of the resumed function, uncaught), the code rejected the async function's own promise with the closure's captured `reason` — the *original* awaited rejection value — instead of the value actually carried by `err`.

`resumeAsyncFunctionWithException` can and does replace the in-flight exception value along the way (any `catch`/`finally` in the resumed function that itself throws a different value), so whenever it did, the substitution was silently discarded and the stale original leaked out instead.

The fix mirrors what the sibling `Resolve` reaction already does correctly 30 lines above: extract the real value via `err.(ExceptionError).GetExceptionValue()` before rejecting.

## Correction to the issue's own repro

The issue guessed a loop was a necessary ingredient (a plain non-looped `try { await refresh() } catch { throw lastError }` "did not reproduce"). Re-tested directly — it reproduces the same way without a loop. The loop was incidental; the actual necessary ingredient is just: an async function's `catch`/`finally`, entered by resuming from an *awaited rejection*, that throws a **different** value than what it caught. A straight rethrow of the same value (the overwhelmingly common shape) hits the same bug but happens to look correct, since `reason == err`'s value — which is why this stayed hidden.

## Relation to #61 / #142

Unrelated. Both of those are about the frame/native-boundary exception-unwinding machinery (`vm.unwindingCrossedNative` boundary scoping, and reentrant-`vm.Call()` frame bookkeeping). This is a plain wrong-variable bug in one Go closure — no interaction with either mechanism.

## Testing

- New regression test `tests/scripts/async_catch_rethrow_new_value.ts` covers four shapes: no loop, with loop (the original repro), `finally` substitution, and a non-`Error` (string) thrown replacement.
- Full smoke suite (`go test ./tests -run TestScripts`) green.
- Spot-checked `language/statements/async-function`, `language/expressions/async-function`, and `built-ins/Promise` Test262 subsets — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
