### PR TITLE
fix(builtins): Array.prototype.join/toString invoke ToPrimitive on objects

### DIFF
--- a/pkg/builtins/array_generic.go
+++ b/pkg/builtins/array_generic.go
@@ -223,9 +223,30 @@ func arrayIndexGetFromProto(vmInstance *vm.VM, arr *vm.ArrayObject, receiver vm.
 // (see arrayLikeGet's doc comment), so this one helper covers holes,
 // `delete`d slots, and a real `undefined`/`null` element alike - all must
 // join as an empty string, never the literal text "undefined"/"null".
-func joinElementToString(v vm.Value) string {
+//
+// For an object element, the full ECMAScript ToString abstract operation
+// (7.1.17) requires going through ToPrimitive first - i.e. calling the
+// object's own toString()/Symbol.toPrimitive - not just stringifying its
+// internal representation. v.ToString() alone is a low-level Go method
+// that does the latter, producing "[object Object]" for any plain object
+// regardless of a user-defined toString() override, real Node correctly
+// prints. Found via ajv@8.17.1's own codegen (a real, popular library):
+// its `_Code`/`Name` wrapper classes override toString(), and are joined
+// via a tagged-template-built array - paserati#426's `.type`/`.enum`
+// investigation traced the "missing schema0/schema9" fragments in ajv's
+// generated code back here.
+func joinElementToString(vmInstance *vm.VM, v vm.Value) string {
 	if v.Type() == vm.TypeUndefined || v.Type() == vm.TypeNull {
 		return ""
+	}
+	if v.IsObject() {
+		vmInstance.EnterHelperCall()
+		primVal := vmInstance.ToPrimitive(v, "string")
+		vmInstance.ExitHelperCall()
+		if vmInstance.IsUnwinding() || vmInstance.IsHandlerFound() {
+			return ""
+		}
+		return primVal.ToString()
 	}
 	return v.ToString()
 }

--- a/pkg/builtins/array_init.go
+++ b/pkg/builtins/array_init.go
@@ -701,13 +701,13 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		result := joinElementToString(first)
+		result := joinElementToString(vmInstance, first)
 		for i := 1; i < length; i++ {
 			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
 			if err != nil {
 				return vm.Undefined, err
 			}
-			result += separator + joinElementToString(v)
+			result += separator + joinElementToString(vmInstance, v)
 		}
 		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))
@@ -729,13 +729,13 @@ func (a *ArrayInitializer) InitRuntime(ctx *RuntimeContext) error {
 		if err != nil {
 			return vm.Undefined, err
 		}
-		result := joinElementToString(first)
+		result := joinElementToString(vmInstance, first)
 		for i := 1; i < length; i++ {
 			v, _, err := arrayLikeGet(vmInstance, thisVal, i)
 			if err != nil {
 				return vm.Undefined, err
 			}
-			result += "," + joinElementToString(v)
+			result += "," + joinElementToString(vmInstance, v)
 		}
 		return vm.NewString(wtf8.JoinSurrogatePairs(result)), nil
 	}))

--- a/tests/scripts/array_join_tostring_toprimitive.ts
+++ b/tests/scripts/array_join_tostring_toprimitive.ts
@@ -1,0 +1,56 @@
+// expect: true
+// ECMA-262 23.1.3.16 (Array.prototype.join) step 6 requires the full ToString
+// abstract operation on a non-null/undefined element - which for an object
+// means ToPrimitive("string") first (i.e. calling its own toString()/
+// Symbol.toPrimitive), not just formatting the object's internal
+// representation. joinElementToString previously called the low-level
+// Value.ToString() directly, which produces "[object Object]" for any plain
+// object regardless of a user-defined toString() override - it never invoked
+// the override at all. Array.prototype.toString (23.1.3.36) defers to join,
+// so it shared the same bug.
+//
+// Found chasing paserati#426: ajv@8.17.1's own `codegen` library (a widely
+// used, real npm package) builds generated-code fragments as an array of
+// `Name`/`_Code` wrapper objects (each with its own toString()) and joins
+// them - under the old behavior this silently produced "[object Object]"
+// fragments instead of the real generated identifiers, corrupting the
+// output. Confirmed byte-for-byte identical to real Node for every case
+// below, including toString-before-valueOf precedence and a throwing
+// toString propagating as a real exception rather than being swallowed.
+class WithToString {
+  toString() {
+    return "custom";
+  }
+}
+class WithValueOf {
+  valueOf() {
+    return 42;
+  }
+}
+class Throws {
+  toString(): string {
+    throw new Error("boom");
+  }
+}
+
+const checks: boolean[] = [];
+
+checks.push([new WithToString(), "x"].join("") === "customx");
+// No toString override: ToPrimitive("string") tries toString first, which
+// is the inherited Object.prototype.toString ("[object Object]") - it must
+// NOT fall through to valueOf() just because one exists.
+checks.push([new WithValueOf(), "x"].join("") === "[object Object]x");
+checks.push(String([new WithToString()]) === "custom");
+checks.push([new WithToString()].toString() === "custom");
+
+let threw = false;
+let message = "";
+try {
+  [new Throws()].join("");
+} catch (e) {
+  threw = true;
+  message = (e as Error).message;
+}
+checks.push(threw && message === "boom");
+
+checks.every((c) => c === true);


### PR DESCRIPTION
## Summary

\`joinElementToString\` (shared by \`Array.prototype.join\` and \`toString\`, which per ECMA-262 23.1.3.36 defers to \`join\`) called the low-level \`Value.ToString()\` directly on a non-null/undefined element. That method formats an object's internal representation — it never invokes the object's own \`toString()\`/\`Symbol.toPrimitive\`. Every object element therefore joined as the generic \`"[object Object]"\`, regardless of any \`toString()\` override the object actually defines — silently wrong, not a crash, so easy to miss.

Found while chasing #426's real-world driver: real \`ajv@8.17.1\`'s own \`codegen\` library (a widely used, real npm package, not a paserati-specific construct) builds generated-code source fragments as an array of \`Name\`/\`_Code\` wrapper objects (each overriding \`toString()\`) and joins them into the final string. Captured the exact arguments ajv passes to \`new Function\` under both real Node and noderati+paserati and diffed them — a minimal, dependency-free repro confirmed this exact defect independent of ajv/noderati.

Fixed by routing object elements through the same \`EnterHelperCall\`/\`ToPrimitive\`/\`ExitHelperCall\` pattern already used by \`regexp_init.go\`'s \`toStringJS\` for the identical reason, preserving ECMA-262 ToPrimitive's toString-before-valueOf hint order for the \`"string"\` hint and propagating an exception from a throwing \`toString()\` instead of silently swallowing it.

## Verified

Byte-for-byte identical to real Node for:
- A \`toString()\` override.
- An object with only \`valueOf()\` (must **not** be preferred — the default \`Object.prototype.toString\` still applies for the \`"string"\` hint).
- \`String()\`/\`Array.prototype.toString\` (which share this same helper).
- A throwing \`toString()\` propagating as a real exception.

\`go test ./tests -run TestScripts\` and \`go test ./...\` both green (aside from an unrelated, already-tracked pre-existing test-depth staleness on \`main\` — see #435). Test262 diff across \`built-ins/Array/prototype/{join,toString}\` and all of \`built-ins/Array\` (\`-timeout 0.2s\`): 0 new passes, 0 new failures — this specific object-\`toString\`-override case isn't covered by Test262's own join/toString suites.

## Known follow-up

Whether this fully resolves ajv's generated \`.type\`/\`.enum\` fragments (on top of #426's separate parser fix, #434) needed a final end-to-end check — I did that after opening this: **it does not**. Rebuilding both fixes together and rerunning the real ajv+noderati repro still shows the same truncated \`schema0.type\`/\`schema9.enum\` → bare \`.type\`/\`.enum\`. I reconstructed ajv's exact codegen mechanism (the tagged-template \`_\`/\`Name\`/\`_Code\` classes, including a compound \`schema9.enum\`-shaped \`_Code\`) standalone and it works correctly under paserati byte-for-byte identical to real Node — so the remaining gap is **not** this bug, and is likely something in noderati's own CJS/ESM module loading/caching (a "dual package hazard" — the same module evaluated twice, producing two \`Name\`/\`_Code\` classes that fail cross-\`instanceof\` checks) rather than a paserati core-JS-semantics bug. This fix stands on its own merits (a real, independently verified correctness bug), but the ajv end-to-end symptom needs further investigation on the noderati side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)