### PR TITLE
fix(compiler,vm): give runtime error positions real columns, not a hardcoded 1 (#153)

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1467,8 +1467,9 @@ func (c *Compiler) compileNode(node parser.Node, hint Register) (Register, error
 		panic("Compiler internal error: typeChecker is nil during compileNode")
 	}
 
-	if c.line != parser.GetTokenFromNode(node).Line {
-		c.line = parser.GetTokenFromNode(node).Line
+	if tok := parser.GetTokenFromNode(node); c.line != tok.Line {
+		c.line = tok.Line
+		c.markPosition(tok.Column)
 		debugPrintf("// DEBUG compiling line %d (%s)\n", c.line, c.compilingFuncName)
 	}
 

--- a/pkg/compiler/emit.go
+++ b/pkg/compiler/emit.go
@@ -12,6 +12,18 @@ func (c *Compiler) emitOpCode(op vm.OpCode, line int) {
 	c.chunk.WriteOpCode(op, line)
 }
 
+// markPosition records that, from here on, the given column applies - keyed
+// on the current end of the chunk being emitted, in the chunk's sparse
+// Columns table (#153). Called only where the compiler already tracks the
+// current line (once per line entered during compileNode's traversal, not
+// per emitted instruction), so this stays far sparser than Lines'
+// one-entry-per-byte table while still giving a runtime error's
+// frame-synthesized position something better than a hardcoded column 1 to
+// report.
+func (c *Compiler) markPosition(column int) {
+	c.chunk.MarkColumn(len(c.chunk.Code), column)
+}
+
 func (c *Compiler) emitByte(b byte) {
 	c.chunk.EmitByte(b)
 }

--- a/pkg/driver/error_position_test.go
+++ b/pkg/driver/error_position_test.go
@@ -104,6 +104,85 @@ func TestRuntimeErrorInsideModuleReportsThatModulesSource(t *testing.T) {
 	}
 }
 
+// TestRuntimeErrorFrameSyntheticPositionHasRealColumn covers #153's other
+// manifestation: an uncaught JS exception's reported position is captured by
+// throwException (via getFrameLineAndColumnInfo) from the executing frame's
+// own bytecode, and used to hardcode Column to 1 unconditionally with the
+// comment "Column tracking not implemented yet" - because Chunk had no
+// column data to recover at all, only a Lines table. The compiler now also
+// populates a sparse Columns table (Chunk.Columns, Compiler.markPosition)
+// that this path consults, so the reported column should be the real one -
+// even though "return x.bar;" is indented well past column 1. (The sibling
+// case - vm.runtimeError()'s own frame-synthesized position, the function
+// named directly in #153 - is covered at the unit level in
+// pkg/vm/runtime_error_report_test.go, since every runtimeError call site
+// reachable from real JS turns out to get wrapped into a catchable
+// TypeError first, same as this one.)
+func TestRuntimeErrorFrameSyntheticPositionHasRealColumn(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	script := "function foo() {\n    let x = null;\n    return x.bar;\n}\nfoo();\n"
+	_, errs := p.RunCode(script, RunOptions{})
+	if len(errs) == 0 {
+		t.Fatal("expected a runtime diagnostic, got none")
+	}
+	pos, ok := positionOfDiagnostic(errs[0])
+	if !ok {
+		t.Fatalf("diagnostic carries no position: %v", errs[0])
+	}
+	if pos.Line != 3 {
+		t.Errorf("position is line %d, want 3 (`return x.bar;`)", pos.Line)
+	}
+	if pos.Column <= 1 {
+		t.Errorf("position is column %d, want the real column of `x.bar` (>1) - looks like the old hardcoded-to-1 fallback", pos.Column)
+	}
+	// "    return x.bar;" - Columns records an entry each time the compiler
+	// crosses onto a new source line (Compiler.markPosition, hooked into
+	// compileNode's existing per-line tracking), keyed on whichever node it
+	// happens to be visiting at that moment - here, `return x.bar;` is the
+	// only statement on line 3, so that's its own `return` keyword, at
+	// column 5. This pins that observed, deliberately-approximate value
+	// rather than demanding token-exact precision (see Chunk.Columns' doc
+	// comment) - see
+	// TestRuntimeErrorFrameSyntheticPositionColumnIsPerLineNotPerStatement
+	// below for the sharper edge of that approximation.
+	if pos.Column != 5 {
+		t.Errorf("position is column %d, want 5 (the `return` keyword starting the failing statement)", pos.Column)
+	}
+}
+
+// TestRuntimeErrorFrameSyntheticPositionColumnIsPerLineNotPerStatement pins
+// down the coarser edge of #153's approximation: Columns records one entry
+// per source *line* the compiler crosses while emitting a chunk, not one per
+// statement. When several statements share a line, a failure in a later one
+// still resolves to whichever entry precedes it in the table - the earlier
+// statement's own column, not the failing statement's. This isn't a bug to
+// fix here (see Chunk.Columns' doc comment on the offset/column trade-off);
+// it exists so a future change to the granularity has something concrete to
+// compare against instead of rediscovering this by surprise.
+func TestRuntimeErrorFrameSyntheticPositionColumnIsPerLineNotPerStatement(t *testing.T) {
+	p := NewPaserati()
+	p.SetSkipTypeCheck(true)
+	// "  let a = 1; let b = null; return b.z;" - three statements, one line.
+	script := "function q() {\n  let a = 1; let b = null; return b.z;\n}\nq();\n"
+	_, errs := p.RunCode(script, RunOptions{})
+	if len(errs) == 0 {
+		t.Fatal("expected a runtime diagnostic, got none")
+	}
+	pos, ok := positionOfDiagnostic(errs[0])
+	if !ok {
+		t.Fatalf("diagnostic carries no position: %v", errs[0])
+	}
+	if pos.Line != 2 {
+		t.Errorf("position is line %d, want 2", pos.Line)
+	}
+	// Column 3 is `let` (the *first* statement on the line), not `return b.z`
+	// where the failure actually is - the documented approximation.
+	if pos.Column != 3 {
+		t.Errorf("position is column %d, want 3 (the line's first statement, `let a = 1`) - if this changed, Columns' granularity did too; update the doc comments alongside it", pos.Column)
+	}
+}
+
 // TestEvalSourceStaysAnonymous guards the other direction: a caller with no
 // file (the REPL, paserati -e) must keep the "<eval>" identity rather than
 // borrowing a name from ModuleName, which is often a synthetic specifier.

--- a/pkg/vm/bytecode.go
+++ b/pkg/vm/bytecode.go
@@ -802,11 +802,29 @@ type ScopeDescriptor struct {
 	CurrentPrivateBrandInfo *PrivateBrandInfoVM
 }
 
+// ColumnEntry records the source column in effect starting at Offset, in a
+// Chunk's sparse Columns table. See Chunk.Columns.
+type ColumnEntry struct {
+	Offset int // Byte offset into Chunk.Code where this column starts applying
+	Column int // 1-based column number (rune index within the line)
+}
+
 // Chunk represents a sequence of bytecode instructions and associated data.
 type Chunk struct {
 	Code      []byte  // The bytecode instructions (OpCodes and operands)
 	Constants []Value // Constant pool (Now uses Value from vm package)
 	Lines     []int   // Line number for each byte in Code (parallel array)
+	// Columns is a sparse, offset-ordered side table of column numbers, unlike
+	// Lines: recording one entry per source line the compiler crosses while
+	// emitting this chunk (see Compiler.markPosition) rather than one per byte
+	// of Code. GetColumn recovers the column in effect at a given offset by
+	// finding the latest entry at or before it - approximate (the start of
+	// whatever line was most recently entered, not necessarily the exact
+	// token at that offset) but enough to point a runtime error's caret at
+	// more than column 1 (#153). Empty for chunks compiled before this table
+	// existed and for hand-assembled chunks; GetColumn degrades to 0 (caller
+	// falls back to column 1) in that case.
+	Columns []ColumnEntry
 	// Source is the file this chunk was compiled from, so a runtime error can
 	// name and quote the right file. Without it every VM-raised error's
 	// Position.Source stayed nil and errors.DisplayErrors fell back to whatever
@@ -867,6 +885,47 @@ func (c *Chunk) GetLine(offset int) int {
 		return 0
 	}
 	return c.Lines[offset]
+}
+
+// GetColumn returns the column in effect at a given bytecode offset, per the
+// sparse Columns table (see Chunk.Columns) - the column of the latest entry
+// at or before offset. Returns 0 (not a valid 1-based column) when Columns is
+// empty or offset precedes every entry, so callers can tell "no data" apart
+// from a genuine column and fall back accordingly.
+func (c *Chunk) GetColumn(offset int) int {
+	entries := c.Columns
+	lo, hi := 0, len(entries)-1
+	result := 0
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if entries[mid].Offset <= offset {
+			result = entries[mid].Column
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return result
+}
+
+// MarkColumn records that, starting at the given bytecode offset, source
+// column applies. Called by the compiler at the same points it tracks the
+// current line (Compiler.markPosition) with offset always len(chunk.Code) at
+// that moment, so across the calls building up one chunk, offset is always
+// non-decreasing (Code only grows by appending, never truncated) and can
+// repeat only immediately - GetColumn's binary search relies on that
+// ordering. A call at the same offset as the table's current last entry
+// (e.g. two line changes with no code emitted between them) overwrites that
+// entry rather than appending a sibling one, so the table never carries two
+// entries for the same offset; only the last entry is ever checked for a
+// repeat; an out-of-order offset older than the last entry is a caller bug,
+// not something this method can safely paper over.
+func (c *Chunk) MarkColumn(offset, column int) {
+	if n := len(c.Columns); n > 0 && c.Columns[n-1].Offset == offset {
+		c.Columns[n-1].Column = column
+		return
+	}
+	c.Columns = append(c.Columns, ColumnEntry{Offset: offset, Column: column})
 }
 
 // NewChunk creates a new, empty Chunk.

--- a/pkg/vm/bytecode_test.go
+++ b/pkg/vm/bytecode_test.go
@@ -123,6 +123,60 @@ func TestAddConstantCapacityBoundaryStrings(t *testing.T) {
 	c.AddConstant(NewString(intToDigits(constantPoolCapacity)))
 }
 
+// TestChunkGetColumn covers #153's Columns table directly: it must recover
+// the column of the latest entry at or before a given offset (binary search
+// over a table built by successive MarkColumn calls, as the compiler makes
+// them during codegen - always in non-decreasing offset order, since offset
+// is always len(chunk.Code) at the time of the call and Code only grows by
+// appending), and return 0 - not some other entry's column, not a panic -
+// when offset precedes every entry or the table is empty.
+func TestChunkGetColumn(t *testing.T) {
+	c := NewChunk()
+	if got := c.GetColumn(0); got != 0 {
+		t.Errorf("empty table: GetColumn(0) = %d, want 0", got)
+	}
+
+	c.MarkColumn(0, 3)
+	c.MarkColumn(4, 15)
+	c.MarkColumn(10, 1)
+
+	cases := []struct {
+		offset int
+		want   int
+	}{
+		{-1, 0},  // before every entry
+		{0, 3},   // exactly the first entry
+		{1, 3},   // between entry 0 and entry 1
+		{3, 3},   // still before entry 1
+		{4, 15},  // exactly the second entry
+		{9, 15},  // between entry 1 and entry 2
+		{10, 1},  // exactly the third entry
+		{100, 1}, // past every entry
+	}
+	for _, tc := range cases {
+		if got := c.GetColumn(tc.offset); got != tc.want {
+			t.Errorf("GetColumn(%d) = %d, want %d", tc.offset, got, tc.want)
+		}
+	}
+
+	// A second MarkColumn call at the *current last* offset overwrites that
+	// entry in place rather than appending a sibling one - the case the
+	// compiler actually hits when the line pointer changes twice with no
+	// code emitted in between (e.g. two statements compiled back to back
+	// with a no-op in between). MarkColumn is only ever called with
+	// len(chunk.Code) as the offset, and Code only grows by appending, so
+	// offsets across calls are non-decreasing and a repeat can only ever
+	// match the most recent entry - never an earlier one, which is why the
+	// overwrite check only looks at the table's last entry.
+	c.MarkColumn(10, 99)
+	if got := c.GetColumn(10); got != 99 {
+		t.Errorf("after overwrite: GetColumn(10) = %d, want 99", got)
+	}
+	if n := len(c.Columns); n != 3 {
+		t.Errorf("overwrite at the last offset changed the entry count to %d, want 3", n)
+	}
+}
+
 func intToDigits(i int) string {
 	// Minimal decimal formatter to avoid pulling in strconv just for test data.
 	if i == 0 {

--- a/pkg/vm/exceptions.go
+++ b/pkg/vm/exceptions.go
@@ -93,8 +93,7 @@ func (vm *VM) throwException(value Value) {
 		vm.unwindingCrossedNative = false
 		// Capture throw location from current frame before unwinding starts
 		if vm.frameCount > 0 {
-			vm.lastThrowLine, vm.lastThrowFuncName = vm.getFrameLineInfo(&vm.frames[vm.frameCount-1])
-			vm.lastThrowColumn = 1 // Column tracking not implemented yet
+			vm.lastThrowLine, vm.lastThrowColumn, vm.lastThrowFuncName = vm.getFrameLineAndColumnInfo(&vm.frames[vm.frameCount-1])
 			// Capture the file too, not just the line. lastThrowLine is a line
 			// in the *throwing* frame's own source, which for a throw inside an
 			// imported module is not the entry script - reporting the one
@@ -398,11 +397,15 @@ func frameSource(frame *CallFrame) *source.SourceFile {
 	return frame.closure.Fn.Chunk.Source
 }
 
-// getFrameLineInfo extracts the line number from a frame at the current instruction position
-// Returns (line, functionName) where line is 1 if no info available
-func (vm *VM) getFrameLineInfo(frame *CallFrame) (int, string) {
+// getFrameLineAndColumnInfo extracts the line and column a frame's current
+// instruction position maps to (line, functionName) where line is 1 if no
+// info is available. The column comes from the chunk's sparse Columns table
+// (#153) at whichever offset actually supplied the line - approximate, like
+// runtimeError's frame-synthesized column, but real position data beats the
+// hardcoded column 1 a fresh throw used to report unconditionally.
+func (vm *VM) getFrameLineAndColumnInfo(frame *CallFrame) (int, int, string) {
 	if frame == nil || frame.closure == nil || frame.closure.Fn == nil {
-		return 1, "<script>"
+		return 1, 1, "<script>"
 	}
 
 	fn := frame.closure.Fn
@@ -412,26 +415,33 @@ func (vm *VM) getFrameLineInfo(frame *CallFrame) (int, string) {
 	}
 
 	if fn.Chunk == nil {
-		return 1, funcName
+		return 1, 1, funcName
 	}
 
 	chunk := fn.Chunk
 	// IP points to the NEXT instruction, error occurred at ip-1
 	instructionPos := frame.ip - 1
 
+	lineOffset := -1
+	line := 1
 	if instructionPos >= 0 && instructionPos < len(chunk.Lines) {
-		return chunk.GetLine(instructionPos), funcName
-	}
-	// Fallback to ip itself if ip-1 is invalid
-	if frame.ip >= 0 && frame.ip < len(chunk.Lines) {
-		return chunk.GetLine(frame.ip), funcName
-	}
-	// Last resort: first line in chunk
-	if len(chunk.Lines) > 0 {
-		return chunk.Lines[0], funcName
+		line, lineOffset = chunk.GetLine(instructionPos), instructionPos
+	} else if frame.ip >= 0 && frame.ip < len(chunk.Lines) {
+		// Fallback to ip itself if ip-1 is invalid
+		line, lineOffset = chunk.GetLine(frame.ip), frame.ip
+	} else if len(chunk.Lines) > 0 {
+		// Last resort: first line in chunk
+		line, lineOffset = chunk.Lines[0], 0
 	}
 
-	return 1, funcName
+	column := 0
+	if lineOffset >= 0 {
+		column = chunk.GetColumn(lineOffset)
+	}
+	if column == 0 {
+		column = 1
+	}
+	return line, column, funcName
 }
 
 // handleUncaughtException handles uncaught exceptions by terminating execution

--- a/pkg/vm/runtime_error_report_test.go
+++ b/pkg/vm/runtime_error_report_test.go
@@ -1,6 +1,10 @@
 package vm
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/nooga/paserati/pkg/errors"
+)
 
 // TestRuntimeErrorSurvivesBrokenFrameCount covers the second half of #156.
 //
@@ -40,5 +44,80 @@ func TestRuntimeErrorSurvivesBrokenFrameCount(t *testing.T) {
 		if msg := vm.errors[0].Message(); msg == "" {
 			t.Errorf("frameCount=%d: recorded an empty message", frameCount)
 		}
+	}
+}
+
+// TestRuntimeErrorFrameSyntheticPositionUsesColumnsTable covers #153:
+// runtimeError's frame-synthesized position - reached whenever a VM-internal
+// invariant check fails (e.g. "Cannot use 'number' as a constructor"; see
+// vm.go/op_*.go's many direct vm.runtimeError(...) call sites) rather than a
+// JS-catchable throw - used to hardcode Column to 1 unconditionally, because
+// Chunk had no column data to recover at all, only a Lines table. It now also
+// consults the chunk's sparse Columns table (Chunk.Columns, populated by the
+// compiler's markPosition), so a chunk that has an entry for the failing
+// instruction's offset gets a real column instead.
+//
+// This drives runtimeError directly against a hand-built frame/chunk (as
+// TestRuntimeErrorSurvivesBrokenFrameCount above does) rather than through
+// real script execution, because every reachable-from-JS runtimeError call
+// site this repo could find happens to get wrapped into a catchable
+// TypeError first (see TestRuntimeErrorFrameSyntheticPositionHasRealColumn in
+// pkg/driver for that path, which goes through throwException instead).
+func TestRuntimeErrorFrameSyntheticPositionUsesColumnsTable(t *testing.T) {
+	chunk := &Chunk{
+		Code:    []byte{byte(OpNop), byte(OpNop), byte(OpNop)},
+		Lines:   []int{5, 5, 5},
+		Columns: []ColumnEntry{{Offset: 0, Column: 9}},
+	}
+	fn := &FunctionObject{Name: "foo", Chunk: chunk}
+	closure := &ClosureObject{Fn: fn}
+
+	vm := NewVM()
+	vm.frameCount = 1
+	vm.frames[0] = CallFrame{closure: closure, ip: 2} // instructionPos = ip-1 = 1
+
+	if got := vm.runtimeError("boom"); got != InterpretRuntimeError {
+		t.Fatalf("got status %v, want InterpretRuntimeError", got)
+	}
+	if len(vm.errors) != 1 {
+		t.Fatalf("recorded %d errors, want 1", len(vm.errors))
+	}
+	re, ok := vm.errors[0].(*errors.RuntimeError)
+	if !ok {
+		t.Fatalf("error is %T, want *errors.RuntimeError", vm.errors[0])
+	}
+	if re.Position.Line != 5 {
+		t.Errorf("line = %d, want 5", re.Position.Line)
+	}
+	if re.Position.Column != 9 {
+		t.Errorf("column = %d, want 9 (from chunk.Columns) - got the old hardcoded-to-1 fallback instead", re.Position.Column)
+	}
+}
+
+// TestRuntimeErrorFrameSyntheticPositionFallsBackWithoutColumnsTable covers
+// the other half of #153: a chunk with no Columns data at all (compiled
+// before this table existed, or hand-assembled, like
+// TestRuntimeErrorSurvivesBrokenFrameCount's zero-value Chunk above) must
+// still fall back to column 1 rather than 0 or some other nonsense value.
+func TestRuntimeErrorFrameSyntheticPositionFallsBackWithoutColumnsTable(t *testing.T) {
+	chunk := &Chunk{
+		Code:  []byte{byte(OpNop), byte(OpNop)},
+		Lines: []int{7, 7},
+		// Columns intentionally left empty.
+	}
+	fn := &FunctionObject{Name: "foo", Chunk: chunk}
+	closure := &ClosureObject{Fn: fn}
+
+	vm := NewVM()
+	vm.frameCount = 1
+	vm.frames[0] = CallFrame{closure: closure, ip: 1}
+
+	vm.runtimeError("boom")
+	re, ok := vm.errors[0].(*errors.RuntimeError)
+	if !ok {
+		t.Fatalf("error is %T, want *errors.RuntimeError", vm.errors[0])
+	}
+	if re.Position.Column != 1 {
+		t.Errorf("column = %d, want the column-1 fallback", re.Position.Column)
 	}
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -19076,6 +19076,7 @@ func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
 	// ip points to the *next* instruction, error occurred at ip-1
 	instructionPos := frame.ip - 1
 	line := 0
+	column := 0
 	funcName := "<script>"
 
 	// Safety check for chunk and bounds before calling GetLine
@@ -19090,20 +19091,39 @@ func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
 			funcName = "<anonymous>"
 		}
 
-		// Ensure instructionPos is valid (non-negative and within bounds)
+		// Ensure instructionPos is valid (non-negative and within bounds).
+		// lineOffset tracks whichever offset actually supplied the line, so
+		// the column lookup below (#153) points at the same instruction
+		// rather than possibly-mismatched fallback offsets.
+		lineOffset := -1
 		if instructionPos >= 0 && instructionPos < len(chunk.Lines) {
 			line = chunk.GetLine(instructionPos)
+			lineOffset = instructionPos
 		} else if frame.ip >= 0 && frame.ip < len(chunk.Lines) {
 			// If ip-1 is invalid, try using ip itself
 			line = chunk.GetLine(frame.ip)
+			lineOffset = frame.ip
 		} else if len(chunk.Lines) > 0 {
 			// Fallback: use the first line if available
 			line = chunk.Lines[0]
+			lineOffset = 0
 		}
 		// If line is still 0 and we have code, default to line 1
 		if line == 0 && len(chunk.Code) > 0 {
 			line = 1
 		}
+		// Column comes from the chunk's sparse Columns table (#153) - only
+		// approximate (the start of whichever source line the compiler most
+		// recently entered at or before lineOffset, not necessarily the exact
+		// token), but real position data beats a hardcoded column 1. Chunks
+		// compiled before this table existed, or with no line data at all,
+		// leave column at 0 and fall through to the column-1 default below.
+		if lineOffset >= 0 {
+			column = chunk.GetColumn(lineOffset)
+		}
+	}
+	if column == 0 {
+		column = 1
 	}
 
 	msg := fmt.Sprintf(format, args...)
@@ -19112,9 +19132,9 @@ func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
 	// that frame's line table, so reporting it against any other file - which is
 	// what a nil Source does, since DisplayErrors then falls back to whatever
 	// the embedder passed, i.e. the entry script - underlines an unrelated line
-	// of an unrelated file (#148). Column stays 1: the bytecode line table has
-	// no column information to recover, and inventing one is worse than
-	// admitting the line is all we know.
+	// of an unrelated file (#148). column above came out of the chunk's sparse
+	// Columns table (#153); it's only approximate, and falls back to 1 for
+	// chunks with no recorded column data.
 	src := frameSource(frame)
 	fileName := "<script>" // TODO: name host-built chunks better
 	if src != nil {
@@ -19123,7 +19143,7 @@ func (vm *VM) runtimeError(format string, args ...interface{}) InterpretResult {
 	runtimeErr := &errors.RuntimeError{
 		Position: errors.Position{
 			Line:     line,
-			Column:   1, // Default to column 1
+			Column:   column,
 			StartPos: 0,
 			EndPos:   0,
 			Source:   src,


### PR DESCRIPTION
## Summary

Fixes the frame-synthesized-position half of #153: `Chunk` had a `Lines []int` table (one entry per byte of `Code`) but nothing recording column, so every position synthesized from a frame's own bytecode hardcoded `Column: 1`.

This implements **Option 2** from the issue: a sparse offset→column side table (`Chunk.Columns`, `Chunk.MarkColumn`/`GetColumn`) rather than a parallel per-byte array (Option 1, which the issue flagged as doubling `Lines`' already substantial per-byte cost, and colliding with #52's `(*VM).run` layout sensitivity). The compiler populates it from the same spot it already tracks the current line during `compileNode`'s traversal (`Compiler.markPosition`, called once per source line crossed, not per emitted instruction), so it stays far sparser than `Lines` while giving `GetColumn`'s binary search real position data to recover.

The recovered column is **approximate** — the column of whichever line the compiler most recently entered at or before a given offset, not necessarily the exact failing sub-expression. When several statements share a line, a later one's column resolves to an earlier statement's rather than its own. Two driver tests document that boundary explicitly rather than leaving it as a surprise.

## Scope note

`vm.runtimeError()` (named directly in #153) is fixed and covered at the unit level (`pkg/vm/runtime_error_report_test.go`), since every call site reachable from real JS turns out to get wrapped into a catchable `TypeError` first. Along the way I found `throwException`'s capture of an uncaught JS exception's throw site (`getFrameLineInfo`, now `getFrameLineAndColumnInfo`) had the exact same bug — a literal `// Column tracking not implemented yet` comment hardcoding `Column: 1` — and is far more user-visible (every uncaught exception goes through it), so it's fixed alongside it.

**Not fixed here:** `executeModule`'s uncaught-module-exception path (`pkg/vm/vm.go`, `"Create a RuntimeError from the exception"` comment) still hardcodes `Position{Line: 1, Column: 1}` outright rather than using `lastThrowLine`/`lastThrowColumn` — a separate, pre-existing gap noticed in passing, not part of #153's own scope.

## Tests

- `pkg/vm/bytecode_test.go`: `TestChunkGetColumn` — the sparse table's binary search and same-offset overwrite behavior directly.
- `pkg/vm/runtime_error_report_test.go`: two tests driving `vm.runtimeError()` against a hand-built frame/chunk, with and without a populated `Columns` table.
- `pkg/driver/error_position_test.go`: two tests through real script execution (`SkipTypeCheck`, so the dynamic runtime check fires instead of the checker's own already-correct static position) — one statement per line, and the shared-line boundary case.

Full `go test ./...` passes.

I'm leaving #153 open rather than closing it from this PR — the issue itself frames this as "a real design decision about debug-info cost", so whoever reviews should be the one to decide the trade-off shipped here settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)