### PR TITLE
fix(checker,compiler): export { ns } now works for a namespace import

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -4345,6 +4345,13 @@ func (c *Checker) processImportBinding(localName, sourceModule, sourceName strin
 			if isTypeOnly {
 				c.env.DefineTypeAlias(localName, types.Any)
 				debugPrintf("// [Checker] Registered unresolved type-only import %s as type alias\n", localName)
+			} else {
+				// The value binding is still real and usable at runtime (e.g. a namespace
+				// import whose type can't be statically resolved) - register it as `any`
+				// so later references (including `export { name }`) can resolve it,
+				// mirroring the no-module-mode fallback path below (paserati#424).
+				c.env.Define(localName, types.Any, false)
+				debugPrintf("// [Checker] Registered unresolved import %s as any\n", localName)
 			}
 		}
 	} else {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4828,6 +4828,27 @@ func (c *Compiler) compileExportNamedDeclaration(node *parser.ExportNamedDeclara
 						importRef := c.moduleBindings.ImportedNames[localName]
 						c.moduleBindings.DefineReExport(exportName, importRef.SourceModule, importRef.SourceName)
 						debugPrintf("// [Compiler] Re-exported (via import): %s as %s from %s\n", importRef.SourceName, exportName, importRef.SourceModule)
+					} else if c.IsModuleMode() && c.moduleBindings.IsImported(localName) &&
+						c.moduleBindings.ImportedNames[localName].ImportType == ImportNamespaceRef {
+						// export { ns } where ns is a namespace import (import * as
+						// ns from "module"). Unlike named/default imports, "*" isn't
+						// a real export name in the source module to re-export by
+						// reference, but the namespace object itself is a genuine
+						// runtime value - materialize it into a global slot exactly
+						// like "export * as ns from 'module'" already does
+						// (compileExportAllDeclaration), and register that slot as
+						// a real (non-re-export) export. See paserati#424.
+						importRef := c.moduleBindings.ImportedNames[localName]
+						globalIdx := int(c.GetOrAssignGlobalIndex(c.moduleGlobalKey(exportName)))
+						c.moduleBindings.DefineExport(localName, exportName, vm.Undefined, nil, globalIdx)
+
+						nsReg := c.regAlloc.Alloc()
+						c.emitEvalModule(importRef.SourceModule, node.Token.Line)
+						c.emitCreateNamespace(nsReg, importRef.SourceModule, node.Token.Line)
+						c.emitSetGlobal(uint16(globalIdx), nsReg, node.Token.Line)
+						c.regAlloc.Free(nsReg)
+
+						debugPrintf("// [Compiler] Exported namespace import: %s as %s from %s\n", localName, exportName, importRef.SourceModule)
 					} else {
 						return BadRegister, NewCompileError(node, fmt.Sprintf("exported name '%s' not found in current scope", localName))
 					}

--- a/tests/scripts/export_namespace_import_named.ts
+++ b/tests/scripts/export_namespace_import_named.ts
@@ -1,0 +1,15 @@
+// expect: 3
+// paserati#424: `export { ns }` where `ns` is bound via `import * as ns`
+// previously failed checker-side ("exported name 'ns' not found in current
+// scope") because unresolved namespace imports were never given a value
+// binding, and (once that's fixed) also failed compiler-side because
+// namespace imports are deliberately excluded from the "re-export via
+// import" path (paserati#163) since "*" isn't a real export name to look up.
+// This is the exact real-world shape from zod/prettier's compiled output:
+// `import * as ns from "./somewhere"; export { ns }; export default ns;`
+import * as ns from "./export_namespace_import_named_lib.ts";
+
+export { ns };
+export default ns;
+
+ns.a + ns.b;

--- a/tests/scripts/export_namespace_import_named_lib.ts
+++ b/tests/scripts/export_namespace_import_named_lib.ts
@@ -1,0 +1,2 @@
+export const a = 1;
+export const b = 2;

--- a/tests/scripts/reexport_of_namespace_import.ts
+++ b/tests/scripts/reexport_of_namespace_import.ts
@@ -1,8 +1,11 @@
-// expect_compile_error: exported name 'NS' not found in current scope
-// paserati#163: re-exporting a *namespace* import (import * as NS; export
-// { NS };) has no established resolution path (there's no real "*" export
-// name to look up in the source module), so this must keep erroring
-// loudly rather than silently compiling to an undefined re-export.
+// expect: 1
+// paserati#424: re-exporting a *namespace* import (import * as NS; export
+// { NS };) is a common real-world pattern (e.g. zod's real index.js does
+// `import * as z from "./v3/external"; export { z };`). The namespace object
+// is materialized into a global slot exactly like "export * as ns from
+// 'module'" already did, and the re-exporting module's own named export
+// resolves to that slot (superseding paserati#163's "not found" error, which
+// predated this being implemented).
 import { NS } from "./reexport_of_namespace_import_index.ts";
 
-NS;
+NS.Foo;


### PR DESCRIPTION
## Summary
- `import * as ns from "./mod"; export { ns };` — the real shape zod and prettier's compiled output use (e.g. zod's `index.js`: `import * as z from "./v3/external"; export { z };`) — previously failed at two layers.
- **Checker**: an unresolved namespace import (`ResolveImportedType` returning `nil`/`Any`) never registered a value binding in `c.env`, unlike the no-module-mode fallback path a few lines below — so the later `export { ns }` legitimately found nothing to resolve.
- **Compiler**: even once the checker accepts it, namespace imports were deliberately excluded from the "re-export via import" path added for #163, since `"*"` isn't a real export name to look up in the source module. That exclusion is now replaced with real handling: the namespace object is materialized into a global slot exactly like `export * as ns from "module"` already does (`compileExportAllDeclaration`), and registered as a genuine export rather than a re-export.

## Testing
- Updated the existing `#163` regression test (`reexport_of_namespace_import.ts`) to reflect that this is now supported instead of a hard error.
- Added `export_namespace_import_named.ts` covering the exact issue #424 repro shape (namespace import + named export + default export of the same binding).
- `go test ./tests -run TestScripts` and `go test ./...` both green.

Fixes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)