### PR TITLE
fix(parser): export { x as undefined } now parses correctly

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -11512,7 +11512,7 @@ func isExportSpecifierName(t lexer.TokenType) bool {
 		lexer.THROW, lexer.TRY, lexer.CATCH, lexer.FINALLY,
 		lexer.FUNCTION, lexer.CLASS, lexer.CONST, lexer.LET, lexer.VAR,
 		lexer.NEW, lexer.DELETE, lexer.TYPEOF, lexer.VOID, lexer.IN, lexer.INSTANCEOF,
-		lexer.THIS, lexer.SUPER, lexer.NULL, lexer.TRUE, lexer.FALSE,
+		lexer.THIS, lexer.SUPER, lexer.NULL, lexer.TRUE, lexer.FALSE, lexer.UNDEFINED,
 		lexer.IMPORT, lexer.EXPORT, lexer.EXTENDS, lexer.IMPLEMENTS,
 		lexer.STATIC, lexer.GET, lexer.SET, lexer.ASYNC, lexer.AWAIT, lexer.YIELD,
 		lexer.TYPE, lexer.INTERFACE, lexer.ENUM, lexer.SATISFIES,

--- a/tests/scripts/export_named_as_undefined.ts
+++ b/tests/scripts/export_named_as_undefined.ts
@@ -1,0 +1,14 @@
+// expect: true
+// paserati#432: `export { x as undefined }` failed to parse at all -
+// isExportSpecifierName's hand-maintained allowlist of keyword tokens
+// permitted as an export specifier name was missing lexer.UNDEFINED. This
+// is a real-world shape: `undefined` is not a reserved word in ECMAScript
+// (the export-specifier grammar uses the broader IdentifierName production,
+// not Identifier), and real zod@3.25.76's own v3/types.js exports exactly
+// this way (`export { undefinedType as undefined, ... }` - `z.undefined()`
+// is one of zod's real schema builders). Real Node parses and runs this
+// without complaint; paserati failed the whole module's parse, so nothing
+// from the file - not just this one export - ever loaded.
+import * as ns from "./export_named_as_undefined_helper.ts";
+
+typeof ns.undefined === "function" && ns.undefined() === "I am undefinedType";

--- a/tests/scripts/export_named_as_undefined_helper.ts
+++ b/tests/scripts/export_named_as_undefined_helper.ts
@@ -1,0 +1,2 @@
+const undefinedType = () => "I am undefinedType";
+export { undefinedType as undefined };


### PR DESCRIPTION
## Summary

`isExportSpecifierName`'s hand-maintained allowlist of keyword tokens permitted as an export specifier name was missing `lexer.UNDEFINED` — every other keyword-shaped token (`NULL`, `TRUE`, `FALSE`, `CLASS`, `DELETE`, ...) was already present and working; this one was simply never added when the lexer gave `undefined` its own dedicated token type instead of lexing it as a plain `IDENT`.

`undefined` is not a reserved word in ECMAScript, and the export-specifier grammar (`ExportSpecifier: IdentifierName as ModuleExportName`) explicitly uses the broader `IdentifierName` production — so any identifier-shaped name is allowed as an export alias, and real Node parses/runs this without complaint.

**Real-world impact**: real `zod@3.25.76` (a very popular package) uses exactly this shape for its own core exports — `v3/types.js` does `export { undefinedType as undefined, ... }` (`z.undefined()` is one of zod's real schema builders). This single missing token type failed the *whole module's* parse, so nothing from the file loaded at all.

Checked the import-binding side too (`import { x as undefined } from "..."`): `isImportBindingName` already delegates to `isContextualKeywordType`, which already includes `lexer.UNDEFINED` — that direction was already correct, no change needed.

## A separate bug found while verifying this

The resulting binding is inert at **runtime** even once parsing succeeds — `let undefined = 42; undefined` still reads the global `undefined` value, not `42`. That's a real, separate, deeper identifier-resolution bug (something treats bare references to `undefined` as always-the-literal, never checking the symbol table). Filed as [#440](https://github.com/nooga/paserati/issues/440) since it's out of this parser-allowlist fix's scope — this PR only fixes the *parse* failure, matching #432's own stated scope.

## Verified

- Against the exact real-world shape (`import * as ns` from a module using `export { undefinedType as undefined }`, calling `ns.undefined()` as a namespace property — as opposed to referencing the bare identifier `undefined`, which is #440's separate bug).
- `go test ./tests -run TestScripts` and `go test ./...` both green.
- Test262 diff across `language/module-code` (592 tests, `-timeout 0.2s`): **0 new passes, 0 new failures**.

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)