### PR TITLE
test: fix stale nested-if depth in new_function_deeply_nested_clean_error.ts (main is currently red)

### DIFF
--- a/tests/scripts/new_function_deeply_nested_clean_error.ts
+++ b/tests/scripts/new_function_deeply_nested_clean_error.ts
@@ -1,18 +1,29 @@
 // expect: true
 // paserati#426: a `new Function(...)` body large/deeply-nested enough to hit
-// the compiler's internal register-allocator limit (this synthetic shape -
-// 150 sequential nested `if`s - mirrors real generated code from JSON-Schema
-// validators, bundled SDK clients, etc.) must surface as a normal, catchable
-// SyntaxError from the `new Function()` call site, never crash the process
-// or leak past user code as an unrecoverable panic. See also
-// compileDynamicFunctionSource in pkg/builtins/function_init.go, which wraps
-// the parse+compile of dynamically-constructed function bodies in its own
-// recover() specifically so an internal compiler panic (not just the clean
-// "register exhaustion" error already returned here) is contained the same
-// way instead of escaping as a raw Go panic.
+// an internal compiler limit (this synthetic shape - sequential nested
+// `if`s - mirrors real generated code from JSON-Schema validators, bundled
+// SDK clients, etc.) must surface as a normal, catchable SyntaxError from
+// the `new Function()` call site, never crash the process or leak past user
+// code as an unrecoverable panic. See also compileDynamicFunctionSource in
+// pkg/builtins/function_init.go, which wraps the parse+compile of
+// dynamically-constructed function bodies in its own recover() specifically
+// so an internal compiler panic (not just a clean, already-returned-as-an-
+// error limit) is contained the same way instead of escaping as a raw Go
+// panic.
+//
+// Depth 2000 (rather than the issue's original 150) deliberately targets
+// the *next* limit past register exhaustion - a separate, pre-existing,
+// already-gracefully-handled "function too large: ... exceeds the 16-bit
+// branch limit" bytecode-size error - because paserati#426's own nested-if
+// *register* leak (conditionReg/consequenceReg held live for an entire
+// nested chain instead of freed once dead) was since fixed, raising the
+// register-exhaustion ceiling from ~118 to over 1000 nested levels. 150
+// no longer errors at all once that leak is fixed, which made this test's
+// original depth stale - see the compiler package's nested-if/ternary
+// register-liveness fix.
 let body = "let x = 0;\n";
 let close = "";
-for (let i = 0; i < 150; i++) {
+for (let i = 0; i < 2000; i++) {
   body += "if (data.a" + i + " !== undefined) { x += " + i + ";\n";
   close += "}\n";
 }


### PR DESCRIPTION
## Summary

**\`main\` currently fails \`go test ./tests -run TestScripts\`.** This test asserts that a 150-level nested-if \`new Function()\` body throws a catchable \`SyntaxError\`. That was true when #430 added it, but #431 (the nested-if/ternary register-leak fix, merged separately) raised the register-exhaustion ceiling from ~118 to over 1000 nested levels — so depth 150 no longer errors at all once both land on \`main\` together. Each PR was correct and green individually; combined, they leave this test stale.

Bumped the depth to 2000, which reliably hits the *next*, unrelated, pre-existing \`"function too large: ... exceeds the 16-bit branch limit"\` bytecode-size error either way — keeping the test's actual assertion (a deeply-nested \`new Function()\` body fails as a catchable \`SyntaxError\`, never crashes) meaningful regardless of the register ceiling.

No production code changes — test-only.

## Verified
- \`go test ./tests -run TestScripts\` and \`go test ./...\` both green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)