### PR TITLE
fix(compiler): nested named function expression loses self-reference with whole-pattern default destructured param

### DIFF
--- a/pkg/compiler/compile_literal.go
+++ b/pkg/compiler/compile_literal.go
@@ -1344,6 +1344,46 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 		debugPrintf("// [Compiling Function Literal] %s: Parameter %s defined in R%d\n", determinedFuncName, param.Name.Value, reg)
 	}
 
+	// 2.5. Handle named function expression binding
+	// For named function expressions like: function g() { g(); }
+	// The name 'g' should be accessible inside and refer to the closure itself.
+	//
+	// This MUST happen before default-parameter/destructuring-parameter compilation
+	// (steps 3 and 3.5 below), which allocate and free temporary registers for things
+	// like the "is this param undefined?" check. If the name binding's register were
+	// allocated afterwards (as it used to be), the allocator could hand it the exact
+	// register number a temp register had just been freed from - and the VM writes
+	// the self-reference into that register number at call setup (see
+	// call.go prepareCall), before any bytecode runs. Default-parameter bytecode
+	// (which runs at function entry, ahead of the rest of the body) would then
+	// clobber the self-reference with its own temporary value before the recursive
+	// call ever executed, e.g. `function fact(n, {step=1}={}) { ...; fact(n-1, {step}); }`
+	// nested inside another function (#443).
+	if needsInnerNameBinding {
+		// Per ECMAScript spec: if a parameter has the same name as the function name,
+		// the parameter shadows the function name binding. Skip creating the inner
+		// binding in this case to avoid overriding the parameter register.
+		shadowedByParam := functionCompiler.parameterNames[funcNameForInnerBinding]
+		if !shadowedByParam && node.RestParameter != nil && node.RestParameter.Name != nil &&
+			node.RestParameter.Name.Value == funcNameForInnerBinding {
+			shadowedByParam = true
+		}
+		if shadowedByParam {
+			needsInnerNameBinding = false
+		} else {
+			// Allocate a register for the function name binding
+			nameBindingReg := functionCompiler.regAlloc.Alloc()
+			// Use DefineImmutable so assignments to the NFE name are silently ignored in non-strict mode
+			functionCompiler.currentSymbolTable.DefineImmutable(funcNameForInnerBinding, nameBindingReg)
+			functionCompiler.regAlloc.Pin(nameBindingReg) // Pin since it can be captured
+
+			// No bytecode needs to be emitted here - the VM will initialize this register
+			// when the function is called (see call.go prepareCall)
+			debugPrintf("// [Compiler] Function name binding '%s' allocated in R%d (will be initialized by VM)\n",
+				funcNameForInnerBinding, nameBindingReg)
+		}
+	}
+
 	// 3. Handle default parameters
 	// Build parameter list for TDZ checking (excluding 'this' and destructuring params)
 	functionCompiler.parameterList = make([]string, 0, len(node.Parameters))
@@ -1537,29 +1577,6 @@ func (c *Compiler) compileFunctionLiteralWithOptions(node *parser.FunctionLitera
 			// Save the pattern for generating destructuring code after function prologue
 			restParamPattern = node.RestParameter.Pattern
 			debugPrintf("// [Compiler] Rest parameter with destructuring pattern in R%d\n", restParamReg)
-		}
-	}
-
-	// 4.5. Handle named function expression binding
-	// For named function expressions like: function g() { g(); }
-	// The name 'g' should be accessible inside and refer to the closure itself
-	if needsInnerNameBinding {
-		// Per ECMAScript spec: if a parameter has the same name as the function name,
-		// the parameter shadows the function name binding. Skip creating the inner
-		// binding in this case to avoid overriding the parameter register.
-		if functionCompiler.parameterNames[funcNameForInnerBinding] {
-			needsInnerNameBinding = false
-		} else {
-			// Allocate a register for the function name binding
-			nameBindingReg := functionCompiler.regAlloc.Alloc()
-			// Use DefineImmutable so assignments to the NFE name are silently ignored in non-strict mode
-			functionCompiler.currentSymbolTable.DefineImmutable(funcNameForInnerBinding, nameBindingReg)
-			functionCompiler.regAlloc.Pin(nameBindingReg) // Pin since it can be captured
-
-			// No bytecode needs to be emitted here - the VM will initialize this register
-			// when the function is called (see call.go prepareCall)
-			debugPrintf("// [Compiler] Function name binding '%s' allocated in R%d (will be initialized by VM)\n",
-				funcNameForInnerBinding, nameBindingReg)
 		}
 	}
 

--- a/tests/scripts/issue443_nested_nfe_destructured_default_selfref.ts
+++ b/tests/scripts/issue443_nested_nfe_destructured_default_selfref.ts
@@ -1,0 +1,74 @@
+// expect: true
+// paserati#443: a named function expression's self-reference (the binding
+// that lets `function fact() { ... fact() ... }` call itself by name) is
+// stored in a dedicated register that the VM initializes with the closure
+// itself right before the function body starts running (see
+// call.go prepareCall / NameBindingRegister). The compiler used to allocate
+// that register LAST - after compiling default-parameter and destructuring-
+// parameter code, which allocates and frees its own temporary registers for
+// things like the "is this param undefined?" check. When the function is
+// nested inside another function (so it can't fall back to resolving its
+// own name as a global/outer-scope variable), the register allocator could
+// hand the name-binding register the exact number a temp register had just
+// been freed from. That temp register's bytecode - default-parameter
+// evaluation, which runs at function entry, ahead of the rest of the body -
+// then clobbered the self-reference with its own temporary value before the
+// recursive call ever executed, throwing "TypeError: object is not a
+// function".
+//
+// Precisely narrowed (see the issue): needs (a) the function nested inside
+// another function (so its own name isn't resolvable as an outer/global
+// variable) and (b) a destructured parameter with a *whole-pattern* default
+// (`{...} = {}`), not just an inner-field default or no default at all. This
+// is exactly the shape used throughout ajv's compiled validators
+// (`function validate0(data, {instancePath="", ...}={}) {...}`), so it broke
+// every recursive ajv schema validation.
+//
+// The fix: reserve and pin the name-binding register right after parameters
+// are defined, before any default-value/destructuring temp registers are
+// allocated, so it can never be recycled out from under the closure.
+
+const checks: boolean[] = [];
+
+// --- Case 1: the issue's own minimal repro, function-declaration nesting ---
+function makeFact(): (n: number) => number {
+  return function fact(n: number, { step = 1 } = {}): number {
+    if (n <= 0) return 0;
+    return step + fact(n - 1, { step });
+  };
+}
+checks.push(makeFact()(3) === 3);
+
+// --- Case 2: nested inside an IIFE, matching what `new Function(src)` (a
+// bare source string compiled as `return (function() { <src> });`) produces
+// under the hood ---
+const fact2 = (function () {
+  return function fact(n: number, { step = 2 } = {}): number {
+    if (n <= 0) return 0;
+    return step + fact(n - 1, { step });
+  };
+})();
+checks.push(fact2(3) === 6);
+
+// --- Case 3: an actual `new Function(...)`-compiled recursive validator,
+// the real-world ajv shape from the issue ---
+const makeFn = new Function(`
+  return function fact(n, {step = 1} = {}) {
+    if (n <= 0) return 0;
+    return step + fact(n - 1, {step});
+  };
+`);
+const fact3 = makeFn();
+checks.push(fact3(4) === 4);
+
+// --- Case 4: sanity check that a parameter actually named the same as the
+// function still shadows the self-binding (the register is reserved eagerly
+// now, but must still be released when shadowed) ---
+function makeShadowed(): (fact: number) => string {
+  return function fact(fact: number): string {
+    return typeof fact;
+  };
+}
+checks.push(makeShadowed()(5) === "number");
+
+checks.every((c) => c);


### PR DESCRIPTION
## Summary

Fixes #443.

A named function expression's self-reference register (the binding that lets `function fact() { ... fact() ... }` call itself by name) is initialized by the VM with the closure itself right at call setup, before any bytecode of the function body runs (`call.go`'s `NameBindingRegister` handling in `prepareCall`). The compiler used to allocate this register *last* — after compiling default-parameter and destructuring-parameter code, which allocates and frees its own temporary registers (e.g. for the "is this param undefined?" check).

When the function is nested inside another function — so its own name can't fall back to resolving as an outer/global variable — the register allocator could hand the self-reference binding the exact register number a temp register had just been freed from. That temp register's bytecode (default-parameter evaluation, which runs at function entry, ahead of the rest of the body) then clobbered the self-reference with its own temporary value before the recursive call ever executed, throwing `TypeError: object is not a function`.

This exact shape — a destructured parameter with a *whole-pattern* default (`{...} = {}`), inside a function nested via `new Function(...)` — is used throughout ajv's compiled validators, breaking every recursive schema validation.

## Fix

Reserve and pin the self-reference register right after parameters are defined, before any default-value/destructuring temp registers get allocated, so it can never be recycled out from under the closure. The existing "does a parameter shadow the function's own name" check moves along with it; a rest-parameter name check was folded in directly (from the AST) since `parameterNames` isn't populated for the rest parameter until later in the original order. This rest-parameter shadowing check is spec-correct on its own merits (ECMAScript: a parameter sharing the function's own name shadows the NFE self-binding), independent of anything below.

## Testing

- `go build ./...`
- `go test ./pkg/...` — all pass
- `go test ./tests/...` — all pass, including new regression test [tests/scripts/issue443_nested_nfe_destructured_default_selfref.ts](tests/scripts/issue443_nested_nfe_destructured_default_selfref.ts) covering: the issue's own minimal repro, an IIFE-nested case matching what `new Function` produces internally, an actual `new Function(...)`-compiled recursive validator (the real-world ajv shape), and a sanity check that a same-named parameter still shadows the self-binding.

## Note

While investigating, I found two unrelated pre-existing bugs (confirmed present on `main` before this fix, not introduced by it) and am fixing them separately in **#447** (based on this branch) rather than expanding this PR's scope:

1. Nested `async function fact(n) { ... await fact(n-1) ... }` self-recursion throws `undefined is not a function` — `executeAsyncFunctionBody` (async.go) builds an async function's first frame by hand instead of going through `prepareCall`, and never applied the same `NameBindingRegister` initialization.
2. **Correction to my earlier note here:** what I originally described as "a rest parameter sharing the function's own name doesn't shadow the NFE self-binding" was a misdiagnosis. The actual bug is unrelated to shadowing or naming at all: the VM hard-codes a variadic function's rest-parameter array at register index `calleeFunc.Arity`, but the compiler could allocate that register out of order whenever a default-parameter value preceded the rest parameter (its freed temporaries got recycled into the rest-parameter's allocation) — landing the rest array one register away from where the VM actually wrote it. A single plain default value reproduces it, no destructuring or naming involved: `function f(n, step = 1, ...rest) { return rest; }` returned garbage instead of the rest array whenever nested register churn shifted things by one. See #447 for the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
