### PR TITLE
fix(parser): enum-declaration parsers no longer leak a typed-nil Statement

### DIFF
--- a/pkg/parser/parse_enum.go
+++ b/pkg/parser/parse_enum.go
@@ -8,7 +8,24 @@ import (
 func (p *Parser) parseEnumDeclarationStatement() *ExpressionStatement {
 	enumDecl := p.parseEnumDeclaration(false) // false for regular enum
 	if enumDecl == nil {
-		return nil
+		// If enum parsing failed (e.g. `enum` reached in a position that
+		// isn't actually a declaration - see paserati#426 Symptom 2, where
+		// an invalid member-access continuation like `.enum` inside a
+		// deeply nested expression re-synced the parser onto the bare
+		// `enum` token, which this function then failed to turn into a
+		// declaration), return a non-nil empty ExpressionStatement instead
+		// of a literal nil. A literal `nil` here is a *ExpressionStatement,
+		// which is a non-nil `Statement` interface value once returned
+		// through parseStatement()'s dispatch (the classic Go typed-nil-in-
+		// interface trap) - callers checking `stmt != nil` then see "true"
+		// and proceed to dereference a nil ExpressionStatement, panicking.
+		// Mirrors the same defensive pattern already used by
+		// parseFunctionDeclarationStatement/parseAsyncFunctionDeclarationStatement
+		// a few hundred lines up in parser.go, for the identical reason.
+		return &ExpressionStatement{
+			Token:      p.curToken,
+			Expression: nil,
+		}
 	}
 
 	return &ExpressionStatement{
@@ -21,7 +38,11 @@ func (p *Parser) parseEnumDeclarationStatement() *ExpressionStatement {
 func (p *Parser) parseConstEnumDeclarationStatement(constToken *lexer.Token) *ExpressionStatement {
 	enumDecl := p.parseEnumDeclaration(true) // true for const enum
 	if enumDecl == nil {
-		return nil
+		// See the identical comment in parseEnumDeclarationStatement above.
+		return &ExpressionStatement{
+			Token:      constToken,
+			Expression: nil,
+		}
 	}
 
 	// Set the const token as the main token (for error reporting)

--- a/tests/scripts/new_function_deeply_nested_clean_error.ts
+++ b/tests/scripts/new_function_deeply_nested_clean_error.ts
@@ -1,18 +1,29 @@
 // expect: true
 // paserati#426: a `new Function(...)` body large/deeply-nested enough to hit
-// the compiler's internal register-allocator limit (this synthetic shape -
-// 150 sequential nested `if`s - mirrors real generated code from JSON-Schema
-// validators, bundled SDK clients, etc.) must surface as a normal, catchable
-// SyntaxError from the `new Function()` call site, never crash the process
-// or leak past user code as an unrecoverable panic. See also
-// compileDynamicFunctionSource in pkg/builtins/function_init.go, which wraps
-// the parse+compile of dynamically-constructed function bodies in its own
-// recover() specifically so an internal compiler panic (not just the clean
-// "register exhaustion" error already returned here) is contained the same
-// way instead of escaping as a raw Go panic.
+// an internal compiler limit (this synthetic shape - sequential nested
+// `if`s - mirrors real generated code from JSON-Schema validators, bundled
+// SDK clients, etc.) must surface as a normal, catchable SyntaxError from
+// the `new Function()` call site, never crash the process or leak past user
+// code as an unrecoverable panic. See also compileDynamicFunctionSource in
+// pkg/builtins/function_init.go, which wraps the parse+compile of
+// dynamically-constructed function bodies in its own recover() specifically
+// so an internal compiler panic (not just a clean, already-returned-as-an-
+// error limit) is contained the same way instead of escaping as a raw Go
+// panic.
+//
+// Depth 2000 (rather than the issue's original 150) deliberately targets
+// the *next* limit past register exhaustion - a separate, pre-existing,
+// already-gracefully-handled "function too large: ... exceeds the 16-bit
+// branch limit" bytecode-size error - because paserati#426's own nested-if
+// *register* leak (conditionReg/consequenceReg held live for an entire
+// nested chain instead of freed once dead) was since fixed, raising the
+// register-exhaustion ceiling from ~118 to over 1000 nested levels. 150
+// (or even 1000) no longer errors at all once that leak is fixed, which
+// would make this test's own premise stale - see the compiler package's
+// nested-if/ternary register-liveness fix.
 let body = "let x = 0;\n";
 let close = "";
-for (let i = 0; i < 150; i++) {
+for (let i = 0; i < 2000; i++) {
   body += "if (data.a" + i + " !== undefined) { x += " + i + ";\n";
   close += "}\n";
 }

--- a/tests/scripts/parser_enum_typed_nil_panic.ts
+++ b/tests/scripts/parser_enum_typed_nil_panic.ts
@@ -1,0 +1,43 @@
+// expect: true
+// paserati#426 Symptom 2 root cause: an invalid member-access continuation
+// whose right-hand token is exactly the reserved word `enum` (e.g. a bare
+// `.enum` where a property/identifier was expected - real ajv@8.17.1's
+// bundled meta-schema validator does this, generating
+// `params:{allowedValues: .enum}`, likely from a noderati/paserati bug
+// elsewhere that drops the intended left-hand operand) resynced the parser
+// onto the bare `enum` token. parseEnumDeclarationStatement/
+// parseConstEnumDeclarationStatement then failed to parse a declaration
+// there and returned a literal Go `nil` typed as `*ExpressionStatement` -
+// the classic Go "typed nil in interface" trap: once implicitly widened to
+// the `Statement` interface by parseStatement()'s dispatch, `stmt != nil`
+// checks upstream see a non-nil interface and proceed to dereference the
+// nil concrete pointer, panicking ("invalid memory address or nil pointer
+// dereference") deep inside parseBlockStatement's hoisting check. This
+// happened to require a genuinely deep enclosing nesting (~37+ levels) to
+// manifest in the wild, but is fully independent of paserati#426 Symptom
+// 1's own register-exhaustion bug - reproduced here with trivial nesting.
+//
+// Fixed by making both enum-declaration-statement parsers return a non-nil
+// empty ExpressionStatement on failure (matching the identical defensive
+// pattern already used by parseFunctionDeclarationStatement/
+// parseAsyncFunctionDeclarationStatement a few hundred lines up in
+// parser.go, for the exact same reason), so a failed parse is a normal
+// compile/syntax error, not an uncaught panic - regardless of how deeply
+// nested the surrounding code is.
+let depth = 40;
+let body = "";
+let close = "";
+for (let i = 0; i < depth; i++) {
+  body += "if (true) {\n";
+  close += "}\n";
+}
+body += "const err = {a: .enum};\n" + close;
+
+let caught = false;
+try {
+  new Function(body);
+} catch (e) {
+  caught = e instanceof SyntaxError;
+}
+
+caught;


### PR DESCRIPTION
## Summary

This is the actual root-cause fix for #426 Symptom 2. #430 (merged) added panic containment via `recover()` in `compileDynamicFunctionSource`, but the user correctly pushed back that the crash was still happening against real `ajv@8.17.1` — containment alone was papering over it, not fixing it. This is the real fix, which somehow didn't make it into #430 before it got merged (I pushed this commit to that branch after the PR had already been merged).

Reproduced the exact real-world panic with ajv@8.17.1's bundled meta-schema validator (real Ajv, run through a local noderati checkout) and bisected the ~27KB generated function body down to an **807-byte, dependency-free synthetic repro**: 37+ levels of nested `if(true){...}`, ending in an object literal whose property value is a bad member-access continuation `.enum` (a `.` followed by the reserved word `enum` with no left-hand object).

**Root cause**: `parseEnumDeclarationStatement`/`parseConstEnumDeclarationStatement` both return a literal Go `nil` (typed `*ExpressionStatement`) when `parseEnumDeclaration` fails. Once returned through `parseStatement()`'s dispatch, that nil concrete pointer gets implicitly widened into a **non-nil `Statement` interface value** — the classic Go "typed nil in interface" trap. `parseBlockStatement`'s hoisting check sees a genuinely non-nil interface, passes its own `stmt != nil` check, then dereferences the nil concrete `*ExpressionStatement` — panicking with exactly "invalid memory address or nil pointer dereference," the crash from the issue, verbatim.

Fixed by returning a non-nil empty `ExpressionStatement` instead, matching the identical defensive pattern already used a few hundred lines up in `parser.go` by `parseFunctionDeclarationStatement`/`parseAsyncFunctionDeclarationStatement` for the exact same reason.

Also bumps `new_function_deeply_nested_clean_error.ts`'s depth from 150 to 2000, needed now that the register-leak fix (#431, merged) raised the register-exhaustion ceiling well past 150 — 2000 reliably hits the unrelated "function too large" bytecode-size limit either way, keeping that test meaningful.

## Verified

- The exact real ajv@8.17.1 repro (via a local noderati checkout) now produces a clean, catchable `SyntaxError` instead of a crash.
- `go test ./tests -run TestScripts` and `go test ./...` both green.
- Test262 diff across `language/statements` (~9,200 tests), `language/statements/class`, `language/expressions/{object,class}` (`-timeout 0.2s`): **0 new passes, 0 new failures**.

## Known follow-up, not fixed here

Confirmed against real Node (captured the real `Function()` constructor args ajv passes under both engines): real ajv correctly generates `params:{type: schema0.type}` / `params:{allowedValues: schema9.enum}`; noderati/paserati's version is missing the `schema0`/`schema9` object reference, leaving bare `.type`/`.enum`. Traced this to a **separate, real paserati bug**: `Array.prototype.join`/`Array.prototype.toString` don't invoke ToPrimitive (a custom `toString()` override) on object elements, falling back to `[object Object]`-style default stringification instead — ajv's own codegen library builds code fragments via exactly this pattern (a tagged-template-built array of `Name`/`_Code` objects joined together). Filed as a separate fix.

Addresses #426 (Symptom 2, actual root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)