### PR TITLE
fix(lexer): \xNN string/template escapes for 0x80-0xFF UTF-8-encode the code point

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -2145,9 +2145,13 @@ func (l *Lexer) readString(quote byte) (string, bool, bool) {
 						return "", hasEscape, false // Invalid or incomplete \xXX
 					}
 				}
-				// Use ParseUint with 32 bits to handle full byte range (0x00-0xFF)
+				// Use ParseUint with 32 bits to handle full byte range (0x00-0xFF).
+				// \xXX names a *code point* (U+0000-U+00FF), not a raw byte - for
+				// 0x80-0xFF that needs a 2-byte UTF-8 encoding (WriteRune), not a
+				// single raw byte (WriteByte), which produces invalid UTF-8/WTF-8
+				// (a lone continuation-range byte). See paserati#425.
 				if codePoint, err := strconv.ParseUint(hexStr, 16, 32); err == nil && codePoint <= 255 {
-					builder.WriteByte(byte(codePoint))
+					builder.WriteRune(rune(codePoint))
 				} else {
 					return "", hasEscape, false // Invalid code point
 				}
@@ -3060,8 +3064,12 @@ func (l *Lexer) readTemplateString(startLine, startCol, startPos int) Token {
 						}
 					}
 					if len(hexStr) == 2 {
+						// \xXX names a *code point* (U+0000-U+00FF), not a raw byte -
+						// for 0x80-0xFF that needs a 2-byte UTF-8 encoding (WriteRune),
+						// not a single raw byte (WriteByte), which produces invalid
+						// UTF-8/WTF-8. See paserati#425.
 						if val, err := strconv.ParseUint(hexStr, 16, 32); err == nil && val <= 255 {
-							cooked.WriteByte(byte(val))
+							cooked.WriteRune(rune(val))
 						}
 					} else {
 						// Incomplete escape - cooked is undefined

--- a/tests/scripts/regexp_dynamic_non_ascii.ts
+++ b/tests/scripts/regexp_dynamic_non_ascii.ts
@@ -1,0 +1,12 @@
+// expect: true
+// paserati#425: new RegExp(str) with a non-ASCII \xNN-escaped char (or a
+// range of them) previously threw "invalid UTF-8" because the JS string
+// itself was corrupted by the lexer bug fixed alongside this (see
+// string_x_escape_non_ascii.ts) - the pattern handed to Go's regexp package
+// contained a lone invalid byte. A regex *literal* with the same escapes
+// compiled without error but silently matched wrong, for the same reason:
+// the test string it was matched against was equally corrupted.
+const re1 = new RegExp("[\xaa]");
+const re2 = /[\xc0-\xd6]/;
+
+re1.test("\xaa") && re2.test("\xc0") && !re2.test("\xd7");

--- a/tests/scripts/string_x_escape_non_ascii.ts
+++ b/tests/scripts/string_x_escape_non_ascii.ts
@@ -1,0 +1,12 @@
+// expect: true
+// paserati#425: `\xNN` for NN in 0x80-0xFF names a Unicode code point
+// (U+0080-U+00FF), not a raw byte - it must be UTF-8-encoded (2 bytes),
+// not written as a single raw byte (which produces invalid UTF-8/WTF-8:
+// a lone continuation-range byte). That corruption was invisible to
+// charCodeAt()/length (which read logical UTF-16 code units) but broke
+// anything that needs valid UTF-8 out of the string, like handing it to
+// Go's regexp.Compile via `new RegExp(str)`.
+const s = "\xaa";
+const bytes = Array.from(new TextEncoder().encode(s));
+
+bytes.length === 2 && bytes[0] === 0xc2 && bytes[1] === 0xaa && s.charCodeAt(0) === 0xaa;


### PR DESCRIPTION
## Summary
`\xNN` names a Unicode code point (U+0000-U+00FF), not a raw byte. Both the string-literal escape reader and the template-literal cooked-string reader wrote the code point straight out as a single raw byte (`builder.WriteByte(byte(codePoint))`) instead of UTF-8-encoding it (`WriteRune`) — correct for 0x00-0x7F (identical either way) but wrong for 0x80-0xFF, which need a 2-byte UTF-8 encoding.

The result was a string whose underlying bytes were invalid UTF-8/WTF-8 (a lone continuation-range byte), even though `charCodeAt()`/`length` still read back the right logical code unit (they decode by UTF-16 code unit, not raw bytes) — masking the corruption until something needed valid UTF-8 out of the string, e.g. handing it to Go's `regexp.Compile` via `new RegExp(str)`. Confirmed via `new TextEncoder().encode("\xaa")` returning byte `aa` instead of the correct `c2 aa`.

This explains both symptoms in #425:
- `new RegExp("[\xaa]")` threw "invalid UTF-8" because the pattern string itself was corrupted.
- A regex *literal* with the same escapes (`/[\xc0-\xd6]/`, processed via a separate, already-correct `WriteRune`-based path in `regex.go` since literal patterns are re-parsed from raw source text) silently matched wrong because the *string being tested against* (`"\xc0"`) was the corrupted one.

## Testing
- Added `string_x_escape_non_ascii.ts` and `regexp_dynamic_non_ascii.ts` smoke tests covering both symptoms.
- `go test ./tests -run TestScripts` and `go test ./...` both green.
- Test262 impact (`built-ins/RegExp`, `built-ins/String`, `language/literals/string`, `language/literals/regexp`; `-timeout 0.2s`): **+113 new passes, 0 regressions**.

Fixes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)