### PR TITLE
fix(compiler): export * from a module that fails to load now fails the import

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -4963,7 +4963,21 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 	// collectExportAllNames marks each module visited as it is entered, which is
 	// enough on its own to stop a module (including this one) from being expanded
 	// more than once.
-	exportNames := c.collectExportAllNames(sourceModuleRecord, sourceModule, make(map[string]bool))
+	exportNames, collectErr := c.collectExportAllNames(sourceModuleRecord, sourceModule, make(map[string]bool), node)
+	if collectErr != nil {
+		// #433: real ESM link-time semantics fail the *whole* importing module
+		// synchronously when a re-exported ("export * from") module (direct or
+		// transitively, through a re-exported barrel) fails to load/parse -- it
+		// is not enough to just omit that module's names from the merged
+		// namespace, which is what silently happened before this check existed
+		// (LoadModule itself returns a nil `error` with the failure recorded
+		// only on the record, see moduleLoader.loadModuleSequential; a bare
+		// "export *" never called emitEvalModule/emitGetModuleExport per name,
+		// unlike a named import or "export * as ns from", so nothing ever
+		// tripped the runtime load-error check in vm.go either -- the failure
+		// had no code path left to surface through at all).
+		return BadRegister, collectErr
+	}
 
 	debugPrintf("// [Compiler] Will re-export %d names from '%s'\n", len(exportNames), sourceModule)
 
@@ -5029,35 +5043,48 @@ func (c *Compiler) compileExportAllDeclaration(node *parser.ExportAllDeclaration
 // another barrel is the common npm shape) and treats a nested "export * as ns"
 // as contributing exactly one name, "ns", per spec. visited guards against
 // re-export cycles by resolved module path.
-func (c *Compiler) collectExportAllNames(rec vm.ModuleRecord, specifier string, visited map[string]bool) []string {
+func (c *Compiler) collectExportAllNames(rec vm.ModuleRecord, specifier string, visited map[string]bool, node parser.Node) ([]string, errors.PaseratiError) {
 	resolvedPath := rec.GetResolvedPath()
 	if resolvedPath == "" {
 		resolvedPath = specifier
 	}
 	if visited[resolvedPath] {
-		return nil
+		return nil, nil
 	}
 	visited[resolvedPath] = true
+
+	// #433: a module that failed to load/parse must fail the *importing*
+	// module's compile, not just silently contribute zero names. LoadModule
+	// reports this only on the record (its own `error` return stays nil, see
+	// moduleLoader.loadModuleSequential) precisely so a failed dependency
+	// doesn't abort the whole program by itself -- a module is allowed to
+	// `import()` a broken one dynamically and handle the rejection. But a
+	// static "export * from" is unconditional and synchronous, like a static
+	// `import`/`export * as ns from`, and must propagate here exactly as
+	// those do.
+	if loadErr := rec.GetError(); loadErr != nil {
+		return nil, NewCompileError(node, fmt.Sprintf("Failed to load module '%s' for re-export: %v", specifier, loadErr))
+	}
 
 	if exportValues := rec.GetExportValues(); len(exportValues) > 0 {
 		names := make([]string, 0, len(exportValues))
 		for name := range exportValues {
 			names = append(names, name)
 		}
-		return names
+		return names, nil
 	}
 	if exportNames := rec.GetExportNames(); len(exportNames) > 0 {
-		return exportNames
+		return exportNames, nil
 	}
 
 	// Nothing populated yet - harvest from the source module's AST.
 	if c.moduleLoader == nil {
-		return nil
+		return nil, nil
 	}
 	// rec is this very module's record; only the concrete type exposes the AST.
 	concreteRec, _ := rec.(*modules.ModuleRecord)
 	if concreteRec == nil || concreteRec.AST == nil {
-		return nil
+		return nil, nil
 	}
 
 	names := c.extractExportNamesFromAST(concreteRec.AST)
@@ -5078,9 +5105,13 @@ func (c *Compiler) collectExportAllNames(rec vm.ModuleRecord, specifier string, 
 		if err != nil {
 			continue
 		}
-		names = append(names, c.collectExportAllNames(nestedRec, all.Source.Value, visited)...)
+		nestedNames, nestedErr := c.collectExportAllNames(nestedRec, all.Source.Value, visited, node)
+		if nestedErr != nil {
+			return nil, nestedErr
+		}
+		names = append(names, nestedNames...)
 	}
-	return names
+	return names, nil
 }
 
 // extractExportNamesFromAST extracts export names from a module's AST

--- a/tests/scripts/export_star_broken_source_helper_lib.ts
+++ b/tests/scripts/export_star_broken_source_helper_lib.ts
@@ -1,0 +1,6 @@
+// paserati#433: helper module that deliberately fails to parse. No `// expect`
+// comment, so scripts_test.go skips it as its own test (comment-scanning
+// happens before any parse is attempted); it exists only to be re-exported
+// by export_star_broken_source_helper_mid.ts.
+export const a = 1;
+this is not valid syntax @#$

--- a/tests/scripts/export_star_broken_source_helper_mid.ts
+++ b/tests/scripts/export_star_broken_source_helper_mid.ts
@@ -1,0 +1,3 @@
+// paserati#433: a barrel that re-exports a module which fails to parse.
+export * from "./export_star_broken_source_helper_lib.ts";
+export const other = 42;

--- a/tests/scripts/export_star_broken_source_propagates.ts
+++ b/tests/scripts/export_star_broken_source_propagates.ts
@@ -1,0 +1,22 @@
+// expect_compile_error: Failed to load module './export_star_broken_source_helper_lib.ts' for re-export
+// paserati#433: "export * from a module that fails to load/parse" was
+// silently dropped instead of propagating the error.
+//
+// Real Node fails the whole importing module synchronously and eagerly when
+// a re-exported ("export * from") module fails to parse - it does not just
+// quietly omit that module's names from the merged namespace. Paserati used
+// to do exactly that: compileExportAllDeclaration's bare "export *" path
+// (unlike "export * as ns from" or a plain named/namespace import) never
+// called emitEvalModule/emitGetModuleExport per name when the source
+// module's export names came back empty, so a failed dependency had no
+// bytecode path left to surface the failure through at all - not even at
+// runtime.
+//
+// export_star_broken_source_helper_mid.ts does `export * from
+// "./export_star_broken_source_helper_lib.ts"`, and that lib module
+// deliberately fails to parse. Importing the barrel must now fail the
+// import at compile time instead of silently producing a namespace missing
+// just that module's names.
+import * as ns from "./export_star_broken_source_helper_mid.ts";
+
+ns.other;


### PR DESCRIPTION
## Summary

`export * from` a module that fails to parse/load was silently dropped instead of propagating the error — the merged namespace just came back missing that module's names, with no error anywhere, at compile time or run time.

Real Node fails the whole importing module synchronously and eagerly when a re-exported (`export * from`) module fails to parse/load. Paserati instead just quietly omitted that module's exports from the merged namespace.

## Root cause

`LoadModule` reports a failed dependency only on the returned `ModuleRecord` (its own `error` return stays `nil` — see `moduleLoader.loadModuleSequential`), precisely so a failed dependency doesn't abort the whole program by itself (a module may `import()` a broken one dynamically and handle the rejection).

`compileExportAllDeclaration`'s bare `export *` path never checked the record for a load error, and `collectExportAllNames()` harvests names from the source module's AST when the checker hasn't already populated them (the skip-typecheck path, #99) — a `nil` AST from a failed parse just produces zero names. With zero names, the per-name loop that would normally call `emitEvalModule`/`emitGetModuleExport` for each re-exported name never ran either, so nothing was left to trip the runtime module-load-error check in `vm.go`.

Compare `export * as ns from`, which unconditionally calls `emitEvalModule` regardless of name resolution and so already surfaced this at runtime — only bare `export *` had no code path left to fail through at all.

## Fix

`collectExportAllNames` now checks `ModuleRecord.GetError()` as soon as it's given a record — this covers both the immediate source and every nested bare `export * from` it recurses into for a re-exported barrel — and returns the load error instead of an empty name list. `compileExportAllDeclaration` propagates that as a compile error, matching how a static `import`/`export * as ns from` already fails synchronously and eagerly, per real ESM semantics.

## Verified

- Against the issue's exact repro (a lib module with a syntax error, re-exported via bare `export *` through a barrel, imported by namespace) with both `--no-typecheck` and full type checking.
- Confirmed `export * as ns from` and a working `export *` barrel are both unaffected.
- `go test ./tests -run TestScripts` and `go test ./...` both green.
- Test262 diff on `language/module-code` (592 tests, `-timeout 0.2s`): **0 new passes, 0 new failures**.

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)