### PR TITLE
fix(compiler): nested if/ternary no longer leak registers per nesting level

### DIFF
--- a/pkg/compiler/compile_expression.go
+++ b/pkg/compiler/compile_expression.go
@@ -1090,17 +1090,23 @@ func (c *Compiler) compileUpdateExpression(node *parser.UpdateExpression, hint R
 
 // compileTernaryExpression compiles condition ? consequence : alternative
 func (c *Compiler) compileTernaryExpression(node *parser.TernaryExpression, hint Register) (Register, errors.PaseratiError) {
-	// Manage temporary registers with automatic cleanup
-	var tempRegs []Register
+	// conditionReg is freed immediately after its one use (the conditional
+	// jump below) instead of being held live through the consequence/
+	// alternative - without this, a chain of nested ternaries
+	// (a ? b : c ? d : e ? ...) pins one register per level for the whole
+	// nested chain, the same class of bug as the nested-if case in
+	// paserati#426. condFreed guards the fallback defer (for the
+	// early-return error path below, before the jump is even emitted)
+	// against double-freeing.
+	conditionReg := c.regAlloc.Alloc()
+	condFreed := false
 	defer func() {
-		for _, reg := range tempRegs {
-			c.regAlloc.Free(reg)
+		if !condFreed {
+			c.regAlloc.Free(conditionReg)
 		}
 	}()
 
 	// 1. Compile condition (not in tail position)
-	conditionReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, conditionReg)
 	oldTailPos := c.inTailPosition
 	c.inTailPosition = false
 	_, err := c.compileNode(node.Condition, conditionReg)
@@ -1111,6 +1117,8 @@ func (c *Compiler) compileTernaryExpression(node *parser.TernaryExpression, hint
 
 	// 2. Jump if false
 	jumpFalsePos := c.emitPlaceholderJump(vm.OpJumpIfFalse, conditionReg, node.Token.Line)
+	c.regAlloc.Free(conditionReg)
+	condFreed = true
 
 	// --- Consequence Path ---
 	// 3. Compile consequence directly to hint (may be in tail position)
@@ -3098,17 +3106,24 @@ func (c *Compiler) compileIfExpression(node *parser.IfExpression, hint Register)
 			debugPrintf("[IfExpr][defer] Patched OpJump (over else) at pos=%d to end (offset=%d)", jumpElsePos, offset)
 		}
 	}()
-	// Manage temporary registers with automatic cleanup
-	var tempRegs []Register
+	// conditionReg is freed immediately after its one use (the conditional
+	// jump below), not deferred to this function's own return, so a deeply
+	// nested if-statement doesn't hold it live for the entire nested chain
+	// underneath it - see paserati#426, where 150+ nested ifs exhausted the
+	// 255-register budget this way even though conditionReg is dead well
+	// before the function returns. condFreed guards the fallback defer (for
+	// the early-return error path below, before the jump is even emitted)
+	// against double-freeing a register that was already freed and possibly
+	// reallocated to something else.
+	conditionReg := c.regAlloc.Alloc()
+	condFreed := false
 	defer func() {
-		for _, reg := range tempRegs {
-			c.regAlloc.Free(reg)
+		if !condFreed {
+			c.regAlloc.Free(conditionReg)
 		}
 	}()
 
 	// 1. Compile the condition
-	conditionReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, conditionReg)
 	_, err := c.compileNode(node.Condition, conditionReg)
 	if err != nil {
 		return BadRegister, err
@@ -3127,21 +3142,30 @@ func (c *Compiler) compileIfExpression(node *parser.IfExpression, hint Register)
 	debugPrintf("[IfExpr] Before OpJumpIfFalse emit: codeLen=%d", len(c.chunk.Code))
 	jumpIfFalsePos = c.emitPlaceholderJump(vm.OpJumpIfFalse, conditionReg, node.Token.Line)
 	debugPrintf("[IfExpr] Emitted OpJumpIfFalse at pos=%d; codeLen now=%d", jumpIfFalsePos, len(c.chunk.Code))
+	// conditionReg's only use was as the jump's operand above - free it now
+	// rather than holding it live through the (possibly deeply nested)
+	// consequence/alternative below.
+	c.regAlloc.Free(conditionReg)
+	condFreed = true
 
-	// 3. Compile the consequence block
-	// Allocate temporary register for consequence compilation and initialize to undefined.
-	// This is important for break/continue inside the block - they copy hint to the loop's
-	// completion register, so hint must have a defined value (undefined if no prior statement).
-	consequenceReg := c.regAlloc.Alloc()
-	tempRegs = append(tempRegs, consequenceReg)
-	c.emitLoadUndefined(consequenceReg, node.Token.Line)
-	consResult, err := c.compileNode(node.Consequence, consequenceReg)
+	// 3. Compile the consequence block directly into hint, rather than into a
+	// separate scratch register that gets copied to hint afterward. hint was
+	// already pre-initialized to undefined above (or is BadRegister, meaning
+	// the caller has no use for a completion value at all - the
+	// overwhelmingly common case for an if-statement not in tail/completion
+	// position), so if the consequence itself produces no completion value,
+	// hint correctly keeps holding that default - exactly the same contract
+	// the old "compile into a scratch register, then conditionally copy to
+	// hint" two-step provided, just without the scratch register. That
+	// register had to stay live for the *entire* nested compilation (a
+	// further-nested if writes into it in turn), so a chain of N nested
+	// if-statements previously pinned N live registers simultaneously for a
+	// value that was always going to end up equal to hint anyway. See
+	// paserati#426 (150+ nested ifs exhausting the 255-register budget at
+	// ~1-2 registers held per nesting level for no reason).
+	_, err = c.compileNode(node.Consequence, hint)
 	if err != nil {
 		return BadRegister, err
-	}
-	// If consequence produced a value, copy it to hint
-	if hint != BadRegister && consResult != BadRegister {
-		c.emitMove(hint, consequenceReg, node.Token.Line)
 	}
 	// Dump disassembly after consequence compilation, before any patching
 	if debugCompiler {
@@ -3167,19 +3191,11 @@ func (c *Compiler) compileIfExpression(node *parser.IfExpression, hint Register)
 			debugPrintf("[IfExpr] Disassembly after patchJumpIfFalse (else path entry):\n%s", c.chunk.DisassembleChunk("<if-else-entry>"))
 		}
 
-		// 6a. Compile the alternative block
-		// Allocate temporary register for alternative compilation and initialize to undefined.
-		// This is important for break/continue inside the block.
-		alternativeReg := c.regAlloc.Alloc()
-		tempRegs = append(tempRegs, alternativeReg)
-		c.emitLoadUndefined(alternativeReg, node.Token.Line)
-		altResult, err := c.compileNode(node.Alternative, alternativeReg)
+		// 6a. Compile the alternative block directly into hint - same
+		// rationale as the consequence above (paserati#426).
+		_, err := c.compileNode(node.Alternative, hint)
 		if err != nil {
 			return BadRegister, err
-		}
-		// If alternative produced a value, copy it to hint
-		if hint != BadRegister && altResult != BadRegister {
-			c.emitMove(hint, alternativeReg, node.Token.Line)
 		}
 
 		// 7a. Backpatch the OpJump to jump *here* (end of else block)

--- a/tests/scripts/if_completion_value_no_leak.ts
+++ b/tests/scripts/if_completion_value_no_leak.ts
@@ -1,0 +1,44 @@
+// expect: true
+// paserati#426 Symptom 1: nested if-statements previously held 1-2 live
+// registers per nesting level for the entire duration of the nested
+// compilation (a condition-temp register freed too late, plus a
+// consequence/alternative scratch register that existed only to be copied
+// into `hint` right after the nested compile finished, i.e. it was always
+// going to hold exactly what `hint` should hold anyway). 150 levels of
+// sequential nested `if`s - not an unusual amount of generated code (this is
+// exactly the shape JSON-Schema-validator codegen and generated SDK clients
+// produce) - exhausted the 255-register budget purely from nesting depth,
+// with real engines handling this trivially. Fixed by freeing the condition
+// register immediately after its one use (the conditional jump) and
+// compiling each branch directly into `hint` instead of a scratch register.
+//
+// This test covers both the raw depth (well past the old ~118-level ceiling)
+// and, since compiling directly into `hint` changes *how* completion values
+// flow without being allowed to change *what* they are, a battery of the
+// completion-value edge cases that distinguish "correct, just fewer
+// registers" from "quietly wrong": break/continue copying a mid-branch
+// value out of a loop, an if/else where only one branch produces a value,
+// and a nested if whose inner branch is empty (hint must stay undefined,
+// not leak the outer branch's own pre-init).
+let body = "let x = 0;\n";
+let close = "";
+for (let i = 0; i < 1000; i++) {
+  body += "if (data.a" + i + " !== undefined) { x += " + i + ";\n";
+  close += "}\n";
+}
+body += close + "return x;";
+const deepFn = new Function("data", body);
+
+const depthOk = deepFn({}) === 0;
+
+const breakVal = eval("for (let i=0;i<3;i++) { if (true) { 42; break; } }") === 42;
+const continueVal = eval("for (let i=0;i<3;i++) { if (true) { 7; continue; } 9; }") === 7;
+const elseOnlyVal = eval("if (false) { 1; } else { }") === undefined;
+const thenOnlyVal = eval("if (true) { } else { 1; }") === undefined;
+const nestedEmptyVal = eval("if (true) { if (true) { } }") === undefined;
+const noElseFalseVal = eval("if (false) { 5; }") === undefined;
+const ifElseTrueVal = eval("if (true) { 1; } else { 2; }") === 1;
+const ifElseFalseVal = eval("if (false) { 1; } else { 2; }") === 2;
+
+depthOk && breakVal && continueVal && elseOnlyVal && thenOnlyVal &&
+  nestedEmptyVal && noElseFalseVal && ifElseTrueVal && ifElseFalseVal;

--- a/tests/scripts/nested_ternary_no_register_leak.ts
+++ b/tests/scripts/nested_ternary_no_register_leak.ts
@@ -1,0 +1,15 @@
+// expect: true
+// paserati#426 Symptom 1 companion: compileTernaryExpression had the same
+// condition-register leak as compileIfExpression (freed only at function
+// return via a deferred cleanup, so a chain of nested ternaries pinned one
+// register per level for the whole nested chain even though each one is
+// dead immediately after the conditional jump consumes it). Verifies a
+// 500-level nested ternary compiles and evaluates correctly instead of
+// hitting "register exhaustion: expression too deeply nested".
+let expr = "0";
+for (let i = 0; i < 500; i++) {
+  expr = "(data.a" + i + " !== undefined ? " + i + " : (" + expr + "))";
+}
+const fn = new Function("data", "return " + expr + ";");
+
+fn({}) === 0 && fn({ a3: true }) === 3 && fn({ a499: true }) === 499;


### PR DESCRIPTION
## Summary

Addresses #426 **Symptom 1**: `"register exhaustion: expression too deeply nested"` from ~118 levels of nested if-statements — well within what real engines handle trivially (the issue's own synthetic repro used 150).

Root cause was two register-**liveness bugs** in `compileIfExpression`/`compileTernaryExpression`, not genuine register pressure — confirmed by attributing the leak with four shape variants (sequential vs. nested, with/without a real condition) before touching any code:

1. **`conditionReg` freed too late.** It was freed only via a function-scoped `defer`, i.e. only once the *whole* if/ternary (including its nested consequence/alternative) finished compiling — even though its only use is the conditional jump emitted immediately after it's computed. A chain of N nested if/ternaries held N condition registers live simultaneously, though only the innermost was ever actually needed at once. Fixed by freeing `conditionReg` right after the jump.
2. **Redundant scratch register in `compileIfExpression`.** Each branch allocated a fresh `consequenceReg`/`alternativeReg`, initialized it to undefined, compiled the branch into it, then copied the result into `hint` — even though `hint` had already been pre-initialized to undefined for exactly the same reason a few lines earlier. That scratch register had to stay live for the *entire* nested compilation underneath it (a further-nested if writes into it in turn), for a value that was always going to equal `hint` anyway. Fixed by compiling each branch directly into `hint`. `compileTernaryExpression` already did this (compiles both branches straight into `hint`) — it just had bug #1 on its own `conditionReg`.

Together these move the practical ceiling from ~118 nested levels to **over 1000** (verified up to depth 1000; beyond ~1000-1200 the *next* limit hit is the pre-existing, already gracefully-handled and tested `"function too large: ... exceeds the 16-bit branch limit"` bytecode-size error — unrelated to registers, not touched by this change).

## Verified as a pure liveness change

- 8 completion-value edge cases (break/continue copying a mid-branch value out of a loop, if/else with only one branch producing a value, a nested if whose inner branch is empty) produce **byte-identical results** before and after.
- Test262 diff across `language/statements` (~9,200 tests), `language/statements/{if,for,while,switch}`, `language/expressions/conditional`, `language/eval-code`: **0 new passes, 0 new failures** — the correct result for a change that alters only which registers hold a value, never what the value is.
- `go test ./tests -run TestScripts` and `go test ./...` both green.

## Scope note

This fixes the issue's **synthetic repro** (150+ nested ifs). The issue's lead real-world symptom — `import { S3Client } from "@aws-sdk/client-s3"` failing under noderati — could **not** be re-tested here (no noderati host or `node_modules` in this repo). If that import still fails after this fix, it indicates a different cause (S3's generated client code is broad/flat, not deeply nested, so it may never have been hitting this specific bug) and needs separate investigation against the noderati host.

**Not addressed here:** the underlying 255-register hard limit itself still exists and can still be hit by genuine register pressure (not just nesting-depth leakage) — raising or spilling past it is real register-allocator work, intentionally out of scope for this change. Issue #426 Symptom 2 (an uncaught panic hitting this same limit through ajv's `new Function()` call) was already fixed separately in #430.

Addresses #426 (Symptom 1, synthetic repro only — see scope note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)