### PR TITLE
fix(compiler): fix the real-world register-exhaustion driver for #426

### DIFF
--- a/pkg/compiler/compile_class.go
+++ b/pkg/compiler/compile_class.go
@@ -518,6 +518,20 @@ func (c *Compiler) compileClassDeclaration(node *parser.ClassDeclaration, hint R
 		// not whichever one the loop ends on.
 		c.declareLoopBodyLocalSpill(classSpillSlot)
 	}
+	// constructorReg's value now lives in the global slot or spill slot above
+	// (the class's own binding was already predefined as global/spilled back
+	// in step 1, so every reference to this class name resolves there, never
+	// through this register again) - free it instead of leaking it for the
+	// rest of the enclosing function/module's compilation. This is the same
+	// missing-free bug already found and fixed for let/const/var
+	// declarations: a source file with many sequential top-level class
+	// declarations (a common bundler/codegen output shape - e.g.
+	// @aws-sdk/client-s3's dist-cjs/index.js declares ~150 `class XCommand
+	// extends ... {}` API command classes back to back inside its CJS
+	// wrapper function) would otherwise exhaust the 255-register budget at
+	// exactly 1 register held per class declaration, regardless of whether
+	// it has a superclass. See paserati#426.
+	c.regAlloc.Free(constructorReg)
 
 	// Restore outer scope
 	if prevSymbolTable != nil {

--- a/pkg/compiler/compile_statement.go
+++ b/pkg/compiler/compile_statement.go
@@ -20,17 +20,34 @@ import (
 // slot (see finalizeClosureBinding) — reusing the spilled symbol's zero-valued
 // Register field (0 != nilRegister) would silently target R0 and leave the slot
 // holding the sentinel, so `f()` later reads an uninitialized value.
+//
+// The global case has the identical hazard and needs the identical guard: a
+// top-level `let`/`const` binding's own predefine pass also leaves a stale,
+// meaningless zero-valued Register field once the symbol is marked IsGlobal
+// (global reads/writes go through GlobalIndex via OpGetGlobal/OpSetGlobal, not
+// a register at all) - so `sym.Register != nilRegister` alone can't tell "this
+// binding has a real, still-live register" from "this is a global whose
+// Register field just happens to read as 0". Reusing it directly (as this
+// function used to, missing the IsGlobal check the sibling non-function value
+// branch in compileLetStatement/compileConstStatement already has) aliases
+// the closure's destination onto whatever unrelated register happens to share
+// that same stale number - harmless by accident as long as nothing else ever
+// frees or reallocates that number, but a real, silent correctness bug once
+// something does (see paserati#426, where fixing an unrelated register leak
+// unmasked this: the closure's destination collided with the enclosing
+// program's own completion-value register once it stopped being permanently,
+// accidentally reserved by the leak).
 func (c *Compiler) closureBindingDest(name string) (reg Register, spilled bool, spillIdx uint16) {
 	if sym, _, found := c.currentSymbolTable.Resolve(name); found {
 		if sym.IsSpilled {
 			return c.regAlloc.Alloc(), true, sym.SpillIndex
 		}
-		if sym.Register != nilRegister {
+		if sym.Register != nilRegister && !sym.IsGlobal {
 			return sym.Register, false, 0
 		}
 	}
-	// Not predefined (or predefined without a register): define temporarily so the
-	// body can self-reference, and allocate a fresh register.
+	// Not predefined (or predefined without a real, live register): define
+	// temporarily so the body can self-reference, and allocate a fresh register.
 	c.currentSymbolTable.Define(name, nilRegister)
 	return c.regAlloc.Alloc(), false, 0
 }
@@ -278,6 +295,20 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 				globalIdx := c.GetOrAssignGlobalIndex(key)
 				c.emitSetGlobalInit(globalIdx, valueReg, node.Name.Token.Line)
 				c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
+				// valueReg is guaranteed a fresh temp here (the branch that
+				// computed it explicitly excludes reusing sym.Register for an
+				// already-global symbol - see TryAllocForVariable() above) -
+				// its value now lives in the global slot, and every future
+				// reference to this name resolves via OpGetGlobal, never this
+				// register again. Free it now instead of leaking it for the
+				// rest of the module's compilation: a module with many
+				// top-level `let`/`const` declarations (a common bundler/
+				// codegen output shape - e.g. @aws-sdk/client-s3's
+				// Aws_restXml.js hoists 720 short-name string constants this
+				// way) would otherwise exhaust the 255-register budget purely
+				// from this leak, with genuinely at most one such register
+				// ever live at a time. See paserati#426.
+				c.regAlloc.Free(valueReg)
 			} else {
 				// Local scope (function or enclosed block): use local symbol table
 				if sym, _, found := c.currentSymbolTable.Resolve(node.Name.Value); found && sym.Register != nilRegister {
@@ -311,6 +342,12 @@ func (c *Compiler) compileLetStatement(node *parser.LetStatement, hint Register)
 					// Update the symbol to be global
 					c.currentSymbolTable.DefineGlobal(node.Name.Value, globalIdx)
 					// Smart pinning: Don't pin here - register will be pinned when/if captured by inner closure
+					// Free the closure register now that the closure lives in
+					// the global slot - Free() is a safe no-op if a closure
+					// defined later already captured it as an upvalue (pinned
+					// registers are skipped). See the identical comment on the
+					// non-function value branch above (paserati#426).
+					c.regAlloc.Free(symbolRef.Register)
 				}
 			}
 		}
@@ -680,6 +717,13 @@ func (c *Compiler) compileVarStatement(node *parser.VarStatement, hint Register)
 					c.MarkVarGlobal(globalIdx)
 				}
 				// Smart pinning: Don't pin here - register will be pinned when/if captured by inner closure
+				// Free the closure register now that the closure lives in the
+				// global slot - see the identical comment on let/const's
+				// analogous function-value branches (paserati#426). A large
+				// bundled CJS file with hundreds of top-level `function`
+				// declarations (a common bundler output shape) would
+				// otherwise leak one register per declaration.
+				c.regAlloc.Free(symbolRef.Register)
 			}
 		}
 	}
@@ -841,6 +885,13 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 				globalIdx := c.GetOrAssignGlobalIndex(c.moduleGlobalKey(node.Name.Value))
 				c.emitSetGlobalInit(globalIdx, valueReg, node.Name.Token.Line)
 				c.currentSymbolTable.DefineGlobalConst(node.Name.Value, globalIdx)
+				// See the identical comment in compileLetStatement's analogous
+				// branch above - valueReg is a fresh temp here (never reused
+				// for an already-global symbol), its value now lives in the
+				// global slot, and leaking it here exhausts the register
+				// budget on a module with many top-level const declarations
+				// (paserati#426).
+				c.regAlloc.Free(valueReg)
 			} else {
 				// Local scope (function or enclosed block): use local symbol table
 				if sym, _, found := c.currentSymbolTable.Resolve(node.Name.Value); found && sym.Register != nilRegister {
@@ -865,6 +916,9 @@ func (c *Compiler) compileConstStatement(node *parser.ConstStatement, hint Regis
 					// Update the symbol to be global const
 					c.currentSymbolTable.DefineGlobalConst(node.Name.Value, globalIdx)
 					// Smart pinning: Don't pin here - register will be pinned when/if captured by inner closure
+					// See the identical comment in compileLetStatement's
+					// analogous function-value branch (paserati#426).
+					c.regAlloc.Free(symbolRef.Register)
 				}
 			}
 		}

--- a/tests/scripts/many_class_declarations_no_register_leak.ts
+++ b/tests/scripts/many_class_declarations_no_register_leak.ts
@@ -1,0 +1,34 @@
+// expect: true
+// paserati#426: compileClassDeclaration allocated a fresh `constructorReg`,
+// stored it into the class's global slot or spill slot (matching how the
+// class binding was predefined back in step 1), then returned without ever
+// freeing it - regardless of whether the class had a superclass. A source
+// file with many sequential class declarations (a common bundler/codegen
+// output shape - e.g. @aws-sdk/client-s3's dist-cjs/index.js declares ~150
+// `class XCommand extends ... {}` API command classes back to back inside
+// its CJS wrapper function - a real, unmodified npm package) exhausted the
+// 255-register budget at exactly 1 register held per class declaration,
+// purely from this leak, with genuinely at most one such register ever
+// live at once.
+//
+// Reproduced with a dependency-free synthetic repro matching that real
+// shape: many distinct class declarations, each `extends` a base class via
+// a fluent builder-style method chain (mirroring @aws-sdk/client-s3's own
+// `class XCommand extends Base.classBuilder().ep({...}).build() {}`
+// pattern), all inside a single wrapper function (CJS bundlers wrap each
+// module's body in exactly this kind of function scope). Fixed by freeing
+// constructorReg once its value is safely stored.
+let body = "";
+for (let i = 0; i < 300; i++) {
+  body += `class Cmd${i} extends Base.classBuilder().ep({i:${i}}).build() {}\n`;
+}
+body =
+  `class Base {
+    static classBuilder() { return this; }
+    static ep(x) { return this; }
+    static build() { return class {}; }
+  }
+  ` + body + "return 300;";
+
+const fn = new Function(body);
+fn() === 300;

--- a/tests/scripts/spread_array_nested.ts
+++ b/tests/scripts/spread_array_nested.ts
@@ -1,4 +1,21 @@
 // Test nested array spread with function calls
+//
+// This one caught a real regression during paserati#426's investigation:
+// closureBindingDest (used when a top-level `let`'s value is a function/
+// arrow literal) reused a predefined global symbol's stale, meaningless
+// zero-valued Register field directly (missing the !sym.IsGlobal check its
+// sibling non-function-value branch already had), aliasing getArray's
+// closure onto whatever unrelated register shared that same stale number -
+// harmless by accident as long as nothing else was ever allowed to reuse
+// that number, which held only because a *different*, since-fixed
+// register-leak bug kept it permanently (accidentally) reserved. Once that
+// leak was fixed, the alias went live: the script's own completion-value
+// register collided with getArray's closure register, and a later spread-
+// element scratch register reused that same now-free number, silently
+// overwriting the in-progress result array before the final spread could
+// read it. Must remain a *bare* completion-value expression (not assigned
+// to a variable first) to exercise this - `const result = [...]` routes
+// into a fresh, unaliased temp instead and doesn't reproduce it.
 let getArray = () => [10, 20];
 let nested = [[1, 2], [3, 4]];
 [...nested[0], ...getArray(), ...nested[1]];


### PR DESCRIPTION
## Summary

Asked to verify #426 was actually fixed before moving on — it wasn't. The real `@aws-sdk/client-s3@3.918.0` import from the issue still failed with `"register exhaustion: expression too deeply nested"` even with #430/#431/#434 all merged. This finds and fixes the actual remaining causes, verified against the real package end-to-end.

Bisected the real S3 client down to two distinct, dependency-free synthetic repros:

### 1. Global-scope `let`/`const`/`var` declarations leak a register each

`@aws-sdk/client-s3`'s `dist-es/protocols/Aws_restXml.js` (8,101 lines) hoists **720** short-name string constants (`const _L = "Location";` etc.) as flat, top-level `const` declarations — a real, common bundler/codegen minification pattern. `compileConstStatement`/`compileLetStatement`/`compileVarStatement`'s "true global scope" branches allocated a fresh temp register, copied it into the global heap slot via `emitSetGlobal(Init)`, and never freed it — every future reference already resolves via `OpGetGlobal`. 720 such declarations exhausted the 255-register budget purely from this leak. Fixed by freeing the temp once safely stored, in all six such branches.

### 2. Class declarations leak their constructor register

`@aws-sdk/client-s3`'s `dist-cjs/index.js` (11,887 lines, the package's actual npm `"main"` entry) declares ~150 `class XCommand extends Base.classBuilder().ep({...}).build() {}` API command classes back to back. Root-caused with a register-allocator trace (removed before this commit) showing `free` shrinking by exactly one slot per class regardless of superclass complexity: `compileClassDeclaration` allocated `constructorReg`, stored it into the class's global/spill slot, and never freed it. Same missing-free pattern as (1), for the class's own constructor register.

### 3. A third, previously-masked bug, found while fixing (1)

Fixing (1) exposed a regression in the existing `spread_array_nested.ts` smoke test: `closureBindingDest` (used when a top-level `let`/`const`'s value is a function/arrow literal) reused a predefined global symbol's `Register` field directly whenever it wasn't `nilRegister`. Correct for a genuinely live local binding, but a top-level declaration's predefine pass leaves the *same* stale, meaningless zero-valued `Register` field on every global symbol (global access never uses a register at all). The sibling non-function-value branch already correctly excludes `IsGlobal` symbols from this reuse — `closureBindingDest` was the one path that didn't. This aliased a global closure onto whatever unrelated register shared that stale number; harmless by accident as long as nothing else was ever allowed to reuse that number — which is exactly what fix (1) changed. Fixed by adding the same `!sym.IsGlobal` guard the sibling branch already has, and documented directly on the test that caught it.

## Verified

- **Against the real package end-to-end**: `import { S3Client, ListBucketsCommand } from "@aws-sdk/client-s3"` under noderati no longer produces "register exhaustion" — it now reaches a genuinely different, unrelated runtime error (`"undefined is not a constructor"` in a static field initializer), confirming compilation itself now succeeds. That remaining error is out of scope here (looks like a separate dependency-resolution/circular-require issue, most likely noderati's to chase) and is **not** fixed in this PR.
- `go test ./tests -run TestScripts` and `go test ./...` both green.
- Test262 diff across the entire `language/` subtree (23,523 tests) plus `built-ins/Array` and `built-ins/Function` (`-timeout 0.2s`): **0 new passes, 0 new failures**.

Addresses #426 (Symptom 1, the real-world driver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)